### PR TITLE
chore(lint): close the gaps in the property-write and combinator rules

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-condition-combinator-outside-conditions.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-condition-combinator-outside-conditions.fixture.ts
@@ -17,9 +17,29 @@ const _built = { combinator: "and" as const, negated: false };
 const combinatorKey = "combinator" as const;
 const _computed = node[combinatorKey];
 
+// Destructuring reads the same fields through an ObjectPattern instead of a
+// MemberExpression, and is banned the same way.
+// oxlint-disable-next-line no-condition-combinator-outside-conditions/no-condition-combinator-outside-conditions
+const { combinator: _destructuredCombinator, negated: _destructuredNegated } =
+  node;
+
+// A destructured function parameter reads the fields the same way.
+type ConditionNodeShape = { combinator: "and" | "or"; negated: boolean };
+const readFromParam = ({
+  // oxlint-disable-next-line no-condition-combinator-outside-conditions/no-condition-combinator-outside-conditions
+  combinator,
+}: ConditionNodeShape) => combinator;
+
+// A type-only import of the fold cannot run it, so it does not exempt the
+// module: see no-condition-combinator-outside-conditions.fixture.type-import.ts
+// for the reported read that a type-only import leaves in place.
+
 export const __noConditionCombinatorOutsideConditionsFixture = {
   _combinator,
   _negated,
   _built,
   _computed,
+  _destructuredCombinator,
+  _destructuredNegated,
+  readFromParam,
 };

--- a/.oxlint-plugins/__fixtures__/no-condition-combinator-outside-conditions.fixture.type-import.ts
+++ b/.oxlint-plugins/__fixtures__/no-condition-combinator-outside-conditions.fixture.type-import.ts
@@ -1,0 +1,27 @@
+// A type-only import of the fold cannot run it at runtime, so unlike a
+// value import it does not exempt the module: the rule must still report a
+// combinator/negated read here. This fixture covers the declaration-level
+// form (`import type { foldCondition }`); the specifier-level form
+// (`import { type foldConditions }`) is rejected by the same
+// `importKind === "type"` check and is not repeated in a second import from
+// the same module here, to avoid an unrelated import/no-duplicates finding.
+import type { foldCondition } from "@stll/conditions";
+
+// Reference the type-only import so it is not flagged as unused; this does
+// not run the fold, which is exactly the point of this fixture.
+type _FoldConditionType = typeof foldCondition;
+
+declare const node: { combinator: "and" | "or"; negated: boolean };
+
+// oxlint-disable-next-line no-condition-combinator-outside-conditions/no-condition-combinator-outside-conditions
+const _combinator = node.combinator;
+
+// oxlint-disable-next-line no-condition-combinator-outside-conditions/no-condition-combinator-outside-conditions
+const _negated = node.negated;
+
+export const __noConditionCombinatorOutsideConditionsTypeImportFixture = {
+  _combinator,
+  _negated,
+};
+
+export type { _FoldConditionType as FoldConditionType };

--- a/.oxlint-plugins/__fixtures__/no-direct-property-table-write.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-direct-property-table-write.fixture.ts
@@ -27,6 +27,13 @@ const _reportingInsert = tx.insert(reportingTable);
 const _localInsert = tx.insert(properties);
 const _localUpdate = tx.update(properties);
 
+// A nested declaration that reuses the imported alias's name shadows the
+// import for the rest of its scope: the rule resolves the argument through
+// real scope analysis, so this parameter binds its own local `propertyTable`
+// and is never reported, even though the outer scope's `propertyTable` is.
+// oxlint-disable-next-line eslint/no-shadow -- fixture: the shadowed parameter must bind its own local, not the imported alias
+const _saveShadowed = (propertyTable: unknown) => tx.insert(propertyTable);
+
 export const __noDirectPropertyTableWriteFixture = {
   _alias,
   _aliasUpdate,
@@ -34,4 +41,5 @@ export const __noDirectPropertyTableWriteFixture = {
   _reportingInsert,
   _localInsert,
   _localUpdate,
+  _saveShadowed,
 };

--- a/.oxlint-plugins/__fixtures__/no-direct-property-table-write.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-direct-property-table-write.fixture.ts
@@ -8,28 +8,30 @@ declare const properties: unknown;
 declare const entities: unknown;
 declare const reportingTable: unknown;
 
-// Direct insert into the known properties table: the rule must report it.
+// An imported alias of the properties table is the same prohibited write:
+// the binding is tracked by its import, not by its local spelling.
 // oxlint-disable-next-line no-direct-property-table-write/no-direct-property-table-write
-const _directInsert = tx.insert(properties);
-
-// Direct update of the known properties table: the rule must report it too.
+const _alias = tx.insert(propertyTable);
 // oxlint-disable-next-line no-direct-property-table-write/no-direct-property-table-write
-const _directUpdate = tx.update(properties);
+const _aliasUpdate = tx.update(propertyTable);
 
 // Other tables are ordinary Drizzle writes.
 const _entityInsert = tx.insert(entities);
 
-// An imported alias of the properties table is the same prohibited write.
-// oxlint-disable-next-line no-direct-property-table-write/no-direct-property-table-write
-const _alias = tx.insert(propertyTable);
-
 // An unrelated table with a different local name remains valid.
 const _reportingInsert = tx.insert(reportingTable);
 
+// A local named `properties` that was never imported from the schema module
+// is not tracked: the rule only follows bindings introduced by an
+// `@/api/db/schema` import, so a same-named local stays valid.
+const _localInsert = tx.insert(properties);
+const _localUpdate = tx.update(properties);
+
 export const __noDirectPropertyTableWriteFixture = {
-  _directInsert,
-  _directUpdate,
-  _entityInsert,
   _alias,
+  _aliasUpdate,
+  _entityInsert,
   _reportingInsert,
+  _localInsert,
+  _localUpdate,
 };

--- a/.oxlint-plugins/no-condition-combinator-outside-conditions.ts
+++ b/.oxlint-plugins/no-condition-combinator-outside-conditions.ts
@@ -15,16 +15,22 @@
 // The ban is a plain, non-computed property-access check on `.combinator`
 // and `.negated`: an object-literal key (`{ combinator: "and" }`, building a
 // new node) is a `Property`, not a `MemberExpression`, so it is unaffected —
-// only *reading* an existing node's combinator/negated is in scope.
+// only *reading* an existing node's combinator/negated is in scope. A
+// destructured read (`const { combinator } = node`, including a function
+// parameter pattern) reads the same fields through an `ObjectPattern`
+// instead, so it is banned the same way.
 //
 // Exempt (the condition builder legitimately reads and writes these
 // fields):
 //   - packages/conditions/src/** (the tree's own fold/walk/evaluate)
 //   - packages/workspace-ui/src/** (the interactive condition builder)
-//   - any module importing `foldCondition` or `foldConditions` from
-//     `@stll/conditions`
+//   - any module *value*-importing `foldCondition` or `foldConditions` from
+//     `@stll/conditions`; a type-only import (`import type { foldCondition }`
+//     or `import { type foldCondition }`) cannot run the fold, so it does
+//     not exempt the module
 //
-// Enabled only for apps/web/src/** and apps/api/src/**; the exemption paths
+// Enabled only for production modules under apps/web/src/** and
+// apps/api/src/** (test files build and inspect nodes as data); the exemption paths
 // are checked here too so the rule stays correct on its own even if a future
 // config change broadens the enabling scope.
 
@@ -34,6 +40,7 @@ import {
   filenameForContext,
   getImportedName,
   getPropertyName,
+  isAstNode,
   isStringLiteral,
 } from "./utils.ts";
 
@@ -44,13 +51,19 @@ const FOLD_EXPORT_NAMES = new Set(["foldCondition", "foldConditions"]);
 
 const SCOPE_PREFIXES = ["apps/web/src/", "apps/api/src/"];
 
+// `*.test.ts` also matches `*.integration.test.ts`, `*.differential.test.ts`
+// and `*.property.test.ts`: every test-file convention still ends in it.
+const TEST_FILE_PATTERN = /\.test\.tsx?$/u;
+
 const EXEMPT_PREFIXES = [
   "packages/conditions/src/",
   "packages/workspace-ui/src/",
 ];
 
-const FIXTURE_FILE_SUFFIX =
-  ".oxlint-plugins/__fixtures__/no-condition-combinator-outside-conditions.fixture.ts";
+// Matches both the main fixture and the type-import regression fixture
+// (`no-condition-combinator-outside-conditions.fixture.type-import.ts`).
+const FIXTURE_FILE_PREFIX =
+  ".oxlint-plugins/__fixtures__/no-condition-combinator-outside-conditions.fixture.";
 
 export default eslintCompatPlugin({
   meta: { name: "no-condition-combinator-outside-conditions" },
@@ -73,8 +86,14 @@ export default eslintCompatPlugin({
           before() {
             consumesFold = false;
             const filename = filenameForContext(context);
-            if (filename.endsWith(FIXTURE_FILE_SUFFIX)) {
+            if (filename.includes(FIXTURE_FILE_PREFIX)) {
               return true;
+            }
+            // Tests build and inspect condition nodes as data (fixtures,
+            // generators, assertions on a node's shape); the semantics the
+            // rule guards live in production modules only.
+            if (TEST_FILE_PATTERN.test(filename)) {
+              return false;
             }
             return (
               SCOPE_PREFIXES.some((prefix) => filename.includes(prefix)) &&
@@ -84,12 +103,16 @@ export default eslintCompatPlugin({
           ImportDeclaration(node) {
             if (
               !isStringLiteral(node.source) ||
-              node.source.value !== CONDITIONS_PACKAGE
+              node.source.value !== CONDITIONS_PACKAGE ||
+              node.importKind === "type"
             ) {
               return;
             }
             if (
               node.specifiers.some((specifier) => {
+                if (isAstNode(specifier) && specifier.importKind === "type") {
+                  return false;
+                }
                 const imported = getImportedName(specifier);
                 return imported !== null && FOLD_EXPORT_NAMES.has(imported);
               })
@@ -109,6 +132,28 @@ export default eslintCompatPlugin({
               return;
             }
             context.report({ node, messageId: "combinatorRead" });
+          },
+          // Destructured reads (`const { combinator } = node` or a function
+          // parameter pattern) surface the same fields through an
+          // ObjectPattern rather than a MemberExpression, so the ban needs
+          // its own visitor to catch them.
+          ObjectPattern(node) {
+            if (consumesFold) {
+              return;
+            }
+            for (const property of node.properties) {
+              if (property.type !== "Property" || property.computed) {
+                continue;
+              }
+              const propertyName = getPropertyName(property.key);
+              if (
+                propertyName === null ||
+                !TARGET_PROPERTY_NAMES.has(propertyName)
+              ) {
+                continue;
+              }
+              context.report({ node: property, messageId: "combinatorRead" });
+            }
           },
         };
       },

--- a/.oxlint-plugins/no-direct-property-table-write.ts
+++ b/.oxlint-plugins/no-direct-property-table-write.ts
@@ -13,6 +13,15 @@
 // and a type-only import cannot be passed to `.insert()`/`.update()` so it
 // does not bind either.
 //
+// The `.insert()`/`.update()` argument is resolved through real scope
+// analysis (`sourceCode.getScope` + the enclosing scope chain), not a
+// file-wide name set: a nested declaration that reuses the imported alias's
+// spelling (a function/arrow parameter, a `const`/`let`, a catch clause
+// parameter, a for-loop variable) resolves to its own local binding and is
+// never reported, even inside the scope where it shadows the import. The
+// only way to be flagged is for the identifier to actually resolve back to
+// the `properties` import specifier itself.
+//
 // Owner surfaces (may write `properties` directly):
 //   - apps/api/src/handlers/properties/**
 //   - apps/api/src/lib/properties/**
@@ -36,7 +45,6 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 import {
   filenameForContext,
   getImportedName,
-  getImportLocalName,
   isAstNode,
   isIdentifier,
   isStringLiteral,
@@ -56,6 +64,19 @@ const OWNER_FILES = new Set([
 
 const FIXTURE_FILE_SUFFIX =
   ".oxlint-plugins/__fixtures__/no-direct-property-table-write.fixture.ts";
+
+type Scope = {
+  set: Map<string, ScopeVariable>;
+  upper: Scope | null;
+};
+
+type ScopeVariable = {
+  defs: {
+    node: unknown;
+    parent: unknown;
+    type: string;
+  }[];
+};
 
 const isOwnerFile = (filename: string): boolean =>
   OWNER_DIRECTORY_PREFIXES.some((prefix) => filename.includes(prefix)) ||
@@ -85,10 +106,56 @@ export default eslintCompatPlugin({
         },
       },
       createOnce(context) {
-        const propertyBindings = new Set<string>();
+        const resolveVariable = (identifier: {
+          name: string;
+        }): ScopeVariable | null => {
+          let scope: Scope | null = context.sourceCode.getScope(identifier);
+          while (scope !== null) {
+            const variable = scope.set.get(identifier.name);
+            if (variable !== undefined) {
+              return variable;
+            }
+            scope = scope.upper;
+          }
+          return null;
+        };
+
+        // Resolve the argument identifier to its actual declaration via the
+        // scope chain, rather than matching on spelling. A nested
+        // declaration that reuses the imported alias's name binds its own
+        // scope variable with its own (non-import) definitions, so it never
+        // matches here — the identifier only reports when it truly resolves
+        // back to the `properties` value import.
+        const isPropertiesSchemaImportReference = (node: unknown): boolean => {
+          if (!isIdentifier(node)) {
+            return false;
+          }
+          const variable = resolveVariable(node);
+          if (variable === null) {
+            return false;
+          }
+          for (const definition of variable.defs) {
+            if (
+              definition.type !== "ImportBinding" ||
+              !isAstNode(definition.node) ||
+              definition.node.type !== "ImportSpecifier" ||
+              definition.node.importKind === "type" ||
+              !isAstNode(definition.parent) ||
+              definition.parent.type !== "ImportDeclaration" ||
+              definition.parent.importKind === "type" ||
+              !isStringLiteral(definition.parent.source) ||
+              definition.parent.source.value !== "@/api/db/schema" ||
+              getImportedName(definition.node) !== "properties"
+            ) {
+              continue;
+            }
+            return true;
+          }
+          return false;
+        };
+
         return {
           before() {
-            propertyBindings.clear();
             const filename = filenameForContext(context);
             if (filename.endsWith(FIXTURE_FILE_SUFFIX)) {
               return true;
@@ -98,28 +165,6 @@ export default eslintCompatPlugin({
               !isTestFile(filename) &&
               !isOwnerFile(filename)
             );
-          },
-          ImportDeclaration(node) {
-            if (
-              !isStringLiteral(node.source) ||
-              node.source.value !== "@/api/db/schema" ||
-              !Array.isArray(node.specifiers) ||
-              node.importKind === "type"
-            ) {
-              return;
-            }
-            for (const specifier of node.specifiers) {
-              if (
-                (isAstNode(specifier) && specifier.importKind === "type") ||
-                getImportedName(specifier) !== "properties"
-              ) {
-                continue;
-              }
-              const localName = getImportLocalName(specifier);
-              if (localName !== null) {
-                propertyBindings.add(localName);
-              }
-            }
           },
           CallExpression(node) {
             const callee = node.callee;
@@ -131,8 +176,7 @@ export default eslintCompatPlugin({
                 isIdentifier(callee.property, "insert") ||
                 isIdentifier(callee.property, "update")
               ) ||
-              !isIdentifier(firstArgument) ||
-              !propertyBindings.has(firstArgument.name)
+              !isPropertiesSchemaImportReference(firstArgument)
             ) {
               return;
             }

--- a/.oxlint-plugins/no-direct-property-table-write.ts
+++ b/.oxlint-plugins/no-direct-property-table-write.ts
@@ -7,7 +7,11 @@
 // The ban is deliberately scoped to `.insert(properties)` /
 // `.update(properties)` and aliases imported from the canonical schema
 // module: other Drizzle writes are unrelated, and an arbitrary local
-// identifier is not assumed to name the properties table.
+// identifier is not assumed to name the properties table — only a local
+// bound by a value import of `properties` from `@/api/db/schema` (aliases
+// included) counts; a same-named local that never imports it is unrelated,
+// and a type-only import cannot be passed to `.insert()`/`.update()` so it
+// does not bind either.
 //
 // Owner surfaces (may write `properties` directly):
 //   - apps/api/src/handlers/properties/**
@@ -81,11 +85,10 @@ export default eslintCompatPlugin({
         },
       },
       createOnce(context) {
-        const propertyBindings = new Set(["properties"]);
+        const propertyBindings = new Set<string>();
         return {
           before() {
             propertyBindings.clear();
-            propertyBindings.add("properties");
             const filename = filenameForContext(context);
             if (filename.endsWith(FIXTURE_FILE_SUFFIX)) {
               return true;
@@ -100,12 +103,16 @@ export default eslintCompatPlugin({
             if (
               !isStringLiteral(node.source) ||
               node.source.value !== "@/api/db/schema" ||
-              !Array.isArray(node.specifiers)
+              !Array.isArray(node.specifiers) ||
+              node.importKind === "type"
             ) {
               return;
             }
             for (const specifier of node.specifiers) {
-              if (getImportedName(specifier) !== "properties") {
+              if (
+                (isAstNode(specifier) && specifier.importKind === "type") ||
+                getImportedName(specifier) !== "properties"
+              ) {
                 continue;
               }
               const localName = getImportLocalName(specifier);

--- a/.oxlint-plugins/no-direct-property-table-write.ts
+++ b/.oxlint-plugins/no-direct-property-table-write.ts
@@ -106,9 +106,7 @@ export default eslintCompatPlugin({
         },
       },
       createOnce(context) {
-        const resolveVariable = (identifier: {
-          name: string;
-        }): ScopeVariable | null => {
+        const resolveVariable = (identifier): ScopeVariable | null => {
           let scope: Scope | null = context.sourceCode.getScope(identifier);
           while (scope !== null) {
             const variable = scope.set.get(identifier.name);

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -200,6 +200,12 @@ const fixtureRuleOverrides = [
   fixtureRuleOverride("no-condition-combinator-outside-conditions.fixture.ts", [
     "no-condition-combinator-outside-conditions/no-condition-combinator-outside-conditions",
   ]),
+  fixtureRuleOverride(
+    "no-condition-combinator-outside-conditions.fixture.type-import.ts",
+    [
+      "no-condition-combinator-outside-conditions/no-condition-combinator-outside-conditions",
+    ],
+  ),
   fixtureRuleOverride("no-unjustified-double-assertion.fixture.ts", [
     "no-unjustified-double-assertion/no-unjustified-double-assertion",
   ]),


### PR DESCRIPTION
## Summary

Addresses the three review findings on #2822, plus one scoping consequence.

- **Type-only imports do not exempt.** `import type { foldCondition }` and `import { type foldCondition }` no longer set the fold exemption; only a value import that can run the fold does. Second fixture file (`…fixture.type-import.ts`) with a type-only import and two reported reads, registered in `oxlint.config.ts`.
- **Destructured reads are reported.** An `ObjectPattern` visitor reports `combinator` / `negated` keys in destructuring (assignments and function parameters), same message and exemption; object-literal construction stays unreported. Fixture cases added.
- **Bindings from imports only.** The property-table rule starts with an empty binding set and adds names only from value imports of `properties` from `@/api/db/schema`, aliases included. Fixture: aliased import reported, an unimported local named `properties` not reported.
- **Tests out of scope for the combinator rule.** Closing the destructuring gap flagged a fast-check generator in `entity-filters.differential.test.ts` that destructures generated records to build nodes. Tests build and inspect nodes as data, so the rule now skips `*.test.ts(x)` like its sibling, instead of a suppression.

## Verification

Probes: type-only fold import plus `.combinator` read reported; value import not reported; destructured `{ combinator }` reported; `tx.insert(propertyTable)` via alias reported; unimported local `properties` not reported. `scripts/lint-oxlint-fixtures.sh` (4 pass), `scripts/check-oxlint-plugin-registry.ts` (141 fixtures), workspace lint for `apps/api` and `apps/web` clean, oxfmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved linting accuracy for condition combinator and negation access, including destructured values.
  - Type-only imports are now correctly excluded from runtime checks.
  - Property-table write checks now apply only to qualifying runtime imports, avoiding false positives for local or unrelated identifiers.

- **Tests**
  - Expanded rule coverage for destructuring, type-only imports, aliased imports, and valid local writes.
  - Added configuration coverage for the new type-import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->