### PR TITLE
fix(api): answer a response-schema failure as a server fault

### DIFF
--- a/apps/api/src/lib/errors/elysia-error.test.ts
+++ b/apps/api/src/lib/errors/elysia-error.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia, t } from "elysia";
+
+import { elysiaErrorAnswer } from "@/api/lib/errors/elysia-error";
+import { httpError } from "@/api/lib/errors/http-error";
+
+// A body whose declared type matches the response schema and whose runtime
+// value does not: the drift a response schema exists to catch, and the only
+// way to reach it here, since the compiler rejects a literal mismatch.
+const driftedBody = (): { ok: string } => JSON.parse('{"unexpected":true}');
+
+// A real Elysia app, so the answers stay bound to the errors the framework
+// actually raises rather than to a hand-written stand-in for them.
+const app = new Elysia()
+  .onError(({ code, error, set }) => {
+    const { status, message } = elysiaErrorAnswer(code, error);
+    set.status = status;
+    return httpError(message);
+  })
+  .post("/typed-body", () => "ok", {
+    body: t.Object({ name: t.String() }),
+  })
+  .get("/typed-response", () => driftedBody(), {
+    response: t.Object({ ok: t.String() }),
+  })
+  .get("/throws", () => {
+    throw new Error("boom");
+  });
+
+const post = async (path: string, body: string) =>
+  await app.handle(
+    new Request(`http://localhost${path}`, {
+      body,
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }),
+  );
+
+const get = async (path: string) =>
+  await app.handle(new Request(`http://localhost${path}`));
+
+describe("answering a framework-raised error", () => {
+  test("a body that does not match its schema is the caller's to fix", async () => {
+    const response = await post("/typed-body", JSON.stringify({ name: 42 }));
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({ message: "Invalid request" });
+  });
+
+  test("a handler output that does not match its response schema is a server fault", async () => {
+    const response = await get("/typed-response");
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      message: "Internal server error",
+    });
+  });
+
+  test("an unparseable body is answered as a malformed request", async () => {
+    const response = await post("/typed-body", "{");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ message: "Malformed request" });
+  });
+
+  test("an unrouted path is answered as not found", async () => {
+    const response = await get("/nowhere");
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ message: "Not found" });
+  });
+
+  test("an error raised inside a handler is answered as a server fault", async () => {
+    const response = await get("/throws");
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      message: "Internal server error",
+    });
+  });
+
+  test("no message from a rejected value reaches the answer", async () => {
+    const rejected = "client-supplied-value";
+    const response = await post(
+      "/typed-body",
+      JSON.stringify({ name: [rejected] }),
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.text()).not.toContain(rejected);
+  });
+});

--- a/apps/api/src/lib/errors/elysia-error.ts
+++ b/apps/api/src/lib/errors/elysia-error.ts
@@ -1,0 +1,68 @@
+/**
+ * Sanitized answers for the errors Elysia raises itself, before or after a
+ * handler runs.
+ *
+ * Elysia serializes `error.message` by default, which for a validation
+ * failure carries the rejected value, so every answer here is a fixed
+ * string.
+ */
+
+import { isResponseValidationError } from "@/api/lib/errors/response-validation";
+
+const ELYSIA_ERROR_CODE = {
+  validation: "VALIDATION",
+  notFound: "NOT_FOUND",
+  parse: "PARSE",
+} as const;
+
+type ElysiaErrorAnswer = {
+  status: number;
+  message: string;
+};
+
+const INTERNAL_ANSWER = {
+  status: 500,
+  message: "Internal server error",
+} as const satisfies ElysiaErrorAnswer;
+
+// Status and body are one decision, so they live in one place: a code
+// answered with a client status keeps the client message that explains it.
+const INVALID_REQUEST_ANSWER = {
+  status: 422,
+  message: "Invalid request",
+} as const satisfies ElysiaErrorAnswer;
+const NOT_FOUND_ANSWER = {
+  status: 404,
+  message: "Not found",
+} as const satisfies ElysiaErrorAnswer;
+const MALFORMED_REQUEST_ANSWER = {
+  status: 400,
+  message: "Malformed request",
+} as const satisfies ElysiaErrorAnswer;
+
+/**
+ * The status and sanitized body for a framework-raised error.
+ *
+ * A response-schema failure is the one validation failure that is not the
+ * caller's: the request satisfied its schema and the handler's output did
+ * not. Answering it 422 asks the caller to fix a request that was already
+ * valid, and files a server fault under the status class that is graded as
+ * an answered client outcome.
+ */
+export const elysiaErrorAnswer = (
+  code: string | number,
+  error: unknown,
+): ElysiaErrorAnswer => {
+  switch (code) {
+    case ELYSIA_ERROR_CODE.validation:
+      return isResponseValidationError(error)
+        ? INTERNAL_ANSWER
+        : INVALID_REQUEST_ANSWER;
+    case ELYSIA_ERROR_CODE.notFound:
+      return NOT_FOUND_ANSWER;
+    case ELYSIA_ERROR_CODE.parse:
+      return MALFORMED_REQUEST_ANSWER;
+    default:
+      return INTERNAL_ANSWER;
+  }
+};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -127,8 +127,8 @@ import { initDocumentDeadlineScoutWorker } from "@/api/lib/document-deadline-sco
 import { initDocumentReviewRunWorker } from "@/api/lib/document-review/run-queue";
 import { initDocumentTranslationRunWorker } from "@/api/lib/document-translation/run-queue";
 import { initEntityDeletionCleanupWorker } from "@/api/lib/entity-deletion-cleanup-queue";
+import { elysiaErrorAnswer } from "@/api/lib/errors/elysia-error";
 import { httpError } from "@/api/lib/errors/http-error";
-import { isResponseValidationError } from "@/api/lib/errors/response-validation";
 import { errorFingerprint, errorTag } from "@/api/lib/errors/utils";
 import { initFileDerivativeWorker } from "@/api/lib/file-derivative-queue";
 import { initFlowRunWorker } from "@/api/lib/flows/flow-run-worker";
@@ -184,12 +184,6 @@ const SESSION_ID_MAX_LENGTH = 64;
 const SESSION_ID_PATTERN = /^[\w-]+$/u;
 const S3_REFRESH_CHECK_INTERVAL_MS = 60_000;
 const WORKER_SHUTDOWN_TIMEOUT_MS = 10_000;
-
-const STATUS_BY_ELYSIA_CODE: Partial<Record<string, number>> = {
-  VALIDATION: 422,
-  NOT_FOUND: 404,
-  PARSE: 400,
-};
 
 const getApiPort = () => {
   const rawPort = env.STELLA_API_PORT ?? env.PORT;
@@ -412,7 +406,10 @@ const api = new Elysia()
 
     const path = getRequestPath(request);
     const reqCtx = getRequestContext(request);
-    const statusCode = STATUS_BY_ELYSIA_CODE[code] ?? 500;
+    const { status: statusCode, message: errorMessage } = elysiaErrorAnswer(
+      code,
+      error,
+    );
 
     if (shouldLogRequest(path)) {
       const durationMs = reqCtx ? performance.now() - reqCtx.startTime : 0;
@@ -455,10 +452,7 @@ const api = new Elysia()
     // with one issue per scanner probe and schema mismatch. A response-schema
     // violation shares the VALIDATION code but is the handler's own fault, so
     // it stays captured along with every other code.
-    if (
-      STATUS_BY_ELYSIA_CODE[code] === undefined ||
-      isResponseValidationError(error)
-    ) {
+    if (statusCode >= 500) {
       captureRequestError(error, {
         request,
         context: {
@@ -473,16 +467,7 @@ const api = new Elysia()
     // Elysia's default would serialize error.message, which
     // may contain DB internals, file names, or document content.
     set.status = statusCode;
-    if (code === "VALIDATION") {
-      return httpError("Invalid request");
-    }
-    if (code === "NOT_FOUND") {
-      return httpError("Not found");
-    }
-    if (code === "PARSE") {
-      return httpError("Malformed request");
-    }
-    return httpError("Internal server error");
+    return httpError(errorMessage);
   })
   .onAfterHandle(async ({ request, responseValue, route, set }) => {
     delete set.headers["X-Powered-By"];


### PR DESCRIPTION
## Proposed change

Elysia raises one `ValidationError` for two different faults: a request that did not match its schema, and a handler whose own output did not match the declared `response` schema. Both arrive at the error sink with `code === "VALIDATION"`; only the error's `type` (`"response"`) separates them.

`server.ts` read only the code, so a response-schema failure was answered `422 "Invalid request"`. That asks the caller to fix a request that was already valid, and files the handler's fault under a status class the request log grades as an answered client outcome (`WARN`, and no error fingerprint attached).

- New `lib/errors/elysia-error.ts` owns the answer for a framework-raised error: status and sanitized message together, since they are one decision. It reads `type` and answers a response-schema failure `500 "Internal server error"`; every other answer is unchanged (`422`, `404 "Not found"`, `400 "Malformed request"`, `500` otherwise).
- `server.ts` drops its status map and its message `if`-chain and asks that owner instead.
- The rate limiter already carried its own copy of the same `type === "response"` predicate to decide whether a validation failure happened before the limit ran. It now imports the shared one, so the two cannot drift.

Tests drive a real Elysia app through the sink so the answers stay bound to the errors the framework actually raises: a mismatched body is `422`, a handler output that drifts from its response schema is `500`, an unparseable body is `400`, an unrouted path is `404`, a handler that throws is `500`, and the rejected value never reaches the answer body.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun --filter @stll/api lint`, `typecheck`, and the `lib/errors` and `lib/rate-limit` suites pass.
- [ ] DARK MODE SUPPORT | Not applicable: no UI change.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH24NTLaKcAddGE5RUgCz8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH24NTLaKcAddGE5RUgCz8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling with consistent, sanitised responses for invalid requests, malformed bodies, missing routes, and server errors.
  * Prevented internal rejected values and error details from being exposed in API responses.

* **Tests**
  * Added coverage for validation failures, malformed requests, missing routes, handler errors, response validation failures, and error-message sanitisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->