### PR TITLE
fix(web): classify a disabled public-law surface and record the API outcome in exception telemetry

### DIFF
--- a/.oxlint-plugins/__fixtures__/require-eden-error-check.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/require-eden-error-check.fixture.ts
@@ -1,10 +1,8 @@
 // Passive regression fixture for require-eden-error-check.
 
 import { api } from "@/lib/api";
-import {
-  toAPIError,
-  unwrapEden as unwrapResponse,
-} from "@/lib/errors/api";
+import { toAPIError, unwrapEden as unwrapResponse } from "@/lib/errors/api";
+import { unwrapPublicLawEden } from "@/lib/public-law-api";
 
 declare const consume: (value: unknown) => void;
 declare const condition: boolean;
@@ -37,8 +35,7 @@ export const directlyEscapedToOpaqueConsumer = async () => {
 
 // Allowed: direct inspection of the error channel and the canonical adapter
 // both handle the response without an intermediate binding.
-export const directlyInspectedError = async () =>
-  (await api.tasks.get()).error;
+export const directlyInspectedError = async () => (await api.tasks.get()).error;
 
 export const directlyAdaptedResponse = async () =>
   unwrapResponse(await api.tasks.get());
@@ -173,9 +170,7 @@ export const checkedOnBothBranches = async () => {
 // Allowed: mutually exclusive awaited branches flow into one binding whose
 // error channel is inspected before its data is consumed.
 export const checkedConditionalAcquisition = async () => {
-  const response = condition
-    ? await api.tasks.get()
-    : await api.tasks.get();
+  const response = condition ? await api.tasks.get() : await api.tasks.get();
   consume(response.error);
   return response.data;
 };
@@ -183,9 +178,7 @@ export const checkedConditionalAcquisition = async () => {
 // MUST flag: a conditional acquisition still needs one dominating error check.
 export const uncheckedConditionalAcquisition = async () => {
   // oxlint-disable-next-line require-eden-error-check/require-eden-error-check -- fixture: both conditional branches flow to one unchecked response binding
-  const response = condition
-    ? await api.tasks.get()
-    : await api.tasks.get();
+  const response = condition ? await api.tasks.get() : await api.tasks.get();
   return response.data;
 };
 
@@ -246,6 +239,13 @@ export const destructuredByAssignment = async () => {
 export const passedToApprovedAdapter = async () => {
   const response = await api.tasks.get();
   return unwrapResponse(response);
+};
+
+// Allowed: a domain adapter registered for its owning module owns the
+// error channel the same way the canonical one does.
+export const passedToDomainAdapter = async () => {
+  const response = await api.tasks.get();
+  return unwrapPublicLawEden(response, "fixture");
 };
 
 // MUST flag: a same-shaped local helper is not the canonical imported

--- a/.oxlint-plugins/no-facade-imports.ts
+++ b/.oxlint-plugins/no-facade-imports.ts
@@ -25,6 +25,7 @@ const ALLOWED_LEAF_IMPORTS = new Set([
   "@/api/lib/analytics/tanstack-ai",
   "@/api/lib/analytics/types",
   "@/lib/errors/api",
+  "@/lib/errors/api-tag",
   "@/lib/errors/auth",
   "@/lib/errors/client",
   "@/lib/errors/localization",

--- a/.oxlint-plugins/require-eden-error-check.ts
+++ b/.oxlint-plugins/require-eden-error-check.ts
@@ -1133,7 +1133,7 @@ export default eslintCompatPlugin({
             assignedResults.length = 0;
           },
           ImportDeclaration(node) {
-            if (node.source?.value !== API_MODULE) {
+            if (node.source.value !== API_MODULE) {
               return;
             }
             for (const specifier of node.specifiers) {

--- a/.oxlint-plugins/require-eden-error-check.ts
+++ b/.oxlint-plugins/require-eden-error-check.ts
@@ -86,8 +86,15 @@ import {
 import type { AstNode } from "./utils.ts";
 
 const API_MODULE = "@/lib/api";
-const ERROR_ADAPTER_MODULE = "@/lib/errors/api";
-const APPROVED_RESPONSE_ADAPTERS = new Set(["unwrapEden"]);
+// Adapters that take the whole Eden response and own its error channel,
+// keyed by the module that exports them.
+const APPROVED_RESPONSE_ADAPTERS: ReadonlyMap<
+  string,
+  ReadonlySet<string>
+> = new Map([
+  ["@/lib/errors/api", new Set(["unwrapEden"])],
+  ["@/lib/public-law-api", new Set(["unwrapPublicLawEden"])],
+]);
 const EDEN_HTTP_METHODS = new Set([
   "delete",
   "get",
@@ -363,15 +370,18 @@ export default eslintCompatPlugin({
                 !isAstNode(definition.node) ||
                 !isAstNode(definition.parent) ||
                 definition.parent.type !== "ImportDeclaration" ||
-                !isStringLiteral(definition.parent.source) ||
-                definition.parent.source.value !== ERROR_ADAPTER_MODULE
+                !isStringLiteral(definition.parent.source)
               ) {
                 return false;
               }
+              const adapters = APPROVED_RESPONSE_ADAPTERS.get(
+                definition.parent.source.value,
+              );
               const importedName = getImportedName(definition.node);
               return (
+                adapters !== undefined &&
                 importedName !== null &&
-                APPROVED_RESPONSE_ADAPTERS.has(importedName)
+                adapters.has(importedName)
               );
             })
           );
@@ -523,22 +533,23 @@ export default eslintCompatPlugin({
             return { states: new Set(states), unsafe: false };
           }
 
-          if (expression.type === "MemberExpression") {
-            if (isBindingIdentifier(expression.object, binding)) {
-              const property =
-                expression.computed === true
-                  ? isStringLiteral(expression.property)
-                    ? expression.property.value
-                    : null
-                  : getPropertyName(expression.property);
-              if (property === "error") {
-                return { states: handledStates(states), unsafe: false };
-              }
-              return {
-                states: new Set(states),
-                unsafe: hasUnhandled(states),
-              };
+          if (
+            expression.type === "MemberExpression" &&
+            isBindingIdentifier(expression.object, binding)
+          ) {
+            const property =
+              expression.computed === true
+                ? isStringLiteral(expression.property)
+                  ? expression.property.value
+                  : null
+                : getPropertyName(expression.property);
+            if (property === "error") {
+              return { states: handledStates(states), unsafe: false };
             }
+            return {
+              states: new Set(states),
+              unsafe: hasUnhandled(states),
+            };
           }
 
           if (
@@ -742,6 +753,234 @@ export default eslintCompatPlugin({
           return { states: current, unsafe };
         };
 
+        const analyzeExitStatement = (
+          node: AstNode,
+          states: ReadonlySet<FlowState>,
+          binding: unknown,
+        ): FlowOutcome => {
+          const argument = analyzeExpression(node.argument, states, binding);
+          const exitsUnhandled = hasUnhandled(argument.states);
+          return {
+            states: deadStates(argument.states),
+            unsafe: argument.unsafe || exitsUnhandled,
+            unsafeExit:
+              argument.unsafeExit ??
+              (exitsUnhandled &&
+              !containsBindingReference(node.argument, binding)
+                ? node
+                : undefined),
+          };
+        };
+
+        // `response === null` / `response !== null` tests split the flow by
+        // presence; any other test is analyzed as an ordinary expression.
+        const nullComparisonOf = (
+          test: unknown,
+          binding: unknown,
+        ): "absent" | "present" | null => {
+          const expression = unwrapExpression(test);
+          if (
+            !isAstNode(expression) ||
+            expression.type !== "BinaryExpression"
+          ) {
+            return null;
+          }
+          const left = unwrapExpression(expression.left);
+          const right = unwrapExpression(expression.right);
+          const comparesBindingToNull =
+            (isBindingIdentifier(left, binding) &&
+              isAstNode(right) &&
+              right.type === "Literal" &&
+              right.value === null) ||
+            (isBindingIdentifier(right, binding) &&
+              isAstNode(left) &&
+              left.type === "Literal" &&
+              left.value === null);
+          if (!comparesBindingToNull) {
+            return null;
+          }
+          if (expression.operator === "===" || expression.operator === "==") {
+            return "absent";
+          }
+          if (expression.operator === "!==" || expression.operator === "!=") {
+            return "present";
+          }
+          return null;
+        };
+
+        const analyzeBranches = (
+          node: AstNode,
+          consequentStates: ReadonlySet<FlowState>,
+          alternateStates: ReadonlySet<FlowState>,
+          binding: unknown,
+        ): FlowOutcome => {
+          const consequent = analyzeStatement(
+            node.consequent,
+            consequentStates,
+            binding,
+          );
+          const alternate = isAstNode(node.alternate)
+            ? analyzeStatement(node.alternate, alternateStates, binding)
+            : {
+                states: new Set(alternateStates),
+                unsafe: false,
+                unsafeExit: undefined,
+              };
+          return {
+            states: mergeStates(consequent.states, alternate.states),
+            unsafe: consequent.unsafe || alternate.unsafe,
+            unsafeExit: consequent.unsafeExit ?? alternate.unsafeExit,
+          };
+        };
+
+        const analyzeIfStatement = (
+          node: AstNode,
+          states: ReadonlySet<FlowState>,
+          binding: unknown,
+        ): FlowOutcome => {
+          const nullComparison = nullComparisonOf(node.test, binding);
+          if (nullComparison !== null) {
+            const absentStates = new Set<FlowState>();
+            const presentStates = new Set<FlowState>();
+            for (const state of states) {
+              if (state === "absent") {
+                absentStates.add(state);
+              } else {
+                presentStates.add(state);
+              }
+            }
+            return nullComparison === "absent"
+              ? analyzeBranches(node, absentStates, presentStates, binding)
+              : analyzeBranches(node, presentStates, absentStates, binding);
+          }
+          const test = analyzeExpression(node.test, states, binding);
+          const branches = analyzeBranches(
+            node,
+            test.states,
+            test.states,
+            binding,
+          );
+          return {
+            states: branches.states,
+            unsafe: test.unsafe || branches.unsafe,
+            unsafeExit: test.unsafeExit ?? branches.unsafeExit,
+          };
+        };
+
+        const analyzeLoopStatement = (
+          node: AstNode,
+          states: ReadonlySet<FlowState>,
+          binding: unknown,
+        ): FlowOutcome => {
+          const entry = analyzeExpression(node.init, states, binding);
+          const test = analyzeExpression(node.test, entry.states, binding);
+          const right = analyzeExpression(node.right, test.states, binding);
+          const body = analyzeStatement(node.body, right.states, binding);
+          const update = analyzeExpression(node.update, body.states, binding);
+          return {
+            states: mergeStates(test.states, update.states),
+            unsafe:
+              entry.unsafe ||
+              test.unsafe ||
+              right.unsafe ||
+              body.unsafe ||
+              update.unsafe,
+            unsafeExit:
+              entry.unsafeExit ??
+              test.unsafeExit ??
+              right.unsafeExit ??
+              body.unsafeExit ??
+              update.unsafeExit,
+          };
+        };
+
+        const analyzeSwitchStatement = (
+          node: AstNode,
+          states: ReadonlySet<FlowState>,
+          binding: unknown,
+        ): FlowOutcome => {
+          const discriminant = analyzeExpression(
+            node.discriminant,
+            states,
+            binding,
+          );
+          const cases = Array.isArray(node.cases) ? node.cases : [];
+          const hasDefault = cases.some(
+            (switchCase) => isAstNode(switchCase) && switchCase.test === null,
+          );
+          const branches: Set<FlowState>[] = hasDefault
+            ? []
+            : [new Set(discriminant.states)];
+          let unsafe = discriminant.unsafe;
+          let unsafeExit = discriminant.unsafeExit;
+          for (const switchCase of cases) {
+            if (!isAstNode(switchCase)) {
+              continue;
+            }
+            const test = analyzeExpression(
+              switchCase.test,
+              discriminant.states,
+              binding,
+            );
+            const branch = analyzeStatements(
+              Array.isArray(switchCase.consequent) ? switchCase.consequent : [],
+              test.states,
+              binding,
+            );
+            branches.push(branch.states);
+            unsafe ||= test.unsafe || branch.unsafe;
+            unsafeExit ??= test.unsafeExit ?? branch.unsafeExit;
+          }
+          return {
+            states: mergeStates(...branches),
+            unsafe,
+            unsafeExit,
+          };
+        };
+
+        const analyzeTryStatement = (
+          node: AstNode,
+          states: ReadonlySet<FlowState>,
+          binding: unknown,
+        ): FlowOutcome => {
+          const tried = analyzeStatement(node.block, states, binding);
+          // An explicit throw carries the state reached in the try body.
+          // Starting catch from the pre-try state would resurrect an
+          // already-inspected response and falsely reject a catch return.
+          const caught = isAstNode(node.handler)
+            ? analyzeStatement(node.handler.body, tried.states, binding)
+            : {
+                states: new Set<FlowState>(),
+                unsafe: false,
+                unsafeExit: undefined,
+              };
+          const combined = {
+            states: mergeStates(tried.states, caught.states),
+            unsafe: tried.unsafe || caught.unsafe,
+            unsafeExit: tried.unsafeExit ?? caught.unsafeExit,
+          };
+          if (!isAstNode(node.finalizer)) {
+            return combined;
+          }
+          const finalizerInput = combined.unsafeExit
+            ? mergeStates(combined.states, states)
+            : combined.states;
+          const finalized = analyzeStatement(
+            node.finalizer,
+            finalizerInput,
+            binding,
+          );
+          const pendingExitHandled =
+            combined.unsafeExit !== undefined &&
+            !hasUnhandled(finalized.states);
+          return {
+            states: finalized.states,
+            unsafe:
+              (combined.unsafe && !pendingExitHandled) || finalized.unsafe,
+            unsafeExit: combined.unsafeExit ?? finalized.unsafeExit,
+          };
+        };
+
         const analyzeStatement = (
           node: unknown,
           states: ReadonlySet<FlowState>,
@@ -751,254 +990,50 @@ export default eslintCompatPlugin({
             return { states: new Set(states), unsafe: false };
           }
 
-          if (node.type === "BlockStatement") {
-            return analyzeStatements(
-              Array.isArray(node.body) ? node.body : [],
-              states,
-              binding,
-            );
-          }
-
-          if (node.type === "ExpressionStatement") {
-            return analyzeExpression(node.expression, states, binding);
-          }
-
-          if (node.type === "VariableDeclaration") {
-            return analyzeDeclarators(
-              Array.isArray(node.declarations) ? node.declarations : [],
-              states,
-              binding,
-            );
-          }
-
-          if (node.type === "ReturnStatement" || node.type === "ThrowStatement") {
-            const argument = analyzeExpression(node.argument, states, binding);
-            const exitsUnhandled = hasUnhandled(argument.states);
-            return {
-              states: deadStates(argument.states),
-              unsafe: argument.unsafe || exitsUnhandled,
-              unsafeExit:
-                argument.unsafeExit ??
-                (exitsUnhandled &&
-                !containsBindingReference(node.argument, binding)
-                  ? node
-                  : undefined),
-            };
-          }
-
-          if (node.type === "IfStatement") {
-            const nullComparison = (() => {
-              const test = unwrapExpression(node.test);
-              if (!isAstNode(test) || test.type !== "BinaryExpression") {
-                return null;
-              }
-              const left = unwrapExpression(test.left);
-              const right = unwrapExpression(test.right);
-              const comparesBindingToNull =
-                (isBindingIdentifier(left, binding) &&
-                  isAstNode(right) &&
-                  right.type === "Literal" &&
-                  right.value === null) ||
-                (isBindingIdentifier(right, binding) &&
-                  isAstNode(left) &&
-                  left.type === "Literal" &&
-                  left.value === null);
-              if (!comparesBindingToNull) {
-                return null;
-              }
-              if (test.operator === "===" || test.operator === "==") {
-                return "absent";
-              }
-              if (test.operator === "!==" || test.operator === "!=") {
-                return "present";
-              }
-              return null;
-            })();
-            if (nullComparison !== null) {
-              const absentStates = new Set<FlowState>();
-              const presentStates = new Set<FlowState>();
-              for (const state of states) {
-                if (state === "absent") {
-                  absentStates.add(state);
-                } else {
-                  presentStates.add(state);
-                }
-              }
-              const consequentStates =
-                nullComparison === "absent" ? absentStates : presentStates;
-              const alternateStates =
-                nullComparison === "absent" ? presentStates : absentStates;
-              const consequent = analyzeStatement(
-                node.consequent,
-                consequentStates,
+          switch (node.type) {
+            case "BlockStatement":
+              return analyzeStatements(
+                Array.isArray(node.body) ? node.body : [],
+                states,
                 binding,
               );
-              const alternate = isAstNode(node.alternate)
-                ? analyzeStatement(node.alternate, alternateStates, binding)
-                : {
-                    states: new Set(alternateStates),
-                    unsafe: false,
-                    unsafeExit: undefined,
-                  };
+            case "ExpressionStatement":
+              return analyzeExpression(node.expression, states, binding);
+            case "VariableDeclaration":
+              return analyzeDeclarators(
+                Array.isArray(node.declarations) ? node.declarations : [],
+                states,
+                binding,
+              );
+            case "ReturnStatement":
+            case "ThrowStatement":
+              return analyzeExitStatement(node, states, binding);
+            case "IfStatement":
+              return analyzeIfStatement(node, states, binding);
+            case "DoWhileStatement": {
+              const body = analyzeStatement(node.body, states, binding);
+              const test = analyzeExpression(node.test, body.states, binding);
               return {
-                states: mergeStates(consequent.states, alternate.states),
-                unsafe: consequent.unsafe || alternate.unsafe,
-                unsafeExit:
-                  consequent.unsafeExit ?? alternate.unsafeExit,
+                states: mergeStates(body.states, test.states),
+                unsafe: body.unsafe || test.unsafe,
+                unsafeExit: body.unsafeExit ?? test.unsafeExit,
               };
             }
-            const test = analyzeExpression(node.test, states, binding);
-            const consequent = analyzeStatement(
-              node.consequent,
-              test.states,
-              binding,
-            );
-            const alternate = isAstNode(node.alternate)
-              ? analyzeStatement(node.alternate, test.states, binding)
-              : {
-                  states: new Set(test.states),
-                  unsafe: false,
-                  unsafeExit: undefined,
-                };
-            return {
-              states: mergeStates(consequent.states, alternate.states),
-              unsafe: test.unsafe || consequent.unsafe || alternate.unsafe,
-              unsafeExit:
-                test.unsafeExit ??
-                consequent.unsafeExit ??
-                alternate.unsafeExit,
-            };
+            case "ForStatement":
+            case "ForInStatement":
+            case "ForOfStatement":
+            case "WhileStatement":
+              return analyzeLoopStatement(node, states, binding);
+            case "SwitchStatement":
+              return analyzeSwitchStatement(node, states, binding);
+            case "TryStatement":
+              return analyzeTryStatement(node, states, binding);
+            case "LabeledStatement":
+            case "WithStatement":
+              return analyzeStatement(node.body, states, binding);
+            default:
+              return analyzeExpression(node, states, binding);
           }
-
-          if (node.type === "DoWhileStatement") {
-            const body = analyzeStatement(node.body, states, binding);
-            const test = analyzeExpression(node.test, body.states, binding);
-            return {
-              states: mergeStates(body.states, test.states),
-              unsafe: body.unsafe || test.unsafe,
-              unsafeExit: body.unsafeExit ?? test.unsafeExit,
-            };
-          }
-
-          if (
-            node.type === "ForStatement" ||
-            node.type === "ForInStatement" ||
-            node.type === "ForOfStatement" ||
-            node.type === "WhileStatement"
-          ) {
-            const entry = analyzeExpression(node.init, states, binding);
-            const test = analyzeExpression(node.test, entry.states, binding);
-            const right = analyzeExpression(node.right, test.states, binding);
-            const body = analyzeStatement(node.body, right.states, binding);
-            const update = analyzeExpression(
-              node.update,
-              body.states,
-              binding,
-            );
-            return {
-              states: mergeStates(test.states, update.states),
-              unsafe:
-                entry.unsafe ||
-                test.unsafe ||
-                right.unsafe ||
-                body.unsafe ||
-                update.unsafe,
-              unsafeExit:
-                entry.unsafeExit ??
-                test.unsafeExit ??
-                right.unsafeExit ??
-                body.unsafeExit ??
-                update.unsafeExit,
-            };
-          }
-
-          if (node.type === "SwitchStatement") {
-            const discriminant = analyzeExpression(
-              node.discriminant,
-              states,
-              binding,
-            );
-            const cases = Array.isArray(node.cases) ? node.cases : [];
-            const hasDefault = cases.some(
-              (switchCase) =>
-                isAstNode(switchCase) && switchCase.test === null,
-            );
-            const branches: Set<FlowState>[] = hasDefault
-              ? []
-              : [new Set(discriminant.states)];
-            let unsafe = discriminant.unsafe;
-            let unsafeExit = discriminant.unsafeExit;
-            for (const switchCase of cases) {
-              if (!isAstNode(switchCase)) {
-                continue;
-              }
-              const test = analyzeExpression(
-                switchCase.test,
-                discriminant.states,
-                binding,
-              );
-              const branch = analyzeStatements(
-                Array.isArray(switchCase.consequent)
-                  ? switchCase.consequent
-                  : [],
-                test.states,
-                binding,
-              );
-              branches.push(branch.states);
-              unsafe ||= test.unsafe || branch.unsafe;
-              unsafeExit ??= test.unsafeExit ?? branch.unsafeExit;
-            }
-            return {
-              states: mergeStates(...branches),
-              unsafe,
-              unsafeExit,
-            };
-          }
-
-          if (node.type === "TryStatement") {
-            const tried = analyzeStatement(node.block, states, binding);
-            // An explicit throw carries the state reached in the try body.
-            // Starting catch from the pre-try state would resurrect an
-            // already-inspected response and falsely reject a catch return.
-            const caught = isAstNode(node.handler)
-              ? analyzeStatement(node.handler.body, tried.states, binding)
-              : {
-                  states: new Set<FlowState>(),
-                  unsafe: false,
-                  unsafeExit: undefined,
-                };
-            const combined = {
-              states: mergeStates(tried.states, caught.states),
-              unsafe: tried.unsafe || caught.unsafe,
-              unsafeExit: tried.unsafeExit ?? caught.unsafeExit,
-            };
-            if (!isAstNode(node.finalizer)) {
-              return combined;
-            }
-            const finalizerInput = combined.unsafeExit
-              ? mergeStates(combined.states, states)
-              : combined.states;
-            const finalized = analyzeStatement(
-              node.finalizer,
-              finalizerInput,
-              binding,
-            );
-            const pendingExitHandled =
-              combined.unsafeExit !== undefined &&
-              !hasUnhandled(finalized.states);
-            return {
-              states: finalized.states,
-              unsafe:
-                (combined.unsafe && !pendingExitHandled) || finalized.unsafe,
-              unsafeExit: combined.unsafeExit ?? finalized.unsafeExit,
-            };
-          }
-
-          if (node.type === "LabeledStatement" || node.type === "WithStatement") {
-            return analyzeStatement(node.body, states, binding);
-          }
-
-          return analyzeExpression(node, states, binding);
         };
 
         const analyzeContinuation = (
@@ -1219,9 +1254,7 @@ export default eslintCompatPlugin({
                     parent.alternate === expression)))
             ) {
               expression = parent;
-              parent = isAstNode(expression.parent)
-                ? expression.parent
-                : null;
+              parent = isAstNode(expression.parent) ? expression.parent : null;
             }
 
             if (

--- a/apps/api/src/lib/errors/response-validation.ts
+++ b/apps/api/src/lib/errors/response-validation.ts
@@ -1,0 +1,11 @@
+/**
+ * Elysia reports every schema violation as `code === "VALIDATION"`, but a
+ * failure on the `response` target means the handler produced output that
+ * breaks its own contract: a server defect answered with a client status.
+ * Sinks that grade validation as a client fault must exempt it.
+ */
+export const isResponseValidationError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "type" in error &&
+  error.type === "response";

--- a/apps/api/src/lib/rate-limit/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.ts
@@ -1,5 +1,6 @@
 import { Elysia, type Context } from "elysia";
 
+import { isResponseValidationError } from "@/api/lib/errors/response-validation";
 import { resolveResponseStatus } from "@/api/lib/observability/response-status";
 
 type MaybePromise<T> = T | Promise<T>;
@@ -200,12 +201,6 @@ const rateLimitErrorStatus = (error: unknown): number | undefined => {
   }
   return undefined;
 };
-
-const isResponseValidationError = (error: unknown): boolean =>
-  typeof error === "object" &&
-  error !== null &&
-  "type" in error &&
-  error.type === "response";
 
 const isEarlyFailureStatus = (statusCode: number): boolean =>
   statusCode === 400 || statusCode === 404 || statusCode === 422;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -448,14 +448,21 @@ const api = new Elysia()
       });
     }
 
-    captureRequestError(error, {
-      request,
-      context: {
-        route: getRouteName(route),
-        method: request.method,
-        elysiaCode: String(code),
-      },
-    });
+    // A framework-answered client fault (a rejected body, an unknown route,
+    // an unparseable request) is the caller's own outcome: the WARN record
+    // above keeps it, and reporting it as an exception would fill the tracker
+    // with one issue per scanner probe and schema mismatch. Every other code
+    // is the server's, and stays captured.
+    if (STATUS_BY_ELYSIA_CODE[code] === undefined) {
+      captureRequestError(error, {
+        request,
+        context: {
+          route: getRouteName(route),
+          method: request.method,
+          elysiaCode: String(code),
+        },
+      });
+    }
 
     // Return a sanitized response for unhandled errors.
     // Elysia's default would serialize error.message, which

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -128,6 +128,7 @@ import { initDocumentReviewRunWorker } from "@/api/lib/document-review/run-queue
 import { initDocumentTranslationRunWorker } from "@/api/lib/document-translation/run-queue";
 import { initEntityDeletionCleanupWorker } from "@/api/lib/entity-deletion-cleanup-queue";
 import { httpError } from "@/api/lib/errors/http-error";
+import { isResponseValidationError } from "@/api/lib/errors/response-validation";
 import { errorFingerprint, errorTag } from "@/api/lib/errors/utils";
 import { initFileDerivativeWorker } from "@/api/lib/file-derivative-queue";
 import { initFlowRunWorker } from "@/api/lib/flows/flow-run-worker";
@@ -451,9 +452,13 @@ const api = new Elysia()
     // A framework-answered client fault (a rejected body, an unknown route,
     // an unparseable request) is the caller's own outcome: the WARN record
     // above keeps it, and reporting it as an exception would fill the tracker
-    // with one issue per scanner probe and schema mismatch. Every other code
-    // is the server's, and stays captured.
-    if (STATUS_BY_ELYSIA_CODE[code] === undefined) {
+    // with one issue per scanner probe and schema mismatch. A response-schema
+    // violation shares the VALIDATION code but is the handler's own fault, so
+    // it stays captured along with every other code.
+    if (
+      STATUS_BY_ELYSIA_CODE[code] === undefined ||
+      isResponseValidationError(error)
+    ) {
       captureRequestError(error, {
         request,
         context: {

--- a/apps/web/src/components/chat/case-law-open.ts
+++ b/apps/web/src/components/chat/case-law-open.ts
@@ -10,9 +10,8 @@ import {
   isCaseLawDecisionId,
   pickCaseLawDecisionHit,
 } from "@/lib/case-law-route";
-import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { unwrapPublicLawEden } from "@/lib/public-law-api";
 import { toSafeId } from "@/lib/safe-id";
 
 type NavigateToCaseLawDecision = (options: {
@@ -43,8 +42,7 @@ const resolveCaseLawDecisionRouteParams = async (
       .decisions({ decisionId: toSafeId<"caseLawDecision">(decisionRef) })
       .get();
 
-    const data = unwrapEden(response);
-    assertPublicLawApiData(data, "resolvePublicCaseLawDecision");
+    const data = unwrapPublicLawEden(response, "resolvePublicCaseLawDecision");
 
     return createCaseLawDecisionRouteParams({
       caseNumber: data.caseNumber,
@@ -60,8 +58,10 @@ const resolveCaseLawDecisionRouteParams = async (
     limit: CASE_LAW_LINK_SEARCH_LIMIT,
   });
 
-  const data = unwrapEden(response);
-  assertPublicLawApiData(data, "searchPublicCaseLawDecisionLinks");
+  const data = unwrapPublicLawEden(
+    response,
+    "searchPublicCaseLawDecisionLinks",
+  );
 
   const hit = pickCaseLawDecisionHit(decisionRef, data.hits);
   if (!hit) {

--- a/apps/web/src/features/case-law/queries/citations.ts
+++ b/apps/web/src/features/case-law/queries/citations.ts
@@ -1,9 +1,8 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { unwrapEden } from "@/lib/errors/api";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { unwrapPublicLawEden } from "@/lib/public-law-api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -52,8 +51,7 @@ export const decisionCitationsInfiniteOptions = (
           fetch: { signal },
         });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicDecisionCitations");
+      const data = unwrapPublicLawEden(response, "listPublicDecisionCitations");
 
       return data;
     },
@@ -74,8 +72,10 @@ export const decisionLeadingCitationsOptions = (
         .decisions({ decisionId: toSafeId<"caseLawDecision">(decisionId) })
         .citations.leading.get({ query: { direction }, fetch: { signal } });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listLeadingDecisionCitations");
+      const data = unwrapPublicLawEden(
+        response,
+        "listLeadingDecisionCitations",
+      );
 
       return data.items;
     },
@@ -97,8 +97,10 @@ export const decisionCitationSummaryOptions = (decisionId: string) =>
         .decisions({ decisionId: toSafeId<"caseLawDecision">(decisionId) })
         .citations.summary.get({ fetch: { signal } });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "summarizePublicDecisionCitations");
+      const data = unwrapPublicLawEden(
+        response,
+        "summarizePublicDecisionCitations",
+      );
 
       return data;
     },

--- a/apps/web/src/features/case-law/queries/decisions.ts
+++ b/apps/web/src/features/case-law/queries/decisions.ts
@@ -3,9 +3,8 @@ import { panic } from "better-result";
 
 import { api } from "@/lib/api";
 import { parseDeterministicDate } from "@/lib/deterministic-date";
-import { unwrapEden } from "@/lib/errors/api";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { unwrapPublicLawEden } from "@/lib/public-law-api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -85,8 +84,7 @@ export const decisionFacetsOptions = (country?: string) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicCaseLawFacets");
+      const data = unwrapPublicLawEden(response, "listPublicCaseLawFacets");
 
       return data;
     },
@@ -103,8 +101,10 @@ export const latestDecisionsOptions = (country: string) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listLatestPublicCaseLawDecisions");
+      const data = unwrapPublicLawEden(
+        response,
+        "listLatestPublicCaseLawDecisions",
+      );
 
       return data;
     },
@@ -149,8 +149,10 @@ export const decisionsInfiniteOptions = (filters: DecisionListFilters = {}) =>
           { fetch: { signal } },
         );
 
-        const data = unwrapEden(response);
-        assertPublicLawApiData(data, "searchPublicCaseLawDecisions");
+        const data = unwrapPublicLawEden(
+          response,
+          "searchPublicCaseLawDecisions",
+        );
 
         return {
           decisions: data.hits.map((h) => ({
@@ -207,8 +209,7 @@ export const decisionsInfiniteOptions = (filters: DecisionListFilters = {}) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicCaseLawDecisions");
+      const data = unwrapPublicLawEden(response, "listPublicCaseLawDecisions");
 
       const facets: SearchFacets = null;
       const { items, ...page } = data;
@@ -227,8 +228,7 @@ export const decisionOptions = (decisionId: string) =>
         .decisions({ decisionId: toSafeId<"caseLawDecision">(decisionId) })
         .get({ fetch: { signal } });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "readPublicCaseLawDecision");
+      const data = unwrapPublicLawEden(response, "readPublicCaseLawDecision");
 
       return data;
     },
@@ -246,8 +246,10 @@ export const decisionBySlugOptions = ({ language, slug }: DecisionBySlugKey) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "readPublicCaseLawDecisionBySlug");
+      const data = unwrapPublicLawEden(
+        response,
+        "readPublicCaseLawDecisionBySlug",
+      );
 
       return data;
     },

--- a/apps/web/src/features/case-law/queries/provisions.ts
+++ b/apps/web/src/features/case-law/queries/provisions.ts
@@ -1,9 +1,8 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { unwrapEden } from "@/lib/errors/api";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { unwrapPublicLawEden } from "@/lib/public-law-api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -52,8 +51,10 @@ export const decisionProvisionsInfiniteOptions = (decisionId: string) =>
           fetch: { signal },
         });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicDecisionProvisions");
+      const data = unwrapPublicLawEden(
+        response,
+        "listPublicDecisionProvisions",
+      );
 
       return data;
     },
@@ -91,8 +92,7 @@ export const statuteByEliOptions = ({ country, eli }: StatuteByEliKey) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "resolvePublicStatuteByEli");
+      const data = unwrapPublicLawEden(response, "resolvePublicStatuteByEli");
 
       return data.items.find((statute) => statute.eli === eli) ?? null;
     },
@@ -116,8 +116,10 @@ export const statuteVersionsOptions = (documentId: string) =>
           fetch: { signal },
         });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicStatuteVersionsForProvision");
+      const data = unwrapPublicLawEden(
+        response,
+        "listPublicStatuteVersionsForProvision",
+      );
 
       return data.items;
     },

--- a/apps/web/src/features/chat/hooks/use-global-chat-mention-registration.ts
+++ b/apps/web/src/features/chat/hooks/use-global-chat-mention-registration.ts
@@ -10,7 +10,10 @@ import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import {
+  PublicLawUnavailableError,
+  toPublicLawError,
+} from "@/lib/public-law-api";
 import { toSafeId } from "@/lib/safe-id";
 
 const GLOBAL_CHAT_MENTION_EXTENSION_ID = "global-chat:org-mentions";
@@ -36,13 +39,20 @@ const searchCaseLawMentions = async (
   });
 
   if (response.error) {
-    getAnalytics().captureError(response.error);
+    const error = toPublicLawError(
+      response.error,
+      "searchPublicCaseLawMentions",
+    );
+    // A surface the deployment keeps off is the preview's expected answer,
+    // not a defect to report on every keystroke; the picker simply has no
+    // decisions to offer.
+    if (!PublicLawUnavailableError.is(error)) {
+      getAnalytics().captureError(error);
+    }
     return [];
   }
-  const data = response.data;
-  assertPublicLawApiData(data, "searchPublicCaseLawMentions");
 
-  return data.hits.map((hit) => ({
+  return response.data.hits.map((hit) => ({
     resource: resourceRef({
       type: RESOURCE_TYPE.CASE_LAW_DECISION,
       id: toSafeId<"caseLawDecision">(hit.decisionId),

--- a/apps/web/src/features/chat/hooks/use-global-chat-mention-registration.ts
+++ b/apps/web/src/features/chat/hooks/use-global-chat-mention-registration.ts
@@ -13,6 +13,7 @@ import { api } from "@/lib/api";
 import {
   PublicLawUnavailableError,
   toPublicLawError,
+  unwrapPublicLawEden,
 } from "@/lib/public-law-api";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -52,7 +53,9 @@ const searchCaseLawMentions = async (
     return [];
   }
 
-  return response.data.hits.map((hit) => ({
+  const data = unwrapPublicLawEden(response, "searchPublicCaseLawMentions");
+
+  return data.hits.map((hit) => ({
     resource: resourceRef({
       type: RESOURCE_TYPE.CASE_LAW_DECISION,
       id: toSafeId<"caseLawDecision">(hit.decisionId),

--- a/apps/web/src/features/statutes/queries/citing-decisions.ts
+++ b/apps/web/src/features/statutes/queries/citing-decisions.ts
@@ -1,9 +1,8 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { unwrapEden } from "@/lib/errors/api";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { unwrapPublicLawEden } from "@/lib/public-law-api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 
 /**
@@ -59,8 +58,10 @@ export const topCitingDecisionsOptions = (key: CitingDecisionsKey) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicTopCitingDecisions");
+      const data = unwrapPublicLawEden(
+        response,
+        "listPublicTopCitingDecisions",
+      );
 
       return data.items;
     },
@@ -82,8 +83,7 @@ export const citingDecisionsInfiniteOptions = (key: CitingDecisionsKey) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicCitingDecisions");
+      const data = unwrapPublicLawEden(response, "listPublicCitingDecisions");
 
       return data;
     },

--- a/apps/web/src/features/statutes/queries/provision-history.ts
+++ b/apps/web/src/features/statutes/queries/provision-history.ts
@@ -1,9 +1,8 @@
 import { infiniteQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { unwrapEden } from "@/lib/errors/api";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { unwrapPublicLawEden } from "@/lib/public-law-api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -45,8 +44,7 @@ export const provisionHistoryOptions = (key: ProvisionHistoryKey) =>
           fetch: { signal },
         });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "readPublicProvisionHistory");
+      const data = unwrapPublicLawEden(response, "readPublicProvisionHistory");
 
       return data;
     },

--- a/apps/web/src/features/statutes/queries/statutes.ts
+++ b/apps/web/src/features/statutes/queries/statutes.ts
@@ -2,10 +2,10 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError, unwrapEden } from "@/lib/errors/api";
+import { APIError } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
-import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { toPublicLawError, unwrapPublicLawEden } from "@/lib/public-law-api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -85,8 +85,7 @@ export const statutesInfiniteOptions = (filters: StatuteListFilters) =>
         fetch: { signal },
       });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "listPublicStatutes");
+      const data = unwrapPublicLawEden(response, "listPublicStatutes");
 
       return data;
     },
@@ -100,8 +99,7 @@ const readStatute = async (documentId: string, signal: AbortSignal) => {
     .statutes({ documentId: toSafeId<"legislationDocument">(documentId) })
     .get({ fetch: { signal } });
 
-  const data = unwrapEden(response);
-  assertPublicLawApiData(data, "readPublicStatute");
+  const data = unwrapPublicLawEden(response, "readPublicStatute");
 
   return data;
 };
@@ -131,19 +129,16 @@ export const statuteAsOfOptions = (key: StatuteAsOfKey) =>
       });
 
       if (response.error) {
-        const error = toAPIError(response.error);
+        const error = toPublicLawError(response.error, "readPublicStatuteAsOf");
 
-        if (error.status === NOT_FOUND_STATUS) {
+        if (APIError.is(error) && error.status === NOT_FOUND_STATUS) {
           return null;
         }
 
         throw error;
       }
 
-      const { data } = response;
-      assertPublicLawApiData(data, "readPublicStatuteAsOf");
-
-      return data;
+      return response.data;
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });
@@ -169,8 +164,7 @@ const readStatuteVersionsPage = async ({
       fetch: { signal },
     });
 
-  const data = unwrapEden(response);
-  assertPublicLawApiData(data, "listPublicStatuteVersions");
+  const data = unwrapPublicLawEden(response, "listPublicStatuteVersions");
 
   return data;
 };

--- a/apps/web/src/features/statutes/queries/statutes.ts
+++ b/apps/web/src/features/statutes/queries/statutes.ts
@@ -138,7 +138,7 @@ export const statuteAsOfOptions = (key: StatuteAsOfKey) =>
         throw error;
       }
 
-      return response.data;
+      return unwrapPublicLawEden(response, "readPublicStatuteAsOf");
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/lib/analytics/exception-fingerprint.test.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.test.ts
@@ -170,3 +170,27 @@ test("fingerprint is stable across content-hashed chunk renames", () => {
   );
   expect(a).not.toBe(c);
 });
+
+test("an API error carries its response identity as a trailing component", () => {
+  const entries = [
+    {
+      type: "ApiError",
+      stacktrace: { frames: [matterViewFrames[1]] },
+    },
+  ];
+  const withoutHttp = fingerprintExceptionEvent({ entries });
+  expect(withoutHttp).toBe("ApiError||matter-view.js:renderMatter|");
+  expect(fingerprintExceptionEvent({ entries, http: { status: 404 } })).toBe(
+    `${withoutHttp}|404`,
+  );
+  expect(
+    fingerprintExceptionEvent({
+      entries,
+      http: { status: 402, code: "usage_limit_exceeded" },
+    }),
+  ).toBe(`${withoutHttp}|402:usage_limit_exceeded`);
+  // Outcomes group separately; the same outcome groups together.
+  expect(
+    fingerprintExceptionEvent({ entries, http: { status: 503 } }),
+  ).not.toBe(fingerprintExceptionEvent({ entries, http: { status: 404 } }));
+});

--- a/apps/web/src/lib/analytics/exception-fingerprint.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.ts
@@ -19,6 +19,17 @@ type FingerprintEntry = {
   stacktrace?: { frames: readonly FingerprintFrame[] };
 };
 
+/**
+ * Response identity of a failed API call: the HTTP status and the server's
+ * stable error code. Both are structural, so an `ApiError` groups per outcome
+ * (a 404 on a gated route, a 402 usage rejection, a 503) instead of one issue
+ * for every failed request.
+ */
+export type ApiErrorIdentity = {
+  status: number;
+  code?: string | undefined;
+};
+
 type ExceptionFingerprintInput = {
   /**
    * Sanitized `$exception_list`: the first entry is the thrown error, later
@@ -27,6 +38,8 @@ type ExceptionFingerprintInput = {
   entries: readonly FingerprintEntry[];
   /** Validated telemetry area slug, when an error boundary declared one. */
   area?: string | undefined;
+  /** Validated API response identity, when the error is an `ApiError`. */
+  http?: ApiErrorIdentity | undefined;
 };
 
 // The asset path up to the basename is deployment layout, not defect
@@ -70,17 +83,26 @@ const frameIdentities = (entry: FingerprintEntry | undefined): string[] => {
 /**
  * Positions are fixed (an empty component stays empty) so one component can
  * never collide with another — the same shape the server-side capture
- * wrapper uses for its `$exception_fingerprint`.
+ * wrapper uses for its `$exception_fingerprint`. The API identity is a
+ * trailing fifth component present only for API errors: appending rather
+ * than reserving keeps every existing identity byte-for-byte stable, and a
+ * class list can never start with a digit, so the two shapes cannot collide.
  */
 export const fingerprintExceptionEvent = ({
   area,
   entries,
+  http,
 }: ExceptionFingerprintInput): string => {
   const classes = entries.map((entry) => entry.type);
-  return [
+  const identity = [
     classes.at(0) ?? "UnknownError",
     area ?? "",
     frameIdentities(entries.at(0)).join(";"),
     classes.slice(1).join(";"),
   ].join("|");
+  if (http === undefined) {
+    return identity;
+  }
+  const code = http.code === undefined ? "" : `:${http.code}`;
+  return `${identity}|${http.status}${code}`;
 };

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { INGESTION_REQUIRED_KEYS } from "@/lib/analytics/posthog-ingestion";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
+import { APIError } from "@/lib/errors/api";
 
 type CapturedBrowserEvent = {
   event: string;
@@ -1422,5 +1423,57 @@ describe("PostHog browser analytics adapter", () => {
 
     expect(resetMock).toHaveBeenCalledTimes(1);
     expect(identifyMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("sanitizer keeps a validated API response identity and groups by it", () => {
+    createPostHogAnalytics({ host: "https://posthog.test", key: "phc_test" });
+
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        $exception_list: [{ type: "ApiError", value: "Not Found" }],
+        error_status: 404,
+        error_code: "not_found",
+      },
+    });
+    expect(sanitized?.properties?.["$exception_fingerprint"]).toBe(
+      "ApiError||||404:not_found",
+    );
+    expect(sanitized?.properties?.["error_status"]).toBe(404);
+    expect(sanitized?.properties?.["error_code"]).toBe("not_found");
+
+    // A free-text code or an out-of-range status never passes through.
+    const rejected = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        $exception_list: [{ type: "ApiError", value: "" }],
+        error_status: 9999,
+        error_code: "Client Smith asked for jana.novakova@example.com",
+      },
+    });
+    expect(rejected?.properties?.["$exception_fingerprint"]).toBe(
+      "ApiError|||",
+    );
+    expect(rejected?.properties).not.toContainKey("error_status");
+    expect(rejected?.properties).not.toContainKey("error_code");
+  });
+
+  test("captureError reports the status and code of an API error", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    analytics.captureError(
+      new APIError({
+        code: "usage_limit_exceeded",
+        message: "Privileged localized text",
+        status: 402,
+      }),
+    );
+
+    expect(captureExceptionMock.mock.calls.at(-1)?.[1]).toEqual({
+      error_code: "usage_limit_exceeded",
+      error_status: 402,
+    });
   });
 });

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { INGESTION_REQUIRED_KEYS } from "@/lib/analytics/posthog-ingestion";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 import { APIError } from "@/lib/errors/api";
+import { ClientTelemetryError } from "@/lib/errors/telemetry";
 
 type CapturedBrowserEvent = {
   event: string;
@@ -1474,6 +1475,30 @@ describe("PostHog browser analytics adapter", () => {
     expect(captureExceptionMock.mock.calls.at(-1)?.[1]).toEqual({
       error_code: "usage_limit_exceeded",
       error_status: 402,
+    });
+  });
+
+  test("captureError finds the API error behind a boundary wrapper", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    analytics.captureError(
+      new ClientTelemetryError({
+        area: "pdf-viewer",
+        message: "[pdf-viewer] Privileged document name",
+        cause: new APIError({
+          code: "forbidden",
+          message: "Privileged localized text",
+          status: 403,
+        }),
+      }),
+    );
+
+    expect(captureExceptionMock.mock.calls.at(-1)?.[1]).toEqual({
+      area: "pdf-viewer",
+      error_code: "forbidden",
+      error_status: 403,
     });
   });
 });

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -1,4 +1,5 @@
 import { CancelledError } from "@tanstack/react-query";
+import { isTaggedError } from "better-result";
 import { posthog } from "posthog-js";
 import type { CaptureResult, SupportedWebVitalsMetrics } from "posthog-js";
 
@@ -6,6 +7,7 @@ import { env } from "@/env";
 import { normalizeTelemetryErrorTypeName } from "@/lib/analytics/error-diagnostics";
 import { isErrorReference } from "@/lib/analytics/error-reference";
 import { fingerprintExceptionEvent } from "@/lib/analytics/exception-fingerprint";
+import type { ApiErrorIdentity } from "@/lib/analytics/exception-fingerprint";
 import { pickIngestionRequired } from "@/lib/analytics/posthog-ingestion";
 import type { sanitizeRouteErrorLifecycleEvent } from "@/lib/analytics/posthog-route-error";
 import { captureRedactedException } from "@/lib/analytics/stack-redaction";
@@ -15,6 +17,7 @@ import type {
   ErrorCaptureContext,
   WebAnalyticsEvent,
 } from "@/lib/analytics/types";
+import { API_ERROR_TAG } from "@/lib/errors/api-tag";
 import { logDevError } from "@/lib/errors/utils";
 
 const isWebAnalyticsEvent = (event: string): event is WebAnalyticsEvent =>
@@ -89,6 +92,61 @@ const telemetryAreaProperty = (
   return typeof area === "string" && TELEMETRY_AREA.test(area)
     ? { area }
     : undefined;
+};
+
+// API error codes are stable server-declared slugs (`usage_limit_exceeded`).
+// Anything else is treated as free text and dropped, so a server that echoed
+// input into `code` could not smuggle it into telemetry.
+const API_ERROR_CODE = /^[a-z][a-z0-9_]{0,63}$/u;
+const HTTP_STATUS_MIN = 100;
+const HTTP_STATUS_MAX = 599;
+
+const isHttpStatus = (value: unknown): value is number =>
+  typeof value === "number" &&
+  Number.isInteger(value) &&
+  value >= HTTP_STATUS_MIN &&
+  value <= HTTP_STATUS_MAX;
+
+// The status and code of an `ApiError` are the only parts of a failed API
+// response that identify the outcome without carrying its payload, so they
+// ride along as flat properties and feed the grouping identity below. The
+// class is recognized by its tag: importing it would close an import cycle
+// through the localized error module.
+const apiErrorTelemetryProperties = (
+  error: unknown,
+): Record<string, number | string> | undefined => {
+  if (
+    !isTaggedError(error) ||
+    error._tag !== API_ERROR_TAG ||
+    !isRecord(error)
+  ) {
+    return undefined;
+  }
+  const status = error["status"];
+  const code = error["code"];
+  if (!isHttpStatus(status)) {
+    return undefined;
+  }
+  return {
+    error_status: status,
+    ...(typeof code === "string" && API_ERROR_CODE.test(code)
+      ? { error_code: code }
+      : {}),
+  };
+};
+
+const apiErrorIdentity = (
+  properties: Record<string, unknown>,
+): ApiErrorIdentity | undefined => {
+  const status = properties["error_status"];
+  if (!isHttpStatus(status)) {
+    return undefined;
+  }
+  const code = properties["error_code"];
+  return {
+    status,
+    ...(typeof code === "string" && API_ERROR_CODE.test(code) ? { code } : {}),
+  };
 };
 
 // Structural frame fields only: code locations and symbol names from the
@@ -166,6 +224,7 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
   const type = sanitizedList.at(0)?.type ?? normalizeTelemetryErrorTypeName("");
   const safeArea =
     typeof area === "string" && TELEMETRY_AREA.test(area) ? area : undefined;
+  const http = apiErrorIdentity(properties);
   return {
     ...event,
     properties: {
@@ -175,12 +234,19 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
       $exception_fingerprint: fingerprintExceptionEvent({
         area: safeArea,
         entries: sanitizedList,
+        http,
       }),
       $exception_list: sanitizedList,
       $exception_type: type,
       ...(typeof appCommit === "string" ? { app_commit: appCommit } : {}),
       ...(typeof appVersion === "string" ? { app_version: appVersion } : {}),
       ...(safeArea === undefined ? {} : { area: safeArea }),
+      ...(http === undefined
+        ? {}
+        : {
+            error_status: http.status,
+            ...(http.code === undefined ? {} : { error_code: http.code }),
+          }),
       ...(isErrorReference(errorReference)
         ? { error_reference: errorReference }
         : {}),
@@ -556,6 +622,7 @@ export const createPostHogAnalytics = ({
         posthog.captureException(redacted, {
           ...errorContextProperties(context),
           ...telemetryAreaProperty(error),
+          ...apiErrorTelemetryProperties(error),
         });
       });
     },

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -107,6 +107,27 @@ const isHttpStatus = (value: unknown): value is number =>
   value >= HTTP_STATUS_MIN &&
   value <= HTTP_STATUS_MAX;
 
+const isApiError = (error: unknown): error is Record<string, unknown> =>
+  isTaggedError(error) && error._tag === API_ERROR_TAG && isRecord(error);
+
+// Error boundaries wrap the failure they caught (`ClientTelemetryError` with
+// the `ApiError` as its cause), so the API error is found anywhere in the
+// cause chain. `cause` is writable, so the walk is bounded against cycles.
+const apiErrorInChain = (
+  error: unknown,
+): Record<string, unknown> | undefined => {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (isRecord(current) && !seen.has(current)) {
+    if (isApiError(current)) {
+      return current;
+    }
+    seen.add(current);
+    current = current["cause"];
+  }
+  return undefined;
+};
+
 // The status and code of an `ApiError` are the only parts of a failed API
 // response that identify the outcome without carrying its payload, so they
 // ride along as flat properties and feed the grouping identity below. The
@@ -115,15 +136,12 @@ const isHttpStatus = (value: unknown): value is number =>
 const apiErrorTelemetryProperties = (
   error: unknown,
 ): Record<string, number | string> | undefined => {
-  if (
-    !isTaggedError(error) ||
-    error._tag !== API_ERROR_TAG ||
-    !isRecord(error)
-  ) {
+  const apiError = apiErrorInChain(error);
+  if (apiError === undefined) {
     return undefined;
   }
-  const status = error["status"];
-  const code = error["code"];
+  const status = apiError["status"];
+  const code = apiError["code"];
   if (!isHttpStatus(status)) {
     return undefined;
   }

--- a/apps/web/src/lib/errors/api-tag.ts
+++ b/apps/web/src/lib/errors/api-tag.ts
@@ -1,0 +1,4 @@
+// The tag of the client's API error, in a leaf module so telemetry can
+// recognize the class structurally without importing the localized error
+// module (which reaches back into analytics through i18n).
+export const API_ERROR_TAG = "ApiError";

--- a/apps/web/src/lib/errors/api.ts
+++ b/apps/web/src/lib/errors/api.ts
@@ -7,13 +7,14 @@ import {
 import type { ApiErrorInput } from "@stll/api-contract";
 
 import type { TranslationKey } from "@/i18n/types";
+import { API_ERROR_TAG } from "@/lib/errors/api-tag";
 import {
   STATUS_ERROR_KEYS,
   STATUS_TO_KEY,
   translateError,
 } from "@/lib/errors/localization";
 
-export class APIError extends TaggedError("ApiError")<{
+export class APIError extends TaggedError(API_ERROR_TAG)<{
   code?: string | undefined;
   status: number;
   message: string;
@@ -35,7 +36,7 @@ export const shouldRetryAPIRequest = (
 
 export type ToAPIErrorProps = ApiErrorInput;
 
-type EdenResponse<T> =
+export type EdenResponse<T> =
   | { data: T; error: null }
   | { data: null; error: ToAPIErrorProps };
 

--- a/apps/web/src/lib/public-law-api.test.ts
+++ b/apps/web/src/lib/public-law-api.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { APIError } from "@/lib/errors/api";
+import {
+  PublicLawUnavailableError,
+  unwrapPublicLawEden,
+} from "@/lib/public-law-api";
+
+describe("unwrapPublicLawEden", () => {
+  test("returns the data of a successful response", () => {
+    const data = { country: [], court: [], year: [] };
+    expect(
+      unwrapPublicLawEden({ data, error: null }, "listPublicCaseLawFacets"),
+    ).toBe(data);
+  });
+
+  test("names a disabled surface instead of a generic API failure", () => {
+    expect(() =>
+      unwrapPublicLawEden(
+        { data: null, error: { status: 404, value: { error: "Not Found" } } },
+        "listPublicCaseLawFacets",
+      ),
+    ).toThrow(PublicLawUnavailableError);
+  });
+
+  test("keeps a missing resource on an enabled surface an API error", () => {
+    expect(() =>
+      unwrapPublicLawEden(
+        { data: null, error: { status: 404, value: { message: "Not found" } } },
+        "readPublicCaseLawDecision",
+      ),
+    ).toThrow(APIError);
+  });
+
+  test("keeps every other failure an API error", () => {
+    expect(() =>
+      unwrapPublicLawEden(
+        { data: null, error: { status: 503, value: null } },
+        "listPublicCaseLawFacets",
+      ),
+    ).toThrow(APIError);
+  });
+});

--- a/apps/web/src/lib/public-law-api.test.ts
+++ b/apps/web/src/lib/public-law-api.test.ts
@@ -15,9 +15,26 @@ describe("unwrapPublicLawEden", () => {
   });
 
   test("names a disabled surface instead of a generic API failure", () => {
+    // The gate body is `{ error: "Not Found" }` alone; the contract type
+    // insists on a message, which the marker check ignores.
     expect(() =>
       unwrapPublicLawEden(
-        { data: null, error: { status: 404, value: { error: "Not Found" } } },
+        {
+          data: null,
+          error: {
+            status: 404,
+            value: { error: "Not Found", message: "Not Found" },
+          },
+        },
+        "listPublicCaseLawFacets",
+      ),
+    ).toThrow(PublicLawUnavailableError);
+  });
+
+  test("a success answer carrying the gate marker is still a disabled surface", () => {
+    expect(() =>
+      unwrapPublicLawEden(
+        { data: { error: "Not Found" } as const, error: null },
         "listPublicCaseLawFacets",
       ),
     ).toThrow(PublicLawUnavailableError);

--- a/apps/web/src/lib/public-law-api.ts
+++ b/apps/web/src/lib/public-law-api.ts
@@ -1,27 +1,69 @@
-import { ClientOperationError } from "@/lib/errors/client";
+import { TaggedError } from "better-result";
 
-type DisabledPublicLawData = {
-  readonly error: "Not Found";
-};
+import { toAPIError } from "@/lib/errors/api";
+import type { APIError, EdenResponse, ToAPIErrorProps } from "@/lib/errors/api";
+
+const PUBLIC_LAW_DISABLED_STATUS = 404;
+const PUBLIC_LAW_DISABLED_MARKER = "Not Found";
+const PUBLIC_LAW_AREA = "public-law";
+
+/**
+ * The deployment answers the public-law routes but keeps the surface off.
+ * Distinct from `APIError` so the boundary can name the cause: the request
+ * was well-formed and the server healthy; the feature is not enabled here.
+ */
+export class PublicLawUnavailableError extends TaggedError(
+  "PublicLawUnavailableError",
+)<{
+  action: string;
+  area: typeof PUBLIC_LAW_AREA;
+  message: string;
+}> {}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
-const isDisabledPublicLawData = (
-  value: unknown,
-): value is DisabledPublicLawData =>
-  isRecord(value) && value["error"] === "Not Found";
+// The public route groups answer `404 { error: "Not Found" }` from a
+// before-handle gate when the surface is off; a missing resource on an
+// enabled surface carries a different body, so the marker is unambiguous.
+const isDisabledPublicLawResponse = ({
+  status,
+  value,
+}: ToAPIErrorProps): boolean =>
+  status === PUBLIC_LAW_DISABLED_STATUS &&
+  isRecord(value) &&
+  value["error"] === PUBLIC_LAW_DISABLED_MARKER;
 
-export function assertPublicLawApiData<T>(
-  data: T,
+/**
+ * Classifies a failed public-law Eden response. Eden files every non-2xx
+ * answer under `error`, so the disabled marker has to be read there, before
+ * the generic `APIError` is raised. Call sites that branch on the failure
+ * themselves (a 404 that is a real answer, a search that degrades to empty)
+ * classify first and decide second.
+ */
+export const toPublicLawError = (
+  error: ToAPIErrorProps,
   action: string,
-): asserts data is Exclude<T, DisabledPublicLawData> {
-  if (!isDisabledPublicLawData(data)) {
-    return;
-  }
+): APIError | PublicLawUnavailableError =>
+  isDisabledPublicLawResponse(error)
+    ? new PublicLawUnavailableError({
+        action,
+        area: PUBLIC_LAW_AREA,
+        message: "Public law is not available.",
+      })
+    : toAPIError(error);
 
-  throw new ClientOperationError({
-    action,
-    message: "Public law is not available.",
-  });
+/**
+ * Unwraps a public-law Eden response, throwing the classified failure.
+ * Taking the whole response is what makes the classification structural: a
+ * helper handed unwrapped data could never see the disabled marker.
+ */
+export function unwrapPublicLawEden<T>(
+  response: EdenResponse<T>,
+  action: string,
+): T {
+  if (response.error) {
+    throw toPublicLawError(response.error, action);
+  }
+  return response.data;
 }

--- a/apps/web/src/lib/public-law-api.ts
+++ b/apps/web/src/lib/public-law-api.ts
@@ -20,19 +20,42 @@ export class PublicLawUnavailableError extends TaggedError(
   message: string;
 }> {}
 
+/**
+ * The body the public route groups answer from their before-handle gate when
+ * the surface is off. Eden types it into the success branch of every
+ * public-law route, so the unwrap below excludes it from the data type.
+ */
+type DisabledPublicLawData = {
+  readonly error: typeof PUBLIC_LAW_DISABLED_MARKER;
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
-// The public route groups answer `404 { error: "Not Found" }` from a
-// before-handle gate when the surface is off; a missing resource on an
-// enabled surface carries a different body, so the marker is unambiguous.
+const isDisabledPublicLawData = (value: unknown): boolean =>
+  isRecord(value) && value["error"] === PUBLIC_LAW_DISABLED_MARKER;
+
+// A generic predicate, so the exclusion narrows the payload type of each
+// route instead of one fixed type.
+const isPublicLawData = <T>(
+  data: T,
+): data is Exclude<T, DisabledPublicLawData> => !isDisabledPublicLawData(data);
+
+// The gate answers with status 404, so Eden files the marker under `error`;
+// a missing resource on an enabled surface carries a different body, so the
+// marker is unambiguous.
 const isDisabledPublicLawResponse = ({
   status,
   value,
 }: ToAPIErrorProps): boolean =>
-  status === PUBLIC_LAW_DISABLED_STATUS &&
-  isRecord(value) &&
-  value["error"] === PUBLIC_LAW_DISABLED_MARKER;
+  status === PUBLIC_LAW_DISABLED_STATUS && isDisabledPublicLawData(value);
+
+const publicLawUnavailable = (action: string) =>
+  new PublicLawUnavailableError({
+    action,
+    area: PUBLIC_LAW_AREA,
+    message: "Public law is not available.",
+  });
 
 /**
  * Classifies a failed public-law Eden response. Eden files every non-2xx
@@ -46,24 +69,27 @@ export const toPublicLawError = (
   action: string,
 ): APIError | PublicLawUnavailableError =>
   isDisabledPublicLawResponse(error)
-    ? new PublicLawUnavailableError({
-        action,
-        area: PUBLIC_LAW_AREA,
-        message: "Public law is not available.",
-      })
+    ? publicLawUnavailable(action)
     : toAPIError(error);
 
 /**
  * Unwraps a public-law Eden response, throwing the classified failure.
  * Taking the whole response is what makes the classification structural: a
- * helper handed unwrapped data could never see the disabled marker.
+ * helper handed unwrapped data could never see the disabled marker. The
+ * marker is also excluded from the data type (and checked at runtime, in
+ * case a gate ever answers it with a success status), so callers read the
+ * payload type alone.
  */
 export function unwrapPublicLawEden<T>(
   response: EdenResponse<T>,
   action: string,
-): T {
+): Exclude<T, DisabledPublicLawData> {
   if (response.error) {
     throw toPublicLawError(response.error, action);
   }
-  return response.data;
+  const { data } = response;
+  if (!isPublicLawData(data)) {
+    throw publicLawUnavailable(action);
+  }
+  return data;
 }


### PR DESCRIPTION
## Summary

- `assertPublicLawApiData` inspected unwrapped data, which a non-2xx answer never yields, so its disabled-surface branch was unreachable. `unwrapPublicLawEden(response, action)` takes the Eden response instead and throws `PublicLawUnavailableError` on the gate marker; `toPublicLawError` serves the two call sites that branch on the failure themselves (a 404 that is a real answer, a mention search that degrades to empty).
- The `require-eden-error-check` rule now keys approved response adapters by module and registers the new one, with a fixture case. Its statement walker is split per statement kind to stay under the complexity ceiling; fixture findings are unchanged.
- `ApiError` exceptions carry their validated `error_status` and `error_code` as properties and group by them through a trailing fingerprint component, so distinct outcomes create distinct issues while existing identities stay byte-for-byte stable. The tag lives in a leaf module (`errors/api-tag`) so the analytics adapter recognises the class without an import cycle.
- The API `onError` hook no longer reports framework-answered client faults (validation, unknown route, parse) as exceptions; the request log keeps them. Handler-level capture is unchanged.
