### PR TITLE
test(ci): exercise each word boundary of the dead-column matcher on its own

### DIFF
--- a/scripts/check-dead-columns.test.ts
+++ b/scripts/check-dead-columns.test.ts
@@ -54,10 +54,22 @@ describe("isColumnReferenced", () => {
     ).toBe(false);
   });
 
-  test("does not match a key as a substring of a longer identifier", () => {
+  // Each boundary is exercised on its own: a fixture with word characters on
+  // both sides would still pass if only one of the two `\b` anchors broke.
+  test("does not match a key that ends a longer identifier", () => {
     expect(
       isColumnReferenced({
-        corpus: "const value = row.notautoInvokeHintAtAll;",
+        corpus: "const value = row.notautoInvokeHint;",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not match a key that starts a longer identifier", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "const value = row.autoInvokeHintAtAll;",
         tsKey: "autoInvokeHint",
         sqlName: "auto_invoke_hint",
       }),


### PR DESCRIPTION
## Summary

Addresses the review finding on #2820: the substring self-test used an identifier with word characters on both sides of the key, so removing either `\b` anchor alone left it passing. It is now two cases, one where the key ends a longer identifier and one where it starts one.

## Verification

`bun test scripts/check-dead-columns.test.ts` (13 pass); oxlint and oxfmt clean.
