### PR TITLE
test(ci): exercise the SQL-name boundaries of the dead-column matcher

### DIFF
--- a/scripts/check-dead-columns.test.ts
+++ b/scripts/check-dead-columns.test.ts
@@ -75,6 +75,26 @@ describe("isColumnReferenced", () => {
       }),
     ).toBe(false);
   });
+
+  test("does not match a SQL name that ends a longer identifier", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "sql`select legacy_auto_invoke_hint from x`",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not match a SQL name that starts a longer identifier", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "sql`select auto_invoke_hint_v2 from x`",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("shouldScanFile", () => {


### PR DESCRIPTION
## Summary

Addresses the review finding on #2821: the SQL-name pattern has its own `\b` anchors, so it gets the same two one-sided cases (`legacy_auto_invoke_hint`, `auto_invoke_hint_v2`) as the key.

## Verification

`bun test scripts/check-dead-columns.test.ts` (15 pass); oxlint and oxfmt clean.
