### PR TITLE
fix(chat): seat compact composer controls on the text line and align follow-up chips

### DIFF
--- a/.changeset/ui-chip-size-scrollbar-none.md
+++ b/.changeset/ui-chip-size-scrollbar-none.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Add the `chip` Button size (a 28px pill at every breakpoint, for chip rows beside a composer) and the `scrollbar-none` utility (a scroll container with no scrollbar and no reserved track). Remove the `scrollbar-hover` utility, which had no remaining consumer.

--- a/apps/web/src/components/ai-elements/conversation.test.tsx
+++ b/apps/web/src/components/ai-elements/conversation.test.tsx
@@ -43,12 +43,12 @@ test("keeps the inline scroll action outside the suggested-followups group", () 
   const suggestedGroupIndex = html.indexOf(
     `aria-label="${messages.chat.suggestedFollowupsLabel}"`,
   );
+  // The group holds only buttons and spans, so its first closing `</div>`
+  // is the group's own.
+  const suggestedGroupEnd = html.indexOf("</div>", suggestedGroupIndex);
 
-  expect(scrollActionIndex).toBeGreaterThan(-1);
-  expect(suggestedGroupIndex).toBeGreaterThan(scrollActionIndex);
-  expect(html.slice(suggestedGroupIndex)).not.toContain(
-    'aria-label="التمرير إلى الأسفل"',
-  );
+  expect(suggestedGroupIndex).toBeGreaterThan(-1);
+  expect(scrollActionIndex).toBeGreaterThan(suggestedGroupEnd);
 });
 
 test("reserves the inline scroll slot while the action is hidden", () => {

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -174,16 +174,20 @@ export const ConversationScrollButton = ({
     </Button>
   );
 
-  return placement === "inline" ? (
+  if (placement !== "inline") {
+    return button;
+  }
+
+  // `size-7` matches the suggested-action chips beside it. `className` lands
+  // on the slot, not the button: the caller positions the slot in its row.
+  return (
     <SuggestedActionSurface
       aria-hidden={!isVisible || undefined}
-      className={cn("size-8 shrink-0", !isVisible && "invisible")}
+      className={cn("size-7 shrink-0", !isVisible && "invisible", className)}
       surface={surface}
     >
       {isVisible && button}
     </SuggestedActionSurface>
-  ) : (
-    button
   );
 };
 

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -130,6 +130,18 @@ type ConversationScrollButtonProps = ConversationScrollButtonBaseProps &
       }
   );
 
+/**
+ * Whether the scroll-to-bottom action shows. Exported so a row that overlays
+ * the inline action can reserve its footprint under the same rule.
+ */
+export const isScrollActionVisible = ({
+  isAtBottom,
+  isScrollable,
+}: {
+  isAtBottom: boolean;
+  isScrollable: boolean;
+}) => isScrollable && !isAtBottom;
+
 export const ConversationScrollButton = ({
   className,
   placement = "floating",
@@ -139,7 +151,7 @@ export const ConversationScrollButton = ({
   const t = useTranslations();
   const { isAtBottom, isScrollable, scrollToBottom } =
     useStickToBottomContext();
-  const isVisible = isScrollable && !isAtBottom;
+  const isVisible = isScrollActionVisible({ isAtBottom, isScrollable });
 
   if (!isVisible && placement === "floating") {
     return null;

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -54,11 +54,11 @@ import type {
 import { ChatComposerActionButton } from "@/components/chat/chat-composer-action-button";
 import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachment-chips";
 import type { ComposerModelsMenuProps } from "@/components/chat/chat-model-options-menu";
+import { ComposerControlSlot } from "@/components/chat/composer-control-slot";
 import {
   COMPOSER_BOX_ANONYMIZED_CLASS,
   COMPOSER_BOX_CLASS,
   COMPOSER_BOX_FOCUS_CLASS,
-  COMPOSER_COMPACT_CONTROL_SLOT_CLASS,
   COMPOSER_COMPACT_ROW_CLASS,
   COMPOSER_COMPACT_TEXT_CELL_CLASS,
   COMPOSER_CONTROL_BUTTON_SIZE,
@@ -851,18 +851,16 @@ export const PromptBar = (props: PromptBarProps) => {
                 {presetScopeChooser.question}
               </span>
               <Button
-                className="h-7 rounded-full px-2.5 text-[12.5px]"
                 onClick={() => resolvePresetScope("selection")}
-                size="sm"
+                size="chip"
                 type="button"
                 variant="ghost"
               >
                 {presetScopeChooser.selectionLabel}
               </Button>
               <Button
-                className="h-7 rounded-full px-2.5 text-[12.5px]"
                 onClick={() => resolvePresetScope("document")}
-                size="sm"
+                size="chip"
                 type="button"
                 variant="ghost"
               >
@@ -935,7 +933,7 @@ export const PromptBar = (props: PromptBarProps) => {
               seats the circle on the editor cell's single text line: the
               shell is items-end, so a bare button would otherwise ride
               below the placeholder's center line. */}
-          <span className={COMPOSER_COMPACT_CONTROL_SLOT_CLASS}>
+          <ComposerControlSlot>
             {minimizedThreadAction ? (
               <Button
                 aria-label={minimizedThreadAction.label}
@@ -978,15 +976,15 @@ export const PromptBar = (props: PromptBarProps) => {
                 }
               />
             )}
-          </span>
+          </ComposerControlSlot>
         </>
       )}
       {layout === "floating" && pendingCount > 0 && (
-        <span className={cn(COMPOSER_COMPACT_CONTROL_SLOT_CLASS, "ps-0.5")}>
+        <ComposerControlSlot className="ps-0.5">
           <span className="bg-muted text-foreground inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1.5 text-[11px] font-semibold tabular-nums">
             {format.number(pendingCount)}
           </span>
-        </span>
+        </ComposerControlSlot>
       )}
       <div
         className={cn(
@@ -1063,7 +1061,7 @@ export const PromptBar = (props: PromptBarProps) => {
             // The control slot mirrors the (+) menu's seating: the shell
             // is items-end, so the slot rides the bottom text line as the
             // editor grows.
-            <span className={COMPOSER_COMPACT_CONTROL_SLOT_CLASS}>
+            <ComposerControlSlot>
               <ChatComposerActionButton
                 canSend={!composerSubmitDisabled && canSubmit}
                 isGenerating={isGenerating}
@@ -1073,7 +1071,7 @@ export const PromptBar = (props: PromptBarProps) => {
                 }}
                 onStop={onStop}
               />
-            </span>
+            </ComposerControlSlot>
           }
         />
         <TooltipPopup side="top">

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -19,6 +19,7 @@ import { ChatComposerActionButton } from "@/components/chat/chat-composer-action
 import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachment-chips";
 import type { ComposerModelsMenuProps } from "@/components/chat/chat-model-options-menu";
 import { ChatPromptImproveButton } from "@/components/chat/chat-prompt-improve-button";
+import { ComposerControlSlot } from "@/components/chat/composer-control-slot";
 import {
   COMPOSER_BOX_ANONYMIZED_CLASS,
   COMPOSER_BOX_CLASS,
@@ -202,6 +203,9 @@ export const ChatInputSurface = ({
   };
 
   const isBlank = isEmpty && attachments.length === 0;
+  // Compact rows seat every control in the shared slot so it centres on the
+  // text line; the large variant lays its controls out in a plain action row.
+  const ControlGroup = variant === "compact" ? ComposerControlSlot : "div";
 
   return (
     // Outer wrapper carries caller positioning (`className`) and the slim
@@ -285,7 +289,7 @@ export const ChatInputSurface = ({
                   : COMPOSER_LARGE_ACTION_ROW_CLASS,
               )}
             >
-              <div
+              <ControlGroup
                 className={cn(
                   COMPOSER_LEADING_GROUP_CLASS,
                   variant === "compact"
@@ -322,7 +326,7 @@ export const ChatInputSurface = ({
                       : undefined
                   }
                 />
-              </div>
+              </ControlGroup>
               <input
                 accept={fileInputAccept}
                 className="hidden"
@@ -332,7 +336,7 @@ export const ChatInputSurface = ({
                 ref={fileInputRef}
                 type="file"
               />
-              <div
+              <ControlGroup
                 className={cn(
                   "flex items-center gap-0.5",
                   variant === "compact" && "col-start-3 row-start-1 self-end",
@@ -357,7 +361,7 @@ export const ChatInputSurface = ({
                   }}
                   onStop={onStop}
                 />
-              </div>
+              </ControlGroup>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/chat/composer-control-slot.tsx
+++ b/apps/web/src/components/chat/composer-control-slot.tsx
@@ -1,0 +1,24 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@stll/ui/utils";
+
+/**
+ * A round control's seat in the compact composer row: as tall as the row's
+ * inner height, with the control centred in it. In a one-line row that
+ * centres the control on the text; as the editor grows the row's `items-end`
+ * keeps the seat on the last line, where the control stays centred on that
+ * line. Every control in a compact row renders through this component; a
+ * bare control would sink to the row's bottom edge, below the text's centre.
+ */
+export const ComposerControlSlot = ({
+  className,
+  ...props
+}: ComponentProps<"span">) => (
+  <span
+    className={cn(
+      "flex h-[calc(--spacing(11)-2px)] shrink-0 items-center",
+      className,
+    )}
+    {...props}
+  />
+);

--- a/apps/web/src/components/chat/composer-control-style.ts
+++ b/apps/web/src/components/chat/composer-control-style.ts
@@ -51,15 +51,6 @@ export const COMPOSER_COMPACT_TEXT_CELL_CLASS = "relative min-w-0 py-[11px]";
 export const COMPOSER_TEXT_CLASS = "text-sm leading-5";
 
 /**
- * A round control's slot in the compact row: as tall as the row's inner
- * height, with the control centred in it. In a one-line row that centres
- * the control on the text; as the editor grows the row's `items-end` keeps
- * the slot on the last line, where the control stays centred on that line.
- */
-export const COMPOSER_COMPACT_CONTROL_SLOT_CLASS =
-  "flex h-[calc(--spacing(11)-2px)] shrink-0 items-center";
-
-/**
  * The `large` (hero) text well: the padding around the editor. The editor's
  * own stature is `min-h-15` (~3 lines of `text-sm` at `leading-5`), applied
  * on the editable element by each surface because the chat editor targets its

--- a/apps/web/src/components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/components/inspector/chat-tab-panel.tsx
@@ -56,10 +56,8 @@ import { ChatComposerDock } from "@/components/chat/chat-composer-dock";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
-import {
-  COMPOSER_COMPACT_CONTROL_SLOT_CLASS,
-  COMPOSER_COMPACT_TEXT_CELL_CLASS,
-} from "@/components/chat/composer-control-style";
+import { ComposerControlSlot } from "@/components/chat/composer-control-slot";
+import { COMPOSER_COMPACT_TEXT_CELL_CLASS } from "@/components/chat/composer-control-style";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import { useInspectorCommandStore } from "@/components/inspector/inspector-command-store";
 import { InspectorTabHeader } from "@/components/inspector/inspector-tab-header";
@@ -904,13 +902,13 @@ const PromptBarPlaceholder = ({ tab }: { tab: ChatTab }) => {
       {/* Same control slot the live send button uses, so the placeholder
           stays pixel-identical; the disabled action button renders the
           canonical Send look without re-copying its styling. */}
-      <span className={COMPOSER_COMPACT_CONTROL_SLOT_CLASS}>
+      <ComposerControlSlot>
         <ChatComposerActionButton
           canSend={false}
           isGenerating={false}
           onSend={noop}
         />
-      </span>
+      </ComposerControlSlot>
     </PromptBarShell>
   );
 };

--- a/apps/web/src/components/suggested-actions.tsx
+++ b/apps/web/src/components/suggested-actions.tsx
@@ -69,7 +69,9 @@ export const SuggestedActionSurface = ({
  * A row (or stack) of click-to-run "suggested action" chips. Horizontal
  * chips scroll sideways so the list never wraps or overflows its container;
  * the row's trailing edge fades so a clipped chip reads as "more to scroll"
- * instead of a hard cut.
+ * instead of a hard cut. The row shows no scrollbar: the fade carries the
+ * overflow signal, and a scrollbar track would add height only when the
+ * chips overflow, so the gap to the composer below would depend on content.
  */
 export const SuggestedActions = ({
   actions,
@@ -92,7 +94,7 @@ export const SuggestedActions = ({
       className={cn(
         "flex max-w-full gap-1.5",
         horizontal
-          ? "scrollbar-hover overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2.5rem),transparent)] rtl:[mask-image:linear-gradient(to_left,black_calc(100%-2.5rem),transparent)]"
+          ? "scrollbar-none overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2.5rem),transparent)] rtl:[mask-image:linear-gradient(to_left,black_calc(100%-2.5rem),transparent)]"
           : "flex-col items-start",
         className,
       )}

--- a/apps/web/src/components/suggested-actions.tsx
+++ b/apps/web/src/components/suggested-actions.tsx
@@ -66,10 +66,10 @@ export const SuggestedActionSurface = ({
 );
 
 /**
- * A row (or stack) of click-to-run "suggested action" chips. Shared by the
- * chat composer's follow-up prompts and the template studio's prompt
- * presets. Horizontal chips scroll sideways so the list never wraps or
- * overflows its container.
+ * A row (or stack) of click-to-run "suggested action" chips. Horizontal
+ * chips scroll sideways so the list never wraps or overflows its container;
+ * the row's trailing edge fades so a clipped chip reads as "more to scroll"
+ * instead of a hard cut.
  */
 export const SuggestedActions = ({
   actions,
@@ -91,7 +91,9 @@ export const SuggestedActions = ({
       aria-label={label}
       className={cn(
         "flex max-w-full gap-1.5",
-        horizontal ? "scrollbar-hover overflow-x-auto" : "flex-col items-start",
+        horizontal
+          ? "scrollbar-hover overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2.5rem),transparent)] rtl:[mask-image:linear-gradient(to_left,black_calc(100%-2.5rem),transparent)]"
+          : "flex-col items-start",
         className,
       )}
       role="group"
@@ -105,11 +107,11 @@ export const SuggestedActions = ({
           <Button
             aria-keyshortcuts={keyShortcut}
             className={cn(
-              "text-foreground h-8 gap-2 rounded-full px-3 text-xs font-normal sm:text-xs",
+              "text-foreground font-normal",
               !horizontal && "max-w-full",
             )}
             onClick={() => onSelect(action.id)}
-            size="sm"
+            size="chip"
             type="button"
             variant={surface === "plain" ? "outline" : "ghost"}
           >

--- a/apps/web/src/components/suggested-actions.tsx
+++ b/apps/web/src/components/suggested-actions.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 
 import { Button } from "@stll/ui/button";
@@ -67,11 +68,13 @@ export const SuggestedActionSurface = ({
 
 /**
  * A row (or stack) of click-to-run "suggested action" chips. Horizontal
- * chips scroll sideways so the list never wraps or overflows its container;
- * the row's trailing edge fades so a clipped chip reads as "more to scroll"
- * instead of a hard cut. The row shows no scrollbar: the fade carries the
- * overflow signal, and a scrollbar track would add height only when the
- * chips overflow, so the gap to the composer below would depend on content.
+ * chips scroll sideways so the list never wraps or overflows its container.
+ * While chips remain past the row's inline end, that edge fades so a clipped
+ * chip reads as "more to scroll" instead of a hard cut; at the end of the
+ * scroll the fade lifts so the last chip shows whole. The row shows no
+ * scrollbar: the fade carries the overflow signal, and a scrollbar track
+ * would add height only when the chips overflow, so the gap to the composer
+ * below would depend on content.
  */
 export const SuggestedActions = ({
   actions,
@@ -82,6 +85,31 @@ export const SuggestedActions = ({
   keyShortcut,
   className,
 }: SuggestedActionsProps) => {
+  // Whether chips remain past the row's inline end: DOM state (overflow and
+  // scroll position), so it is measured through a callback ref whose
+  // observer lives exactly as long as the node. The row is keyed on the chip
+  // set, so a new set of chips remounts it and re-measures from the start.
+  const [moreInlineEnd, setMoreInlineEnd] = useState(false);
+  const horizontalRowRef = useCallback((row: HTMLDivElement | null) => {
+    if (!row) {
+      return undefined;
+    }
+    const measure = () => {
+      // `scrollLeft` runs negative in RTL; the remaining distance does not.
+      const remaining =
+        row.scrollWidth - row.clientWidth - Math.abs(row.scrollLeft);
+      setMoreInlineEnd(remaining > 1);
+    };
+    const observer = new ResizeObserver(measure);
+    observer.observe(row);
+    row.addEventListener("scroll", measure, { passive: true });
+    measure();
+    return () => {
+      observer.disconnect();
+      row.removeEventListener("scroll", measure);
+    };
+  }, []);
+
   if (actions.length === 0) {
     return null;
   }
@@ -94,10 +122,18 @@ export const SuggestedActions = ({
       className={cn(
         "flex max-w-full gap-1.5",
         horizontal
-          ? "scrollbar-none overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2.5rem),transparent)] rtl:[mask-image:linear-gradient(to_left,black_calc(100%-2.5rem),transparent)]"
+          ? [
+              "scrollbar-none overflow-x-auto",
+              moreInlineEnd &&
+                "[mask-image:linear-gradient(to_right,black_calc(100%-2.5rem),transparent)] rtl:[mask-image:linear-gradient(to_left,black_calc(100%-2.5rem),transparent)]",
+            ]
           : "flex-col items-start",
         className,
       )}
+      key={
+        horizontal ? actions.map((action) => action.id).join("\n") : undefined
+      }
+      ref={horizontal ? horizontalRowRef : undefined}
       role="group"
     >
       {actions.map((action) => (

--- a/apps/web/src/features/chat/components/suggested-followup-chips.tsx
+++ b/apps/web/src/features/chat/components/suggested-followup-chips.tsx
@@ -30,6 +30,11 @@ type SuggestedFollowupChipsProps = {
  * caller's choice: `surface="overlay"` (default) for a row floating above the
  * composer, or `surface="plain"` when rendered inside the thread card so the
  * chips sit within the chat window.
+ *
+ * The inline scroll-to-bottom action overlays the row's trailing end (over
+ * the chips' fade-out) rather than taking a leading slot, so the first chip
+ * starts flush with the composer's leading edge whether or not the action
+ * is showing.
  */
 export const SuggestedFollowupChips = ({
   className,
@@ -47,21 +52,21 @@ export const SuggestedFollowupChips = ({
   const resolvedSurface = surface ?? "overlay";
 
   return (
-    <div className={cn("flex max-w-full items-start gap-1.5 pb-2", className)}>
-      {stickToBottom !== null && (
-        <ConversationScrollButton
-          placement="inline"
-          surface={resolvedSurface}
-        />
-      )}
+    <div className={cn("relative max-w-full pb-2", className)}>
       <SuggestedActions
         actions={prompts.map((prompt) => ({ id: prompt, label: prompt }))}
-        className="min-w-0 flex-1"
         label={t("chat.suggestedFollowupsLabel")}
         onSelect={onSelect}
         orientation="horizontal"
         surface={resolvedSurface}
       />
+      {stickToBottom !== null && (
+        <ConversationScrollButton
+          className="absolute end-0 top-0"
+          placement="inline"
+          surface={resolvedSurface}
+        />
+      )}
     </div>
   );
 };

--- a/apps/web/src/features/chat/components/suggested-followup-chips.tsx
+++ b/apps/web/src/features/chat/components/suggested-followup-chips.tsx
@@ -2,7 +2,10 @@ import { useTranslations } from "use-intl";
 
 import { cn } from "@stll/ui/utils";
 
-import { ConversationScrollButton } from "@/components/ai-elements/conversation";
+import {
+  ConversationScrollButton,
+  isScrollActionVisible,
+} from "@/components/ai-elements/conversation";
 import { SuggestedActions } from "@/components/suggested-actions";
 import { useMaybeStickToBottomContext } from "@/hooks/use-stick-to-bottom";
 
@@ -50,11 +53,17 @@ export const SuggestedFollowupChips = ({
   }
 
   const resolvedSurface = surface ?? "overlay";
+  // While the action overlays the row's inline end, the row reserves that
+  // footprint so the last chip can scroll clear of it. `pe-11` covers the
+  // action's 44px coarse-pointer hit area, not only its 28px circle.
+  const reserveScrollAction =
+    stickToBottom !== null && isScrollActionVisible(stickToBottom);
 
   return (
     <div className={cn("relative max-w-full pb-2", className)}>
       <SuggestedActions
         actions={prompts.map((prompt) => ({ id: prompt, label: prompt }))}
+        className={cn(reserveScrollAction && "pe-11")}
         label={t("chat.suggestedFollowupsLabel")}
         onSelect={onSelect}
         orientation="horizontal"

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -738,7 +738,11 @@ export const ChatThreadPage = ({
                 className="absolute inset-x-0 bottom-0 z-20 mx-auto w-full max-w-5xl px-4"
                 ref={composerBlockRef}
               >
+                {/* `px-2` mirrors the tray's `p-2` so the first chip starts on
+                  the composer box's leading edge; `pb-0` because the tray
+                  padding alone separates the chips from the box here. */}
                 <SuggestedFollowupChips
+                  className="px-2 pb-0"
                   onSelect={(prompt) => {
                     controller.setContent(prompt);
                     detached(

--- a/packages/ui/src/components/button-variants.tsx
+++ b/packages/ui/src/components/button-variants.tsx
@@ -20,6 +20,11 @@ export const buttonVariants = cva(
     },
     variants: {
       size: {
+        // Pill chip beside a composer: pinned to the composer's round
+        // controls (28px at every breakpoint) so a chip row and the control
+        // row below it share one scale. Text stays `text-xs` at every
+        // breakpoint for the same reason.
+        chip: "h-7 gap-1.5 rounded-full px-2.5 text-xs before:rounded-full sm:text-xs",
         default: "h-9 px-[calc(--spacing(3)-1px)] sm:h-8",
         icon: "size-9 sm:size-8",
         "icon-lg": "size-10 sm:size-9",

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -1200,36 +1200,15 @@
   }
 }
 
-/* Horizontal prompt rows stay visually quiet until the pointer confirms that
- * the clipped content is relevant. The track keeps a stable thin gutter so
- * revealing the thumb does not shift the chips. */
-@utility scrollbar-hover {
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
+/* A scroll container with no scrollbar and no reserved track. For strips
+ * whose overflow is signalled another way (an edge fade, a visible partial
+ * item): a hover-revealed scrollbar would still reserve its track only when
+ * the content overflows, so the strip's height would depend on its content. */
+@utility scrollbar-none {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 
   &::-webkit-scrollbar {
-    width: 0.5rem;
-    height: 0.5rem;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 9999px;
-    background-color: transparent;
-  }
-
-  &:hover {
-    scrollbar-color: var(--color-border) transparent;
-  }
-
-  &:hover::-webkit-scrollbar-thumb {
-    background-color: var(--color-border);
-  }
-
-  &:hover::-webkit-scrollbar-thumb:hover {
-    background-color: var(--color-muted-foreground);
+    display: none;
   }
 }


### PR DESCRIPTION
## Composer controls

The chat page's compact composer aligned its leading and trailing control groups with a bare `self-end`, so the 28px controls sat ~7px below the text line's centre. The docked bars (inspector chat, file overlay) seated their controls in `COMPOSER_COMPACT_CONTROL_SLOT_CLASS`; the chat page did not.

The slot is now a component, `ComposerControlSlot`, and the class constant is deleted. Every compact row (chat page, docked bar, inspector placeholder) renders its controls through it, so a call site cannot apply a partial copy or skip it.

## Follow-up chips

- The inline scroll-to-bottom action overlays the row's trailing end instead of reserving a leading slot, so the first chip starts flush with the composer box. The chat page passes the tray's horizontal inset to the row.
- The horizontal chip row fades at its trailing edge (`mask-image`, direction-aware) instead of hard-clipping a chip mid-word.
- The strip hides its scrollbar (new `scrollbar-none` theme utility). The hover-revealed scrollbar reserved its track only when the chips overflowed, so the strip's height and the gap to the composer depended on prompt length. `scrollbar-hover` had no other user and is removed.
- `@stll/ui` Button gains a `chip` size: 28px pill, `text-xs` at every breakpoint, matching the composer's round controls. `SuggestedActions` and the docked bar's preset-scope chips use it instead of hand-copied `h-7 rounded-full …` classes (the preset chips move from 12.5px to 12px text).

The DOM-order assertion in `conversation.test.tsx` follows the trailing placement; the "outside the group" and "reserved slot" invariants are unchanged.
