### PR TITLE
chore(api): make the projection guard mandatory and exact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1043,6 +1043,15 @@ jobs:
         if: needs.ci-plan.outputs.package_checks_required == 'true'
         run: bun test scripts/check-dead-columns.test.ts
 
+      # Self-test the projection-totality module classifier: a regression
+      # here would either silently stop flagging an unguarded resource
+      # projection or start flagging unrelated modules, in both cases
+      # undermining the check:projection-totality gate in the code-quality
+      # job.
+      - name: Test projection-totality classification
+        if: needs.ci-plan.outputs.package_checks_required == 'true'
+        run: bun test scripts/check-projection-totality.test.ts
+
       # Fail PRs that change the desktop bridge surface without
       # bumping BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs.
       # See scripts/check-bridge-version.sh for rationale.
@@ -1113,6 +1122,9 @@ jobs:
 
       - name: Dead columns
         run: bun run check:dead-columns
+
+      - name: Projection totality
+        run: bun run check:projection-totality
 
       - name: Result consumption
         env:

--- a/apps/api/src/handlers/contacts/list-query.ts
+++ b/apps/api/src/handlers/contacts/list-query.ts
@@ -2,6 +2,7 @@ import { and, count, eq, gt, ilike, or } from "drizzle-orm";
 
 import type { ContactType } from "@stll/api-contract";
 
+import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
 import { contacts, workspaces } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -119,22 +120,52 @@ const decodeCursor = (cursor: string): DecodedCursor | null => {
 const encodeCursor = (displayName: string, id: string): string =>
   encodePaginationCursor([displayName, id]);
 
-// The shape the `.select({...})` below must project, plus the one
-// aggregate (`clientMatterCount`) that traces back to no single column.
-type ContactListItem = Pick<
-  ContactRow,
-  | "id"
-  | "type"
-  | "displayName"
-  | "firstName"
-  | "lastName"
-  | "organizationName"
-  | "emails"
-  | "phones"
-  | "tags"
-  | "color"
-  | "createdAt"
-> & { clientMatterCount: number };
+// The exact `.select({...})` passed to the query below. Hoisted so the
+// selection and the derived `ContactListItem` type can never drift apart:
+// a column added to one without the other is either a totality-guard
+// failure (added to the select, not the row type -- impossible, since the
+// row type is derived from the select) or simply doesn't compile.
+const CONTACT_LIST_SELECTION = {
+  id: contacts.id,
+  type: contacts.type,
+  displayName: contacts.displayName,
+  firstName: contacts.firstName,
+  lastName: contacts.lastName,
+  organizationName: contacts.organizationName,
+  emails: contacts.emails,
+  phones: contacts.phones,
+  tags: contacts.tags,
+  color: contacts.color,
+  createdAt: contacts.createdAt,
+  clientMatterCount: count(workspaces.id),
+} as const;
+
+// Select + from + join only: the row shape this produces is unaffected by
+// the `.where()`/`.groupBy()`/`.orderBy()`/`.limit()` the real query below
+// chains onto it, so this alone is enough to derive `ContactListItem` from.
+const selectContactListRows = ({
+  tx,
+  organizationId,
+}: {
+  tx: Transaction;
+  organizationId: SafeId<"organization">;
+}) =>
+  tx
+    .select(CONTACT_LIST_SELECTION)
+    .from(contacts)
+    .leftJoin(
+      workspaces,
+      and(
+        eq(workspaces.clientId, contacts.id),
+        eq(workspaces.organizationId, organizationId),
+      ),
+    );
+
+// The join-derived aggregate (`clientMatterCount`) traces back to no single
+// column, so it stays excluded from the reverse totality check via `Omit`.
+type ContactListItem = Awaited<
+  ReturnType<typeof selectContactListRows>
+>[number];
 
 // Totality guard, bidirectional: every schema column must be projected onto
 // the response or explicitly excused above, and the projection cannot carry
@@ -147,7 +178,8 @@ type MissingProjectedContactListColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedContactListColumn = UnbackedProjectionKeys<
   ContactRow,
-  Omit<ContactListItem, "clientMatterCount">
+  Omit<ContactListItem, "clientMatterCount">,
+  (typeof UNPROJECTED_CONTACT_LIST_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedContactListColumn extends never ? true : never;
@@ -194,40 +226,14 @@ export const listContactsPage = async ({
       }
     }
 
-    const rows = await tx
-      .select({
-        id: contacts.id,
-        type: contacts.type,
-        displayName: contacts.displayName,
-        firstName: contacts.firstName,
-        lastName: contacts.lastName,
-        organizationName: contacts.organizationName,
-        emails: contacts.emails,
-        phones: contacts.phones,
-        tags: contacts.tags,
-        color: contacts.color,
-        createdAt: contacts.createdAt,
-        clientMatterCount: count(workspaces.id),
-      })
-      .from(contacts)
-      .leftJoin(
-        workspaces,
-        and(
-          eq(workspaces.clientId, contacts.id),
-          eq(workspaces.organizationId, organizationId),
-        ),
-      )
+    const rows = await selectContactListRows({ tx, organizationId })
       .where(and(...conditions))
       .groupBy(contacts.id)
       .orderBy(contacts.displayName, contacts.id)
       .limit(limit + 1);
 
-    // Ties the `.select({...})` above to `ContactListItem`: if either drops
-    // a field the other still names, this check stops typechecking.
-    const projectedRows = rows satisfies ContactListItem[];
-
     return createCursorPage({
-      rows: projectedRows,
+      rows,
       limit,
       cursorForItem: (item) => encodeCursor(item.displayName, item.id),
     });

--- a/apps/api/src/handlers/notifications/read-model.ts
+++ b/apps/api/src/handlers/notifications/read-model.ts
@@ -88,7 +88,8 @@ type MissingProjectedNotificationColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedNotificationColumn = UnbackedProjectionKeys<
   NotificationRow,
-  NotificationListItem
+  NotificationListItem,
+  (typeof UNPROJECTED_NOTIFICATION_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedNotificationColumn extends never ? true : never;

--- a/apps/api/src/handlers/playbooks/read.ts
+++ b/apps/api/src/handlers/playbooks/read.ts
@@ -73,7 +73,8 @@ type MissingProjectedPlaybookListColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedPlaybookListColumn = UnbackedProjectionKeys<
   PlaybookDefinitionRow,
-  PlaybookDefinitionListItem
+  PlaybookDefinitionListItem,
+  (typeof UNPROJECTED_PLAYBOOK_LIST_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedPlaybookListColumn extends never ? true : never;
@@ -252,7 +253,8 @@ type MissingProjectedPlaybookDetailColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedPlaybookDetailColumn = UnbackedProjectionKeys<
   PlaybookDefinitionRow,
-  PlaybookDefinitionDetail
+  PlaybookDefinitionDetail,
+  (typeof UNPROJECTED_PLAYBOOK_DETAIL_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedPlaybookDetailColumn extends never

--- a/apps/api/src/handlers/properties/list.ts
+++ b/apps/api/src/handlers/properties/list.ts
@@ -87,7 +87,8 @@ type MissingProjectedPropertyColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedPropertyColumn = UnbackedProjectionKeys<
   PropertyRow,
-  PropertyListItem
+  PropertyListItem,
+  (typeof UNPROJECTED_PROPERTY_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedPropertyColumn extends never ? true : never;

--- a/apps/api/src/handlers/saved-searches/response.ts
+++ b/apps/api/src/handlers/saved-searches/response.ts
@@ -36,7 +36,8 @@ type MissingProjectedSavedSearchColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedSavedSearchColumn = UnbackedProjectionKeys<
   SavedSearchRow,
-  SavedSearchResponse
+  SavedSearchResponse,
+  (typeof UNPROJECTED_SAVED_SEARCH_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedSavedSearchColumn extends never ? true : never;

--- a/apps/api/src/handlers/skills/comments/list.ts
+++ b/apps/api/src/handlers/skills/comments/list.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { and, asc, eq } from "drizzle-orm";
 import { t } from "elysia";
 
+import type { Transaction } from "@/api/db/root";
 import { abortableTx } from "@/api/db/safe-db";
 import { agentSkillComments } from "@/api/db/schema";
 import { loadVisibleSkill } from "@/api/lib/agent-skills/access";
@@ -25,23 +26,32 @@ const UNPROJECTED_SKILL_COMMENT_COLUMNS = [
   "organizationId",
 ] as const satisfies readonly (keyof AgentSkillCommentRow)[];
 
-// The shape the `.select({...})` below must project. Kept as an explicit
-// type (rather than derived) so the totality guard has something concrete
-// to check both directions against.
-type SkillCommentListItem = Pick<
-  AgentSkillCommentRow,
-  | "id"
-  | "revisionId"
-  | "proposalId"
-  | "rangeStart"
-  | "rangeEnd"
-  | "anchorText"
-  | "body"
-  | "authorId"
-  | "resolvedAt"
-  | "resolvedBy"
-  | "createdAt"
->;
+// The exact `.select({...})` passed to the query below. Hoisted so the
+// selection and the derived `SkillCommentListItem` type can never drift
+// apart.
+const SKILL_COMMENT_LIST_SELECTION = {
+  id: agentSkillComments.id,
+  revisionId: agentSkillComments.revisionId,
+  proposalId: agentSkillComments.proposalId,
+  rangeStart: agentSkillComments.rangeStart,
+  rangeEnd: agentSkillComments.rangeEnd,
+  anchorText: agentSkillComments.anchorText,
+  body: agentSkillComments.body,
+  authorId: agentSkillComments.authorId,
+  resolvedAt: agentSkillComments.resolvedAt,
+  resolvedBy: agentSkillComments.resolvedBy,
+  createdAt: agentSkillComments.createdAt,
+} as const;
+
+// Select + from only: the row shape this produces is unaffected by the
+// `.where()`/`.orderBy()`/`.limit()` the real query below chains onto it,
+// so this alone is enough to derive `SkillCommentListItem` from.
+const selectSkillCommentListRows = (tx: Transaction) =>
+  tx.select(SKILL_COMMENT_LIST_SELECTION).from(agentSkillComments);
+
+type SkillCommentListItem = Awaited<
+  ReturnType<typeof selectSkillCommentListRows>
+>[number];
 
 // Totality guard, bidirectional: every schema column must be projected onto
 // the response or explicitly excused above, and the projection cannot carry
@@ -53,7 +63,8 @@ type MissingProjectedSkillCommentColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedSkillCommentColumn = UnbackedProjectionKeys<
   AgentSkillCommentRow,
-  SkillCommentListItem
+  SkillCommentListItem,
+  (typeof UNPROJECTED_SKILL_COMMENT_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedSkillCommentColumn extends never ? true : never;
@@ -86,21 +97,7 @@ const listSkillComments = createSafeRootHandler(
           organizationId: session.activeOrganizationId,
         });
 
-        return await tx
-          .select({
-            id: agentSkillComments.id,
-            revisionId: agentSkillComments.revisionId,
-            proposalId: agentSkillComments.proposalId,
-            rangeStart: agentSkillComments.rangeStart,
-            rangeEnd: agentSkillComments.rangeEnd,
-            anchorText: agentSkillComments.anchorText,
-            body: agentSkillComments.body,
-            authorId: agentSkillComments.authorId,
-            resolvedAt: agentSkillComments.resolvedAt,
-            resolvedBy: agentSkillComments.resolvedBy,
-            createdAt: agentSkillComments.createdAt,
-          })
-          .from(agentSkillComments)
+        return await selectSkillCommentListRows(tx)
           .where(
             and(
               eq(agentSkillComments.skillId, params.skillId),
@@ -118,12 +115,7 @@ const listSkillComments = createSafeRootHandler(
       }),
     );
 
-    // Ties the `.select({...})` above to `SkillCommentListItem`: if either
-    // drops a field the other still names, this assignment stops
-    // typechecking.
-    const projectedItems = items satisfies SkillCommentListItem[];
-
-    return Result.ok({ items: projectedItems });
+    return Result.ok({ items });
   },
 );
 

--- a/apps/api/src/handlers/templates/list.ts
+++ b/apps/api/src/handlers/templates/list.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { member, user } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
 import type { SafeDb } from "@/api/db/safe-db";
 import { templates } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -79,26 +80,61 @@ export const decodeTemplateListCursor = (
 export const encodeTemplateListCursor = (id: SafeId<"template">): string =>
   encodePaginationCursor([id]);
 
-// The shape the `.select({...})` below must project, plus the two
-// author-identity fields that come from the joined `user` row rather than
-// from `templates` itself.
-type TemplateListItem = Pick<
-  TemplateRow,
-  | "id"
-  | "name"
-  | "fileName"
-  | "fieldCount"
-  | "sizeBytes"
-  | "categoryId"
-  | "createdAt"
-  | "updatedAt"
-  | "lastUsedAt"
-  | "useCount"
-  | "tags"
-  | "languages"
-  | "whenToUse"
-  | "whenNotToUse"
-> & { authorName: string | null; authorImage: string | null };
+// The exact `.select({...})` passed to the query below. Hoisted so the
+// selection and the derived `TemplateListItem` type can never drift apart.
+const TEMPLATE_LIST_SELECTION = {
+  id: templates.id,
+  name: templates.name,
+  fileName: templates.fileName,
+  fieldCount: templates.fieldCount,
+  sizeBytes: templates.sizeBytes,
+  categoryId: templates.categoryId,
+  createdAt: templates.createdAt,
+  updatedAt: templates.updatedAt,
+  lastUsedAt: templates.lastUsedAt,
+  useCount: templates.useCount,
+  tags: templates.tags,
+  languages: templates.languages,
+  whenToUse: templates.whenToUse,
+  whenNotToUse: templates.whenNotToUse,
+  authorName: user.name,
+  authorImage: user.image,
+} as const;
+
+// Select + from + join only: the row shape this produces is unaffected by
+// the `.where()`/`.orderBy()`/`.limit()` the real query below chains onto
+// it, so this alone is enough to derive `TemplateListItem` from. Both joins
+// are left joins, so `authorName`/`authorImage` come out nullable -- a
+// departed or otherwise unresolved author renders as anonymous rather than
+// failing the query.
+const selectTemplateListRows = ({
+  tx,
+  organizationId,
+}: {
+  tx: Transaction;
+  organizationId: SafeId<"organization">;
+}) =>
+  tx
+    .select(TEMPLATE_LIST_SELECTION)
+    .from(templates)
+    // Author identity only for users still in the org: scope the
+    // user join through membership so departed users render as
+    // anonymous instead of leaking profile data.
+    .leftJoin(
+      member,
+      and(
+        eq(member.userId, templates.createdBy),
+        eq(member.organizationId, organizationId),
+      ),
+    )
+    .leftJoin(user, eq(user.id, member.userId));
+
+// The two author-identity fields come from the joined `user` row rather than
+// from `templates` itself, so they stay excluded from the reverse totality
+// check via `Omit`.
+type TemplateListItem = Awaited<
+  ReturnType<typeof selectTemplateListRows>
+>[number];
 
 // Totality guard, bidirectional: every schema column must be projected onto
 // the response or explicitly excused above, and the projection cannot carry
@@ -111,7 +147,8 @@ type MissingProjectedTemplateListColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedTemplateListColumn = UnbackedProjectionKeys<
   TemplateRow,
-  Omit<TemplateListItem, "authorName" | "authorImage">
+  Omit<TemplateListItem, "authorName" | "authorImage">,
+  (typeof UNPROJECTED_TEMPLATE_LIST_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedTemplateListColumn extends never ? true : never;
@@ -162,49 +199,15 @@ export const listTemplatesHandler = async function* ({
 
   const result = yield* Result.await(
     safeDb((tx) =>
-      tx
-        .select({
-          id: templates.id,
-          name: templates.name,
-          fileName: templates.fileName,
-          fieldCount: templates.fieldCount,
-          sizeBytes: templates.sizeBytes,
-          categoryId: templates.categoryId,
-          createdAt: templates.createdAt,
-          updatedAt: templates.updatedAt,
-          lastUsedAt: templates.lastUsedAt,
-          useCount: templates.useCount,
-          tags: templates.tags,
-          languages: templates.languages,
-          whenToUse: templates.whenToUse,
-          whenNotToUse: templates.whenNotToUse,
-          authorName: user.name,
-          authorImage: user.image,
-        })
-        .from(templates)
-        // Author identity only for users still in the org: scope the
-        // user join through membership so departed users render as
-        // anonymous instead of leaking profile data.
-        .leftJoin(
-          member,
-          and(
-            eq(member.userId, templates.createdBy),
-            eq(member.organizationId, organizationId),
-          ),
-        )
-        .leftJoin(user, eq(user.id, member.userId))
+      selectTemplateListRows({ tx, organizationId })
         .where(and(...conditions))
         .orderBy(desc(templates.createdAt), desc(templates.id))
         .limit(limit + 1),
     ),
   );
 
-  // Ties the `.select({...})` above to `TemplateListItem`: if either drops
-  // a field the other still names, this check stops typechecking.
-  const projectedResult = result satisfies TemplateListItem[];
-
   const page = createCursorPage({
-    rows: projectedResult,
+    rows: result,
     limit,
     cursorForItem: (item) => encodeTemplateListCursor(item.id),
   });

--- a/apps/api/src/handlers/workspaces/workspace-members-read.ts
+++ b/apps/api/src/handlers/workspaces/workspace-members-read.ts
@@ -39,7 +39,8 @@ type MissingProjectedWorkspaceMemberColumn = UnprojectedColumns<
 >;
 type UnexpectedProjectedWorkspaceMemberColumn = UnbackedProjectionKeys<
   WorkspaceMemberRow,
-  typeof WORKSPACE_MEMBER_COLUMNS
+  typeof WORKSPACE_MEMBER_COLUMNS,
+  (typeof UNPROJECTED_WORKSPACE_MEMBER_COLUMNS)[number]
 >;
 
 true satisfies MissingProjectedWorkspaceMemberColumn extends never

--- a/apps/api/src/lib/projection-totality.ts
+++ b/apps/api/src/lib/projection-totality.ts
@@ -10,7 +10,11 @@
  * the bottom of a projection module with the idiom below: one line fails if a
  * row column is neither projected nor named in an explicit, reasoned
  * `Excused` list, and the other fails if the projection carries a key that
- * traces back to no real column (a typo, or a column since dropped).
+ * traces back to no real column (a typo, a column since dropped, or a column
+ * that is named in `Excused` and so must not be projected). Both helpers take
+ * the same `Excused` type argument, so a column can never be simultaneously
+ * "reasoned as excused" and "actually sent to the client" without a compile
+ * error pointing at the drift.
  *
  * ```ts
  * const UNPROJECTED_WIDGET_COLUMNS = [
@@ -25,7 +29,8 @@
  * >;
  * type UnexpectedProjectedWidgetColumn = UnbackedProjectionKeys<
  *   WidgetRow,
- *   WidgetListItem
+ *   WidgetListItem,
+ *   (typeof UNPROJECTED_WIDGET_COLUMNS)[number]
  * >;
  *
  * true satisfies MissingProjectedWidgetColumn extends never ? true : never;
@@ -40,8 +45,16 @@ export type UnprojectedColumns<
   Excused extends keyof Row = never,
 > = Exclude<Exclude<keyof Row, Excused>, keyof Projection>;
 
-/** Keys of Projection that no Row column backs. */
-export type UnbackedProjectionKeys<Row, Projection> = Exclude<
-  keyof Projection,
-  keyof Row
->;
+/**
+ * Keys of Projection that no non-excused Row column backs: a typo, a column
+ * since dropped, or — since `Excused` is subtracted from the allowed set
+ * before the check — a column reasoned as excused above that the projection
+ * sends to the client anyway. That last case is what keeps the two guards
+ * honest against each other: an excused column that starts being projected
+ * fails here, instead of staying green because it is still a real row key.
+ */
+export type UnbackedProjectionKeys<
+  Row,
+  Projection,
+  Excused extends keyof Row = never,
+> = Exclude<keyof Projection, Exclude<keyof Row, Excused>>;

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "check:auth-md-spec": "bun packages/scripts/src/auth-md-spec-drift.ts",
     "check:resolutions": "bun scripts/check-resolution-ranges.ts",
     "check:dead-columns": "bun scripts/check-dead-columns.ts",
+    "check:projection-totality": "bun scripts/check-projection-totality.ts",
     "check:result-consumption": "bun packages/scripts/src/result-consumption.ts",
     "check:docs-sources": "bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings .claude/mcp/doc-sources.ts",
     "check:railway-template-draft": "bun scripts/check-railway-template-draft.ts",

--- a/scripts/check-projection-totality.test.ts
+++ b/scripts/check-projection-totality.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isResourceProjectionModule,
+  shouldScanHandlerFile,
+} from "./check-projection-totality";
+
+describe("shouldScanHandlerFile", () => {
+  test("scans ordinary handler source", () => {
+    expect(
+      shouldScanHandlerFile("apps/api/src/handlers/properties/list.ts"),
+    ).toBe(true);
+    expect(
+      shouldScanHandlerFile("apps/api/src/handlers/skills/comments/list.ts"),
+    ).toBe(true);
+  });
+
+  test("excludes the route table", () => {
+    expect(shouldScanHandlerFile("apps/api/src/handlers/routes.ts")).toBe(
+      false,
+    );
+  });
+
+  test("excludes schema re-exports", () => {
+    expect(shouldScanHandlerFile("apps/api/src/handlers/schema.ts")).toBe(
+      false,
+    );
+    expect(
+      shouldScanHandlerFile("apps/api/src/handlers/chat/schema-tools.ts"),
+    ).toBe(false);
+  });
+
+  test("excludes test files, including integration and db suites", () => {
+    expect(
+      shouldScanHandlerFile("apps/api/src/handlers/skills/create.test.ts"),
+    ).toBe(false);
+    expect(
+      shouldScanHandlerFile(
+        "apps/api/src/handlers/docx-suggestions/read.db.test.ts",
+      ),
+    ).toBe(false);
+    expect(
+      shouldScanHandlerFile(
+        "apps/api/src/handlers/chat/hydrate-messages.integration.test.ts",
+      ),
+    ).toBe(false);
+  });
+
+  test("excludes non-TypeScript files", () => {
+    expect(
+      shouldScanHandlerFile("apps/api/src/handlers/skills/README.md"),
+    ).toBe(false);
+  });
+});
+
+describe("isResourceProjectionModule", () => {
+  test("classifies a row-typed list module by filename", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/properties/list.ts",
+        content: "type PropertyRow = typeof properties.$inferSelect;",
+      }),
+    ).toBe(true);
+  });
+
+  test("classifies a non-list-named module that still declares $inferSelect", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/saved-searches/response.ts",
+        content: "type SavedSearchRow = typeof savedSearches.$inferSelect;",
+      }),
+    ).toBe(true);
+  });
+
+  test("classifies a module reading via findMany or findFirst, named accordingly", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/playbooks/read.ts",
+        content: "tx.query.playbookDefinitions.findFirst({ where: {} });",
+      }),
+    ).toBe(true);
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/workspaces/get.ts",
+        content: "tx.query.workspaces.findMany({ where: {} });",
+      }),
+    ).toBe(true);
+  });
+
+  test("classifies a module reading via an inline .select({ ... })", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/contacts/list-query.ts",
+        content: "tx.select({ id: contacts.id }).from(contacts);",
+      }),
+    ).toBe(true);
+  });
+
+  test("does not classify a module that reads rows but is not client-facing by name or $inferSelect", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/tasks/reconcile-cache.ts",
+        content: "tx.query.tasks.findMany({ where: {} });",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not classify a client-facing-named module that reads no schema rows", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/templates/list-cursor.ts",
+        content: "export const decodeCursor = (cursor: string) => cursor;",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not classify an unrelated helper with neither marker", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/chat/tools/registry-adapter.ts",
+        content: "export const buildAdapter = () => ({});",
+      }),
+    ).toBe(false);
+  });
+});

--- a/scripts/check-projection-totality.ts
+++ b/scripts/check-projection-totality.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env bun
+// The totality guards in apps/api/src/lib/projection-totality.ts (see that
+// file) only protect a handler that opts in by importing them. A handler
+// that reads schema rows and sends them to a client but never imports the
+// guard can drift silently, exactly like `properties/list.ts` once did
+// before the guard existed at all. This script makes that opt-in
+// mandatory: it finds every handler module shaped like a resource
+// projection and fails CI unless it either imports the guard or carries a
+// reasoned allowlist entry admitting it is unguarded.
+//
+// This does not retrofit guards -- it only makes the current gap visible
+// and keeps it from growing unnoticed. A module on the allowlist is backlog,
+// not an exception to fix later without review.
+//
+// Usage: bun scripts/check-projection-totality.ts
+
+import { panic } from "better-result";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+const HANDLERS_ROOT = path.join(REPO_ROOT, "apps/api/src/handlers");
+const ALLOWLIST_PATH = path.join(
+  REPO_ROOT,
+  "scripts/projection-totality.allowlist.json",
+);
+const PROJECTION_TOTALITY_IMPORT = "@/api/lib/projection-totality";
+
+type AllowlistEntry = {
+  file: string;
+  reason: string;
+};
+
+type ProjectionModule = {
+  relativePath: string;
+  guarded: boolean;
+};
+
+// A resource-projection module's basename names the read side of a
+// resource: a list/detail page, a get, or a response/read-model shaped for
+// return to a client. Deliberately loose (a "list-pagination.ts" or
+// "list-cursor.ts" helper matches too) -- a false positive only costs an
+// allowlist line, while a false negative hides a real gap.
+const CLIENT_FACING_FILENAME =
+  /(^|\/)(list|get|read|read-model|response|list-query|detail)(\.|-)/u;
+
+// Any one of these substrings is enough to call a file "reads rows from a
+// schema table": a row type derived straight from the table, or a query
+// method that returns whole rows. `.select({` only matches an inline
+// selection object; a module whose select passes a hoisted selection
+// constant is still caught because such modules also declare a
+// `$inferSelect` row type for their totality guard.
+const READS_SCHEMA_ROWS_MARKERS = [
+  "$inferSelect",
+  ".findMany(",
+  ".findFirst(",
+  ".select({",
+] as const;
+
+/**
+ * True when `relativePath` (posix-separated, relative to the repo root)
+ * is a handler module this check should classify at all: application
+ * `.ts` source under apps/api/src/handlers, excluding tests, the route
+ * table, and schema re-exports.
+ */
+export const shouldScanHandlerFile = (relativePath: string): boolean => {
+  if (!relativePath.endsWith(".ts")) {
+    return false;
+  }
+  // Also excludes *.integration.test.ts, *.property.test.ts, and
+  // *.db.test.ts, which share this suffix.
+  if (relativePath.endsWith(".test.ts")) {
+    return false;
+  }
+  const basename = path.basename(relativePath);
+  if (basename === "routes.ts") {
+    return false;
+  }
+  if (/^schema.*\.ts$/u.test(basename)) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * True when a handler module is shaped like a resource projection: it reads
+ * rows from a schema table AND returns them to a client, per the two marker
+ * sets above.
+ */
+export const isResourceProjectionModule = ({
+  relativePath,
+  content,
+}: {
+  relativePath: string;
+  content: string;
+}): boolean => {
+  const readsSchemaRows = READS_SCHEMA_ROWS_MARKERS.some((marker) =>
+    content.includes(marker),
+  );
+  if (!readsSchemaRows) {
+    return false;
+  }
+  return (
+    CLIENT_FACING_FILENAME.test(relativePath) ||
+    content.includes("$inferSelect")
+  );
+};
+
+const walk = (directory: string, out: string[]): void => {
+  for (const entry of readdirSync(directory)) {
+    const absolute = path.join(directory, entry);
+    const stats = statSync(absolute);
+    if (stats.isDirectory()) {
+      walk(absolute, out);
+    } else if (stats.isFile()) {
+      out.push(absolute);
+    }
+  }
+};
+
+const collectHandlerFiles = (): string[] => {
+  const files: string[] = [];
+  walk(HANDLERS_ROOT, files);
+  return files.filter((absolute) =>
+    shouldScanHandlerFile(
+      path.relative(REPO_ROOT, absolute).split(path.sep).join("/"),
+    ),
+  );
+};
+
+const collectProjectionModules = (
+  files: readonly string[],
+): ProjectionModule[] => {
+  const modules: ProjectionModule[] = [];
+  for (const absolute of files) {
+    const relativePath = path
+      .relative(REPO_ROOT, absolute)
+      .split(path.sep)
+      .join("/");
+    const content = readFileSync(absolute, "utf-8");
+    if (!isResourceProjectionModule({ relativePath, content })) {
+      continue;
+    }
+    modules.push({
+      relativePath,
+      guarded: content.includes(PROJECTION_TOTALITY_IMPORT),
+    });
+  }
+  return modules;
+};
+
+const isAllowlistEntry = (value: unknown): value is AllowlistEntry =>
+  typeof value === "object" &&
+  value !== null &&
+  "file" in value &&
+  "reason" in value &&
+  typeof value.file === "string" &&
+  typeof value.reason === "string" &&
+  // The reason is the only reviewable evidence that an exception is
+  // deliberate; an empty one is not an allowlist entry.
+  value.reason.trim().length > 0;
+
+const loadAllowlist = (): AllowlistEntry[] => {
+  const raw = readFileSync(ALLOWLIST_PATH, "utf-8");
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed) || !parsed.every(isAllowlistEntry)) {
+    return panic(
+      `${path.relative(REPO_ROOT, ALLOWLIST_PATH)} must be a JSON array of { file, reason } entries`,
+    );
+  }
+  return parsed;
+};
+
+const main = (): void => {
+  const handlerFiles = collectHandlerFiles();
+  const projectionModules = collectProjectionModules(handlerFiles);
+
+  const projectionModuleByPath = new Map(
+    projectionModules.map((module) => [module.relativePath, module]),
+  );
+  const allowlist = loadAllowlist();
+  let failed = false;
+
+  for (const entry of allowlist) {
+    const module = projectionModuleByPath.get(entry.file);
+    if (!module) {
+      failed = true;
+      console.error(
+        `stale allowlist entry: ${entry.file} no longer exists or no longer classifies as a resource projection module -- remove it from ${path.relative(REPO_ROOT, ALLOWLIST_PATH)}`,
+      );
+    } else if (module.guarded) {
+      failed = true;
+      console.error(
+        `stale allowlist entry: ${entry.file} now imports ${PROJECTION_TOTALITY_IMPORT} -- remove it from ${path.relative(REPO_ROOT, ALLOWLIST_PATH)}`,
+      );
+    }
+  }
+
+  const allowlistedPaths = new Set(allowlist.map((entry) => entry.file));
+  const unguarded = projectionModules.filter((module) => !module.guarded);
+  const missingGuardOrAllowlist = unguarded.filter(
+    (module) => !allowlistedPaths.has(module.relativePath),
+  );
+
+  for (const module of missingGuardOrAllowlist) {
+    failed = true;
+    console.error(
+      `unguarded resource projection: ${module.relativePath} reads schema rows and returns them to a client, but imports no totality guard from ${PROJECTION_TOTALITY_IMPORT} and carries no ${path.relative(REPO_ROOT, ALLOWLIST_PATH)} entry`,
+    );
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  console.log(
+    `check-projection-totality: OK, ${projectionModules.length} resource projection modules found ` +
+      `(${projectionModules.length - unguarded.length} guarded, ${unguarded.length} allowlisted backlog).`,
+  );
+};
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/projection-totality.allowlist.json
+++ b/scripts/projection-totality.allowlist.json
@@ -1,0 +1,430 @@
+[
+  {
+    "file": "apps/api/src/handlers/bilingual-translations/read-run.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/billing-codes/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/annotations/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/decisions/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/decisions/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/ingestion/pipeline.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/matter-links/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/polarity/rule-engine.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/provisions/list-for-decision.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/research/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/case-law/research/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/catalogue/list-catalogue.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/get-messages.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/get-older-messages.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/get-suggested-prompts.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/get-thread-recap.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/get-thread-title.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/get-threads.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/memory-context.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/chat/stream-chat.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/clauses/read.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/contacts/create.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/contacts/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/document-reviews/list-runs.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/document-reviews/list-sources.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/document-translations/read-run.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/document-types/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/docx-suggestions/read.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/list-files.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/list-folders.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-field-file.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-filesystem-tree.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-group-counts.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-property-facets.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-summaries-count.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-summaries.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-version-by-id.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/entities/read-versions.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/expenses/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/files/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/flows/read.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/invoices/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/invoices/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/legislation/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/legislation/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/lists/generation-candidates/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/lists/generations/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/lists/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/lists/items/activity/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/lists/items/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/lists/items/sources/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/lists/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/mcp-connectors/connect.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/mcp-connectors/create-connection.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/mcp-connectors/list-connections.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/mcp-connectors/list-connectors.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/memories/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/notifications/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/organization-settings/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/organization-settings/read-ai-config.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/organization-settings/read-anonymization-blacklist.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/organization-settings/read-deepl-availability.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/organization-settings/read-deepl-config.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/organization-settings/read-web-search-config.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/playbooks/list-versions.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/playbooks/recent/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/rates/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/reports/export-history.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/reports/list-templates.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/reports/read-export.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/saved-searches/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/sharepoint/list-drive-root.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/signals/read.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/skills/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/skills/list-commands.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/skills/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/skills/proposals/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/skills/proposals/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/skills/revisions/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/skills/revisions/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/style-sets/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/tasks/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/templates/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/time-entries/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/time-entries/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/time-entries/summary/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/uploads/update.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/usage/get-entitlement.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/usage/get-lane.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/usage/list-seat-assignments.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/user-files/read-content.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/user-files/read-thumbnail.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/view-templates/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/views/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/work-obligations/queues/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/anonymization-allowlist/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/anonymization-terms/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/get.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/read-active.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/read-activity.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/read-justifications.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/read-navigation.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/read-overview-activity.query.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/read-overview.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/read-workflow-status.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  }
+]


### PR DESCRIPTION
## Summary

Addresses the three review findings on #2817.

- **Excused columns cannot be projected.** `UnbackedProjectionKeys<Row, Projection, Excused>` now excludes the excused set, so projected and excused columns must be disjoint; every guard passes its allowlist type. Proof: projecting `system` in `properties/list.ts` fails typecheck at the guard line.
- **Item types derived from the select.** `contacts/list-query.ts`, `templates/list.ts`, `skills/comments/list.ts` hoist their select map into a small builder and take `Awaited<ReturnType<typeof select…Rows>>[number]` as the item type, the idiom already used in `scheduler/tasks/file-derivative-repair.ts`. The `satisfies Item[]` lines are gone. Proof: adding the excused `skillId` to the skill-comment select fails typecheck at the guard line.
- **The guard is mandatory.** `scripts/check-projection-totality.ts` classifies `apps/api/src/handlers/**` modules that read rows from a table and expose a resource, and requires either an import of the guard or an entry in `scripts/projection-totality.allowlist.json`; stale entries fail. Today: 115 modules, 8 guarded, 107 allowlisted as the visible backlog. Wired as `check:projection-totality` next to the dead-column check, with its classifier self-test.

## Verification

API typecheck clean; `check:projection-totality` exit 0; 12 classifier tests; type-aware oxlint and oxfmt clean; contacts (41), templates list including the PGlite pagination integration test (6), skill comments (7); scripts typecheck clean.
