### PR TITLE
refactor(conditions): one predicate decides which filter leaves compile

### DIFF
--- a/.changeset/effective-leaf-predicate.md
+++ b/.changeset/effective-leaf-predicate.md
@@ -1,0 +1,5 @@
+---
+"@stll/conditions": minor
+---
+
+Export `isEffectiveLeaf`, a pure structural check for whether a `compare`/`predicate` leaf compiles to a real restriction or to nothing, so every consumer that reads which leaves a filter tree keeps agrees on the same rule.

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -14,6 +14,7 @@ import {
   type RefOperand,
   evaluateCondition,
   foldCondition,
+  isEffectiveLeaf,
   pruneIncomplete,
 } from "@stll/conditions";
 
@@ -482,31 +483,28 @@ const compileBuiltinCompare = (
 ): SQL | null => {
   const col = builtinColumn(field);
   if (op === "eq") {
-    return value === "" ? null : eq(col, value);
+    return eq(col, value);
   }
   if (op === "neq") {
-    return value === "" ? null : (or(ne(col, value), isNull(col)) ?? null);
+    return or(ne(col, value), isNull(col)) ?? null;
   }
   return compareOpSql(op, sql`${col}`, value);
 };
 
 const compileCompare = (node: CompareNode): SQL | null => {
-  // `formula` operands have no SQL transpilation; skip the leaf rather than
-  // coerce it. They are stripped at the persistence boundary, so this is a
-  // belt-and-suspenders guard against a hand-crafted filter.
-  if (node.left.type === "formula" || node.right.type === "formula") {
+  // The structural completeness/support rule lives in `isEffectiveLeaf`,
+  // shared with the web's kind reader so both agree on which leaves compile
+  // to nothing: a `formula` operand on either side, a non-literal `right`, a
+  // `left` that is not a property or builtin column, or a blank literal
+  // (an in-progress filter — operator chosen, value not yet entered).
+  if (!isEffectiveLeaf(node)) {
     return null;
   }
-  // The filter UI always compares a ref operand against a literal.
+  // `isEffectiveLeaf` guarantees `right` is a non-empty literal and `left` is
+  // a property or builtin operand — the only shapes below need to handle.
   const value = literalString(node.right);
   if (value === null) {
-    return null;
-  }
-  // An ordered comparison with an empty literal is an incomplete filter
-  // (operator chosen, value not yet entered); drop it so an in-progress
-  // "date is before …" doesn't match nearly every row.
-  if (value === "" && node.op !== "eq" && node.op !== "neq") {
-    return null;
+    return panic("effective compare has a non-literal right operand");
   }
   if (node.left.type === "property") {
     return propertyExists(
@@ -517,7 +515,7 @@ const compileCompare = (node: CompareNode): SQL | null => {
   if (node.left.type === "builtin") {
     return compileBuiltinCompare(node.left.field, node.op, value);
   }
-  return null;
+  return panic("effective compare has an unsupported left operand");
 };
 
 // -- Predicate nodes --
@@ -550,18 +548,11 @@ const compilePropertyPredicate = (
   propertyId: string,
   node: PredicateNode,
 ): SQL | null => {
+  // `isEffectiveLeaf` (checked by `compilePredicate` before dispatching here)
+  // already guarantees a non-empty payload for every op below that needs one
+  // (`contains`/`not_contains`/`starts_with`/`ends_with`/`contains_all`/`in`)
+  // and rules out `is_truthy`, which has no SQL form for a property at all.
   const text = String(node.value ?? "");
-  // Incomplete value-bearing text predicate (no value yet) is a no-op, like the
-  // ordered compare path; contains_all/in already null out on an empty payload.
-  if (
-    text === "" &&
-    (node.op === "contains" ||
-      node.op === "not_contains" ||
-      node.op === "starts_with" ||
-      node.op === "ends_with")
-  ) {
-    return null;
-  }
   // Same matcher for arrays and scalars (membership/emptiness ops).
   const same = (match: (v: SQL) => SQL) =>
     propertyValueMatches(propertyId, match, match);
@@ -592,21 +583,19 @@ const compilePropertyPredicate = (
       return sql`NOT ${same((v) => sql`${v} <> ''`)}`;
     case "contains_all": {
       const wanted = asValueArray(node.value);
-      if (wanted.length === 0) {
-        return null;
-      }
       const clauses = wanted.map((want) => same((v) => sql`${v} = ${want}`));
       return and(...clauses) ?? null;
     }
     case "in": {
       const values = asValueArray(node.value);
-      if (values.length === 0) {
-        return null;
-      }
       // `typedPgArray` binds a real `ARRAY[...]::text[]`; a bare `ANY(${values})`
       // expands to a row constructor `ANY(($1, $2))`, which Postgres rejects.
       return same((v) => sql`${v} = ANY(${typedPgArray(values, "text")})`);
     }
+    // Unreachable: `isEffectiveLeaf` already rejects `is_truthy` for a
+    // property predicate before `compilePredicate` dispatches here. Kept as
+    // an explicit case (rather than folded into `default`) so this switch
+    // stays exhaustive over every `PredicateOp`.
     case "is_truthy":
       return null;
     default:
@@ -622,15 +611,15 @@ const compileBuiltinPredicate = (
   switch (node.op) {
     case "in": {
       const values = asValueArray(node.value);
-      if (values.length === 0) {
-        return null;
-      }
       return inArray(col, values);
     }
     case "is_empty":
       return sql`(${col} IS NULL OR ${col} = '')`;
     case "is_not_empty":
       return sql`(${col} IS NOT NULL AND ${col} <> '')`;
+    // Unreachable: `isEffectiveLeaf` already rejects every one of these ops
+    // for a builtin predicate before `compilePredicate` dispatches here.
+    // Kept explicit so this switch stays exhaustive over every `PredicateOp`.
     case "is_truthy":
     case "contains":
     case "not_contains":
@@ -644,9 +633,9 @@ const compileBuiltinPredicate = (
 };
 
 const compileKindPredicate = (node: PredicateNode): SQL | null => {
-  if (node.op !== "in") {
-    return null;
-  }
+  // `isEffectiveLeaf` already guarantees `node.op === "in"` with a non-empty
+  // payload; the only thing left to check here is whether that payload names
+  // a recognized `EntityKind` — a domain fact `@stll/conditions` doesn't own.
   const expanded = expandKindValues(asValueArray(node.value));
   if (expanded.length === 0) {
     return null;
@@ -655,6 +644,13 @@ const compileKindPredicate = (node: PredicateNode): SQL | null => {
 };
 
 const compilePredicate = (node: PredicateNode): SQL | null => {
+  // The structural completeness/support rule lives in `isEffectiveLeaf`,
+  // shared with the web's kind reader: an unsupported op for the operand's
+  // type, or a payload-bearing op with nothing entered yet, compiles to
+  // nothing.
+  if (!isEffectiveLeaf(node)) {
+    return null;
+  }
   switch (node.operand.type) {
     case "kind":
       return compileKindPredicate(node);
@@ -662,6 +658,9 @@ const compilePredicate = (node: PredicateNode): SQL | null => {
       return compilePropertyPredicate(node.operand.propertyId, node);
     case "builtin":
       return compileBuiltinPredicate(node.operand.field, node);
+    // Unreachable: `isEffectiveLeaf` already rejects every one of these
+    // operand types. Kept explicit so this switch stays exhaustive over
+    // every `Operand` type.
     case "path":
     case "formula":
     case "literal":

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
@@ -198,6 +198,64 @@ describe("view entity kinds", () => {
     ).toEqual(["task"]);
   });
 
+  // A compare that the SQL compiler drops as incomplete (an ordered op
+  // against an empty literal — the operator is chosen, the value has not
+  // been entered yet) must be dropped here too, not treated as an
+  // unrestricted sibling: SQL only ever restricts to the surviving `kind in
+  // […]` branch, matching `entity-filters.ts`'s `compileCompare`.
+  test("an incomplete compare inside an or does not widen a sibling kind restriction", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "or",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task"],
+            },
+            {
+              type: "compare",
+              left: { type: "property", propertyId: "due-date" },
+              op: "lt",
+              right: { type: "literal", value: "" },
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["task"]);
+  });
+
+  // The complement: a genuinely complete, unrelated compare DOES compile to
+  // SQL, so it keeps the `or` group unrestricted, exactly as it would keep
+  // a real WHERE clause from restricting to `kind`.
+  test("a complete unrelated compare inside an or leaves the view unrestricted", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "or",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task"],
+            },
+            {
+              type: "compare",
+              left: { type: "property", propertyId: "due-date" },
+              op: "lt",
+              right: { type: "literal", value: "2026-01-01" },
+            },
+          ],
+        },
+      ]),
+    ).toBeNull();
+  });
+
   test("a group whose children are all dropped is dropped itself", () => {
     expect(
       viewEntityKinds([

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
@@ -1,5 +1,9 @@
 import { isEntityKind } from "@stll/api-contract";
-import { conditionIncludesKind, foldConditions } from "@stll/conditions";
+import {
+  conditionIncludesKind,
+  foldConditions,
+  isEffectiveLeaf,
+} from "@stll/conditions";
 import type { ConditionNode, FoldHandlers } from "@stll/conditions";
 
 import type { EntityKind } from "@/lib/types";
@@ -39,11 +43,14 @@ export const viewEntityKinds = (
 
 /**
  * What a node contributes to the kinds a view admits. Unlike the fold's
- * generic drop rule (a `null` result), this never reports "dropped" — a
- * predicate or compare other than `kind in […]` still compiles to SQL, it
- * just does not restrict which kind rows match, so it folds to
- * `UNRESTRICTED` rather than `null`. Only an empty group is ever dropped,
- * and that is handled by the fold itself before `group` below is called.
+ * generic drop rule (a `null` result), a *compiling* predicate or compare
+ * other than `kind in […]` never reports "dropped" — it still restricts SQL
+ * rows, just not by kind, so it folds to `UNRESTRICTED` rather than `null`.
+ * A leaf `isEffectiveLeaf` rejects (an incomplete filter, or a shape the SQL
+ * compiler does not support) genuinely IS dropped here too, exactly as it is
+ * dropped from the compiled SQL — see `isEffectiveLeaf`'s doc comment for the
+ * shared rule. An empty group is dropped the same way, but that is handled
+ * by the fold itself before `group` below is called.
  */
 type AdmittedKinds =
   | { type: "unrestricted" }
@@ -54,6 +61,9 @@ const UNRESTRICTED = {
 } as const satisfies AdmittedKinds;
 
 const admittedKindsForLeaf: FoldHandlers<AdmittedKinds>["leaf"] = (node) => {
+  if (!isEffectiveLeaf(node)) {
+    return null;
+  }
   if (
     node.type !== "predicate" ||
     node.operand.type !== "kind" ||

--- a/packages/conditions/src/effective-leaf.property.test.ts
+++ b/packages/conditions/src/effective-leaf.property.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import { isEffectiveLeaf } from "./effective-leaf";
+import { type FoldHandlers, foldCondition } from "./fold";
+import {
+  COMPARE_OPS,
+  type CompareNode,
+  type Combinator,
+  type ConditionNode,
+  type Operand,
+  PREDICATE_OPS,
+  type PredicateNode,
+} from "./schema";
+
+/**
+ * Differential check between `isEffectiveLeaf` and `foldCondition`: whatever
+ * the fold's own drop rule decides for a tree whose `leaf` handler defers to
+ * `isEffectiveLeaf` must equal calling `isEffectiveLeaf` on each leaf
+ * directly. Both sides own a different half of "which leaves survive"
+ * (fold.ts owns the group/empty-group mechanics, this predicate owns the
+ * leaf-level decision); this is the guarantee that composing them behaves.
+ */
+
+const operandArb: fc.Arbitrary<Operand> = fc.oneof(
+  fc
+    .constantFrom("a", "b")
+    .map((propertyId): Operand => ({ type: "property", propertyId })),
+  fc
+    .constantFrom("status", "priority")
+    .map((field): Operand => ({ type: "builtin", field })),
+  fc.constant<Operand>({ type: "kind" }),
+  fc.constantFrom("a", "b").map((path): Operand => ({ type: "path", path })),
+  fc.constant<Operand>({ type: "formula", expr: "x" }),
+  fc
+    .oneof(
+      fc.constant(""),
+      fc.string(),
+      fc.array(fc.string(), { maxLength: 2 }),
+    )
+    .map((value): Operand => ({ type: "literal", value })),
+);
+
+const compareLeafArb: fc.Arbitrary<CompareNode> = fc
+  .tuple(operandArb, fc.constantFrom(...COMPARE_OPS), operandArb)
+  .map(([left, op, right]) => ({ type: "compare" as const, left, op, right }));
+
+const predicateValueArb = fc.oneof(
+  fc.constant(undefined),
+  fc.string(),
+  fc.array(fc.string(), { maxLength: 2 }),
+);
+
+const predicateLeafArb: fc.Arbitrary<PredicateNode> = fc
+  .tuple(operandArb, fc.constantFrom(...PREDICATE_OPS), predicateValueArb)
+  .map(([operand, op, value]): PredicateNode => {
+    const node: PredicateNode = { type: "predicate", operand, op };
+    if (value !== undefined) {
+      node.value = value;
+    }
+    return node;
+  });
+
+const leafArb: fc.Arbitrary<ConditionNode> = fc.oneof(
+  compareLeafArb,
+  predicateLeafArb,
+);
+
+const { node: nodeArb } = fc.letrec<{ node: ConditionNode }>((tie) => ({
+  node: fc.oneof(
+    { weight: 3, arbitrary: leafArb },
+    {
+      weight: 1,
+      arbitrary: fc
+        .record({
+          combinator: fc.constantFrom<Combinator>("and", "or"),
+          negated: fc.boolean(),
+          children: fc.array(tie("node"), { minLength: 1, maxLength: 3 }),
+        })
+        .map(({ combinator, negated, children }): ConditionNode => ({
+          type: "group",
+          combinator,
+          negated,
+          children,
+        })),
+    },
+  ),
+}));
+
+const isLeafNode = (node: ConditionNode): node is CompareNode | PredicateNode =>
+  node.type === "compare" || node.type === "predicate";
+
+const collectLeaves = (
+  node: ConditionNode,
+): readonly (CompareNode | PredicateNode)[] =>
+  isLeafNode(node) ? [node] : node.children.flatMap(collectLeaves);
+
+describe("isEffectiveLeaf + foldCondition (property-based)", () => {
+  test("leaves surviving the fold equal the leaves isEffectiveLeaf accepts, and an emptied group never reaches group", () => {
+    fc.assert(
+      fc.property(nodeArb, (node) => {
+        const expected = new Set(
+          collectLeaves(node).filter((leaf) => isEffectiveLeaf(leaf)),
+        );
+
+        const handlers: FoldHandlers<ConditionNode> = {
+          leaf: (leaf) => (isEffectiveLeaf(leaf) ? leaf : null),
+          group: (groupNode, children) => {
+            // fold.ts's own contract: `group` is never called with an empty
+            // `children` array — an emptied group is dropped before it runs.
+            expect(children.length).toBeGreaterThan(0);
+            return { ...groupNode, children: [...children] };
+          },
+        };
+
+        const folded = foldCondition(node, handlers);
+        const survivors = new Set(folded === null ? [] : collectLeaves(folded));
+
+        expect(survivors).toEqual(expected);
+      }),
+      propertyConfig(),
+    );
+  });
+});

--- a/packages/conditions/src/effective-leaf.test.ts
+++ b/packages/conditions/src/effective-leaf.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from "bun:test";
+
+import { isEffectiveLeaf } from "./effective-leaf";
+import type { CompareNode, PredicateNode } from "./schema";
+
+describe("isEffectiveLeaf — compare", () => {
+  test("a complete property compare is effective", () => {
+    const node: CompareNode = {
+      type: "compare",
+      left: { type: "property", propertyId: "p1" },
+      op: "eq",
+      right: { type: "literal", value: "alpha" },
+    };
+    expect(isEffectiveLeaf(node)).toBe(true);
+  });
+
+  test("a complete builtin compare is effective", () => {
+    const node: CompareNode = {
+      type: "compare",
+      left: { type: "builtin", field: "status" },
+      op: "gt",
+      right: { type: "literal", value: "open" },
+    };
+    expect(isEffectiveLeaf(node)).toBe(true);
+  });
+
+  test("an empty literal is incomplete for an ordered comparison", () => {
+    const node: CompareNode = {
+      type: "compare",
+      left: { type: "property", propertyId: "p1" },
+      op: "lt",
+      right: { type: "literal", value: "" },
+    };
+    expect(isEffectiveLeaf(node)).toBe(false);
+  });
+
+  test("an empty literal is incomplete for eq/neq too", () => {
+    const eqNode: CompareNode = {
+      type: "compare",
+      left: { type: "property", propertyId: "p1" },
+      op: "eq",
+      right: { type: "literal", value: "" },
+    };
+    const neqNode: CompareNode = { ...eqNode, op: "neq" };
+    expect(isEffectiveLeaf(eqNode)).toBe(false);
+    expect(isEffectiveLeaf(neqNode)).toBe(false);
+  });
+
+  test("a formula operand on either side has no SQL form", () => {
+    const leftFormula: CompareNode = {
+      type: "compare",
+      left: { type: "formula", expr: "rent * 12" },
+      op: "eq",
+      right: { type: "literal", value: "100" },
+    };
+    const rightFormula: CompareNode = {
+      type: "compare",
+      left: { type: "property", propertyId: "p1" },
+      op: "eq",
+      right: { type: "formula", expr: "rent * 12" },
+    };
+    expect(isEffectiveLeaf(leftFormula)).toBe(false);
+    expect(isEffectiveLeaf(rightFormula)).toBe(false);
+  });
+
+  test("a non-literal right operand is unsupported", () => {
+    const node: CompareNode = {
+      type: "compare",
+      left: { type: "property", propertyId: "p1" },
+      op: "eq",
+      right: { type: "property", propertyId: "p2" },
+    };
+    expect(isEffectiveLeaf(node)).toBe(false);
+  });
+
+  test("a left operand that is neither property nor builtin is unsupported", () => {
+    const kindLeft: CompareNode = {
+      type: "compare",
+      left: { type: "kind" },
+      op: "eq",
+      right: { type: "literal", value: "task" },
+    };
+    const pathLeft: CompareNode = {
+      type: "compare",
+      left: { type: "path", path: "a" },
+      op: "eq",
+      right: { type: "literal", value: "task" },
+    };
+    const literalLeft: CompareNode = {
+      type: "compare",
+      left: { type: "literal", value: "x" },
+      op: "eq",
+      right: { type: "literal", value: "task" },
+    };
+    expect(isEffectiveLeaf(kindLeft)).toBe(false);
+    expect(isEffectiveLeaf(pathLeft)).toBe(false);
+    expect(isEffectiveLeaf(literalLeft)).toBe(false);
+  });
+});
+
+describe("isEffectiveLeaf — predicate: kind", () => {
+  test("kind in […] with a payload is effective", () => {
+    const node: PredicateNode = {
+      type: "predicate",
+      operand: { type: "kind" },
+      op: "in",
+      value: ["task"],
+    };
+    expect(isEffectiveLeaf(node)).toBe(true);
+  });
+
+  test("kind in [] (empty payload) is incomplete", () => {
+    const node: PredicateNode = {
+      type: "predicate",
+      operand: { type: "kind" },
+      op: "in",
+      value: [],
+    };
+    expect(isEffectiveLeaf(node)).toBe(false);
+  });
+
+  test("a kind predicate op other than in is unsupported", () => {
+    const node: PredicateNode = {
+      type: "predicate",
+      operand: { type: "kind" },
+      op: "is_not_empty",
+    };
+    expect(isEffectiveLeaf(node)).toBe(false);
+  });
+});
+
+describe("isEffectiveLeaf — predicate: builtin", () => {
+  test("builtin in […] with a payload is effective", () => {
+    const node: PredicateNode = {
+      type: "predicate",
+      operand: { type: "builtin", field: "status" },
+      op: "in",
+      value: ["open"],
+    };
+    expect(isEffectiveLeaf(node)).toBe(true);
+  });
+
+  test("builtin in [] (empty payload) is incomplete", () => {
+    const node: PredicateNode = {
+      type: "predicate",
+      operand: { type: "builtin", field: "status" },
+      op: "in",
+      value: [],
+    };
+    expect(isEffectiveLeaf(node)).toBe(false);
+  });
+
+  test("builtin is_empty / is_not_empty need no payload and are effective", () => {
+    const isEmpty: PredicateNode = {
+      type: "predicate",
+      operand: { type: "builtin", field: "priority" },
+      op: "is_empty",
+    };
+    const isNotEmpty: PredicateNode = { ...isEmpty, op: "is_not_empty" };
+    expect(isEffectiveLeaf(isEmpty)).toBe(true);
+    expect(isEffectiveLeaf(isNotEmpty)).toBe(true);
+  });
+
+  test("builtin does not support contains/starts_with/ends_with/contains_all/is_truthy", () => {
+    const unsupportedOps = [
+      "is_truthy",
+      "contains",
+      "not_contains",
+      "starts_with",
+      "ends_with",
+      "contains_all",
+    ] as const;
+    for (const op of unsupportedOps) {
+      const node: PredicateNode = {
+        type: "predicate",
+        operand: { type: "builtin", field: "status" },
+        op,
+        value: "open",
+      };
+      expect(isEffectiveLeaf(node)).toBe(false);
+    }
+  });
+});
+
+describe("isEffectiveLeaf — predicate: property", () => {
+  test("property is_empty / is_not_empty need no payload and are effective", () => {
+    const isEmpty: PredicateNode = {
+      type: "predicate",
+      operand: { type: "property", propertyId: "p1" },
+      op: "is_empty",
+    };
+    const isNotEmpty: PredicateNode = { ...isEmpty, op: "is_not_empty" };
+    expect(isEffectiveLeaf(isEmpty)).toBe(true);
+    expect(isEffectiveLeaf(isNotEmpty)).toBe(true);
+  });
+
+  test("property is_truthy has no SQL form regardless of payload", () => {
+    const node: PredicateNode = {
+      type: "predicate",
+      operand: { type: "property", propertyId: "p1" },
+      op: "is_truthy",
+    };
+    expect(isEffectiveLeaf(node)).toBe(false);
+  });
+
+  test("contains/not_contains/starts_with/ends_with need a non-empty value", () => {
+    const valueOps = [
+      "contains",
+      "not_contains",
+      "starts_with",
+      "ends_with",
+    ] as const;
+    for (const op of valueOps) {
+      const missing: PredicateNode = {
+        type: "predicate",
+        operand: { type: "property", propertyId: "p1" },
+        op,
+      };
+      const blank: PredicateNode = { ...missing, value: "" };
+      const present: PredicateNode = { ...missing, value: "alpha" };
+      expect(isEffectiveLeaf(missing)).toBe(false);
+      expect(isEffectiveLeaf(blank)).toBe(false);
+      expect(isEffectiveLeaf(present)).toBe(true);
+    }
+  });
+
+  test("contains_all / in need a non-empty payload array", () => {
+    const arrayOps = ["contains_all", "in"] as const;
+    for (const op of arrayOps) {
+      const empty: PredicateNode = {
+        type: "predicate",
+        operand: { type: "property", propertyId: "p1" },
+        op,
+        value: [],
+      };
+      const present: PredicateNode = { ...empty, value: ["alpha"] };
+      expect(isEffectiveLeaf(empty)).toBe(false);
+      expect(isEffectiveLeaf(present)).toBe(true);
+    }
+  });
+});
+
+describe("isEffectiveLeaf — predicate: unsupported operand types", () => {
+  test("path/formula/literal operands are never effective", () => {
+    const pathNode: PredicateNode = {
+      type: "predicate",
+      operand: { type: "path", path: "a" },
+      op: "is_not_empty",
+    };
+    const formulaNode: PredicateNode = {
+      type: "predicate",
+      operand: { type: "formula", expr: "rent * 12" },
+      op: "is_not_empty",
+    };
+    const literalNode: PredicateNode = {
+      type: "predicate",
+      operand: { type: "literal", value: "x" },
+      op: "is_not_empty",
+    };
+    expect(isEffectiveLeaf(pathNode)).toBe(false);
+    expect(isEffectiveLeaf(formulaNode)).toBe(false);
+    expect(isEffectiveLeaf(literalNode)).toBe(false);
+  });
+});

--- a/packages/conditions/src/effective-leaf.test.ts
+++ b/packages/conditions/src/effective-leaf.test.ts
@@ -224,6 +224,34 @@ describe("isEffectiveLeaf — predicate: property", () => {
     }
   });
 
+  test("a text op whose array payload is blank once coerced is incomplete", () => {
+    // The compiler matches these ops against String(value): [""] is "" and
+    // would otherwise compile to a match-everything pattern.
+    for (const op of [
+      "contains",
+      "not_contains",
+      "starts_with",
+      "ends_with",
+    ] as const) {
+      expect(
+        isEffectiveLeaf({
+          type: "predicate",
+          operand: { type: "property", propertyId: "p" },
+          op,
+          value: [""],
+        }),
+      ).toBe(false);
+      expect(
+        isEffectiveLeaf({
+          type: "predicate",
+          operand: { type: "property", propertyId: "p" },
+          op,
+          value: ["a"],
+        }),
+      ).toBe(true);
+    }
+  });
+
   test("contains_all / in need a non-empty payload array", () => {
     const arrayOps = ["contains_all", "in"] as const;
     for (const op of arrayOps) {

--- a/packages/conditions/src/effective-leaf.ts
+++ b/packages/conditions/src/effective-leaf.ts
@@ -1,0 +1,136 @@
+/**
+ * The single owner of "does this leaf compile to anything at all" —
+ * structural facts about a `compare`/`predicate` node's own shape that make
+ * it produce no SQL restriction, independent of what it compiles *to*. The
+ * API's SQL compiler (`entity-filters.ts`) and any other reader that has to
+ * agree with it on which leaves survive (e.g. a client-side "what kinds does
+ * this filter admit" pass) call this instead of re-deriving the rule, so the
+ * two never drift apart on an in-progress or unsupported leaf.
+ *
+ * The rule is purely structural — decidable from the node's own shape, with
+ * no database or domain lookup:
+ *  - `compare`: effective only when `right` is a non-empty `literal` operand
+ *    and `left` is a `property` or `builtin` operand. Every compare op
+ *    (`eq`/`neq` included) against a blank literal is an in-progress filter —
+ *    the operator is chosen, the value has not been entered yet, and blank
+ *    equality is expressed with `is_empty` instead. A `formula` operand on
+ *    either side, a non-literal `right`, or any other `left` shape
+ *    (`kind`/`path`/`literal`) has no SQL transpilation.
+ *  - `predicate`, by `operand.type`:
+ *    - `kind`: only `op: "in"` with a non-empty payload.
+ *    - `builtin`: only `in` (non-empty payload), `is_empty`, `is_not_empty`.
+ *    - `property`: `is_empty`/`is_not_empty` need no payload; `contains`,
+ *      `not_contains`, `starts_with`, `ends_with`, `contains_all`, `in` need
+ *      a non-empty payload; `is_truthy` is not supported on a property at
+ *      all (there is no SQL form for it, with or without a value).
+ *    - `path`/`formula`/`literal`: never effective.
+ *
+ * What stays OUT of this predicate, by design: anything that needs context
+ * the package cannot see. Whether the `kind in […]` payload actually names a
+ * recognized `EntityKind` (as opposed to a stale/unknown string) depends on
+ * the domain's kind enum, not on AST shape — that filtering stays in the API,
+ * layered on top of this predicate's "has a payload at all" check. The same
+ * goes for anything that would require knowing a property's existence or
+ * declared type; this package has no such lookup, so it can only ever be
+ * asked "given this node's own fields, could it possibly restrict anything."
+ */
+import type { CompareNode, PredicateNode, PredicateOp } from "./schema";
+
+/** True when there is a real (non-empty) payload to test against. */
+const hasPredicatePayload = (value: PredicateNode["value"]): boolean => {
+  if (value === undefined) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return value !== "";
+};
+
+const isEffectiveCompare = (node: CompareNode): boolean => {
+  if (node.left.type === "formula" || node.right.type === "formula") {
+    return false;
+  }
+  if (node.right.type !== "literal") {
+    return false;
+  }
+  if (node.left.type !== "property" && node.left.type !== "builtin") {
+    return false;
+  }
+  return String(node.right.value) !== "";
+};
+
+const isEffectiveBuiltinPredicate = (
+  op: PredicateOp,
+  value: PredicateNode["value"],
+): boolean => {
+  switch (op) {
+    case "in":
+      return hasPredicatePayload(value);
+    case "is_empty":
+    case "is_not_empty":
+      return true;
+    case "is_truthy":
+    case "contains":
+    case "not_contains":
+    case "starts_with":
+    case "ends_with":
+    case "contains_all":
+      return false;
+    default:
+      return op satisfies never;
+  }
+};
+
+const isEffectivePropertyPredicate = (
+  op: PredicateOp,
+  value: PredicateNode["value"],
+): boolean => {
+  switch (op) {
+    case "is_empty":
+    case "is_not_empty":
+      return true;
+    case "is_truthy":
+      return false;
+    case "contains":
+    case "not_contains":
+    case "starts_with":
+    case "ends_with":
+    case "contains_all":
+    case "in":
+      return hasPredicatePayload(value);
+    default:
+      return op satisfies never;
+  }
+};
+
+const isEffectivePredicate = (node: PredicateNode): boolean => {
+  switch (node.operand.type) {
+    case "kind":
+      return node.op === "in" && hasPredicatePayload(node.value);
+    case "builtin":
+      return isEffectiveBuiltinPredicate(node.op, node.value);
+    case "property":
+      return isEffectivePropertyPredicate(node.op, node.value);
+    case "path":
+    case "formula":
+    case "literal":
+      return false;
+    default:
+      return node.operand satisfies never;
+  }
+};
+
+/**
+ * Whether a leaf's own shape lets it compile to a real SQL restriction. See
+ * the module doc comment for the exact rule and its deliberate boundary.
+ *
+ * A `false` result means the leaf compiles to nothing (an incomplete filter,
+ * or a shape SQL does not support) and should be dropped exactly like a
+ * `fold` leaf handler returning `null` — never treated as "matches
+ * everything," which would wrongly widen an `or` around it.
+ */
+export const isEffectiveLeaf = (node: CompareNode | PredicateNode): boolean =>
+  node.type === "compare"
+    ? isEffectiveCompare(node)
+    : isEffectivePredicate(node);

--- a/packages/conditions/src/effective-leaf.ts
+++ b/packages/conditions/src/effective-leaf.ts
@@ -20,9 +20,10 @@
  *    - `kind`: only `op: "in"` with a non-empty payload.
  *    - `builtin`: only `in` (non-empty payload), `is_empty`, `is_not_empty`.
  *    - `property`: `is_empty`/`is_not_empty` need no payload; `contains`,
- *      `not_contains`, `starts_with`, `ends_with`, `contains_all`, `in` need
- *      a non-empty payload; `is_truthy` is not supported on a property at
- *      all (there is no SQL form for it, with or without a value).
+ *      `not_contains`, `starts_with`, `ends_with` need a payload that is
+ *      non-blank in its string form (`[""]` coerces to `""`); `contains_all`,
+ *      `in` need a non-empty array; `is_truthy` is not supported on a
+ *      property at all (there is no SQL form for it, with or without a value).
  *    - `path`/`formula`/`literal`: never effective.
  *
  * What stays OUT of this predicate, by design: anything that needs context
@@ -46,6 +47,16 @@ const hasPredicatePayload = (value: PredicateNode["value"]): boolean => {
   }
   return value !== "";
 };
+
+/**
+ * The scalar text ops (`contains`, `not_contains`, `starts_with`,
+ * `ends_with`) match the payload's string form: the compiler coerces the
+ * value with `String(...)`, so `[""]` collapses to `""` and `["a", "b"]` to
+ * `"a,b"`. A payload that is blank once coerced is an in-progress filter and
+ * must not compile into a match-everything pattern.
+ */
+const hasScalarTextPayload = (value: PredicateNode["value"]): boolean =>
+  value !== undefined && String(value) !== "";
 
 const isEffectiveCompare = (node: CompareNode): boolean => {
   if (node.left.type === "formula" || node.right.type === "formula") {
@@ -96,6 +107,7 @@ const isEffectivePropertyPredicate = (
     case "not_contains":
     case "starts_with":
     case "ends_with":
+      return hasScalarTextPayload(value);
     case "contains_all":
     case "in":
       return hasPredicatePayload(value);

--- a/packages/conditions/src/fold.test.ts
+++ b/packages/conditions/src/fold.test.ts
@@ -112,6 +112,38 @@ describe("foldCondition", () => {
     expect(foldCondition(node, handlers)).toBe("task&message&document");
   });
 
+  test("a nested group whose own `group` handler returns null is dropped, leaving only its surviving siblings", () => {
+    // Unlike an emptied group (dropped by the fold itself before `group`
+    // runs), this nested group has one surviving leaf child — `group` is
+    // called for it, and here it chooses to reject that combination itself
+    // (e.g. an `or()` of the underlying value type comes back falsy). The
+    // parent must see only the other sibling, not a hole or a crash.
+    const rejectingHandlers: FoldHandlers<string> = {
+      leaf: keepKindLeaf,
+      group: (node, children) => {
+        // Reject any nested "or" group outright; keep the top-level "and".
+        if (node.combinator === "or") {
+          return null;
+        }
+        return joinGroup(node, children);
+      },
+    };
+    const node: ConditionNode = {
+      type: "group",
+      combinator: "and",
+      children: [
+        kindPredicate("task"),
+        {
+          type: "group",
+          combinator: "or",
+          children: [kindPredicate("message")],
+        },
+        kindPredicate("document"),
+      ],
+    };
+    expect(foldCondition(node, rejectingHandlers)).toBe("task&document");
+  });
+
   test("returns null for a top-level leaf that compiles to nothing", () => {
     expect(
       foldCondition(

--- a/packages/conditions/src/index.ts
+++ b/packages/conditions/src/index.ts
@@ -7,3 +7,4 @@ export * from "./schema";
 export * from "./evaluate";
 export * from "./walk";
 export * from "./fold";
+export * from "./effective-leaf";


### PR DESCRIPTION
## Summary

Closes the remaining review findings on #2819.

- **`isEffectiveLeaf`** (`packages/conditions/src/effective-leaf.ts`): the structural rule for a predicate or compare that compiles to nothing. Catalogued from every early `return null` in the API compiler: formula operands, non-literal right sides, blank literals, `kind` predicates that are not a non-empty `in`, unsupported built-in ops, property predicates whose op needs a payload but has none, `is_truthy`, and `path`/`formula`/`literal` operands. Context-dependent filtering (entity-kind vocabulary) stays in the API and is documented as such.
- **`entity-filters.ts`**: `compileCompare` / `compilePredicate` gate on the shared predicate; the ad hoc checks are gone; exhaustive switch cases kept for the lint rule. Unit and pglite differential tests pass (38).
- **`view-kind-filters.ts`**: the leaf handler drops ineffective leaves like the compiler. `or(kind in [task], date before "")` now yields `["task"]`; a complete unrelated compare inside an `or` still yields `null`.
- **Tests**: one case per catalogued condition; a fast-check property test that a fold's surviving leaves equal the effective ones and that `group` never sees an empty group; the nested-group case where `group` itself rejects a child (from the fold review).
- Changeset: `@stll/conditions` minor.

## Verification

`bun test packages/conditions` (62), API entity-filters unit and differential (38), web view folder (23); package, API, and web typechecks clean; type-aware oxlint and oxfmt clean; no new nullish array fallbacks.
