### PR TITLE
refactor(conditions): one fold owns which filter nodes survive

### DIFF
--- a/.changeset/fold-condition-tree.md
+++ b/.changeset/fold-condition-tree.md
@@ -1,0 +1,5 @@
+---
+"@stll/conditions": minor
+---
+
+Export `foldCondition`/`foldConditions`, a generic fold over the condition tree that owns the drop rule for a group with no surviving children, so every consumer that reads which nodes a filter compiles to agrees on the same structural semantics.

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -7,11 +7,13 @@ import {
   type CompareNode,
   type ConditionNode,
   type ConditionValue,
+  type FoldHandlers,
   type GroupNode,
   type Operand,
   type PredicateNode,
   type RefOperand,
   evaluateCondition,
+  foldCondition,
   pruneIncomplete,
 } from "@stll/conditions";
 
@@ -671,38 +673,29 @@ const compilePredicate = (node: PredicateNode): SQL | null => {
 
 // -- Group nodes --
 
-const compileGroup = (node: GroupNode): SQL | null => {
-  const children: SQL[] = [];
-  for (const child of node.children) {
-    const compiled = compileNode(child);
-    if (compiled) {
-      children.push(compiled);
-    }
-  }
-  if (children.length === 0) {
-    return null;
-  }
-
-  const combined =
-    node.combinator === "and" ? and(...children) : or(...children);
-  if (!combined) {
-    return null;
-  }
-  return node.negated ? not(combined) : combined;
-};
-
-const compileNode = (node: ConditionNode): SQL | null => {
-  switch (node.type) {
-    case "group":
-      return compileGroup(node);
-    case "compare":
-      return compileCompare(node);
-    case "predicate":
-      return compilePredicate(node);
-    default:
+/**
+ * The structural fold rule (see `@stll/conditions`'s `foldCondition`): a leaf
+ * compiles via `compileCompare`/`compilePredicate`, and a group combines its
+ * already-dropped-of-`null` children with `and`/`or` then `not` when negated.
+ * A group left with no surviving children never reaches `group` at all — the
+ * fold drops it before this callback runs, matching the old `compileGroup`'s
+ * `children.length === 0` guard.
+ */
+const conditionFoldHandlers: FoldHandlers<SQL> = {
+  leaf: (node) =>
+    node.type === "compare" ? compileCompare(node) : compilePredicate(node),
+  group: (node, children) => {
+    const combined =
+      node.combinator === "and" ? and(...children) : or(...children);
+    if (!combined) {
       return null;
-  }
+    }
+    return node.negated ? not(combined) : combined;
+  },
 };
+
+const compileNode = (node: ConditionNode): SQL | null =>
+  foldCondition(node, conditionFoldHandlers);
 
 /**
  * Compiles the implicit-AND filter array into SQL WHERE conditions

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
@@ -1,6 +1,6 @@
 import { isEntityKind } from "@stll/api-contract";
-import { conditionIncludesKind } from "@stll/conditions";
-import type { ConditionNode, GroupNode, PredicateNode } from "@stll/conditions";
+import { conditionIncludesKind, foldConditions } from "@stll/conditions";
+import type { ConditionNode, FoldHandlers } from "@stll/conditions";
 
 import type { EntityKind } from "@/lib/types";
 
@@ -15,9 +15,10 @@ export const includesListItems = (filters: readonly ConditionNode[]): boolean =>
  * The entity kinds a view's filters admit, read from its `kind in […]`
  * predicates, or `null` when the view does not provably restrict the kind.
  *
- * The rules mirror how the API compiles a filter to SQL: a group with no
- * compiled children is dropped, and never counts as a restriction or as an
- * "everything" branch of its parent; an `and` intersects the sets its
+ * The rules mirror how the API compiles a filter to SQL (`@stll/conditions`'s
+ * `foldCondition`/`foldConditions` own that structural agreement): a group
+ * with no compiled children is dropped, and never counts as a restriction or
+ * as an "everything" branch of its parent; an `and` intersects the sets its
  * restricted children admit (an unrestricted child is ignored); an `or` is
  * restricted only when every remaining child is, and is then their union;
  * a negated group, and any predicate or compare node other than
@@ -27,41 +28,29 @@ export const includesListItems = (filters: readonly ConditionNode[]): boolean =>
 export const viewEntityKinds = (
   filters: readonly ConditionNode[],
 ): readonly EntityKind[] | null => {
-  const admitted = admittedKindsForAnd(filters);
+  const admitted = combineAnd(foldConditions(filters, kindFoldHandlers) ?? []);
   return admitted.type === "kinds" ? [...admitted.kinds] : null;
 };
 
 /**
- * What a node contributes to the kinds a view admits. `dropped` is a node
- * the query compiler discards (an empty group, recursively), which must not
- * be confused with `unrestricted`: an `or` over a task restriction and a
- * dropped group still shows only tasks.
+ * What a node contributes to the kinds a view admits. Unlike the fold's
+ * generic drop rule (a `null` result), this never reports "dropped" — a
+ * predicate or compare other than `kind in […]` still compiles to SQL, it
+ * just does not restrict which kind rows match, so it folds to
+ * `UNRESTRICTED` rather than `null`. Only an empty group is ever dropped,
+ * and that is handled by the fold itself before `group` below is called.
  */
 type AdmittedKinds =
-  | { type: "dropped" }
   | { type: "unrestricted" }
   | { type: "kinds"; kinds: ReadonlySet<EntityKind> };
 
-const DROPPED = { type: "dropped" } as const satisfies AdmittedKinds;
 const UNRESTRICTED = {
   type: "unrestricted",
 } as const satisfies AdmittedKinds;
 
-const admittedKinds = (node: ConditionNode): AdmittedKinds => {
-  switch (node.type) {
-    case "compare":
-      return UNRESTRICTED;
-    case "predicate":
-      return admittedKindsForPredicate(node);
-    case "group":
-      return admittedKindsForGroup(node);
-    default:
-      return node satisfies never;
-  }
-};
-
-const admittedKindsForPredicate = (node: PredicateNode): AdmittedKinds => {
+const admittedKindsForLeaf: FoldHandlers<AdmittedKinds>["leaf"] = (node) => {
   if (
+    node.type !== "predicate" ||
     node.operand.type !== "kind" ||
     node.op !== "in" ||
     !Array.isArray(node.value)
@@ -77,13 +66,10 @@ const admittedKindsForPredicate = (node: PredicateNode): AdmittedKinds => {
   return { type: "kinds", kinds };
 };
 
-const admittedKindsForGroup = (node: GroupNode): AdmittedKinds => {
-  const children = node.children
-    .map(admittedKinds)
-    .filter((child) => child.type !== "dropped");
-  if (children.length === 0) {
-    return DROPPED;
-  }
+const admittedKindsForGroup: FoldHandlers<AdmittedKinds>["group"] = (
+  node,
+  children,
+) => {
   if (node.negated) {
     return UNRESTRICTED;
   }
@@ -97,11 +83,10 @@ const admittedKindsForGroup = (node: GroupNode): AdmittedKinds => {
   }
 };
 
-/** The implicit `and` over a filter list; an all-dropped list restricts nothing. */
-const admittedKindsForAnd = (nodes: readonly ConditionNode[]): AdmittedKinds =>
-  combineAnd(
-    nodes.map(admittedKinds).filter((child) => child.type !== "dropped"),
-  );
+const kindFoldHandlers: FoldHandlers<AdmittedKinds> = {
+  leaf: admittedKindsForLeaf,
+  group: admittedKindsForGroup,
+};
 
 /** Intersection of restricted children; unrestricted children are ignored. */
 const combineAnd = (children: readonly AdmittedKinds[]): AdmittedKinds => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
@@ -28,7 +28,12 @@ export const includesListItems = (filters: readonly ConditionNode[]): boolean =>
 export const viewEntityKinds = (
   filters: readonly ConditionNode[],
 ): readonly EntityKind[] | null => {
-  const admitted = combineAnd(foldConditions(filters, kindFoldHandlers) ?? []);
+  // A filter whose nodes are all dropped restricts nothing.
+  const survivors = foldConditions(filters, kindFoldHandlers);
+  if (survivors === null) {
+    return null;
+  }
+  const admitted = combineAnd(survivors);
   return admitted.type === "kinds" ? [...admitted.kinds] : null;
 };
 

--- a/packages/conditions/src/fold.test.ts
+++ b/packages/conditions/src/fold.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+
+import { type FoldHandlers, foldCondition, foldConditions } from "./fold";
+import type { ConditionNode } from "./schema";
+
+const kindPredicate = (value: string): ConditionNode => ({
+  type: "predicate",
+  operand: { type: "kind" },
+  op: "in",
+  value: [value],
+});
+
+/** `leaf` keeps every "kind in [x]" predicate and drops everything else. */
+const keepKindLeaf: FoldHandlers<string>["leaf"] = (node) => {
+  if (
+    node.type === "predicate" &&
+    node.operand.type === "kind" &&
+    node.op === "in" &&
+    Array.isArray(node.value)
+  ) {
+    return node.value.join(",");
+  }
+  return null;
+};
+
+/** `group` joins surviving children and records negation/combinator. */
+const joinGroup: FoldHandlers<string>["group"] = (node, children) => {
+  const combined = children.join(node.combinator === "and" ? "&" : "|");
+  return node.negated ? `!(${combined})` : combined;
+};
+
+const handlers: FoldHandlers<string> = { leaf: keepKindLeaf, group: joinGroup };
+
+describe("foldCondition", () => {
+  test("a leaf returning null is dropped", () => {
+    const unrestricted: ConditionNode = {
+      type: "predicate",
+      operand: { type: "property", propertyId: "status" },
+      op: "is_not_empty",
+    };
+    expect(foldCondition(unrestricted, handlers)).toBeNull();
+  });
+
+  test("a group whose children are all dropped is dropped without calling group", () => {
+    let groupCalls = 0;
+    const countingHandlers: FoldHandlers<string> = {
+      leaf: keepKindLeaf,
+      group: (node, children) => {
+        groupCalls += 1;
+        return joinGroup(node, children);
+      },
+    };
+    const node: ConditionNode = {
+      type: "group",
+      combinator: "and",
+      children: [
+        {
+          type: "predicate",
+          operand: { type: "property", propertyId: "status" },
+          op: "is_not_empty",
+        },
+        {
+          type: "group",
+          combinator: "or",
+          children: [],
+        },
+      ],
+    };
+    expect(foldCondition(node, countingHandlers)).toBeNull();
+    // Only the empty nested group would have been eligible, and an empty
+    // group is dropped before `group` is ever invoked for it.
+    expect(groupCalls).toBe(0);
+  });
+
+  test("a nested dropped group does not affect siblings", () => {
+    const node: ConditionNode = {
+      type: "group",
+      combinator: "or",
+      children: [
+        kindPredicate("task"),
+        { type: "group", combinator: "and", children: [] },
+      ],
+    };
+    expect(foldCondition(node, handlers)).toBe("task");
+  });
+
+  test("negated reaches the group callback", () => {
+    const node: ConditionNode = {
+      type: "group",
+      combinator: "and",
+      negated: true,
+      children: [kindPredicate("task")],
+    };
+    expect(foldCondition(node, handlers)).toBe("!(task)");
+  });
+
+  test("order of surviving children is preserved", () => {
+    const node: ConditionNode = {
+      type: "group",
+      combinator: "and",
+      children: [
+        kindPredicate("task"),
+        {
+          type: "predicate",
+          operand: { type: "property", propertyId: "status" },
+          op: "is_not_empty",
+        },
+        kindPredicate("message"),
+        kindPredicate("document"),
+      ],
+    };
+    expect(foldCondition(node, handlers)).toBe("task&message&document");
+  });
+
+  test("returns null for a top-level leaf that compiles to nothing", () => {
+    expect(
+      foldCondition(
+        {
+          type: "compare",
+          left: { type: "formula", expr: "x" },
+          op: "eq",
+          right: { type: "literal", value: 1 },
+        },
+        { leaf: () => null, group: joinGroup },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("foldConditions", () => {
+  test("returns null when every top-level node is dropped", () => {
+    expect(
+      foldConditions(
+        [
+          {
+            type: "predicate",
+            operand: { type: "property", propertyId: "status" },
+            op: "is_not_empty",
+          },
+          { type: "group", combinator: "or", children: [] },
+        ],
+        handlers,
+      ),
+    ).toBeNull();
+  });
+
+  test("returns the surviving results, in order, for the caller to combine", () => {
+    expect(
+      foldConditions(
+        [kindPredicate("task"), kindPredicate("message")],
+        handlers,
+      ),
+    ).toEqual(["task", "message"]);
+  });
+
+  test("drops nodes that fold to null while keeping the rest", () => {
+    expect(
+      foldConditions(
+        [
+          {
+            type: "predicate",
+            operand: { type: "property", propertyId: "status" },
+            op: "is_not_empty",
+          },
+          kindPredicate("task"),
+        ],
+        handlers,
+      ),
+    ).toEqual(["task"]);
+  });
+});

--- a/packages/conditions/src/fold.ts
+++ b/packages/conditions/src/fold.ts
@@ -1,0 +1,94 @@
+/**
+ * The single owner of "which condition nodes survive compilation" — the
+ * structural rule that decides whether a leaf or group contributes anything
+ * at all, independent of what it is compiled *to*. Every consumer that reads
+ * a condition tree down to a smaller value per node (SQL, an admitted-kinds
+ * set, …) must agree on this rule, or the query compiler and a client-side
+ * reading of the same filter can disagree about which nodes exist.
+ *
+ * The rule, made explicit here instead of re-implemented per consumer:
+ *  - A leaf (`compare`/`predicate`) may fold to `null`, meaning it compiles
+ *    to nothing (an incomplete filter, an unsupported operator, …).
+ *  - A group's `null` children are dropped before its surviving children
+ *    are handed to the `group` callback, in their original order.
+ *  - A group left with zero surviving children folds to `null` *without*
+ *    calling `group` — the group itself is dropped, recursively, the same
+ *    way an empty AND/OR compiles to no SQL. `group` never has to handle
+ *    an empty `children` array.
+ *  - A group may itself still fold to `null` (its `group` callback returned
+ *    `null`, e.g. `and()`/`or()` of the underlying value type came back
+ *    falsy) — that also drops it from its parent.
+ *  - `negated` is not applied by the fold; it is passed through on the
+ *    `GroupNode` so `group` can honour it (or ignore it, for callers where
+ *    negation is itself something that drops the restriction, such as
+ *    "what kinds does this admit").
+ */
+import type {
+  CompareNode,
+  ConditionNode,
+  GroupNode,
+  PredicateNode,
+} from "./schema";
+
+export type FoldHandlers<T> = {
+  /** Compile a leaf node, or return `null` if it compiles to nothing. */
+  leaf: (node: PredicateNode | CompareNode) => T | null;
+  /**
+   * Combine a group's surviving (non-`null`) children, in source order.
+   * Never called with an empty `children` array — a group with no
+   * surviving children is dropped before `group` would be invoked.
+   */
+  group: (node: GroupNode, children: readonly T[]) => T | null;
+};
+
+/**
+ * Folds a single condition node per {@link FoldHandlers}. See the module
+ * doc comment for the exact drop rule.
+ */
+export const foldCondition = <T>(
+  node: ConditionNode,
+  handlers: FoldHandlers<T>,
+): T | null => {
+  switch (node.type) {
+    case "compare":
+    case "predicate":
+      return handlers.leaf(node);
+    case "group": {
+      const children: T[] = [];
+      for (const child of node.children) {
+        const folded = foldCondition(child, handlers);
+        if (folded !== null) {
+          children.push(folded);
+        }
+      }
+      if (children.length === 0) {
+        return null;
+      }
+      return handlers.group(node, children);
+    }
+    default:
+      return node satisfies never;
+  }
+};
+
+/**
+ * Folds a top-level condition list — the implicit AND root every filter
+ * array represents. Applies the same drop rule per node and returns the
+ * surviving results in source order for the caller to combine (there is no
+ * synthetic root `GroupNode` to hand to `group`, since a top-level list
+ * carries no `combinator`/`negated` of its own). Returns `null` when every
+ * node was dropped.
+ */
+export const foldConditions = <T>(
+  nodes: readonly ConditionNode[],
+  handlers: FoldHandlers<T>,
+): readonly T[] | null => {
+  const results: T[] = [];
+  for (const node of nodes) {
+    const folded = foldCondition(node, handlers);
+    if (folded !== null) {
+      results.push(folded);
+    }
+  }
+  return results.length === 0 ? null : results;
+};

--- a/packages/conditions/src/index.ts
+++ b/packages/conditions/src/index.ts
@@ -6,3 +6,4 @@
 export * from "./schema";
 export * from "./evaluate";
 export * from "./walk";
+export * from "./fold";


### PR DESCRIPTION
## Summary

Closes the follow-up noted on #2815. Three review rounds found three divergences between `compileGroup` in the API and `viewEntityKinds` on the web, because each re-derived the same structural rule by hand.

- **`@stll/conditions`**: `foldCondition(node, { leaf, group })` and `foldConditions(nodes, handlers)`. A `leaf` may return `null` (compiles to nothing); a group's `null` children are removed, in order, before `group` is called; a group with no surviving children folds to `null` without calling `group`; `negated` is passed through for `group` to honour. `foldConditions` applies the rule to a top-level list and returns the survivors or `null`. Six unit tests, including a call counter proving `group` never sees an empty group.
- **`apps/api/src/lib/entity-filters.ts`**: `compileGroup` is gone; `compileNode` is the fold with `leaf` dispatching to the existing compilers and `group` doing `and`/`or` then `not`. Behaviour identical; the differential test (pglite) passes.
- **`view-kind-filters.ts`**: the local `dropped` state is gone; the reader is the same fold with `leaf` returning a kind set or `UNRESTRICTED`, and `group` the existing and/or/negated combination. All 13 tests unchanged and passing.
- Changeset: `@stll/conditions` minor.

## Verification

`bun test packages/conditions` (41), `entity-filters` unit and differential tests (38), `view-kind-filters` (13); API, web, and package typechecks clean; type-aware oxlint and oxfmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reusable condition-tree folding utilities for processing individual conditions and condition lists.
  - Exposed the new functionality through the conditions package’s public API.

- **Improvements**
  - Standardised handling of empty or discarded condition groups across filtering and query processing.
  - Preserved condition ordering, grouping, and negation behaviour while ensuring consistent results between workspace filters and API queries.

- **Tests**
  - Added comprehensive coverage for nested groups, discarded conditions, empty results, ordering, and negation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->