### PR TITLE
fix(desktop): clipboard manager papercuts

### DIFF
--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -282,6 +282,14 @@ impl ClipboardItem {
     }
   }
 
+  fn set_copied_at(&mut self, new_copied_at: DateTime<Utc>) {
+    match self {
+      Self::Text { copied_at, .. } | Self::FormattedText { copied_at, .. } => {
+        *copied_at = new_copied_at;
+      }
+    }
+  }
+
   fn replace_content(&mut self, new_plain_text: String, new_html: Option<String>) {
     let (copied_at, group_id, id, name, source_app) = match self {
       Self::Text {
@@ -698,6 +706,25 @@ impl ClipboardManager {
     let duplicate = item.duplicate_at(copied_at);
     self.items.insert(0, duplicate);
     prune_items(&mut self.items, self.retention, copied_at);
+    self.persist_or_restore(checkpoint)?;
+    Ok(true)
+  }
+
+  /// A clip copied back from history becomes the newest one: the system
+  /// clipboard now holds it, and the capture that would have moved it to the
+  /// front is suppressed to keep the item's identity and metadata.
+  pub fn touch_item(
+    &mut self,
+    id: &str,
+    copied_at: DateTime<Utc>,
+  ) -> Result<bool, String> {
+    let Some(index) = self.items.iter().position(|item| item.id() == id) else {
+      return Ok(false);
+    };
+    let checkpoint = self.checkpoint();
+    let mut item = self.items.remove(index);
+    item.set_copied_at(copied_at);
+    self.items.insert(0, item);
     self.persist_or_restore(checkpoint)?;
     Ok(true)
   }
@@ -1957,6 +1984,25 @@ mod tests {
     assert_eq!(manager.items[0].name(), original.name());
     assert_eq!(manager.items[0].source_app(), original.source_app());
     assert_eq!(manager.items[1], original);
+  }
+
+  #[test]
+  fn touching_an_item_refreshes_its_timestamp_and_moves_it_to_the_front() {
+    let now = Utc::now();
+    let mut manager = ready_manager();
+    let newest = text_item(now - Duration::minutes(1), "newest");
+    let older = text_item(now - Duration::hours(2), "older");
+    let older_id = older.id().to_string();
+    manager.items = vec![newest.clone(), older];
+
+    assert!(manager.touch_item(&older_id, now).unwrap());
+    assert_eq!(manager.items.len(), 2);
+    assert_eq!(manager.items[0].id(), older_id);
+    assert_eq!(manager.items[0].copied_at(), now);
+    assert_eq!(manager.items[0].plain_text(), "older");
+    assert_eq!(manager.items[1], newest);
+
+    assert!(!manager.touch_item("missing", now).unwrap());
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/clipboard_commands.rs
+++ b/apps/desktop/src-tauri/src/clipboard_commands.rs
@@ -315,7 +315,7 @@ fn write_history_item(state: &ClipboardAppState, id: &str) -> Result<(), String>
     let mut manager = state.lock().map_err(|_| lock_error())?;
     let item = manager
       .item(id)
-      .ok_or_else(|| "clipboard item no longer exists".to_string())?;
+      .ok_or_else(|| ITEM_NOT_FOUND_ERROR.to_string())?;
     manager.suppress_next(&item, false);
     item
   };
@@ -324,6 +324,15 @@ fn write_history_item(state: &ClipboardAppState, id: &str) -> Result<(), String>
       manager.clear_suppression();
     }
     return Err(error);
+  }
+  // The clipboard already holds the clip; failing to reorder history must not
+  // report the copy itself as failed.
+  let touched = state
+    .lock()
+    .map_err(|_| lock_error())
+    .and_then(|mut manager| manager.touch_item(id, chrono::Utc::now()));
+  if let Err(error) = touched {
+    tracing::warn!(error = %error, "copied clipboard item could not be moved to the front");
   }
   Ok(())
 }
@@ -335,6 +344,7 @@ pub fn clipboard_copy_item(
   window: WebviewWindow,
 ) -> Result<(), String> {
   write_history_item(state.inner(), &id)?;
+  let _ = window.emit(HISTORY_EVENT, ());
   clipboard_window::hide(&window)
 }
 

--- a/apps/desktop/src-tauri/src/clipboard_commands.rs
+++ b/apps/desktop/src-tauri/src/clipboard_commands.rs
@@ -310,12 +310,30 @@ pub fn clipboard_close_editor(window: WebviewWindow) -> Result<(), String> {
   })
 }
 
-fn write_history_item(state: &ClipboardAppState, id: &str) -> Result<(), String> {
+/// Copying a clip is two steps the user perceives separately: the write to
+/// the system clipboard, then moving the clip to the front of history. The
+/// tag tells the window which one failed.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum ClipboardCopyError {
+  /// Nothing reached the system clipboard.
+  Copy { message: String },
+  /// The window could not hide after a successful copy.
+  Hide { message: String },
+  /// The system clipboard holds the clip, but history could not record it.
+  History { message: String },
+}
+
+fn write_history_item(
+  state: &ClipboardAppState,
+  id: &str,
+) -> Result<(), ClipboardCopyError> {
+  let copy_error = |message: String| ClipboardCopyError::Copy { message };
   let item = {
-    let mut manager = state.lock().map_err(|_| lock_error())?;
+    let mut manager = state.lock().map_err(|_| copy_error(lock_error()))?;
     let item = manager
       .item(id)
-      .ok_or_else(|| ITEM_NOT_FOUND_ERROR.to_string())?;
+      .ok_or_else(|| copy_error(ITEM_NOT_FOUND_ERROR.to_string()))?;
     manager.suppress_next(&item, false);
     item
   };
@@ -323,18 +341,14 @@ fn write_history_item(state: &ClipboardAppState, id: &str) -> Result<(), String>
     if let Ok(mut manager) = state.lock() {
       manager.clear_suppression();
     }
-    return Err(error);
+    return Err(copy_error(error));
   }
-  // The clipboard already holds the clip; failing to reorder history must not
-  // report the copy itself as failed.
-  let touched = state
+  state
     .lock()
     .map_err(|_| lock_error())
-    .and_then(|mut manager| manager.touch_item(id, chrono::Utc::now()));
-  if let Err(error) = touched {
-    tracing::warn!(error = %error, "copied clipboard item could not be moved to the front");
-  }
-  Ok(())
+    .and_then(|mut manager| manager.touch_item(id, chrono::Utc::now()))
+    .map(|_| ())
+    .map_err(|message| ClipboardCopyError::History { message })
 }
 
 #[tauri::command]
@@ -342,10 +356,17 @@ pub fn clipboard_copy_item(
   id: String,
   state: State<'_, ClipboardAppState>,
   window: WebviewWindow,
-) -> Result<(), String> {
-  write_history_item(state.inner(), &id)?;
+) -> Result<(), ClipboardCopyError> {
+  let history = match write_history_item(state.inner(), &id) {
+    Err(error @ ClipboardCopyError::Copy { .. }) => return Err(error),
+    outcome => outcome,
+  };
+  // The clip is on the system clipboard either way, so the hand-off proceeds
+  // and a history failure is reported after it.
   let _ = window.emit(HISTORY_EVENT, ());
   clipboard_window::hide(&window)
+    .map_err(|message| ClipboardCopyError::Hide { message })?;
+  history
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/clipboard_window.rs
+++ b/apps/desktop/src-tauri/src/clipboard_window.rs
@@ -418,6 +418,10 @@ fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
   .always_on_top(true)
   .content_protected(content_protected)
   .decorations(false)
+  // Tauri's native drag-drop handler consumes every drop on macOS and
+  // Windows, so HTML5 drops (a card onto a group chip) never reach the
+  // webview. The window accepts no OS file drops.
+  .disable_drag_drop_handler()
   .effects(
     EffectsBuilder::new()
       .effect(Effect::UnderWindowBackground)

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -502,7 +502,8 @@ const ClipboardCard = ({
           dateTime={item.copiedAt}
           title={copiedAtLabel}
         >
-          {relativeTime}
+          <span aria-hidden="true">{relativeTime}</span>
+          <span className="sr-only">{copiedAtLabel}</span>
         </time>
         {index < 9 ? (
           <kbd className="bg-muted text-muted-foreground shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[10px] tabular-nums">

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -112,9 +112,14 @@ import {
   measureClipboardSnapshotRequest,
   observeClipboardReopens,
 } from "./clipboard-startup-timing";
-import { CLIPBOARD_RETENTIONS, isClipboardSnapshot } from "./clipboard-types";
+import {
+  CLIPBOARD_RETENTIONS,
+  isClipboardCopyError,
+  isClipboardSnapshot,
+} from "./clipboard-types";
 import type {
   ClipboardCaptureStatus,
+  ClipboardCopyErrorKind,
   ClipboardRetention,
   ClipboardGroup,
   ClipboardGroupColor,
@@ -151,6 +156,28 @@ const RETENTION_LABEL_KEYS = {
   year: "retentionYear",
 } as const satisfies Record<ClipboardRetention, string>;
 const CLIPBOARD_CARD_SELECTOR = "[data-clipboard-id]";
+// Which step of a copy failed decides what the user is told: only a `copy`
+// failure means the clip never reached the system clipboard.
+const COPY_FAILURE_FEEDBACK = {
+  copy: {
+    messageKey: "errorPaste",
+    operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardCopy,
+  },
+  hide: {
+    messageKey: "errorUpdateHistory",
+    operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardWindowHide,
+  },
+  history: {
+    messageKey: "errorUpdateHistory",
+    operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardHistoryUpdate,
+  },
+} as const satisfies Record<
+  ClipboardCopyErrorKind,
+  {
+    messageKey: "errorPaste" | "errorUpdateHistory";
+    operation: (typeof DESKTOP_TELEMETRY_OPERATIONS)[keyof typeof DESKTOP_TELEMETRY_OPERATIONS];
+  }
+>;
 // Must match the card's `w-[246px]` and the rail's `gap-3 px-5`.
 const CLIPBOARD_CARD_WIDTH = 246;
 const CLIPBOARD_CARD_GAP = 12;
@@ -1354,14 +1381,19 @@ const ClipboardApp = () => {
 
   const copyItem = (item: ClipboardItem) => {
     setError((current) => (current?.source === "operation" ? null : current));
-    void invoke("clipboard_copy_item", { id: item.id }).catch(() => {
-      reportDesktopError({
-        code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
-        operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardCopy,
-        window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
-      });
-      setError({ message: t("errorPaste"), source: "operation" });
-    });
+    void invoke("clipboard_copy_item", { id: item.id }).catch(
+      (error: unknown) => {
+        // An unrecognised rejection means the clip never left the window.
+        const kind = isClipboardCopyError(error) ? error.kind : "copy";
+        const feedback = COPY_FAILURE_FEEDBACK[kind];
+        reportDesktopError({
+          code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+          operation: feedback.operation,
+          window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+        });
+        setError({ message: t(feedback.messageKey), source: "operation" });
+      },
+    );
   };
 
   const openEditor = (id: string) => {

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -27,6 +27,7 @@ import {
   CopyPlusIcon,
   CheckIcon,
   ClockIcon,
+  EllipsisIcon,
   FileTextIcon,
   FolderInputIcon,
   FolderPlusIcon,
@@ -1695,8 +1696,11 @@ const ClipboardApp = () => {
     };
   }, [handleKeyDown, handleKeyDownCapture]);
 
-  const nextCaptureStatus: ClipboardCaptureStatus =
-    snapshot.captureStatus === "active" ? "paused" : "active";
+  const captureActive = snapshot.captureStatus === "active";
+  const nextCaptureStatus: ClipboardCaptureStatus = captureActive
+    ? "paused"
+    : "active";
+  const captureActionLabel = captureActive ? t("pause") : t("resume");
   let persistenceWarningLabel = t("memoryOnly");
   if (snapshot.persistence.status === "deletionOnly") {
     persistenceWarningLabel = t("errorReadHistory");
@@ -1886,19 +1890,6 @@ const ClipboardApp = () => {
                 <ShieldAlertIcon aria-hidden="true" className="size-3.5" />
               </span>
             ) : null}
-            <Button
-              aria-label={t("welcomeHelp")}
-              className="size-11 rounded-full"
-              onClick={() => {
-                setWelcomeDismissed(false);
-                setWelcomeRequested(true);
-              }}
-              size="icon"
-              title={t("welcomeHelp")}
-              variant="ghost"
-            >
-              <CircleHelpIcon aria-hidden="true" className="size-4" />
-            </Button>
           </div>
 
           <nav
@@ -2015,77 +2006,83 @@ const ClipboardApp = () => {
         </InputGroup>
 
         <div className="flex shrink-0 items-center gap-0.5 justify-self-end">
-          <Button
-            aria-label={
-              snapshot.captureStatus === "active" ? t("pause") : t("resume")
-            }
-            className="size-11 rounded-full"
-            onClick={() => {
-              applySnapshotCommand("clipboard_set_capture_status", {
-                status: nextCaptureStatus,
-              });
-            }}
-            size="icon"
-            title={
-              snapshot.captureStatus === "active" ? t("pause") : t("resume")
-            }
-            variant="ghost"
-          >
-            {snapshot.captureStatus === "active" ? (
-              <PauseIcon aria-hidden="true" className="size-4" />
-            ) : (
-              <PlayIcon aria-hidden="true" className="size-4" />
-            )}
-          </Button>
           <Menu>
             <MenuTrigger
               render={
                 <Button
-                  aria-label={t("retention")}
+                  aria-label={t("moreOptions")}
                   className="size-11 rounded-full"
                   size="icon"
-                  title={t("retention")}
+                  title={t("moreOptions")}
                   variant="ghost"
                 />
               }
             >
-              <ClockIcon aria-hidden="true" className="size-4" />
+              <EllipsisIcon aria-hidden="true" className="size-4" />
             </MenuTrigger>
-            <MenuPopup align="end" className="w-56">
-              <MenuRadioGroup value={snapshot.retention}>
-                {CLIPBOARD_RETENTIONS.map((retention) => (
-                  <MenuRadioItem
-                    className="min-h-11 rounded-xl"
-                    key={retention}
-                    onClick={() => {
-                      applySnapshotCommand("clipboard_set_retention", {
-                        retention,
-                      });
-                    }}
-                    value={retention}
-                  >
-                    {t(RETENTION_LABEL_KEYS[retention])}
-                  </MenuRadioItem>
-                ))}
-              </MenuRadioGroup>
+            <MenuPopup align="end" className="w-60" side="top">
+              <MenuItem
+                className="min-h-11 rounded-xl"
+                onClick={() => {
+                  applySnapshotCommand("clipboard_set_capture_status", {
+                    status: nextCaptureStatus,
+                  });
+                }}
+              >
+                {captureActive ? <PauseIcon /> : <PlayIcon />}
+                {captureActionLabel}
+              </MenuItem>
+              <MenuSub>
+                <MenuSubTrigger className="min-h-11 rounded-xl">
+                  <ClockIcon />
+                  {t("retention")}
+                </MenuSubTrigger>
+                <MenuSubPopup className="w-56">
+                  <MenuRadioGroup value={snapshot.retention}>
+                    {CLIPBOARD_RETENTIONS.map((retention) => (
+                      <MenuRadioItem
+                        className="min-h-11 rounded-xl"
+                        key={retention}
+                        onClick={() => {
+                          applySnapshotCommand("clipboard_set_retention", {
+                            retention,
+                          });
+                        }}
+                        value={retention}
+                      >
+                        {t(RETENTION_LABEL_KEYS[retention])}
+                      </MenuRadioItem>
+                    ))}
+                  </MenuRadioGroup>
+                </MenuSubPopup>
+              </MenuSub>
+              <MenuItem
+                className="min-h-11 rounded-xl"
+                disabled={
+                  snapshot.items.length === 0 &&
+                  snapshot.persistence.status !== "deletionOnly"
+                }
+                onClick={() => {
+                  setDialog({ type: "clearHistory" });
+                }}
+                variant="destructive"
+              >
+                <Trash2Icon />
+                {t("clear")}
+              </MenuItem>
+              <MenuSeparator />
+              <MenuItem
+                className="min-h-11 rounded-xl"
+                onClick={() => {
+                  setWelcomeDismissed(false);
+                  setWelcomeRequested(true);
+                }}
+              >
+                <CircleHelpIcon />
+                {t("welcomeHelp")}
+              </MenuItem>
             </MenuPopup>
           </Menu>
-          <Button
-            aria-label={t("clear")}
-            className="size-11 rounded-full"
-            disabled={
-              snapshot.items.length === 0 &&
-              snapshot.persistence.status !== "deletionOnly"
-            }
-            onClick={() => {
-              setDialog({ type: "clearHistory" });
-            }}
-            size="icon"
-            title={t("clear")}
-            variant="ghost"
-          >
-            <Trash2Icon aria-hidden="true" className="size-4" />
-          </Button>
           <Button
             aria-label={t("close")}
             className="size-11 rounded-full"

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -42,7 +42,7 @@ import {
   Trash2Icon,
   XIcon,
 } from "lucide-react";
-import { useTranslations } from "use-intl";
+import { useFormatter, useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/button";
 import { Checkbox } from "@stll/ui/checkbox";
@@ -264,6 +264,7 @@ const ClipboardCard = ({
   sourceVisual,
 }: ClipboardCardProps) => {
   const t = useTranslations("clipboard");
+  const format = useFormatter();
   const cancelNameEditRef = useRef(false);
   const [editingName, setEditingName] = useState(false);
   const [nameDraft, setNameDraft] = useState(item.name ?? "");
@@ -275,6 +276,10 @@ const ClipboardCard = ({
   }).format(age.value);
   const relativeTime =
     age.type === "lessThan" ? `<${formattedAge}` : formattedAge;
+  const copiedAtLabel = format.dateTime(new Date(item.copiedAt), {
+    dateStyle: "full",
+    timeStyle: "medium",
+  });
   const sourceAppName = item.sourceApp?.name ?? null;
   const sourceTintIndex = clipboardSourceTintIndex(
     item.sourceApp?.identifier ?? sourceAppName,
@@ -468,6 +473,7 @@ const ClipboardCard = ({
         <time
           className="text-muted-foreground shrink-0 text-xs tabular-nums"
           dateTime={item.copiedAt}
+          title={copiedAtLabel}
         >
           {relativeTime}
         </time>

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1890,6 +1890,23 @@ const ClipboardApp = () => {
                 <ShieldAlertIcon aria-hidden="true" className="size-3.5" />
               </span>
             ) : null}
+            <Button
+              aria-label={t("createGroup")}
+              className="size-11 shrink-0 rounded-full"
+              disabled={snapshot.groups.length >= 24}
+              onClick={() =>
+                setDialog({
+                  color: nextGroupColor,
+                  name: "",
+                  type: "createGroup",
+                })
+              }
+              size="icon"
+              title={t("createGroup")}
+              variant="ghost"
+            >
+              <FolderPlusIcon aria-hidden="true" className="size-4" />
+            </Button>
           </div>
 
           <nav
@@ -1960,23 +1977,6 @@ const ClipboardApp = () => {
                 <Trash2Icon aria-hidden="true" className="size-3.5" />
               </Button>
             ) : null}
-            <Button
-              aria-label={t("createGroup")}
-              className="size-11 shrink-0 rounded-full"
-              disabled={snapshot.groups.length >= 24}
-              onClick={() =>
-                setDialog({
-                  color: nextGroupColor,
-                  name: "",
-                  type: "createGroup",
-                })
-              }
-              size="icon"
-              title={t("createGroup")}
-              variant="ghost"
-            >
-              <FolderPlusIcon aria-hidden="true" className="size-4" />
-            </Button>
           </nav>
         </div>
 

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1117,7 +1117,7 @@ const ClipboardApp = () => {
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
-  const [error, setError] = useState<ClipboardAppError | null>(null);
+  const [appError, setError] = useState<ClipboardAppError | null>(null);
   const [dialog, setDialog] = useState<ClipboardDialogState>({
     type: "closed",
   });
@@ -1745,13 +1745,13 @@ const ClipboardApp = () => {
     persistenceWarningLabel = t("errorReadHistory");
   }
   let feedback: ReactNode = null;
-  if (error) {
+  if (appError) {
     feedback = (
       <div
         className="bg-destructive text-destructive-foreground absolute inset-x-0 top-0 z-20 px-5 py-1.5 text-center text-xs"
         role="alert"
       >
-        {error.message}
+        {appError.message}
       </div>
     );
   }

--- a/apps/desktop/src/clipboard/clipboard-types.ts
+++ b/apps/desktop/src/clipboard/clipboard-types.ts
@@ -141,6 +141,24 @@ const isPersistence = (value: unknown): value is ClipboardPersistence => {
   );
 };
 
+export const CLIPBOARD_COPY_ERROR_KINDS = ["copy", "hide", "history"] as const;
+
+export type ClipboardCopyErrorKind =
+  (typeof CLIPBOARD_COPY_ERROR_KINDS)[number];
+
+/** Rejection payload of `clipboard_copy_item`; `kind` names the failed step. */
+export type ClipboardCopyError = {
+  kind: ClipboardCopyErrorKind;
+  message: string;
+};
+
+export const isClipboardCopyError = (
+  value: unknown,
+): value is ClipboardCopyError =>
+  isRecord(value) &&
+  CLIPBOARD_COPY_ERROR_KINDS.some((kind) => kind === value["kind"]) &&
+  typeof value["message"] === "string";
+
 export type ClipboardEditorContext = {
   groups: ClipboardGroup[];
   item: ClipboardItem;

--- a/apps/desktop/src/i18n/langs/cs.json
+++ b/apps/desktop/src/i18n/langs/cs.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → procházet",
     "local": "Místní",
     "memoryOnly": "Šifrované úložiště není dostupné. Historie zůstane jen do ukončení stella desktop.",
+    "moreOptions": "Další možnosti",
     "noResults": "Žádné odpovídající výstřižky",
     "noResultsDescription": "Zkuste jiné slovo nebo frázi.",
     "noGroup": "Bez skupiny",

--- a/apps/desktop/src/i18n/langs/de.json
+++ b/apps/desktop/src/i18n/langs/de.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → navigieren",
     "local": "Lokal",
     "memoryOnly": "Der verschlüsselte Speicher ist nicht verfügbar. Der Verlauf bleibt nur bis zum Beenden von stella desktop erhalten.",
+    "moreOptions": "Weitere Optionen",
     "noResults": "Keine passenden Inhalte",
     "noResultsDescription": "Versuchen Sie ein anderes Wort oder einen anderen Ausdruck.",
     "noGroup": "Keine Gruppe",

--- a/apps/desktop/src/i18n/langs/en.json
+++ b/apps/desktop/src/i18n/langs/en.json
@@ -133,6 +133,7 @@
     "keyboardNavigate": "← → navigate",
     "local": "Local",
     "memoryOnly": "Encrypted storage is unavailable. History will be kept only until stella desktop quits.",
+    "moreOptions": "More options",
     "noResults": "No matching clips",
     "noResultsDescription": "Try a different word or phrase.",
     "noGroup": "No group",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → navegar",
     "local": "Local",
     "memoryOnly": "El almacenamiento cifrado no está disponible. El historial se conservará solo hasta cerrar stella desktop.",
+    "moreOptions": "Más opciones",
     "noResults": "No hay recortes coincidentes",
     "noResultsDescription": "Prueba con otra palabra o frase.",
     "noGroup": "Sin grupo",

--- a/apps/desktop/src/i18n/langs/et.json
+++ b/apps/desktop/src/i18n/langs/et.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → liigu",
     "local": "Kohalik",
     "memoryOnly": "Krüpteeritud salvestusruum pole saadaval. Ajalugu säilib ainult stella desktop sulgemiseni.",
+    "moreOptions": "Rohkem valikuid",
     "noResults": "Sobivaid lõikeid pole",
     "noResultsDescription": "Proovi teist sõna või fraasi.",
     "noGroup": "Rühmata",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → naviguer",
     "local": "Local",
     "memoryOnly": "Le stockage chiffré est indisponible. L’historique sera conservé uniquement jusqu’à la fermeture de stella desktop.",
+    "moreOptions": "Plus d’options",
     "noResults": "Aucun extrait correspondant",
     "noResultsDescription": "Essayez un autre mot ou une autre expression.",
     "noGroup": "Aucun groupe",

--- a/apps/desktop/src/i18n/langs/hu.json
+++ b/apps/desktop/src/i18n/langs/hu.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → navigálás",
     "local": "Helyi",
     "memoryOnly": "A titkosított tárhely nem érhető el. Az előzmények csak a stella desktop bezárásáig maradnak meg.",
+    "moreOptions": "További lehetőségek",
     "noResults": "Nincs egyező kivágás",
     "noResultsDescription": "Próbáljon másik szót vagy kifejezést.",
     "noGroup": "Nincs csoport",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → naršyti",
     "local": "Vietinė",
     "memoryOnly": "Šifruota saugykla nepasiekiama. Istorija bus laikoma tik iki stella desktop uždarymo.",
+    "moreOptions": "Daugiau parinkčių",
     "noResults": "Atitinkančių iškarpų nėra",
     "noResultsDescription": "Išbandykite kitą žodį ar frazę.",
     "noGroup": "Be grupės",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → pārvietoties",
     "local": "Lokāli",
     "memoryOnly": "Šifrētā krātuve nav pieejama. Vēsture tiks saglabāta tikai līdz stella desktop aizvēršanai.",
+    "moreOptions": "Vairāk iespēju",
     "noResults": "Nav atbilstošu izgriezumu",
     "noResultsDescription": "Mēģiniet citu vārdu vai frāzi.",
     "noGroup": "Bez grupas",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → nawigacja",
     "local": "Lokalnie",
     "memoryOnly": "Zaszyfrowana pamięć jest niedostępna. Historia zostanie zachowana tylko do zamknięcia stella desktop.",
+    "moreOptions": "Więcej opcji",
     "noResults": "Brak pasujących wycinków",
     "noResultsDescription": "Spróbuj innego słowa lub wyrażenia.",
     "noGroup": "Bez grupy",

--- a/apps/desktop/src/i18n/langs/sk.json
+++ b/apps/desktop/src/i18n/langs/sk.json
@@ -131,6 +131,7 @@
     "keyboardNavigate": "← → prechádzať",
     "local": "Miestne",
     "memoryOnly": "Šifrované úložisko nie je dostupné. História zostane len do ukončenia stella desktop.",
+    "moreOptions": "Ďalšie možnosti",
     "noResults": "Žiadne zodpovedajúce výstrižky",
     "noResultsDescription": "Skúste iné slovo alebo frázu.",
     "noGroup": "Bez skupiny",

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -146,15 +146,17 @@ body:has(.clipboard-editor-window) .font-sans {
 
 /* While the search field holds focus the selected card stays the Enter
  * target but renders exactly like its siblings: the highlight would read as
- * a competing focus. It returns when ArrowUp hands focus back to the rail. */
-.clipboard-window:not(:has(.clipboard-search-input:focus))
+ * a competing focus. It returns when ArrowUp hands focus back to the rail.
+ * `.clipboard-search-input` lands on the input's wrapper, so the guard reads
+ * `:focus-within` rather than `:focus`. */
+.clipboard-window:not(:has(.clipboard-search-input:focus-within))
   .clipboard-card[aria-current="true"] {
   box-shadow:
     inset 0 0 0 1.5px color-mix(in srgb, var(--foreground) 30%, transparent),
     0 12px 30px rgb(23 28 38 / 0.16);
 }
 
-.clipboard-window:not(:has(.clipboard-search-input:focus))
+.clipboard-window:not(:has(.clipboard-search-input:focus-within))
   .clipboard-card[aria-current="true"]::after {
   border-color: var(--option-blue);
   box-shadow: inset 0 0 0 1px
@@ -163,7 +165,7 @@ body:has(.clipboard-editor-window) .font-sans {
 }
 
 /* Match the resting opacity of unselected cards (opacity-86, full on hover). */
-.clipboard-window:has(.clipboard-search-input:focus)
+.clipboard-window:has(.clipboard-search-input:focus-within)
   .clipboard-card[aria-current="true"]:not(:hover) {
   opacity: 0.86;
 }
@@ -196,7 +198,7 @@ body:has(.clipboard-editor-window) .font-sans {
 }
 
 .dark
-  .clipboard-window:not(:has(.clipboard-search-input:focus))
+  .clipboard-window:not(:has(.clipboard-search-input:focus-within))
   .clipboard-card[aria-current="true"] {
   box-shadow:
     inset 0 0 0 1.5px color-mix(in srgb, var(--color-white) 32%, transparent),

--- a/apps/desktop/tests/clipboard-types.test.ts
+++ b/apps/desktop/tests/clipboard-types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   CLIPBOARD_RETENTIONS,
+  isClipboardCopyError,
   isClipboardSnapshot,
 } from "../src/clipboard/clipboard-types";
 
@@ -53,5 +54,21 @@ describe("clipboard snapshot retention", () => {
         }),
       ).toBe(false);
     }
+  });
+});
+
+describe("clipboard copy error", () => {
+  test("accepts every failed step the copy command reports", () => {
+    for (const kind of ["copy", "hide", "history"]) {
+      expect(isClipboardCopyError({ kind, message: "failed" })).toBe(true);
+    }
+  });
+
+  test("rejects other rejection payloads", () => {
+    expect(isClipboardCopyError("clipboard item no longer exists")).toBe(false);
+    expect(isClipboardCopyError({ kind: "unknown", message: "failed" })).toBe(
+      false,
+    );
+    expect(isClipboardCopyError({ kind: "copy" })).toBe(false);
   });
 });


### PR DESCRIPTION
Six small clipboard-window fixes, one per commit.

- **Search focus**: the card highlight guard matched `.clipboard-search-input:focus`, but the class lands on the input's wrapper span, so ArrowDown into search left the selected card ringed. The guard now uses `:focus-within`.
- **Copied clip moves to the front**: copying from history suppresses the capture that would re-file the clip, so it kept its old position and timestamp. `clipboard_copy_item` now refreshes `copiedAt` and moves the item to index 0, keeping id, name, group and source app. Rust test included.
- **Drag onto groups on macOS**: Tauri's native drag-drop handler reports every drop as consumed, so the webview never received the HTML5 drop. The clipboard window takes no OS file drops, so the handler is disabled via `disable_drag_drop_handler()`.
- **"…" menu**: pause/resume, retention, clear history and the help sheet move from four footer buttons into one menu next to the close button. New `clipboard.moreOptions` key in all desktop catalogs.
- **New-group button always visible**: it sat at the end of the scrolling group rail; it now sits before the rail, next to the Stella mark.
- **Full timestamp on hover**: the relative age in the card footer carries the exact date and time as its title, formatted through `useFormatter`.