### PR TITLE
chore(ci): tighten the dead-column check per review

### DIFF
--- a/scripts/check-dead-columns.test.ts
+++ b/scripts/check-dead-columns.test.ts
@@ -57,7 +57,7 @@ describe("isColumnReferenced", () => {
   test("does not match a key as a substring of a longer identifier", () => {
     expect(
       isColumnReferenced({
-        corpus: "const value = row.notAutoInvokeHintAtAll;",
+        corpus: "const value = row.notautoInvokeHintAtAll;",
         tsKey: "autoInvokeHint",
         sqlName: "auto_invoke_hint",
       }),
@@ -75,6 +75,15 @@ describe("shouldScanFile", () => {
 
   test("excludes the schema definitions", () => {
     expect(shouldScanFile("apps/api/src/db/schema.ts")).toBe(false);
+  });
+
+  test("excludes spec files as well as test files", () => {
+    expect(shouldScanFile("apps/web/src/components/search.spec.ts")).toBe(
+      false,
+    );
+    expect(shouldScanFile("apps/web/src/components/search.spec.tsx")).toBe(
+      false,
+    );
     expect(shouldScanFile("apps/api/src/db/schema/properties.ts")).toBe(false);
   });
 

--- a/scripts/check-dead-columns.ts
+++ b/scripts/check-dead-columns.ts
@@ -42,6 +42,13 @@ const IGNORED_COLUMN_KEYS = new Set([
 
 // The schema definitions themselves obviously reference every column; excluding
 // them is what makes this a "used elsewhere" check rather than a tautology.
+const TEST_FILE_SUFFIXES = [
+  ".test.ts",
+  ".test.tsx",
+  ".spec.ts",
+  ".spec.tsx",
+] as const;
+
 const EXCLUDED_PATH_PREFIXES = ["apps/api/src/db/schema"] as const;
 // Migrations replay column names verbatim and would make every column look
 // referenced; generated/vendor output belongs out for the same reason.
@@ -97,8 +104,8 @@ export const shouldScanFile = (relativePath: string): boolean => {
     return false;
   }
   // Also excludes *.integration.test.ts and *.property.test.ts, which share
-  // this suffix.
-  if (relativePath.endsWith(".test.ts") || relativePath.endsWith(".test.tsx")) {
+  // the `.test` suffix.
+  if (TEST_FILE_SUFFIXES.some((suffix) => relativePath.endsWith(suffix))) {
     return false;
   }
   if (
@@ -189,7 +196,10 @@ const isAllowlistEntry = (value: unknown): value is AllowlistEntry =>
   "reason" in value &&
   typeof value.table === "string" &&
   typeof value.column === "string" &&
-  typeof value.reason === "string";
+  typeof value.reason === "string" &&
+  // The reason is the only reviewable evidence that an exception is
+  // deliberate; an empty one is not an allowlist entry.
+  value.reason.trim().length > 0;
 
 const loadAllowlist = (): AllowlistEntry[] => {
   const raw = readFileSync(ALLOWLIST_PATH, "utf-8");


### PR DESCRIPTION
## Summary

Addresses the three review findings on #2818.

- `.spec.ts` / `.spec.tsx` are excluded from the reference scan like `.test.*`, with a regression test.
- An allowlist entry with a blank `reason` is rejected: the reason is the only reviewable evidence that an exception is deliberate.
- The substring self-test now uses an identifier containing the exact key (`notautoInvokeHintAtAll`) so a broken word boundary is detected.

## Verification

`bun scripts/check-dead-columns.ts` exit 0; `bun test scripts/check-dead-columns.test.ts`; type-aware oxlint and oxfmt clean.
