### PR TITLE
chore(ci): classify suffix-named read handlers and run the new gates locally

### DIFF
--- a/scripts/check-projection-totality.test.ts
+++ b/scripts/check-projection-totality.test.ts
@@ -63,6 +63,23 @@ describe("isResourceProjectionModule", () => {
     ).toBe(true);
   });
 
+  test("classifies a handler whose operation is a basename suffix", () => {
+    expect(
+      isResourceProjectionModule({
+        relativePath: "apps/api/src/handlers/rates/entries-read.ts",
+        content: "const row = await tx.query.rateEntries.findFirst({});",
+      }),
+    ).toBe(true);
+    expect(
+      isResourceProjectionModule({
+        relativePath:
+          "apps/api/src/handlers/workspaces/workspace-contacts-read.ts",
+        content:
+          "const rows = await tx.select({ id: contacts.id }).from(contacts);",
+      }),
+    ).toBe(true);
+  });
+
   test("classifies a non-list-named module that still declares $inferSelect", () => {
     expect(
       isResourceProjectionModule({

--- a/scripts/check-projection-totality.ts
+++ b/scripts/check-projection-totality.ts
@@ -42,7 +42,7 @@ type ProjectionModule = {
 // "list-cursor.ts" helper matches too) -- a false positive only costs an
 // allowlist line, while a false negative hides a real gap.
 const CLIENT_FACING_FILENAME =
-  /(^|\/)(list|get|read|read-model|response|list-query|detail)(\.|-)/u;
+  /(^|[/-])(list|get|read|read-model|response|list-query|detail)(\.|-)/u;
 
 // Any one of these substrings is enough to call a file "reads rows from a
 // schema table": a row type derived straight from the table, or a query

--- a/scripts/projection-totality.allowlist.json
+++ b/scripts/projection-totality.allowlist.json
@@ -168,6 +168,10 @@
     "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
   },
   {
+    "file": "apps/api/src/handlers/flows/run-read.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
     "file": "apps/api/src/handlers/invoices/get.ts",
     "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
   },
@@ -268,6 +272,10 @@
     "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
   },
   {
+    "file": "apps/api/src/handlers/rates/entries-read.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
     "file": "apps/api/src/handlers/rates/list.ts",
     "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
   },
@@ -325,6 +333,10 @@
   },
   {
     "file": "apps/api/src/handlers/style-sets/list.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/tasks/entity-links-read.ts",
     "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
   },
   {
@@ -425,6 +437,10 @@
   },
   {
     "file": "apps/api/src/handlers/workspaces/read-workflow-status.ts",
+    "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
+  },
+  {
+    "file": "apps/api/src/handlers/workspaces/workspace-contacts-read.ts",
     "reason": "unguarded as of 2026-09-02; add the projection guard when next touched"
   }
 ]

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -96,6 +96,21 @@ run_code_check() {
   bun run code-check
 }
 
+run_dead_columns_guard() {
+  # A schema column referenced nowhere in application code is a defect in
+  # waiting; the matcher self-test runs first so a broken matcher cannot
+  # pass silently.
+  bun test scripts/check-dead-columns.test.ts || return 1
+  bun run check:dead-columns
+}
+
+run_projection_totality_guard() {
+  # Every resource projection module carries the bidirectional column guard
+  # or an allowlisted reason; the classifier self-test runs first.
+  bun test scripts/check-projection-totality.test.ts || return 1
+  bun run check:projection-totality
+}
+
 run_typecheck_coverage() {
   bun scripts/typecheck-coverage.ts --self-test || return 1
   bun scripts/typecheck-coverage.ts
@@ -261,6 +276,8 @@ run_step "React Compiler bailout guard" bun scripts/rc-bailouts.ts --check
 run_step "Oxlint override union guard" bun test \
   scripts/oxlint-override-union.test.ts
 run_step "Ratchet guard" run_ratchet_guard
+run_step "Dead columns" run_dead_columns_guard
+run_step "Projection totality" run_projection_totality_guard
 run_step "Module-mock ledger membership" run_module_mock_ledger_guard
 run_step "Suppression waiver ledger" run_suppression_waiver_guard
 run_step "Crawl posture guard" run_crawl_posture_guard


### PR DESCRIPTION
## Summary

Addresses the two review findings on #2824.

- **Suffix-named handlers.** The client-facing filename pattern accepted the operation only at the start of a path segment, so `rates/entries-read.ts`, `tasks/entity-links-read.ts`, `workspaces/workspace-contacts-read.ts`, and `flows/run-read.ts` were never classified. The pattern now also accepts the operation after a `-`; the four are allowlisted into the backlog (119 modules: 8 guarded, 111 allowlisted). Classifier test added for the suffix form.
- **Local parity.** `scripts/verify.sh` gains "Dead columns" and "Projection totality" steps, each running its matcher or classifier self-test first, right after the ratchet guard.

## Verification

`bun scripts/check-projection-totality.ts` exit 0; classifier tests (13 pass); oxlint and oxfmt clean on the changed files.
