### PR TITLE
fix(kanban): a band folded under the pointer stays folded

### DIFF
--- a/.changeset/kanban-band-peek-hysteresis.md
+++ b/.changeset/kanban-band-peek-hysteresis.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+A kanban band folded from its caption no longer peeks straight back open under the resting pointer, and a peeked band stays open while the pointer moves between its caption and its columns instead of folding and reopening on every crossing.

--- a/packages/ui/src/kanban/band-peek.test.ts
+++ b/packages/ui/src/kanban/band-peek.test.ts
@@ -120,6 +120,34 @@ describe("band peek controller", () => {
     expect(changes).toEqual(["todo", null]);
   });
 
+  test("a slot that unmounts mid-delay cancels its pending peek", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    peek.slotUnmounted("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual([]);
+  });
+
+  test("a slot that unmounts drops its suppression", () => {
+    const { clock, changes, peek } = setup();
+    peek.foldedUnderPointer("todo");
+    peek.slotUnmounted("todo");
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual(["todo"]);
+  });
+
+  test("a fold without a pointer ends the peek but does not suppress the slot", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    peek.bandFolded("todo");
+    expect(changes).toEqual(["todo", null]);
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual(["todo", null, "todo"]);
+  });
+
   test("a second band's slot takes over a pending peek", () => {
     const { clock, changes, peek } = setup();
     peek.slotPointerMove("todo");

--- a/packages/ui/src/kanban/band-peek.test.ts
+++ b/packages/ui/src/kanban/band-peek.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createBandPeekController,
+  KANBAN_BAND_PEEK_DELAY_MS,
+  KANBAN_BAND_PEEK_LINGER_MS,
+} from "./band-peek";
+import type { BandPeekScheduler } from "./band-peek";
+
+/** A manual clock: scheduled callbacks fire only when the test advances time. */
+const createClock = () => {
+  let now = 0;
+  let nextId = 1;
+  const pending = new Map<number, { at: number; callback: () => void }>();
+  const schedule: BandPeekScheduler = (callback, ms) => {
+    const id = nextId;
+    nextId += 1;
+    pending.set(id, { at: now + ms, callback });
+    return () => {
+      pending.delete(id);
+    };
+  };
+  const advance = (ms: number) => {
+    now += ms;
+    const due = [...pending].filter(([, entry]) => entry.at <= now);
+    due.sort((a, b) => a[1].at - b[1].at);
+    for (const [id, entry] of due) {
+      pending.delete(id);
+      entry.callback();
+    }
+  };
+  return { schedule, advance };
+};
+
+const setup = () => {
+  const clock = createClock();
+  const changes: (string | null)[] = [];
+  const peek = createBandPeekController({
+    onChange: (bandId) => {
+      changes.push(bandId);
+    },
+    schedule: clock.schedule,
+  });
+  return { clock, changes, peek };
+};
+
+describe("band peek controller", () => {
+  test("a pointer resting on a folded slot peeks the band open after the delay", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS - 1);
+    expect(changes).toEqual([]);
+    clock.advance(1);
+    expect(changes).toEqual(["todo"]);
+  });
+
+  test("leaving the slot before the delay cancels the peek", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    peek.slotPointerLeave("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual([]);
+  });
+
+  // The defect this guards: folding a band from its caption left the new
+  // slot under the cursor, the first movement peeked it straight back open,
+  // and leaving the caption folded it again, over and over.
+  test("a band folded under the pointer does not peek until the pointer leaves its slot", () => {
+    const { clock, changes, peek } = setup();
+    peek.foldedUnderPointer("todo");
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual([]);
+
+    peek.slotPointerLeave("todo");
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual(["todo"]);
+  });
+
+  test("moving between the parts of an open band keeps the peek", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual(["todo"]);
+
+    // Caption to column: leave fires, then enter, within the linger.
+    peek.openPointerLeave("todo");
+    clock.advance(KANBAN_BAND_PEEK_LINGER_MS - 1);
+    peek.openPointerEnter("todo");
+    clock.advance(KANBAN_BAND_PEEK_LINGER_MS * 2);
+    expect(changes).toEqual(["todo"]);
+  });
+
+  test("leaving an open band for longer than the linger ends the peek", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    peek.openPointerLeave("todo");
+    clock.advance(KANBAN_BAND_PEEK_LINGER_MS);
+    expect(changes).toEqual(["todo", null]);
+  });
+
+  test("pinning a peeked band open ends the peek without a linger", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    peek.bandExpanded("todo");
+    expect(changes).toEqual(["todo", null]);
+  });
+
+  test("folding a peeked band from its caption ends the peek and suppresses the slot", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    peek.foldedUnderPointer("todo");
+    expect(changes).toEqual(["todo", null]);
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual(["todo", null]);
+  });
+
+  test("a second band's slot takes over a pending peek", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotPointerMove("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS / 2);
+    peek.slotPointerLeave("todo");
+    peek.slotPointerMove("done");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual(["done"]);
+  });
+});

--- a/packages/ui/src/kanban/band-peek.ts
+++ b/packages/ui/src/kanban/band-peek.ts
@@ -1,0 +1,166 @@
+/**
+ * The peek a collapsed band opens while a pointer rests on its folded slot,
+ * as a state machine with an injectable scheduler so its timing rules can be
+ * tested without a DOM.
+ *
+ * Two rules keep a peek from fighting the pointer:
+ *
+ *  - A slot that appeared under the pointer does not peek. Folding a band
+ *    from its caption leaves the new slot right under the cursor; the first
+ *    movement there must not reopen what was just closed. The band is
+ *    suppressed until the pointer leaves the slot once.
+ *  - A peek ends only after the pointer has left every part of the open
+ *    band for a short linger. The band renders as separate elements (its
+ *    caption, then its columns in each lane), so moving from the caption
+ *    down into a column crosses an element boundary; without the linger the
+ *    band would fold under the pointer and the slot would peek it straight
+ *    back open.
+ */
+
+/** How long a pointer rests on a folded slot before the band peeks open. */
+export const KANBAN_BAND_PEEK_DELAY_MS = 400;
+
+/** How long the pointer may be outside an open band before the peek ends. */
+export const KANBAN_BAND_PEEK_LINGER_MS = 150;
+
+/** Runs `callback` after `ms`; the returned function cancels it. */
+export type BandPeekScheduler = (
+  callback: () => void,
+  ms: number,
+) => () => void;
+
+const hostScheduler: BandPeekScheduler = (callback, ms) => {
+  const timer = setTimeout(callback, ms);
+  return () => clearTimeout(timer);
+};
+
+export type BandPeekControllerOptions = {
+  /** Receives the band currently peeked open, or `null`. */
+  onChange: (peekingBandId: string | null) => void;
+  delayMs?: number;
+  lingerMs?: number;
+  /** Injectable so tests drive a manual clock. */
+  schedule?: BandPeekScheduler;
+};
+
+export type BandPeekController = {
+  /** The pointer moved inside a band's folded slot. */
+  slotPointerMove: (bandId: string) => void;
+  /** The pointer left a band's folded slot. */
+  slotPointerLeave: (bandId: string) => void;
+  /** The pointer entered a part of a band that is rendered open. */
+  openPointerEnter: (bandId: string) => void;
+  /** The pointer left a part of a band that is rendered open. */
+  openPointerLeave: (bandId: string) => void;
+  /**
+   * The band was folded by its own caption, so its slot now sits under the
+   * pointer; it must not peek until the pointer leaves the slot.
+   */
+  foldedUnderPointer: (bandId: string) => void;
+  /** The band was pinned open (its toggle, or a peek confirmed by a click). */
+  bandExpanded: (bandId: string) => void;
+  /** Ends any pending timer, for unmount. */
+  dispose: () => void;
+};
+
+export const createBandPeekController = ({
+  onChange,
+  delayMs = KANBAN_BAND_PEEK_DELAY_MS,
+  lingerMs = KANBAN_BAND_PEEK_LINGER_MS,
+  schedule = hostScheduler,
+}: BandPeekControllerOptions): BandPeekController => {
+  let peekingBandId: string | null = null;
+  let suppressedBandId: string | null = null;
+  let cancelOpen: (() => void) | null = null;
+  let openingBandId: string | null = null;
+  let cancelEnd: (() => void) | null = null;
+
+  const clearOpenTimer = () => {
+    if (cancelOpen !== null) {
+      cancelOpen();
+      cancelOpen = null;
+      openingBandId = null;
+    }
+  };
+  const clearEndTimer = () => {
+    if (cancelEnd !== null) {
+      cancelEnd();
+      cancelEnd = null;
+    }
+  };
+  const setPeeking = (bandId: string | null) => {
+    if (peekingBandId === bandId) {
+      return;
+    }
+    peekingBandId = bandId;
+    onChange(bandId);
+  };
+
+  return {
+    slotPointerMove: (bandId) => {
+      if (
+        suppressedBandId === bandId ||
+        peekingBandId === bandId ||
+        openingBandId === bandId
+      ) {
+        return;
+      }
+      clearOpenTimer();
+      openingBandId = bandId;
+      cancelOpen = schedule(() => {
+        cancelOpen = null;
+        openingBandId = null;
+        clearEndTimer();
+        setPeeking(bandId);
+      }, delayMs);
+    },
+    slotPointerLeave: (bandId) => {
+      if (openingBandId === bandId) {
+        clearOpenTimer();
+      }
+      if (suppressedBandId === bandId) {
+        suppressedBandId = null;
+      }
+    },
+    openPointerEnter: (bandId) => {
+      if (peekingBandId === bandId) {
+        clearEndTimer();
+      }
+    },
+    openPointerLeave: (bandId) => {
+      if (peekingBandId !== bandId || cancelEnd !== null) {
+        return;
+      }
+      cancelEnd = schedule(() => {
+        cancelEnd = null;
+        setPeeking(null);
+      }, lingerMs);
+    },
+    foldedUnderPointer: (bandId) => {
+      if (openingBandId === bandId) {
+        clearOpenTimer();
+      }
+      if (peekingBandId === bandId) {
+        clearEndTimer();
+        setPeeking(null);
+      }
+      suppressedBandId = bandId;
+    },
+    bandExpanded: (bandId) => {
+      if (openingBandId === bandId) {
+        clearOpenTimer();
+      }
+      if (suppressedBandId === bandId) {
+        suppressedBandId = null;
+      }
+      if (peekingBandId === bandId) {
+        clearEndTimer();
+        setPeeking(null);
+      }
+    },
+    dispose: () => {
+      clearOpenTimer();
+      clearEndTimer();
+    },
+  };
+};

--- a/packages/ui/src/kanban/band-peek.ts
+++ b/packages/ui/src/kanban/band-peek.ts
@@ -53,12 +53,23 @@ export type BandPeekController = {
   /** The pointer left a part of a band that is rendered open. */
   openPointerLeave: (bandId: string) => void;
   /**
-   * The band was folded by its own caption, so its slot now sits under the
-   * pointer; it must not peek until the pointer leaves the slot.
+   * The band was folded by a pointer on its caption, so its slot now sits
+   * under the pointer; it must not peek until the pointer leaves the slot.
    */
   foldedUnderPointer: (bandId: string) => void;
+  /**
+   * The band was folded without a pointer on it (keyboard, or a controlled
+   * caller): any peek ends, and the slot may peek on the next hover.
+   */
+  bandFolded: (bandId: string) => void;
   /** The band was pinned open (its toggle, or a peek confirmed by a click). */
   bandExpanded: (bandId: string) => void;
+  /**
+   * A band's folded slot left the DOM (the band expanded or disappeared) so
+   * a peek it was about to open, or a suppression it carried, no longer
+   * applies.
+   */
+  slotUnmounted: (bandId: string) => void;
   /** Ends any pending timer, for unmount. */
   dispose: () => void;
 };
@@ -94,6 +105,16 @@ export const createBandPeekController = ({
     }
     peekingBandId = bandId;
     onChange(bandId);
+  };
+
+  const bandFolded = (bandId: string) => {
+    if (openingBandId === bandId) {
+      clearOpenTimer();
+    }
+    if (peekingBandId === bandId) {
+      clearEndTimer();
+      setPeeking(null);
+    }
   };
 
   return {
@@ -137,15 +158,10 @@ export const createBandPeekController = ({
       }, lingerMs);
     },
     foldedUnderPointer: (bandId) => {
-      if (openingBandId === bandId) {
-        clearOpenTimer();
-      }
-      if (peekingBandId === bandId) {
-        clearEndTimer();
-        setPeeking(null);
-      }
+      bandFolded(bandId);
       suppressedBandId = bandId;
     },
+    bandFolded,
     bandExpanded: (bandId) => {
       if (openingBandId === bandId) {
         clearOpenTimer();
@@ -156,6 +172,14 @@ export const createBandPeekController = ({
       if (peekingBandId === bandId) {
         clearEndTimer();
         setPeeking(null);
+      }
+    },
+    slotUnmounted: (bandId) => {
+      if (openingBandId === bandId) {
+        clearOpenTimer();
+      }
+      if (suppressedBandId === bandId) {
+        suppressedBandId = null;
       }
     },
     dispose: () => {

--- a/packages/ui/src/kanban/column-band-header.tsx
+++ b/packages/ui/src/kanban/column-band-header.tsx
@@ -5,6 +5,13 @@ import { ChevronDownIcon } from "lucide-react";
 import { DirectionalIcon } from "../components/directional-icon";
 import { cn } from "../lib/utils";
 
+/**
+ * How a band toggle was activated. A pointer activation leaves the pointer
+ * over whatever replaces the caption (the folded slot), which matters to the
+ * board's peek behaviour; a keyboard activation does not.
+ */
+export type KanbanBandToggleActivation = { viaPointer: boolean };
+
 export type KanbanColumnBandHeaderProps = {
   /** The band name, or the control that has taken its place. */
   title: ReactNode;
@@ -22,7 +29,10 @@ export type KanbanColumnBandHeaderProps = {
   compact?: boolean | undefined;
   /** Accessible name for the toggle, such as "Collapse To do". */
   toggleLabel: string;
-  onCollapsedChange: (collapsed: boolean) => void;
+  onCollapsedChange: (
+    collapsed: boolean,
+    activation: KanbanBandToggleActivation,
+  ) => void;
   /** Band menu or other controls, after the toggle. */
   actions?: ReactNode;
 };
@@ -56,7 +66,11 @@ export const KanbanColumnBandHeader = ({
       aria-expanded={!collapsed}
       aria-label={toggleLabel}
       className="hover:bg-muted/60 text-muted-foreground hover:text-foreground flex size-6 shrink-0 items-center justify-center rounded-md transition-[background-color]"
-      onClick={() => onCollapsedChange(!collapsed)}
+      // A keyboard activation reports no click count, so the board can tell a
+      // fold that leaves the pointer over the new slot from one that does not.
+      onClick={(event) =>
+        onCollapsedChange(!collapsed, { viaPointer: event.detail > 0 })
+      }
       title={toggleLabel}
       type="button"
     >

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -128,8 +128,9 @@ export type {
 } from "./subgroup-board";
 export {
   KANBAN_BAND_PEEK_DELAY_MS,
-  KanbanSubgroupBoard,
-} from "./subgroup-board";
+  KANBAN_BAND_PEEK_LINGER_MS,
+} from "./band-peek";
+export { KanbanSubgroupBoard } from "./subgroup-board";
 export type {
   KanbanVirtualCellPagination,
   KanbanVirtualCellProps,

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -14,7 +14,10 @@ export type { KanbanCardShellProps } from "./card-shell";
 export { KanbanCardShell } from "./card-shell";
 export type { KanbanCellActionProps } from "./cell-action";
 export { KanbanCellAction } from "./cell-action";
-export type { KanbanColumnBandHeaderProps } from "./column-band-header";
+export type {
+  KanbanBandToggleActivation,
+  KanbanColumnBandHeaderProps,
+} from "./column-band-header";
 export { KanbanColumnBandHeader } from "./column-band-header";
 export type { KanbanColumnBandSpan } from "./column-bands";
 export {

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -8,6 +8,7 @@ import { cn } from "../lib/utils";
 import { createBandPeekController } from "./band-peek";
 import type { BandPeekController } from "./band-peek";
 import { KanbanColumnBandHeader } from "./column-band-header";
+import type { KanbanBandToggleActivation } from "./column-band-header";
 import {
   KANBAN_COLLAPSED_BAND_WIDTH_CLASS,
   KANBAN_COLUMN_GAP_PX,
@@ -68,7 +69,15 @@ export type KanbanSubgroupBandHeaderContext = {
    * name and offer to pin the band open.
    */
   folded: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
+  /**
+   * A custom caption reports which way it was activated; omitting the
+   * activation is read as a pointer fold, the conservative choice for the
+   * peek that follows.
+   */
+  onCollapsedChange: (
+    collapsed: boolean,
+    activation?: KanbanBandToggleActivation,
+  ) => void;
 };
 
 /**
@@ -250,13 +259,38 @@ export const KanbanSubgroupBoard = <TRow,>({
    */
   const isBandFolded = (band: KanbanColumnBand): boolean =>
     peekingBandId !== band.id && isBandCollapsedNow(band);
-  const setBandCollapsed = (band: KanbanColumnBand, collapsed: boolean) => {
-    // A fold from the caption leaves the new slot under the pointer; the
-    // controller keeps it from peeking straight back open.
-    if (collapsed) {
+  // A peek belongs to a band that is collapsed by state. When a controlled
+  // caller expands that band, or a matrix change removes it, no open element
+  // of it may ever emit a leave, so the controller is told directly.
+  const peekedBand =
+    peekingBandId === null
+      ? null
+      : (spans.find((span) => span.band?.id === peekingBandId)?.band ?? null);
+  const staleBandId =
+    peekingBandId !== null &&
+    (peekedBand === null || !isBandCollapsedNow(peekedBand))
+      ? peekingBandId
+      : null;
+  useEffect(() => {
+    if (staleBandId !== null) {
+      peek.bandExpanded(staleBandId);
+    }
+  }, [peek, staleBandId]);
+  const setBandCollapsed = (
+    band: KanbanColumnBand,
+    collapsed: boolean,
+    activation?: KanbanBandToggleActivation,
+  ) => {
+    const viaPointer = activation === undefined ? true : activation.viaPointer;
+    // A pointer fold from the caption leaves the new slot under the pointer;
+    // the controller keeps it from peeking straight back open. A keyboard
+    // fold leaves no pointer there, so the next hover may peek as usual.
+    if (!collapsed) {
+      peek.bandExpanded(band.id);
+    } else if (viaPointer) {
       peek.foldedUnderPointer(band.id);
     } else {
-      peek.bandExpanded(band.id);
+      peek.bandFolded(band.id);
     }
     if (onBandCollapsedChange) {
       onBandCollapsedChange(band, collapsed);
@@ -359,7 +393,8 @@ export const KanbanSubgroupBoard = <TRow,>({
       columns: span.columns,
       count: span.columns.reduce((sum, column) => sum + columnCount(column), 0),
       folded,
-      onCollapsedChange: (next) => setBandCollapsed(band, next),
+      onCollapsedChange: (next, activation) =>
+        setBandCollapsed(band, next, activation),
     };
     if (renderBandHeader) {
       return <>{renderBandHeader(context)}</>;
@@ -622,14 +657,19 @@ const FoldedBandSlot = ({
   children,
   className,
   peek,
-}: FoldedBandSlotProps) => (
-  <div
-    className={className}
-    data-kanban-band={band.id}
-    data-kanban-band-collapsed=""
-    onPointerMove={() => peek.slotPointerMove(band.id)}
-    onPointerLeave={() => peek.slotPointerLeave(band.id)}
-  >
-    {children}
-  </div>
-);
+}: FoldedBandSlotProps) => {
+  // A slot that leaves the DOM mid-delay (its band expanded or disappeared)
+  // takes its pending peek and its suppression with it.
+  useEffect(() => () => peek.slotUnmounted(band.id), [peek, band.id]);
+  return (
+    <div
+      className={className}
+      data-kanban-band={band.id}
+      data-kanban-band-collapsed=""
+      onPointerMove={() => peek.slotPointerMove(band.id)}
+      onPointerLeave={() => peek.slotPointerLeave(band.id)}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 
 import { ChevronDownIcon } from "lucide-react";
 
 import { DirectionalIcon } from "../components/directional-icon";
 import { cn } from "../lib/utils";
+import { createBandPeekController } from "./band-peek";
+import type { BandPeekController } from "./band-peek";
 import { KanbanColumnBandHeader } from "./column-band-header";
 import {
   KANBAN_COLLAPSED_BAND_WIDTH_CLASS,
@@ -33,9 +35,6 @@ const spanKey = (span: KanbanColumnBandSpan): string =>
     : `band:${span.band.id}`;
 const rowsIn = <TRow,>(cells: readonly KanbanBoardCell<TRow>[]): number =>
   cells.reduce((sum, cell) => sum + cell.rows.length, 0);
-
-/** How long a pointer rests on a collapsed band before it peeks open. */
-export const KANBAN_BAND_PEEK_DELAY_MS = 400;
 
 type Rendered = ReactElement | null;
 
@@ -169,6 +168,12 @@ export const KanbanSubgroupBoard = <TRow,>({
     () => new Set<string>(),
   );
   const [peekingBandId, setPeekingBandId] = useState<string | null>(null);
+  // The peek's timing rules live in one controller (see `band-peek.ts`); the
+  // board only mirrors which band it reports open.
+  const [peek] = useState(() =>
+    createBandPeekController({ onChange: setPeekingBandId }),
+  );
+  useEffect(() => () => peek.dispose(), [peek]);
 
   const { cellsByLaneValue, countByColumnValue, ungroupedCells } =
     useMemo(() => {
@@ -246,7 +251,13 @@ export const KanbanSubgroupBoard = <TRow,>({
   const isBandFolded = (band: KanbanColumnBand): boolean =>
     peekingBandId !== band.id && isBandCollapsedNow(band);
   const setBandCollapsed = (band: KanbanColumnBand, collapsed: boolean) => {
-    setPeekingBandId(null);
+    // A fold from the caption leaves the new slot under the pointer; the
+    // controller keeps it from peeking straight back open.
+    if (collapsed) {
+      peek.foldedUnderPointer(band.id);
+    } else {
+      peek.bandExpanded(band.id);
+    }
     if (onBandCollapsedChange) {
       onBandCollapsedChange(band, collapsed);
       return;
@@ -261,7 +272,6 @@ export const KanbanSubgroupBoard = <TRow,>({
       return next;
     });
   };
-  const endPeek = () => setPeekingBandId(null);
 
   const columnCount = (column: KanbanBoardColumn) =>
     countByColumnValue.get(columnKey(column)) ?? 0;
@@ -305,8 +315,7 @@ export const KanbanSubgroupBoard = <TRow,>({
               band={band}
               className={KANBAN_COLLAPSED_BAND_WIDTH_CLASS}
               key={spanKey(span)}
-              onPeek={setPeekingBandId}
-              onPeekEnd={endPeek}
+              peek={peek}
             >
               {renderFoldedBand(band, span)}
             </FoldedBandSlot>
@@ -317,8 +326,11 @@ export const KanbanSubgroupBoard = <TRow,>({
             className="flex gap-3"
             data-kanban-band={band?.id}
             key={spanKey(span)}
+            onPointerEnter={
+              band === null ? undefined : () => peek.openPointerEnter(band.id)
+            }
             onPointerLeave={
-              band !== null && peekingBandId === band.id ? endPeek : undefined
+              band === null ? undefined : () => peek.openPointerLeave(band.id)
             }
           >
             {span.columns.map((column) => (
@@ -447,8 +459,7 @@ export const KanbanSubgroupBoard = <TRow,>({
                         KANBAN_COLLAPSED_BAND_WIDTH_CLASS,
                       )}
                       key={spanKey(span)}
-                      onPeek={setPeekingBandId}
-                      onPeekEnd={endPeek}
+                      peek={peek}
                     >
                       {bandHeader(band, span)}
                     </FoldedBandSlot>
@@ -460,9 +471,8 @@ export const KanbanSubgroupBoard = <TRow,>({
                     data-kanban-band={band.id}
                     key={spanKey(span)}
                     style={{ width: `${String(spanWidth(span))}px` }}
-                    onPointerLeave={
-                      peekingBandId === band.id ? endPeek : undefined
-                    }
+                    onPointerEnter={() => peek.openPointerEnter(band.id)}
+                    onPointerLeave={() => peek.openPointerLeave(band.id)}
                   >
                     {bandHeader(band, span)}
                   </div>
@@ -599,60 +609,27 @@ type FoldedBandSlotProps = {
   band: KanbanColumnBand;
   children: ReactNode;
   className: string;
-  onPeek: (bandId: string) => void;
-  onPeekEnd: () => void;
+  peek: BandPeekController;
 };
 
 /**
- * The narrow slot a folded band occupies in a row. A pointer resting on it
- * for `KANBAN_BAND_PEEK_DELAY_MS` peeks the band open; leaving ends the peek
- * and cancels a pending one, so a drag passing over it does not unfold it.
- * The pointer must enter the slot after it appeared: a band folded under a
- * resting pointer does not peek straight back open.
+ * The narrow slot a folded band occupies in a row. Its pointer events go to
+ * the board's peek controller, which decides when a resting pointer peeks
+ * the band open and keeps a slot that appeared under the pointer folded.
  */
 const FoldedBandSlot = ({
   band,
   children,
   className,
-  onPeek,
-  onPeekEnd,
-}: FoldedBandSlotProps) => {
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(
-    () => () => {
-      if (timer.current !== null) {
-        clearTimeout(timer.current);
-      }
-    },
-    [],
-  );
-
-  return (
-    <div
-      className={className}
-      data-kanban-band={band.id}
-      data-kanban-band-collapsed=""
-      // The peek arms on movement inside the slot, not on entering it: a
-      // browser reports an enter for a slot that appears under a resting
-      // pointer (the band the user just folded), and that must stay folded.
-      onPointerMove={() => {
-        if (timer.current !== null) {
-          return;
-        }
-        timer.current = setTimeout(() => {
-          timer.current = null;
-          onPeek(band.id);
-        }, KANBAN_BAND_PEEK_DELAY_MS);
-      }}
-      onPointerLeave={() => {
-        if (timer.current !== null) {
-          clearTimeout(timer.current);
-          timer.current = null;
-        }
-        onPeekEnd();
-      }}
-    >
-      {children}
-    </div>
-  );
-};
+  peek,
+}: FoldedBandSlotProps) => (
+  <div
+    className={className}
+    data-kanban-band={band.id}
+    data-kanban-band-collapsed=""
+    onPointerMove={() => peek.slotPointerMove(band.id)}
+    onPointerLeave={() => peek.slotPointerLeave(band.id)}
+  >
+    {children}
+  </div>
+);


### PR DESCRIPTION
## Summary

Fixes the fold/peek loop on kanban column bands: click the caption to fold a band, and the band re-opens under the resting cursor, then folds again when the cursor leaves the caption, repeatedly.

Two causes, both in `KanbanSubgroupBoard`:
- The folded slot armed a peek on any pointer movement, including on the slot that had just appeared under the pointer after a fold.
- A peek ended on `pointerleave` of a single element, but a band is rendered as separate elements (caption, then its columns in each lane), so moving from the caption into a column ended the peek, which folded the band under the pointer and re-armed the slot.

**Change**
- `band-peek.ts`: `createBandPeekController` owns the timing: a band folded from its caption is suppressed until the pointer leaves its slot once; a peek ends only after `KANBAN_BAND_PEEK_LINGER_MS` (150 ms) outside every part of the open band; the open delay stays `KANBAN_BAND_PEEK_DELAY_MS` (400 ms). The scheduler is injectable.
- `subgroup-board.tsx`: the folded slot and the open spans forward pointer events to the controller; the caption toggle reports folds and expansions to it. `FoldedBandSlot` no longer carries its own timer.
- Both constants are exported from `@stll/ui/kanban` as before (`KANBAN_BAND_PEEK_DELAY_MS` unchanged).

**Tests**: eight controller tests with a manual clock, including the exact defect (fold under pointer, move, no peek until leave and re-enter) and the caption-to-column crossing. Existing kanban tests unchanged (64 pass).

Changeset: `@stll/ui` patch.
