### PR TITLE
chore(deps): resolve fast-uri to 3.1.6 to clear four new advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -965,7 +965,7 @@
     "brace-expansion": "5.0.9",
     "expo-constants": "57.0.15",
     "expo-modules-core": "57.0.14",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "fast-xml-parser": "5.10.1",
     "ip-address": "10.5.0",
     "lucide-react": "1.30.0",
@@ -3607,7 +3607,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "brace-expansion": "5.0.9",
     "expo-constants": "57.0.15",
     "expo-modules-core": "57.0.14",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "fast-xml-parser": "5.10.1",
     "ip-address": "10.5.0",
     "lucide-react": "1.30.0",


### PR DESCRIPTION
## Summary

`bun audit (high/critical)` fails on every PR since today: the root `resolutions` pin `fast-uri@3.1.5` now carries four high advisories (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp). The pin moves to 3.1.6, which carries the fixes and is past the five-day release quarantine (3.1.7 was published today and is still blocked).

## Verification

`bun install` and `bun run security:audit` locally with the new pin; no other dependency changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `fast-uri` package to version 3.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->