### PR TITLE
fix(mcp): name the scoping input workspace_id across tools

### DIFF
--- a/.changeset/wise-pianos-shout.md
+++ b/.changeset/wise-pianos-shout.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": patch
+---
+
+Rename the workspace-scoping tool input to `workspace_id`, so the generated commands take `--workspace-id` instead of `--matter-id` (matter-entity commands keep `--matter-id`). The MCP surface still accepts `matter_id` as a deprecated alias for one release.

--- a/.changeset/wise-pianos-shout.md
+++ b/.changeset/wise-pianos-shout.md
@@ -1,5 +1,5 @@
 ---
-"@stll/cli": patch
+"@stll/cli": minor
 ---
 
-Rename the workspace-scoping tool input to `workspace_id`, so the generated commands take `--workspace-id` instead of `--matter-id` (matter-entity commands keep `--matter-id`). The MCP surface still accepts `matter_id` as a deprecated alias for one release.
+Rename the workspace-scoping tool input to `workspace_id`. Breaking for the generated commands that scoped to a workspace: they now take `--workspace-id` instead of `--matter-id`, as does `stella upload`. Matter-entity commands (`matter save`, `matter delete`, `matter list`, `matter link-contact`) keep `--matter-id`. `--input` still accepts the deprecated `matter_id` key for one release.

--- a/apps/api/evals/agent-orientation.ts
+++ b/apps/api/evals/agent-orientation.ts
@@ -463,18 +463,21 @@ const TASKS: readonly Task[] = [
   },
   {
     id: "run-playbook",
-    request: "Run playbook pb_diligence_v2 over matter mat_17.",
+    request: "Run playbook pb_diligence_v2 over workspace ws_diligence_17.",
     mcp: {
       toolName: "run_playbook",
       checkArgs: (args) => [
-        ...field(args, "workspace_id", "mat_17"),
+        ...field(args, "workspace_id", "ws_diligence_17"),
         ...field(args, "playbook_id", "pb_diligence_v2"),
       ],
     },
     cli: {
       kind: "command",
       path: ["playbook", "run"],
-      flags: { "workspace-id": "mat_17", "playbook-id": "pb_diligence_v2" },
+      flags: {
+        "workspace-id": "ws_diligence_17",
+        "playbook-id": "pb_diligence_v2",
+      },
     },
   },
   {

--- a/apps/api/evals/agent-orientation.ts
+++ b/apps/api/evals/agent-orientation.ts
@@ -417,12 +417,12 @@ const TASKS: readonly Task[] = [
       "List every document and folder in workspace ws_acme_2024, the top level.",
     mcp: {
       toolName: "list_documents",
-      checkArgs: (args) => field(args, "matter_id", "ws_acme_2024"),
+      checkArgs: (args) => field(args, "workspace_id", "ws_acme_2024"),
     },
     cli: {
       kind: "command",
       path: ["document", "list"],
-      flags: { "matter-id": "ws_acme_2024" },
+      flags: { "workspace-id": "ws_acme_2024" },
     },
   },
   {
@@ -467,14 +467,14 @@ const TASKS: readonly Task[] = [
     mcp: {
       toolName: "run_playbook",
       checkArgs: (args) => [
-        ...field(args, "matter_id", "mat_17"),
+        ...field(args, "workspace_id", "mat_17"),
         ...field(args, "playbook_id", "pb_diligence_v2"),
       ],
     },
     cli: {
       kind: "command",
       path: ["playbook", "run"],
-      flags: { "matter-id": "mat_17", "playbook-id": "pb_diligence_v2" },
+      flags: { "workspace-id": "mat_17", "playbook-id": "pb_diligence_v2" },
     },
   },
   {
@@ -584,7 +584,7 @@ const TASKS: readonly Task[] = [
       path: ["upload"],
       flags: {
         file: "./contract-v2.docx",
-        "matter-id": "ws_acme_2024",
+        "workspace-id": "ws_acme_2024",
         "entity-id": "doc_42",
       },
     },

--- a/apps/api/scripts/export-mcp-tool-registry.ts
+++ b/apps/api/scripts/export-mcp-tool-registry.ts
@@ -18,6 +18,7 @@ import {
   MCP_OAUTH_PROTOCOL_SCOPES,
   STELLA_API_CONTRACT,
 } from "@/api/mcp/constants";
+import { DEPRECATED_MCP_INPUT_ALIASES } from "@/api/mcp/deprecated-input-aliases";
 import { MCP_ERROR_CODES } from "@/api/mcp/error-codes";
 import { listMcpResources } from "@/api/mcp/resources";
 import { DEFAULT_MCP_CLI_ANNOTATIONS } from "@/api/mcp/static-cli-metadata";
@@ -161,6 +162,8 @@ export const MCP_ERROR_CODES = ${JSON.stringify(MCP_ERROR_CODES, null, 2)} as co
 export type McpErrorCode = (typeof MCP_ERROR_CODES)[number];
 export const MCP_CLI_TOOL_SCOPES = ${JSON.stringify(MCP_CLI_TOOL_SCOPES, null, 2)} as const;
 export type McpCliToolScope = (typeof MCP_CLI_TOOL_SCOPES)[number];
+/** Deprecated tool-input names the server still accepts, keyed to their replacement. */
+export const MCP_DEPRECATED_INPUT_ALIASES = ${JSON.stringify(DEPRECATED_MCP_INPUT_ALIASES, null, 2)} as const;
 `,
 );
 process.stderr.write(`Wrote ${mcpContractOutputPath.pathname}\n`);

--- a/apps/api/src/handlers/chat/chat-prompt.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.ts
@@ -1176,7 +1176,7 @@ const buildActiveFilePrompt = ({
       ? buildActiveDocxEditPrompt(activeFile, toolAvailability)
       : "",
     `Do NOT call matter-wide retrieval (\`external_list_documents\`) for these open-ended questions — the user does not want answers synthesised from other files in the matter. The chat history is always available; reference earlier turns directly without re-fetching.`,
-    `Widen the scope to the rest of the matter ONLY when the user explicitly asks (e.g., "compare with the other contracts", "search across the matter", or names another document). When that happens, call \`external_list_documents\` scoped to \`matter_id: "${matterRef}"\` to find the other files, then read each with \`external_read_content_across_matters\`. \`external_search_across_matters\` has no matter filter and searches every matter you can access — do not use it for "the rest of this matter" follow-ups; it is only appropriate if the user explicitly asks to search beyond this matter.`,
+    `Widen the scope to the rest of the matter ONLY when the user explicitly asks (e.g., "compare with the other contracts", "search across the matter", or names another document). When that happens, call \`external_list_documents\` scoped to \`workspace_id: "${matterRef}"\` to find the other files, then read each with \`external_read_content_across_matters\`. \`external_search_across_matters\` has no matter filter and searches every matter you can access — do not use it for "the rest of this matter" follow-ups; it is only appropriate if the user explicitly asks to search beyond this matter.`,
   ]
     .filter((section) => section.length > 0)
     .join("\n");

--- a/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/follow-ups.test.ts
@@ -152,7 +152,7 @@ describe("follow-up (a): detail-mode workspace resolution from the fetched row",
     };
 
     const result = await runRegistryReadTool({
-      // No matter_id: the workspace is unknowable from args and must come from
+      // No workspace_id: the workspace is unknowable from args and must come from
       // the fetched row. Before the fix this failed closed at entry.entityId.
       args: { time_entry_id: TE_UUID },
       context: buildContext(tx),

--- a/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.test.ts
@@ -46,7 +46,7 @@ describe("registry tool input ref hydration", () => {
     const matterRef = registry.toMatterRef(workspaceId);
     const input = {
       decisionId: matterRef,
-      matter_id: matterRef,
+      workspace_id: matterRef,
       nested: { title: matterRef },
     };
 
@@ -58,7 +58,7 @@ describe("registry tool input ref hydration", () => {
       }),
     ).toEqual({
       decisionId: matterRef,
-      matter_id: workspaceId,
+      workspace_id: workspaceId,
       nested: { title: matterRef },
     });
   });
@@ -109,7 +109,7 @@ describe("registry tool input ref hydration", () => {
   test("round-trips a persisted tool input back to its resolved ids", () => {
     const registry = createChatRefRegistry();
     const persistedInput = {
-      matter_id: WS_UUID,
+      workspace_id: WS_UUID,
       task_id: TASK_UUID,
       name: "respond to outside counsel",
     };
@@ -123,7 +123,7 @@ describe("registry tool input ref hydration", () => {
 
     // The model-facing call carries refs again, never the tenant ids.
     expect(hydrated).toEqual({
-      matter_id: "mat_1",
+      workspace_id: "mat_1",
       task_id: "ent_1",
       name: "respond to outside counsel",
     });
@@ -148,12 +148,12 @@ describe("registry tool input ref hydration", () => {
 
     expect(
       hydrateRegistryToolInputRefs({
-        input: { matter_id: WS_UUID },
+        input: { workspace_id: WS_UUID },
         inputState: PERSISTED_REF_INPUT_STATE,
         refRegistry: registry,
         toolName: "save_task",
       }),
-    ).toEqual({ matter_id: existingRef });
+    ).toEqual({ workspace_id: existingRef });
   });
 
   test("leaves a call with no declared input refs untouched", () => {
@@ -176,12 +176,12 @@ describe("registry tool input ref hydration", () => {
 
     expect(
       hydrateRegistryToolInputRefs({
-        input: { matter_id: ref, name: "draft" },
+        input: { workspace_id: ref, name: "draft" },
         inputState: LEGACY_REF_INPUT_STATE,
         refRegistry: registry,
         toolName: "save_task",
       }),
-    ).toEqual({ matter_id: ref, name: "draft" });
+    ).toEqual({ workspace_id: ref, name: "draft" });
   });
 
   test("hydrates a versioned persisted ID that looks like a ref", () => {
@@ -190,25 +190,25 @@ describe("registry tool input ref hydration", () => {
     const tokenShapedId = toSafeId<"workspace">("mat_1");
 
     const hydrated = hydrateRegistryToolInputRefs({
-      input: { matter_id: tokenShapedId },
+      input: { workspace_id: tokenShapedId },
       inputState: PERSISTED_REF_INPUT_STATE,
       refRegistry: registry,
       toolName: "save_task",
     });
 
-    expect(hydrated).toEqual({ matter_id: "mat_2" });
+    expect(hydrated).toEqual({ workspace_id: "mat_2" });
     expect(
       dehydrateRefs({
         args: asArgs(hydrated),
         inputRefs: SAVE_TASK_INPUT_REFS,
         refRegistry: registry,
       }).unwrap().args,
-    ).toEqual({ matter_id: tokenShapedId });
+    ).toEqual({ workspace_id: tokenShapedId });
   });
 
   test("preserves an unresolved ref as unresolved across v2 replay", () => {
     const unresolvedInputRefs: ChatUnresolvedInputRefContext[] = [];
-    const input = { matter_id: "mat_999", name: "draft" };
+    const input = { workspace_id: "mat_999", name: "draft" };
     const persistedInput = resolveRegistryToolInputRefs({
       input,
       onRefUnresolved: (unresolved) => {
@@ -225,7 +225,7 @@ describe("registry tool input ref hydration", () => {
     expect(unresolvedInputRefs).toEqual([
       {
         kind: "matter",
-        param: "matter_id",
+        param: "workspace_id",
         ref: "mat_999",
         toolCallId: "tool-1",
       },

--- a/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.ts
@@ -69,7 +69,7 @@ const INPUT_REFS_BY_TOOL = buildInputRefsByTool();
 /**
  * The workspace an entity param's ref key needs. Chat's write tools that take
  * an entity id also take the matter it lives in (`save_task`'s `task_id` beside
- * its `matter_id`), so the sibling matter param is the reliable source; without
+ * its `workspace_id`), so the sibling matter param is the reliable source; without
  * one the registry falls back to a ref it already minted for that entity id.
  */
 const findMatterWorkspaceId = ({

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -173,7 +173,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
   list_documents: {
     chatProjectable: true,
     inputRefs: [
-      { kind: "matter", param: "matter_id" },
+      { kind: "matter", param: "workspace_id" },
       { kind: "entity", param: "parent_id" },
     ],
     projection: LIST_DOCUMENTS_PROJECTION,
@@ -185,7 +185,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
   },
   list_properties: {
     chatProjectable: true,
-    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    inputRefs: [{ kind: "matter", param: "workspace_id" }],
     projection: LIST_PROPERTIES_PROJECTION,
   },
 
@@ -193,7 +193,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
   list_tasks: {
     chatProjectable: true,
     inputRefs: [
-      { kind: "matter", param: "matter_id" },
+      { kind: "matter", param: "workspace_id" },
       { kind: "entity", param: "task_id" },
     ],
     projection: LIST_TASKS_PROJECTION,
@@ -217,7 +217,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
   list_time_entries: {
     chatProjectable: true,
     inputRefs: [
-      { kind: "matter", param: "matter_id" },
+      { kind: "matter", param: "workspace_id" },
       { kind: "entity", param: "entity_id" },
     ],
     projection: LIST_TIME_ENTRIES_PROJECTION,
@@ -230,7 +230,7 @@ export const READ_TOOL_REF_FIELD_MAP = {
   },
   list_invoices: {
     chatProjectable: true,
-    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    inputRefs: [{ kind: "matter", param: "workspace_id" }],
     projection: LIST_INVOICES_PROJECTION,
   },
   get_usage: {
@@ -321,13 +321,13 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
   },
   save_task: {
     chatProjectable: true,
-    // `task_id` and `link_entity_id` are entity refs; `matter_id` a matter ref.
+    // `task_id` and `link_entity_id` are entity refs; `workspace_id` a matter ref.
     // `add_assignee_user_id`/`remove_assignee_user_id` are user handles and
     // `unlink_link_id` is an entity-link handle: none carry a chat ref kind, so
     // they pass through as-is.
     inputRefs: [
       { kind: "entity", param: "task_id" },
-      { kind: "matter", param: "matter_id" },
+      { kind: "matter", param: "workspace_id" },
       { kind: "entity", param: "link_entity_id" },
     ],
     projection: SAVE_TASK_PROJECTION,
@@ -346,11 +346,11 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
   // --- Documents / properties -----------------------------------------------
   save_document: {
     chatProjectable: true,
-    // `entity_id` and `parent_id` are entity refs; `matter_id` a matter ref.
+    // `entity_id` and `parent_id` are entity refs; `workspace_id` a matter ref.
     // `version_id` is an entity-version handle, not a chat ref: passes through.
     inputRefs: [
       { kind: "entity", param: "entity_id" },
-      { kind: "matter", param: "matter_id" },
+      { kind: "matter", param: "workspace_id" },
       { kind: "entity", param: "parent_id" },
     ],
     projection: SAVE_DOCUMENT_PROJECTION,
@@ -384,7 +384,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
     // `time_entry_id` is a billing handle (passes through); `timezone_id` is an
     // IANA tz string, not an id.
     inputRefs: [
-      { kind: "matter", param: "matter_id" },
+      { kind: "matter", param: "workspace_id" },
       { kind: "entity", param: "entity_id" },
     ],
     projection: SAVE_TIME_ENTRY_PROJECTION,
@@ -411,7 +411,7 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
   run_playbook: {
     chatProjectable: true,
     // `playbook_id` is an org-scoped library handle: passes through.
-    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    inputRefs: [{ kind: "matter", param: "workspace_id" }],
     projection: RUN_PLAYBOOK_PROJECTION,
   },
 
@@ -419,9 +419,9 @@ export const WRITE_TOOL_REF_FIELD_MAP = {
   manage_organization: {
     chatProjectable: true,
     // `user_id` is a workspace-member (user) handle, not a chat ref: passes
-    // through. `matter_id` is a matter ref (used by the add/remove member
+    // through. `workspace_id` is a matter ref (used by the add/remove member
     // actions that scope to a matter).
-    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    inputRefs: [{ kind: "matter", param: "workspace_id" }],
     projection: MANAGE_ORGANIZATION_PROJECTION,
   },
 

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -531,7 +531,7 @@ const CONTRACT_CORPUS = {
   list_documents: [
     {
       mode: "list",
-      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      buildArgs: (refRegistry) => ({ workspace_id: matterRef(refRegistry) }),
       tx: () => ({
         select: selectQueue([
           [
@@ -693,7 +693,7 @@ const CONTRACT_CORPUS = {
   list_properties: [
     {
       mode: "list",
-      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      buildArgs: (refRegistry) => ({ workspace_id: matterRef(refRegistry) }),
       tx: () => ({
         select: selectQueue([
           [
@@ -713,7 +713,7 @@ const CONTRACT_CORPUS = {
   list_tasks: [
     {
       mode: "list",
-      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      buildArgs: (refRegistry) => ({ workspace_id: matterRef(refRegistry) }),
       tx: () => ({
         select: selectQueue([
           [
@@ -950,7 +950,7 @@ const CONTRACT_CORPUS = {
   list_time_entries: [
     {
       mode: "list",
-      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      buildArgs: (refRegistry) => ({ workspace_id: matterRef(refRegistry) }),
       tx: () => ({
         select: selectQueue([
           [
@@ -977,7 +977,7 @@ const CONTRACT_CORPUS = {
     },
     {
       mode: "list",
-      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      buildArgs: (refRegistry) => ({ workspace_id: matterRef(refRegistry) }),
       tx: () => ({
         select: selectQueue([
           [
@@ -1036,7 +1036,7 @@ const CONTRACT_CORPUS = {
   list_invoices: [
     {
       mode: "list",
-      buildArgs: (refRegistry) => ({ matter_id: matterRef(refRegistry) }),
+      buildArgs: (refRegistry) => ({ workspace_id: matterRef(refRegistry) }),
       tx: () => ({
         select: selectQueue([
           [

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.test.ts
@@ -118,14 +118,14 @@ describe("runRegistryWriteTool (orchestration)", () => {
       applyChatApprovalConfirmation({
         args: {
           action: "remove_member",
-          matter_id: WS_UUID,
+          workspace_id: WS_UUID,
           user_id: "user_2",
         },
         toolName: "manage_organization",
       }),
     ).toEqual({
       action: "remove_member",
-      matter_id: WS_UUID,
+      workspace_id: WS_UUID,
       user_id: "user_2",
       confirm: true,
     });

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -55,7 +55,7 @@ export type SimpleRefKind = Exclude<RegistryRefKind, "entity">;
  * How an entity output ref recovers its owning workspace id, which
  * `toEntityRef` needs alongside the entity id. MCP handlers name these fields
  * differently per tool (a sibling `workspaceId`, a fixed `matter.id`, or the
- * tool's resolved `matter_id` input), so the source is declared per field
+ * tool's resolved `workspace_id` input), so the source is declared per field
  * rather than guessed from key names.
  */
 export type EntityWorkspaceSource =

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -310,16 +310,16 @@ export const READ_CONTACT_PROJECTION = v.strictObject({
 /**
  * list_documents. Source of truth: `handleListDocumentsTool`
  * (`document-tools.ts`) — the selected entity columns minus the cursor
- * timestamp. `matter_id` is required input, so it is every row's workspace.
+ * timestamp. `workspace_id` is required input, so it is every row's workspace.
  */
 export const LIST_DOCUMENTS_PROJECTION = v.strictObject({
   documents: v.array(
     v.strictObject({
-      id: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+      id: chatEntityRef({ from: "inputParam", param: "workspace_id" }),
       name: v.string(),
       kind: v.string(),
       parentId: v.nullable(
-        chatEntityRef({ from: "inputParam", param: "matter_id" }),
+        chatEntityRef({ from: "inputParam", param: "workspace_id" }),
       ),
     }),
   ),
@@ -658,7 +658,7 @@ export const LIST_PROPERTIES_PROJECTION = v.strictObject({
 export const LIST_TASKS_LIST_PROJECTION = v.strictObject({
   tasks: v.array(
     v.strictObject({
-      id: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+      id: chatEntityRef({ from: "inputParam", param: "workspace_id" }),
       name: v.string(),
       status: v.nullable(v.string()),
       priority: v.nullable(v.string()),
@@ -1056,7 +1056,7 @@ const timeEntryFieldEntries = (workspace: { from: "inputParam" | "sibling" }) =>
     entityId: v.nullable(
       chatEntityRef(
         workspace.from === "inputParam"
-          ? { from: "inputParam", param: "matter_id" }
+          ? { from: "inputParam", param: "workspace_id" }
           : { from: "sibling", key: "workspaceId" },
       ),
     ),
@@ -1075,7 +1075,7 @@ const timeEntryFieldEntries = (workspace: { from: "inputParam" | "sibling" }) =>
   }) as const;
 
 /**
- * list_time_entries, list branch: matter_id is schema-required, so it is
+ * list_time_entries, list branch: workspace_id is schema-required, so it is
  * every row's workspace. `visibility` is explicit because ordinary members
  * and interns receive only their own entries, not the matter total.
  */
@@ -1132,7 +1132,7 @@ const invoiceLineEntityProjection = () =>
 
 /**
  * list_invoices. Source of truth: `handleListInvoicesTool`
- * (`billing-tools.ts`). Detail mode (invoice_id) may omit matter_id, so every
+ * (`billing-tools.ts`). Detail mode (invoice_id) may omit workspace_id, so every
  * line item's entity recovers its workspace from the invoice's own resolved
  * `workspaceId` rather than from the (absent) input arg; list mode returns no
  * line items.
@@ -1602,13 +1602,13 @@ export const SAVE_CONTACT_PROJECTION = v.strictObject({
 
 /**
  * save_task: create returns `{ taskId }` (a new entity whose workspace is the
- * resolved `matter_id`, required on create via `ensureActiveWorkspace`);
+ * resolved `workspace_id`, required on create via `ensureActiveWorkspace`);
  * update returns `{ taskId, updated: true }` echoing the input task, which
  * hydration catches first via the dehydrated-entity reuse map, so the
  * `inputParam` source only drives the create case.
  */
 export const SAVE_TASK_PROJECTION = v.strictObject({
-  taskId: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+  taskId: chatEntityRef({ from: "inputParam", param: "workspace_id" }),
   updated: v.optional(v.literal(true)),
 });
 
@@ -1631,11 +1631,11 @@ export const LINK_MATTER_CONTACT_PROJECTION = v.union([
 
 /**
  * save_document: create returns `{ entityId }` (a new document whose
- * workspace is the resolved `matter_id`, required on create); update returns
+ * workspace is the resolved `workspace_id`, required on create); update returns
  * `{ updated: true }`.
  */
 export const SAVE_DOCUMENT_CREATE_PROJECTION = v.strictObject({
-  entityId: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+  entityId: chatEntityRef({ from: "inputParam", param: "workspace_id" }),
 });
 
 export const SAVE_DOCUMENT_UPDATE_PROJECTION = v.strictObject({

--- a/apps/api/src/lib/chat/tool-defect-memo.test.ts
+++ b/apps/api/src/lib/chat/tool-defect-memo.test.ts
@@ -13,20 +13,20 @@ describe("createChatToolDefectMemo", () => {
     expect(memo.isKnownDefect("list_matters", { matter_id: "mat_2" })).toBe(
       false,
     );
-    expect(memo.isKnownDefect("list_documents", { matter_id: "mat_1" })).toBe(
-      false,
-    );
+    expect(
+      memo.isKnownDefect("list_documents", { workspace_id: "mat_1" }),
+    ).toBe(false);
     expect(memo.isKnownDefect("list_matters", {})).toBe(false);
   });
 
   test("keying is insensitive to argument object key order", () => {
     const memo = createChatToolDefectMemo();
-    memo.recordDefect("list_tasks", { matter_id: "mat_1", limit: 10 });
+    memo.recordDefect("list_tasks", { workspace_id: "mat_1", limit: 10 });
 
     // The model re-emitting the same call with reordered keys is the same
     // call; a key-order-sensitive memo would let the retry through.
     expect(
-      memo.isKnownDefect("list_tasks", { limit: 10, matter_id: "mat_1" }),
+      memo.isKnownDefect("list_tasks", { limit: 10, workspace_id: "mat_1" }),
     ).toBe(true);
   });
 

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -679,7 +679,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "stella:templates"
     ],
     "access": "write",
-    "description": "Fill a registered template and persist the generated DOCX directly in a matter, without requiring the client to upload bytes. Use action='create_document' to create a new document (optionally inside parent_id), or action='create_version' with entity_id to append a version to an existing document. Call list_templates first to learn the field paths and which are required. A required field that is not AI-fillable must be provided, or the fill fails with the exact list of missing fields; ask the user for those values instead of guessing. Returns the entity and version identifiers plus any unmatched placeholders or unused values.",
+    "description": "Fill a registered template and persist the generated DOCX directly in a workspace, without requiring the client to upload bytes. Use action='create_document' to create a new document (optionally inside parent_id), or action='create_version' with entity_id to append a version to an existing document. Call list_templates first to learn the field paths and which are required. A required field that is not AI-fillable must be provided, or the fill fails with the exact list of missing fields; ask the user for those values instead of guessing. Returns the entity and version identifiers plus any unmatched placeholders or unused values.",
     "annotations": {
       "title": "Save filled template",
       "idempotentHint": false,
@@ -700,9 +700,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "type": "string",
           "description": "Template id, as returned by list_templates"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
-          "description": "Matter/workspace receiving the filled DOCX"
+          "description": "Workspace receiving the filled DOCX. Deprecated input alias: matter_id."
         },
         "entity_id": {
           "type": "string",
@@ -731,7 +731,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "required": [
         "action",
         "template_id",
-        "matter_id",
+        "workspace_id",
         "idempotency_key",
         "values"
       ],
@@ -1185,7 +1185,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "list_documents",
     "scope": "stella:read",
     "access": "read",
-    "description": "List the documents and folders in a matter. Use 'flat' mode to enumerate every document and folder in the matter, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the matter root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
+    "description": "List the documents and folders in a workspace. Use 'flat' mode to enumerate every document and folder in the workspace, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the workspace root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
     "annotations": {
       "title": "List documents",
       "readOnlyHint": true,
@@ -1194,14 +1194,14 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "inputSchema": {
       "type": "object",
       "required": [
-        "matter_id"
+        "workspace_id"
       ],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list documents in"
+          "description": "Workspace ID to list documents in. Deprecated input alias: matter_id."
         },
         "mode": {
           "enum": [
@@ -1209,7 +1209,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
             "children"
           ],
           "type": "string",
-          "description": "'flat' lists every document and folder in the matter; 'children' lists only the direct children of parent_id (or the matter root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected."
+          "description": "'flat' lists every document and folder in the workspace; 'children' lists only the direct children of parent_id (or the workspace root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected."
         },
         "parent_id": {
           "type": "string",
@@ -1278,7 +1278,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "save_document",
     "scope": "stella:documents_write",
     "access": "write",
-    "description": "Create a document or folder, or update an existing one. Omit entity_id to create: pass matter_id and name, optionally a parent_id folder and kind ('document' by default, or 'folder'). Creating makes an empty named entity; uploading file content is a separate step. Pass entity_id to update: set name to rename; parent_id to move it into a folder or move_to_root to move it to the matter root; version_id with label and/or description to annotate a version. An update needs at least one change. Returns the entity ID.",
+    "description": "Create a document or folder, or update an existing one. Omit entity_id to create: pass workspace_id and name, optionally a parent_id folder and kind ('document' by default, or 'folder'). Creating makes an empty named entity; uploading file content is a separate step. Pass entity_id to update: set name to rename; parent_id to move it into a folder or move_to_root to move it to the workspace root; version_id with label and/or description to annotate a version. An update needs at least one change. Returns the entity ID.",
     "annotations": {
       "title": "Save document",
       "idempotentHint": false,
@@ -1294,10 +1294,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "minLength": 1,
           "description": "Document entity ID to update; omit to create"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to create the entity in; required when creating"
+          "description": "Workspace ID to create the entity in; required when creating. Deprecated input alias: matter_id."
         },
         "name": {
           "type": "string",
@@ -1482,14 +1482,14 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "inputSchema": {
       "type": "object",
       "required": [
-        "matter_id"
+        "workspace_id"
       ],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list properties for"
+          "description": "Workspace ID to list properties for. Deprecated input alias: matter_id."
         },
         "limit": {
           "type": "integer",
@@ -1972,7 +1972,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "list_tasks",
     "scope": "stella:read",
     "access": "read",
-    "description": "List tasks in a matter, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass matter_id to list the matter's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each item's id, name, item type, status, priority, and due date.",
+    "description": "List tasks in a workspace, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass workspace_id to list the workspace's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each item's id, name, item type, status, priority, and due date.",
     "annotations": {
       "title": "List tasks",
       "readOnlyHint": true,
@@ -1983,10 +1983,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list tasks in; required unless task_id is given"
+          "description": "Workspace ID to list tasks in; required unless task_id is given. Deprecated input alias: matter_id."
         },
         "task_id": {
           "type": "string",
@@ -2029,7 +2029,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "save_task",
     "scope": "stella:matters_write",
     "access": "write",
-    "description": "Create or update a task, and manage its assignees and entity links. Omit task_id to create a task (matter_id and name required). Pass task_id to update: set name, item_type, status, priority, or due_date (ISO YYYY-MM-DD, null to clear); add or remove one assignee (add_assignee_user_id / remove_assignee_user_id); link the task to another entity (link_entity_id) or remove a link (unlink_link_id). Returns the task ID.",
+    "description": "Create or update a task, and manage its assignees and entity links. Omit task_id to create a task (workspace_id and name required). Pass task_id to update: set name, item_type, status, priority, or due_date (ISO YYYY-MM-DD, null to clear); add or remove one assignee (add_assignee_user_id / remove_assignee_user_id); link the task to another entity (link_entity_id) or remove a link (unlink_link_id). Returns the task ID.",
     "annotations": {
       "title": "Save task",
       "idempotentHint": false,
@@ -2045,10 +2045,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "minLength": 1,
           "description": "Task entity ID to update; omit to create"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to create the task in; required when creating"
+          "description": "Workspace ID to create the task in; required when creating. Deprecated input alias: matter_id."
         },
         "name": {
           "type": "string",
@@ -2491,7 +2491,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "run_playbook",
     "scope": "stella:knowledge_write",
     "access": "write",
-    "description": "Run a review playbook over a matter's documents. Materializes the playbook's extraction and verdict columns onto the matter's table and starts the AI review; findings populate asynchronously. Pass matter_id and playbook_id. Returns the number of columns queued for review.",
+    "description": "Run a review playbook over a workspace's documents. Materializes the playbook's extraction and verdict columns onto the workspace's table and starts the AI review; findings populate asynchronously. Pass workspace_id and playbook_id. Returns the number of columns queued for review.",
     "annotations": {
       "title": "Run playbook",
       "idempotentHint": false,
@@ -2500,15 +2500,15 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "inputSchema": {
       "type": "object",
       "required": [
-        "matter_id",
+        "workspace_id",
         "playbook_id"
       ],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace id to run the playbook over"
+          "description": "Workspace id to run the playbook over. Deprecated input alias: matter_id."
         },
         "playbook_id": {
           "type": "string",
@@ -2523,7 +2523,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:read",
     "access": "read",
     "feature": "FEATURE_TIME_BILLING",
-    "description": "List time entries in a matter, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass matter_id to list the matter's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status. The response includes visibility: all_entries for billing reviewers, or own_entries when the caller can see only their own time; own_entries is not a matter total.",
+    "description": "List time entries in a workspace, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass workspace_id to list the workspace's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status. The response includes visibility: all_entries for billing reviewers, or own_entries when the caller can see only their own time; own_entries is not a matter total.",
     "annotations": {
       "title": "List time entries",
       "readOnlyHint": true,
@@ -2534,10 +2534,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list time entries in; required unless time_entry_id is given"
+          "description": "Workspace ID to list time entries in; required unless time_entry_id is given. Deprecated input alias: matter_id."
         },
         "time_entry_id": {
           "type": "string",
@@ -2595,7 +2595,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:billing_write",
     "access": "write",
     "feature": "FEATURE_TIME_BILLING",
-    "description": "Create or update a time entry. Omit time_entry_id to create (matter_id, date_worked, timezone_id, duration_minutes, and narrative required; entity_id is optional context). Pass time_entry_id to update: set date_worked (with timezone_id), duration_minutes, narrative, invoice_narrative, billable, no_charge, entity_id (move the entry), task_code, and/or activity_code. The timekeeper's effective rate is resolved server-side. Durations are whole minutes. Returns the time entry ID.",
+    "description": "Create or update a time entry. Omit time_entry_id to create (workspace_id, date_worked, timezone_id, duration_minutes, and narrative required; entity_id is optional context). Pass time_entry_id to update: set date_worked (with timezone_id), duration_minutes, narrative, invoice_narrative, billable, no_charge, entity_id (move the entry), task_code, and/or activity_code. The timekeeper's effective rate is resolved server-side. Durations are whole minutes. Returns the time entry ID.",
     "annotations": {
       "title": "Save time entry",
       "idempotentHint": false,
@@ -2611,10 +2611,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "minLength": 1,
           "description": "Time entry ID to update; omit to create"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to create the entry in; required when creating"
+          "description": "Workspace ID to create the entry in; required when creating. Deprecated input alias: matter_id."
         },
         "entity_id": {
           "anyOf": [
@@ -2734,7 +2734,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:read",
     "access": "read",
     "feature": "FEATURE_TIME_BILLING",
-    "description": "Resolve the effective hourly rate for a user on a given date in a matter, using the matter's default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
+    "description": "Resolve the effective hourly rate for a user on a given date in a workspace, using its default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
     "annotations": {
       "title": "Resolve billing rate",
       "readOnlyHint": true,
@@ -2743,16 +2743,16 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "inputSchema": {
       "type": "object",
       "required": [
-        "matter_id",
+        "workspace_id",
         "user_id",
         "date"
       ],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to resolve the rate in"
+          "description": "Workspace ID to resolve the rate in. Deprecated input alias: matter_id."
         },
         "user_id": {
           "type": "string",
@@ -2773,7 +2773,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:read",
     "access": "read",
     "feature": "FEATURE_TIME_BILLING",
-    "description": "List invoices in a matter, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass matter_id to list the matter's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
+    "description": "List invoices in a workspace, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass workspace_id to list the workspace's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
     "annotations": {
       "title": "List invoices",
       "readOnlyHint": true,
@@ -2784,10 +2784,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list invoices in; required unless invoice_id is given"
+          "description": "Workspace ID to list invoices in; required unless invoice_id is given. Deprecated input alias: matter_id."
         },
         "invoice_id": {
           "type": "string",
@@ -2925,7 +2925,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "list_audit_log",
     "scope": "stella:admin_read",
     "access": "read",
-    "description": "Read the organization's audit trail (compliance view). Returns audit entries newest first, each with its action, resource type and id, actor user id, workspace, timestamp, and change detail. Filter by matter_id, action, resource_type (with optional resource_id), user_id, and a created-at range (from/to, ISO date-time). Paginate with limit and cursor. Requires organization audit-log access.",
+    "description": "Read the organization's audit trail (compliance view). Returns audit entries newest first, each with its action, resource type and id, actor user id, workspace, timestamp, and change detail. Filter by workspace_id, action, resource_type (with optional resource_id), user_id, and a created-at range (from/to, ISO date-time). Paginate with limit and cursor. Requires organization audit-log access.",
     "annotations": {
       "title": "List audit log",
       "readOnlyHint": true,
@@ -2936,10 +2936,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Only entries scoped to this matter/workspace"
+          "description": "Only entries scoped to this workspace. Deprecated input alias: matter_id."
         },
         "action": {
           "type": "string",
@@ -2990,7 +2990,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "manage_organization",
     "scope": "stella:admin_write",
     "access": "write",
-    "description": "Manage organization members and non-secret settings. Member actions require matter_id and user_id. update_org_settings controls matter numbering, prompt caching, and document processing. Manage provider secrets in the dashboard.",
+    "description": "Manage organization members and non-secret settings. Member actions require workspace_id and user_id. update_org_settings controls matter numbering, prompt caching, and document processing. Manage provider secrets in the dashboard.",
     "annotations": {
       "title": "Manage organization",
       "idempotentHint": false,
@@ -3012,10 +3012,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "type": "string",
           "description": "Administrative action to perform"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace id for add_member and remove_member"
+          "description": "Workspace id for add_member and remove_member. Deprecated input alias: matter_id."
         },
         "user_id": {
           "type": "string",
@@ -3563,7 +3563,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "name": "list_documents",
     "scope": "stella:read_anonymized",
     "access": "read",
-    "description": "List the documents and folders in a matter. Use 'flat' mode to enumerate every document and folder in the matter, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the matter root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
+    "description": "List the documents and folders in a workspace. Use 'flat' mode to enumerate every document and folder in the workspace, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the workspace root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
     "annotations": {
       "title": "List documents",
       "readOnlyHint": true,
@@ -3572,14 +3572,14 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "inputSchema": {
       "type": "object",
       "required": [
-        "matter_id"
+        "workspace_id"
       ],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list documents in"
+          "description": "Workspace ID to list documents in. Deprecated input alias: matter_id."
         },
         "mode": {
           "enum": [
@@ -3587,7 +3587,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
             "children"
           ],
           "type": "string",
-          "description": "'flat' lists every document and folder in the matter; 'children' lists only the direct children of parent_id (or the matter root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected."
+          "description": "'flat' lists every document and folder in the workspace; 'children' lists only the direct children of parent_id (or the workspace root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected."
         },
         "parent_id": {
           "type": "string",
@@ -3665,14 +3665,14 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "inputSchema": {
       "type": "object",
       "required": [
-        "matter_id"
+        "workspace_id"
       ],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list properties for"
+          "description": "Workspace ID to list properties for. Deprecated input alias: matter_id."
         },
         "limit": {
           "type": "integer",
@@ -3736,7 +3736,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "name": "list_tasks",
     "scope": "stella:read_anonymized",
     "access": "read",
-    "description": "List tasks in a matter, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass matter_id to list the matter's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each item's id, name, item type, status, priority, and due date.",
+    "description": "List tasks in a workspace, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass workspace_id to list the workspace's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each item's id, name, item type, status, priority, and due date.",
     "annotations": {
       "title": "List tasks",
       "readOnlyHint": true,
@@ -3747,10 +3747,10 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list tasks in; required unless task_id is given"
+          "description": "Workspace ID to list tasks in; required unless task_id is given. Deprecated input alias: matter_id."
         },
         "task_id": {
           "type": "string",
@@ -3881,7 +3881,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "scope": "stella:read_anonymized",
     "access": "read",
     "feature": "FEATURE_TIME_BILLING",
-    "description": "List time entries in a matter, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass matter_id to list the matter's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status. The response includes visibility: all_entries for billing reviewers, or own_entries when the caller can see only their own time; own_entries is not a matter total.",
+    "description": "List time entries in a workspace, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass workspace_id to list the workspace's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status. The response includes visibility: all_entries for billing reviewers, or own_entries when the caller can see only their own time; own_entries is not a matter total.",
     "annotations": {
       "title": "List time entries",
       "readOnlyHint": true,
@@ -3892,10 +3892,10 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list time entries in; required unless time_entry_id is given"
+          "description": "Workspace ID to list time entries in; required unless time_entry_id is given. Deprecated input alias: matter_id."
         },
         "time_entry_id": {
           "type": "string",
@@ -3953,7 +3953,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "scope": "stella:read_anonymized",
     "access": "read",
     "feature": "FEATURE_TIME_BILLING",
-    "description": "Resolve the effective hourly rate for a user on a given date in a matter, using the matter's default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
+    "description": "Resolve the effective hourly rate for a user on a given date in a workspace, using its default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
     "annotations": {
       "title": "Resolve billing rate",
       "readOnlyHint": true,
@@ -3962,16 +3962,16 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "inputSchema": {
       "type": "object",
       "required": [
-        "matter_id",
+        "workspace_id",
         "user_id",
         "date"
       ],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to resolve the rate in"
+          "description": "Workspace ID to resolve the rate in. Deprecated input alias: matter_id."
         },
         "user_id": {
           "type": "string",
@@ -3992,7 +3992,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "scope": "stella:read_anonymized",
     "access": "read",
     "feature": "FEATURE_TIME_BILLING",
-    "description": "List invoices in a matter, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass matter_id to list the matter's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
+    "description": "List invoices in a workspace, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass workspace_id to list the workspace's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
     "annotations": {
       "title": "List invoices",
       "readOnlyHint": true,
@@ -4003,10 +4003,10 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list invoices in; required unless invoice_id is given"
+          "description": "Workspace ID to list invoices in; required unless invoice_id is given. Deprecated input alias: matter_id."
         },
         "invoice_id": {
           "type": "string",

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -369,13 +369,13 @@ const loadUserNames = async ({
 
 const listTimeEntriesArgsSchema = v.pipe(
   v.strictObject({
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
         v.description(
-          "Matter/workspace ID to list time entries in; required unless " +
-            "time_entry_id is given",
+          "Workspace ID to list time entries in; required unless " +
+            "time_entry_id is given. Deprecated input alias: matter_id.",
         ),
       ),
     ),
@@ -446,15 +446,16 @@ const listTimeEntriesArgsSchema = v.pipe(
       ),
     ),
   }),
-  // List mode needs a matter to scope to; detail mode uses time_entry_id alone.
+  // List mode needs a workspace to scope to; detail mode uses time_entry_id
+  // alone.
   v.forward(
     v.partialCheck(
-      [["matter_id"], ["time_entry_id"]],
-      ({ matter_id, time_entry_id }) =>
-        time_entry_id !== undefined || matter_id !== undefined,
-      "Provide matter_id to list entries, or time_entry_id to read one entry",
+      [["workspace_id"], ["time_entry_id"]],
+      ({ workspace_id, time_entry_id }) =>
+        time_entry_id !== undefined || workspace_id !== undefined,
+      "Provide workspace_id to list entries, or time_entry_id to read one entry",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
 );
 
@@ -513,10 +514,13 @@ const handleListTimeEntriesTool: TypedMcpToolHandler<
     if (!workspaceId) {
       return notFoundResult("Time entry not found or not accessible");
     }
-    // A supplied matter_id must name the entry's own matter; otherwise an entry
+    // A supplied workspace_id must name the entry's own matter; otherwise an entry
     // from a different accessible matter would be returned.
-    if (input.matter_id !== undefined && input.matter_id !== workspaceId) {
-      return errorResult("time_entry_id does not belong to matter_id");
+    if (
+      input.workspace_id !== undefined &&
+      input.workspace_id !== workspaceId
+    ) {
+      return errorResult("time_entry_id does not belong to workspace_id");
     }
     const row = await context.scopedDb((tx) =>
       tx
@@ -546,7 +550,7 @@ const handleListTimeEntriesTool: TypedMcpToolHandler<
     });
     const entry = {
       ...entryRow,
-      // Detail mode may be reached by time_entry_id alone (no matter_id), so
+      // Detail mode may be reached by time_entry_id alone (no workspace_id), so
       // carry the resolved owning workspace on the row itself; the chat
       // ref-mediation layer reads it to mint the entity's ref instead of
       // relying on an input arg that can be absent.
@@ -576,9 +580,12 @@ const handleListTimeEntriesTool: TypedMcpToolHandler<
     };
   }
 
-  // List mode. matter_id is guaranteed present by the schema.
-  const matterId = input.matter_id ?? "";
-  const workspaceId = ensureWorkspaceAccess({ context, workspaceId: matterId });
+  // List mode. workspace_id is guaranteed present by the schema.
+  const requestedWorkspaceId = input.workspace_id ?? "";
+  const workspaceId = ensureWorkspaceAccess({
+    context,
+    workspaceId: requestedWorkspaceId,
+  });
   if (!workspaceId) {
     return notFoundResult("Matter not found or not accessible");
   }
@@ -706,12 +713,13 @@ const saveTimeEntryArgsSchema = v.pipe(
         v.description("Time entry ID to update; omit to create"),
       ),
     ),
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
         v.description(
-          "Matter/workspace ID to create the entry in; required when creating",
+          "Workspace ID to create the entry in; required when creating. " +
+            "Deprecated input alias: matter_id.",
         ),
       ),
     ),
@@ -802,7 +810,7 @@ const saveTimeEntryArgsSchema = v.pipe(
   v.partialCheck(
     [
       ["time_entry_id"],
-      ["matter_id"],
+      ["workspace_id"],
       ["date_worked"],
       ["timezone_id"],
       ["duration_minutes"],
@@ -810,22 +818,22 @@ const saveTimeEntryArgsSchema = v.pipe(
     ],
     (i) =>
       i.time_entry_id !== undefined ||
-      (i.matter_id !== undefined &&
+      (i.workspace_id !== undefined &&
         i.date_worked !== undefined &&
         i.timezone_id !== undefined &&
         i.duration_minutes !== undefined &&
         i.narrative !== undefined),
-    "Creating a time entry requires matter_id, date_worked, timezone_id, duration_minutes, and narrative",
+    "Creating a time entry requires workspace_id, date_worked, timezone_id, duration_minutes, and narrative",
   ),
-  // matter_id names the workspace to create in; it cannot change on update.
+  // workspace_id names the workspace to create in; it cannot change on update.
   v.forward(
     v.partialCheck(
-      [["time_entry_id"], ["matter_id"]],
-      ({ time_entry_id, matter_id }) =>
-        time_entry_id === undefined || matter_id === undefined,
-      "matter_id applies only when creating; omit it when updating a time entry",
+      [["time_entry_id"], ["workspace_id"]],
+      ({ time_entry_id, workspace_id }) =>
+        time_entry_id === undefined || workspace_id === undefined,
+      "workspace_id applies only when creating; omit it when updating a time entry",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
   // invoice_narrative and no_charge are update-only in the backing
   // handler, so reject them on a create.
@@ -881,7 +889,7 @@ const handleSaveTimeEntryTool: TypedMcpToolHandler<
     }
     const workspaceId = ensureActiveWorkspace({
       context,
-      workspaceId: input.matter_id ?? "",
+      workspaceId: input.workspace_id ?? "",
     });
     if (typeof workspaceId !== "string") {
       return workspaceId;
@@ -1065,10 +1073,12 @@ const handleDeleteTimeEntryTool: TypedMcpToolHandler<
 // --- resolve_rate -------------------------------------------------------
 
 const resolveRateArgsSchema = v.strictObject({
-  matter_id: v.pipe(
+  workspace_id: v.pipe(
     v.string(),
     v.minLength(1),
-    v.description("Matter/workspace ID to resolve the rate in"),
+    v.description(
+      "Workspace ID to resolve the rate in. Deprecated input alias: matter_id.",
+    ),
   ),
   user_id: v.pipe(
     v.string(),
@@ -1094,7 +1104,7 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
 
   const workspaceId = ensureWorkspaceAccess({
     context,
-    workspaceId: parsed.output.matter_id,
+    workspaceId: parsed.output.workspace_id,
   });
   if (!workspaceId) {
     return notFoundResult("Matter not found or not accessible");
@@ -1143,13 +1153,13 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
 
 const listInvoicesArgsSchema = v.pipe(
   v.strictObject({
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
         v.description(
-          "Matter/workspace ID to list invoices in; required unless " +
-            "invoice_id is given",
+          "Workspace ID to list invoices in; required unless invoice_id is " +
+            "given. Deprecated input alias: matter_id.",
         ),
       ),
     ),
@@ -1181,12 +1191,12 @@ const listInvoicesArgsSchema = v.pipe(
   }),
   v.forward(
     v.partialCheck(
-      [["matter_id"], ["invoice_id"]],
-      ({ matter_id, invoice_id }) =>
-        invoice_id !== undefined || matter_id !== undefined,
-      "Provide matter_id to list invoices, or invoice_id to read one invoice",
+      [["workspace_id"], ["invoice_id"]],
+      ({ workspace_id, invoice_id }) =>
+        invoice_id !== undefined || workspace_id !== undefined,
+      "Provide workspace_id to list invoices, or invoice_id to read one invoice",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
 );
 
@@ -1261,8 +1271,11 @@ const handleListInvoicesTool: TypedMcpToolHandler<
     if (!workspaceId) {
       return notFoundResult("Invoice not found or not accessible");
     }
-    if (input.matter_id !== undefined && input.matter_id !== workspaceId) {
-      return errorResult("invoice_id does not belong to matter_id");
+    if (
+      input.workspace_id !== undefined &&
+      input.workspace_id !== workspaceId
+    ) {
+      return errorResult("invoice_id does not belong to workspace_id");
     }
     const invoiceRow = await readInvoiceDetail({
       context,
@@ -1275,7 +1288,7 @@ const handleListInvoicesTool: TypedMcpToolHandler<
 
     const invoice = {
       id: invoiceRow.id,
-      // Detail mode may be reached by invoice_id alone (no matter_id), so carry
+      // Detail mode may be reached by invoice_id alone (no workspace_id), so carry
       // the resolved owning workspace on the invoice; the chat ref-mediation
       // layer reads it to mint the line items' entity refs.
       workspaceId,
@@ -1338,9 +1351,12 @@ const handleListInvoicesTool: TypedMcpToolHandler<
     };
   }
 
-  // List mode. matter_id is guaranteed present by the schema.
-  const matterId = input.matter_id ?? "";
-  const workspaceId = ensureWorkspaceAccess({ context, workspaceId: matterId });
+  // List mode. workspace_id is guaranteed present by the schema.
+  const requestedWorkspaceId = input.workspace_id ?? "";
+  const workspaceId = ensureWorkspaceAccess({
+    context,
+    workspaceId: requestedWorkspaceId,
+  });
   if (!workspaceId) {
     return notFoundResult("Matter not found or not accessible");
   }
@@ -1454,10 +1470,10 @@ export const BILLING_TOOL_DEFINITIONS = [
       openWorldHint: false,
     },
     description:
-      "List time entries in a matter, or read one entry in detail. Pass " +
-      "time_entry_id to get a single entry. Otherwise pass matter_id to list " +
-      "the matter's entries, optionally filtered by entity_id (the item the " +
-      "time was logged against), user_id, a date-worked range (date_from/" +
+      "List time entries in a workspace, or read one entry in detail. Pass " +
+      "time_entry_id to get a single entry. Otherwise pass workspace_id to " +
+      "list the workspace's entries, optionally filtered by entity_id (the " +
+      "item the time was logged against), user_id, a date-worked range (date_from/" +
       "date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, " +
       "user, date, minutes, rate (minor currency units), currency, narrative, " +
       "and status. The response includes visibility: all_entries for billing " +
@@ -1467,7 +1483,7 @@ export const BILLING_TOOL_DEFINITIONS = [
     jsonSchemaProjectionWaiver: {
       ignoreActions: ["partial_check"],
       reason:
-        "The matter_id/time_entry_id cross-field requirement stays authoritative in the runtime schema.",
+        "The workspace_id/time_entry_id cross-field requirement stays authoritative in the runtime schema.",
     },
     access: "read",
     anonymized: {
@@ -1485,7 +1501,7 @@ export const BILLING_TOOL_DEFINITIONS = [
   }),
   defineValibotMcpTool({
     description:
-      "Create or update a time entry. Omit time_entry_id to create (matter_id, " +
+      "Create or update a time entry. Omit time_entry_id to create (workspace_id, " +
       "date_worked, timezone_id, duration_minutes, and narrative required; " +
       "entity_id is optional context). Pass time_entry_id to update: " +
       "set date_worked (with timezone_id), duration_minutes, narrative, " +
@@ -1542,8 +1558,8 @@ export const BILLING_TOOL_DEFINITIONS = [
     },
     description:
       "Resolve the effective hourly rate for a user on a given date in a " +
-      "matter, using the matter's default rate table (user-specific rate " +
-      "first, then the table default). Returns the hourly rate in integer " +
+      "workspace, using its default rate table (user-specific rate first, " +
+      "then the table default). Returns the hourly rate in integer " +
       "minor currency units (e.g. cents) and the currency, or nulls when no " +
       "rate applies.",
     inputSchema: resolveRateArgsSchema,
@@ -1562,16 +1578,16 @@ export const BILLING_TOOL_DEFINITIONS = [
       openWorldHint: false,
     },
     description:
-      "List invoices in a matter, or read one invoice in detail. Pass " +
+      "List invoices in a workspace, or read one invoice in detail. Pass " +
       "invoice_id to get a single invoice with its line items (time entries " +
-      "and expenses). Otherwise pass matter_id to list the matter's invoices. " +
-      "Returns each invoice's id, number, reference, status, dates, currency, " +
+      "and expenses). Otherwise pass workspace_id to list the workspace's " +
+      "invoices. Returns each invoice's id, number, reference, status, dates, currency, " +
       "and total (integer minor currency units).",
     inputSchema: listInvoicesArgsSchema,
     jsonSchemaProjectionWaiver: {
       ignoreActions: ["partial_check"],
       reason:
-        "The matter_id/invoice_id cross-field requirement stays authoritative in the runtime schema.",
+        "The workspace_id/invoice_id cross-field requirement stays authoritative in the runtime schema.",
     },
     access: "read",
     anonymized: {

--- a/apps/api/src/mcp/deprecated-input-aliases.ts
+++ b/apps/api/src/mcp/deprecated-input-aliases.ts
@@ -1,0 +1,85 @@
+import type { McpToolInputSchema } from "@/api/mcp/tool-types";
+
+/**
+ * Deprecated MCP input field names, each mapped to the field it was renamed to.
+ *
+ * The scoping container is a workspace everywhere else in the product (the UI,
+ * the CLI capability commands, and every handler, which maps the field straight
+ * to `workspaceId`), so the tools name it `workspace_id`. `matter_id` stays
+ * accepted for one release so an existing agent prompt keeps working; it is
+ * normalized here, at dispatch, rather than per tool, so the advertised schema
+ * names only the canonical field and the rename cannot be half-applied.
+ *
+ * A tool whose subject IS the matter record (`save_matter`, `delete_matter`,
+ * `list_matters`, `link_matter_contact`) declares `matter_id` itself; the alias
+ * never applies there, because the rewrite is keyed off the advertised schema.
+ *
+ * Delete this module when the deprecation window closes.
+ */
+export const DEPRECATED_MCP_INPUT_ALIASES = {
+  matter_id: "workspace_id",
+} as const satisfies Record<string, string>;
+
+/** A deprecated name and its replacement, both supplied with different values. */
+export type DeprecatedInputAliasConflict = {
+  alias: string;
+  canonical: string;
+};
+
+type DeprecatedInputAliasNormalization =
+  | { status: "normalized"; args: Record<string, unknown> }
+  | { status: "conflict"; conflicts: readonly DeprecatedInputAliasConflict[] };
+
+/**
+ * Rewrites deprecated input names onto their canonical field for one tool call.
+ * A deprecated name the tool still declares is left alone, and supplying both
+ * names with different values is a conflict rather than a silent winner.
+ */
+export const applyDeprecatedInputAliases = ({
+  args,
+  inputSchema,
+}: {
+  args: Record<string, unknown>;
+  inputSchema: McpToolInputSchema;
+}): DeprecatedInputAliasNormalization => {
+  const properties = inputSchema.properties ?? {};
+  const conflicts: DeprecatedInputAliasConflict[] = [];
+  const renames = new Map<string, string>();
+
+  for (const [alias, canonical] of Object.entries(
+    DEPRECATED_MCP_INPUT_ALIASES,
+  )) {
+    const applies =
+      alias in args && !(alias in properties) && canonical in properties;
+    if (!applies) {
+      continue;
+    }
+    if (canonical in args && args[canonical] !== args[alias]) {
+      conflicts.push({ alias, canonical });
+      continue;
+    }
+    renames.set(alias, canonical);
+  }
+
+  if (conflicts.length > 0) {
+    return { conflicts, status: "conflict" };
+  }
+  if (renames.size === 0) {
+    return { args, status: "normalized" };
+  }
+  return {
+    args: Object.fromEntries(
+      Object.entries(args).map(([key, value]) => [
+        renames.get(key) ?? key,
+        value,
+      ]),
+    ),
+    status: "normalized",
+  };
+};
+
+export const deprecatedInputAliasConflictMessage = ({
+  alias,
+  canonical,
+}: DeprecatedInputAliasConflict): string =>
+  `${alias} is a deprecated alias for ${canonical}; they were supplied with different values`;

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -610,18 +610,20 @@ const decodeEntityPageCursor = (
 
 const listDocumentsArgsSchema = v.pipe(
   v.strictObject({
-    matter_id: v.pipe(
+    workspace_id: v.pipe(
       v.string(),
       v.minLength(1),
-      v.description("Matter/workspace ID to list documents in"),
+      v.description(
+        "Workspace ID to list documents in. Deprecated input alias: matter_id.",
+      ),
     ),
     mode: v.optional(
       v.pipe(
         v.picklist(["flat", "children"]),
         v.description(
-          "'flat' lists every document and folder in the matter; 'children' " +
-            "lists only the direct children of parent_id (or the matter root " +
-            "when parent_id is omitted). Defaults to 'flat', or 'children' when " +
+          "'flat' lists every document and folder in the workspace; 'children' " +
+            "lists only the direct children of parent_id (or the workspace " +
+            "root when parent_id is omitted). Defaults to 'flat', or 'children' when " +
             "parent_id is provided. Passing parent_id with mode 'flat' is " +
             "rejected.",
         ),
@@ -706,7 +708,7 @@ const handleListDocumentsTool: TypedMcpToolHandler<
 
   const workspaceId = ensureWorkspaceAccess({
     context,
-    workspaceId: parsed.output.matter_id,
+    workspaceId: parsed.output.workspace_id,
   });
   if (!workspaceId) {
     return notFoundResult("Matter not found or not accessible");
@@ -1598,12 +1600,13 @@ const saveDocumentArgsSchema = v.pipe(
         v.description("Document entity ID to update; omit to create"),
       ),
     ),
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
         v.description(
-          "Matter/workspace ID to create the entity in; required when creating",
+          "Workspace ID to create the entity in; required when creating. " +
+            "Deprecated input alias: matter_id.",
         ),
       ),
     ),
@@ -1669,15 +1672,15 @@ const saveDocumentArgsSchema = v.pipe(
       ),
     ),
   }),
-  // Creating (no entity_id) requires matter_id and name.
+  // Creating (no entity_id) requires workspace_id and name.
   v.forward(
     v.partialCheck(
-      [["entity_id"], ["matter_id"]],
-      ({ entity_id, matter_id }) =>
-        entity_id !== undefined || matter_id !== undefined,
-      "matter_id is required to create a document",
+      [["entity_id"], ["workspace_id"]],
+      ({ entity_id, workspace_id }) =>
+        entity_id !== undefined || workspace_id !== undefined,
+      "workspace_id is required to create a document",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
   v.forward(
     v.partialCheck(
@@ -1687,16 +1690,16 @@ const saveDocumentArgsSchema = v.pipe(
     ),
     ["name"],
   ),
-  // matter_id and kind describe the entity to create; neither applies to an
+  // workspace_id and kind describe the entity to create; neither applies to an
   // update.
   v.forward(
     v.partialCheck(
-      [["entity_id"], ["matter_id"]],
-      ({ entity_id, matter_id }) =>
-        entity_id === undefined || matter_id === undefined,
-      "matter_id applies only when creating; omit it when updating a document",
+      [["entity_id"], ["workspace_id"]],
+      ({ entity_id, workspace_id }) =>
+        entity_id === undefined || workspace_id === undefined,
+      "workspace_id applies only when creating; omit it when updating a document",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
   v.forward(
     v.partialCheck(
@@ -1792,7 +1795,7 @@ const createDocumentEntity = async ({
 
   const workspaceId = ensureActiveWorkspace({
     context,
-    workspaceId: input.matter_id ?? "",
+    workspaceId: input.workspace_id ?? "",
   });
   if (typeof workspaceId !== "string") {
     return workspaceId;
@@ -2240,10 +2243,12 @@ const handleDeleteDocumentTool: TypedMcpToolHandler<
 };
 
 const listPropertiesArgsSchema = v.strictObject({
-  matter_id: v.pipe(
+  workspace_id: v.pipe(
     v.string(),
     v.minLength(1),
-    v.description("Matter/workspace ID to list properties for"),
+    v.description(
+      "Workspace ID to list properties for. Deprecated input alias: matter_id.",
+    ),
   ),
   limit: v.optional(
     v.pipe(
@@ -2287,7 +2292,7 @@ const handleListPropertiesTool: TypedMcpToolHandler<
 
   const workspaceId = ensureWorkspaceAccess({
     context,
-    workspaceId: parsed.output.matter_id,
+    workspaceId: parsed.output.workspace_id,
   });
   if (!workspaceId) {
     return notFoundResult("Matter not found or not accessible");
@@ -2548,11 +2553,12 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
       openWorldHint: false,
     },
     description:
-      "List the documents and folders in a matter. Use 'flat' mode to " +
-      "enumerate every document and folder in the matter, or 'children' mode " +
-      "to walk the folder tree one level at a time (pass parent_id to list a " +
-      "folder's direct children, or omit it for the matter root). Returns each " +
-      "entity's id, name, kind (document or folder), and parentId. Read a " +
+      "List the documents and folders in a workspace. Use 'flat' mode to " +
+      "enumerate every document and folder in the workspace, or 'children' " +
+      "mode to walk the folder tree one level at a time (pass parent_id to " +
+      "list a folder's direct children, or omit it for the workspace root). " +
+      "Returns each entity's id, name, kind (document or folder), and " +
+      "parentId. Read a " +
       "document's metadata, fields, or versions with read_document.",
     inputSchema: listDocumentsArgsSchema,
     jsonSchemaProjectionWaiver: {
@@ -2601,12 +2607,12 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
   defineValibotMcpTool({
     description:
       "Create a document or folder, or update an existing one. Omit entity_id " +
-      "to create: pass matter_id and name, optionally a parent_id folder and " +
-      "kind ('document' by default, or 'folder'). Creating makes an empty named " +
+      "to create: pass workspace_id and name, optionally a parent_id folder " +
+      "and kind ('document' by default, or 'folder'). Creating makes an empty named " +
       "entity; uploading file content is a separate step. Pass entity_id to " +
       "update: set name to rename; parent_id to move it into a folder or " +
-      "move_to_root to move it to the matter root; version_id with label and/or " +
-      "description to annotate a version. An update needs at least one change. " +
+      "move_to_root to move it to the workspace root; version_id with label " +
+      "and/or description to annotate a version. An update needs at least one change. " +
       "Returns the entity ID.",
     inputSchema: saveDocumentArgsSchema,
     jsonSchemaProjectionWaiver: {

--- a/apps/api/src/mcp/egress-canary.test.ts
+++ b/apps/api/src/mcp/egress-canary.test.ts
@@ -725,7 +725,7 @@ describe("MCP anonymization canary corpus", () => {
     const context = buildContext({ tx });
 
     const response = await DOCUMENT_TOOL_HANDLERS.list_documents({
-      args: { matter_id: "ws_1" },
+      args: { workspace_id: "ws_1" },
       context,
     });
     const result = await finalize(context, response);
@@ -937,7 +937,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await DOCUMENT_TOOL_HANDLERS.list_properties({
-        args: { matter_id: "ws_1" },
+        args: { workspace_id: "ws_1" },
         context,
       });
       const result = await finalize(context, response);
@@ -969,7 +969,7 @@ describe("MCP anonymization canary corpus", () => {
     const context = buildContext({ tx });
 
     const response = await MATTER_TOOL_HANDLERS.list_tasks({
-      args: { matter_id: "ws_1" },
+      args: { workspace_id: "ws_1" },
       context,
     });
     const result = await finalize(context, response);
@@ -1171,7 +1171,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await BILLING_TOOL_HANDLERS.list_time_entries({
-        args: { matter_id: "ws_1" },
+        args: { workspace_id: "ws_1" },
         context,
       });
       const result = await finalize(context, response);
@@ -1254,7 +1254,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await BILLING_TOOL_HANDLERS.list_invoices({
-        args: { matter_id: "ws_1" },
+        args: { workspace_id: "ws_1" },
         context,
       });
       const result = await finalize(context, response);

--- a/apps/api/src/mcp/input-vocabulary.test.ts
+++ b/apps/api/src/mcp/input-vocabulary.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyDeprecatedInputAliases,
+  DEPRECATED_MCP_INPUT_ALIASES,
+} from "@/api/mcp/deprecated-input-aliases";
+import { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions";
+import type { McpToolDefinition } from "@/api/mcp/tool-types";
+
+/**
+ * The scoping container has one name on the advertised surface: `workspace_id`.
+ * The product UI, the CLI capability commands, and every handler (which maps
+ * the field straight to `workspaceId`) already call it that; the tools used to
+ * call it `matter_id`, and an agent-orientation eval showed models guessing the
+ * workspace vocabulary for the CLI. This suite is the class guard for that
+ * rename: a new tool that scopes to a workspace under any other name, or a
+ * renamed tool that quietly regains `matter_id`, fails here rather than
+ * reaching the wire.
+ */
+
+/**
+ * Tools whose subject IS the matter record, so `matter_id` names the thing
+ * being read or written rather than the container it lives in. Each entry
+ * carries the reason it is exempt; nothing else may declare the name.
+ */
+const MATTER_ENTITY_TOOLS: Readonly<Record<string, string>> = {
+  save_matter:
+    "creates or updates the matter record itself; the id selects the record to update",
+  delete_matter: "deletes the matter record named by the id",
+  list_matters:
+    "lists matter records, or reads one matter's overview when the id is given",
+  link_matter_contact:
+    "links a contact to the matter record named by the id (the join row's matter side)",
+};
+
+/** The one name a workspace-scoping input may carry. */
+const CANONICAL_SCOPING_FIELD = "workspace_id";
+
+/**
+ * Every other spelling of the container that has appeared, or could plausibly
+ * appear, on an input. Advertised names are snake_case (enforced in
+ * `registry-quality.test.ts`), but the camelCase spellings are listed too so a
+ * hand-written schema cannot slip one through.
+ */
+const REJECTED_SCOPING_FIELDS = [
+  "matter",
+  "matterId",
+  "matter_id",
+  "workspace",
+  "workspaceId",
+] as const;
+
+/**
+ * The tools that scope to a workspace container, pinned explicitly. Derived
+ * membership is compared against this list, so adding or removing a scoping
+ * input is a reviewed change rather than a silent one.
+ */
+const WORKSPACE_SCOPED_TOOLS = [
+  "list_documents",
+  "save_document",
+  "list_properties",
+  "list_tasks",
+  "save_task",
+  "run_playbook",
+  "list_time_entries",
+  "save_time_entry",
+  "resolve_rate",
+  "list_invoices",
+  "list_audit_log",
+  "manage_organization",
+  "save_filled_template",
+] as const;
+
+const tools: readonly McpToolDefinition[] = DEFAULT_MCP_TOOL_DEFINITIONS;
+
+const inputPropertyNames = (tool: McpToolDefinition): readonly string[] =>
+  Object.keys(tool.inputSchema.properties ?? {});
+
+describe("MCP input vocabulary: the container is a workspace", () => {
+  test("only matter-entity tools declare matter_id", () => {
+    const offenders = tools
+      .filter((tool) => inputPropertyNames(tool).includes("matter_id"))
+      .map((tool) => tool.name)
+      .filter((name) => !(name in MATTER_ENTITY_TOOLS));
+    expect(
+      offenders,
+      `These tools scope to a workspace but name the input matter_id: ${offenders.join(", ")}. Rename the input to ${CANONICAL_SCOPING_FIELD}; matter_id survives only where the matter record itself is the subject.`,
+    ).toEqual([]);
+  });
+
+  test("every matter-entity exemption is still used", () => {
+    // The converse: an exemption that no longer matches a real declaration is
+    // stale permission to reintroduce the old name.
+    const declaring = new Set(
+      tools
+        .filter((tool) => inputPropertyNames(tool).includes("matter_id"))
+        .map((tool) => tool.name),
+    );
+    const unused = Object.keys(MATTER_ENTITY_TOOLS).filter(
+      (name) => !declaring.has(name),
+    );
+    expect(unused).toEqual([]);
+  });
+
+  test("no input uses another spelling of the container", () => {
+    const offenders: string[] = [];
+    for (const tool of tools) {
+      const exempt = tool.name in MATTER_ENTITY_TOOLS;
+      for (const name of inputPropertyNames(tool)) {
+        const rejected = REJECTED_SCOPING_FIELDS.some(
+          (candidate) => candidate === name,
+        );
+        if (rejected && !(exempt && name === "matter_id")) {
+          offenders.push(`${tool.name}.${name}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Name the workspace-scoping input ${CANONICAL_SCOPING_FIELD}: ${offenders.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  test("the workspace-scoped tool set matches the pinned list", () => {
+    const declaring = tools
+      .filter((tool) =>
+        inputPropertyNames(tool).includes(CANONICAL_SCOPING_FIELD),
+      )
+      .map((tool) => tool.name);
+    expect([...declaring].sort()).toEqual([...WORKSPACE_SCOPED_TOOLS].sort());
+  });
+
+  test("every scoping field is documented as a workspace", () => {
+    const offenders: string[] = [];
+    for (const tool of tools) {
+      const property = tool.inputSchema.properties?.[CANONICAL_SCOPING_FIELD];
+      const description =
+        typeof property === "object" &&
+        property !== null &&
+        "description" in property
+          ? property.description
+          : undefined;
+      if (typeof description !== "string") {
+        continue;
+      }
+      if (!description.toLowerCase().includes("workspace")) {
+        offenders.push(tool.name);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("deprecated input aliases", () => {
+  const schemaOf = (name: string) => {
+    const tool = tools.find((candidate) => candidate.name === name);
+    if (!tool) {
+      throw new Error(`No such tool: ${name}`);
+    }
+    return tool.inputSchema;
+  };
+
+  test("matter_id is still accepted as workspace_id for one release", () => {
+    expect(DEPRECATED_MCP_INPUT_ALIASES.matter_id).toBe(
+      CANONICAL_SCOPING_FIELD,
+    );
+    expect(
+      applyDeprecatedInputAliases({
+        args: { limit: 10, matter_id: "ws_1" },
+        inputSchema: schemaOf("list_documents"),
+      }),
+    ).toEqual({
+      args: { limit: 10, workspace_id: "ws_1" },
+      status: "normalized",
+    });
+  });
+
+  test("a matter-entity tool keeps its own matter_id", () => {
+    expect(
+      applyDeprecatedInputAliases({
+        args: { matter_id: "ws_1", name: "Acme" },
+        inputSchema: schemaOf("save_matter"),
+      }),
+    ).toEqual({
+      args: { matter_id: "ws_1", name: "Acme" },
+      status: "normalized",
+    });
+  });
+
+  test("both names with different values is a conflict, not a winner", () => {
+    expect(
+      applyDeprecatedInputAliases({
+        args: { matter_id: "ws_1", workspace_id: "ws_2" },
+        inputSchema: schemaOf("list_documents"),
+      }),
+    ).toEqual({
+      conflicts: [{ alias: "matter_id", canonical: "workspace_id" }],
+      status: "conflict",
+    });
+  });
+
+  test("both names with the same value collapse to the canonical one", () => {
+    expect(
+      applyDeprecatedInputAliases({
+        args: { matter_id: "ws_1", workspace_id: "ws_1" },
+        inputSchema: schemaOf("list_documents"),
+      }),
+    ).toEqual({ args: { workspace_id: "ws_1" }, status: "normalized" });
+  });
+});

--- a/apps/api/src/mcp/instructions.ts
+++ b/apps/api/src/mcp/instructions.ts
@@ -23,7 +23,7 @@ export const MCP_INSTRUCTIONS_DOCUMENTS_MAX_CHARS = 1000;
  * snake_case input-name ratchet that enforces the input half structurally.
  */
 export const MCP_CASING_RULE =
-  "Casing: tool inputs are snake_case (`matter_id`); response payloads are camelCase (`workspaceId`, `entityId`, `nextCursor`).";
+  "Casing: tool inputs are snake_case (`workspace_id`); response payloads are camelCase (`workspaceId`, `entityId`, `nextCursor`).";
 
 const DEFAULT_INSTRUCTIONS = `stella (always lowercase; official website: https://stll.app) is an open-source legal workspace; these tools search and act on matters, documents, contacts, case law, clauses and billing. Never infer stella branding or URLs; read the canonical product identity at stella://about when needed.
 

--- a/apps/api/src/mcp/internal-failure-envelope.test.ts
+++ b/apps/api/src/mcp/internal-failure-envelope.test.ts
@@ -124,12 +124,12 @@ const REPRESENTATIVE_DB_FAILURES: {
   {
     file: "billing-tools.ts",
     handler: BILLING_TOOL_HANDLERS.resolve_rate,
-    args: { matter_id: "ws_1", user_id: "user_2", date: "2024-01-01" },
+    args: { workspace_id: "ws_1", user_id: "user_2", date: "2024-01-01" },
   },
   {
     file: "document-tools.ts",
     handler: DOCUMENT_TOOL_HANDLERS.save_document,
-    args: { matter_id: "ws_1", kind: "document", name: "Doc" },
+    args: { workspace_id: "ws_1", kind: "document", name: "Doc" },
   },
   {
     file: "knowledge-tools.ts",
@@ -142,7 +142,7 @@ const REPRESENTATIVE_DB_FAILURES: {
   {
     file: "research-admin-tools.ts",
     handler: RESEARCH_ADMIN_TOOL_HANDLERS.manage_organization,
-    args: { action: "add_member", matter_id: "ws_1", user_id: "user_2" },
+    args: { action: "add_member", workspace_id: "ws_1", user_id: "user_2" },
   },
 ];
 
@@ -279,7 +279,7 @@ describe("internalFailureResult preserves expected handler errors", () => {
 // 5xx must not.
 describe("save_time_entry threads backing handler errors correctly", () => {
   const TIME_ENTRY_CREATE_ARGS = {
-    matter_id: "ws_1",
+    workspace_id: "ws_1",
     entity_id: "entity_1",
     date_worked: "2024-01-01",
     timezone_id: "Europe/Prague",

--- a/apps/api/src/mcp/knowledge-tools.test.ts
+++ b/apps/api/src/mcp/knowledge-tools.test.ts
@@ -361,7 +361,7 @@ describe("MCP knowledge tools", () => {
     startWorkflowMock.mockResolvedValue({ status: "started" });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", playbook_id: "pb_1" },
+      args: { workspace_id: "ws_1", playbook_id: "pb_1" },
       context: createContext({
         scopedDb: createPlaybookScopedDb({
           id: PLAYBOOK_ID,
@@ -427,7 +427,7 @@ describe("MCP knowledge tools", () => {
     startWorkflowMock.mockResolvedValue({ status: "failed" });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", playbook_id: "pb_1" },
+      args: { workspace_id: "ws_1", playbook_id: "pb_1" },
       context: createContext({
         scopedDb: createPlaybookScopedDb({
           id: PLAYBOOK_ID,

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -1424,10 +1424,12 @@ const handleListPlaybooksTool: TypedMcpToolHandler<
 // --- run_playbook -------------------------------------------------------
 
 const runPlaybookArgsSchema = v.strictObject({
-  matter_id: v.pipe(
+  workspace_id: v.pipe(
     v.string(),
     v.minLength(1),
-    v.description("Matter/workspace id to run the playbook over"),
+    v.description(
+      "Workspace id to run the playbook over. Deprecated input alias: matter_id.",
+    ),
   ),
   playbook_id: v.pipe(
     v.string(),
@@ -1466,7 +1468,7 @@ const handleRunPlaybookTool: TypedMcpToolHandler<
   // active, matching the HTTP run route behind the active-only workspace group.
   const workspaceId = ensureActiveWorkspace({
     context,
-    workspaceId: parsed.output.matter_id,
+    workspaceId: parsed.output.workspace_id,
   });
   if (typeof workspaceId !== "string") {
     return workspaceId;
@@ -1667,10 +1669,10 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
   }),
   defineValibotMcpTool({
     description:
-      "Run a review playbook over a matter's documents. Materializes the " +
-      "playbook's extraction and verdict columns onto the matter's table and " +
-      "starts the AI review; findings populate asynchronously. Pass matter_id " +
-      "and playbook_id. Returns the number of columns queued for review.",
+      "Run a review playbook over a workspace's documents. Materializes the " +
+      "playbook's extraction and verdict columns onto the workspace's table " +
+      "and starts the AI review; findings populate asynchronously. Pass " +
+      "workspace_id and playbook_id. Returns the number of columns queued for review.",
     inputSchema: runPlaybookArgsSchema,
     annotations: {
       title: "Run playbook",

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -942,12 +942,13 @@ const resolveTaskWorkspace = async ({
 
 const listTasksArgsSchema = v.pipe(
   v.strictObject({
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
         v.description(
-          "Matter/workspace ID to list tasks in; required unless task_id is given",
+          "Workspace ID to list tasks in; required unless task_id is given. " +
+            "Deprecated input alias: matter_id.",
         ),
       ),
     ),
@@ -1003,15 +1004,15 @@ const listTasksArgsSchema = v.pipe(
       ),
     ),
   }),
-  // List mode needs a matter to scope to; detail mode uses task_id alone.
+  // List mode needs a workspace to scope to; detail mode uses task_id alone.
   v.forward(
     v.partialCheck(
-      [["matter_id"], ["task_id"]],
-      ({ matter_id, task_id }) =>
-        task_id !== undefined || matter_id !== undefined,
-      "Provide matter_id to list tasks, or task_id to read one task",
+      [["workspace_id"], ["task_id"]],
+      ({ workspace_id, task_id }) =>
+        task_id !== undefined || workspace_id !== undefined,
+      "Provide workspace_id to list tasks, or task_id to read one task",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
 );
 
@@ -1136,14 +1137,14 @@ const handleListTasksTool: TypedMcpToolHandler<
     if (owner.status !== "ok") {
       return notFoundResult("Task not found or not accessible");
     }
-    // When matter_id is also supplied it must name the task's own matter;
+    // When workspace_id is also supplied it must name the task's own matter;
     // otherwise a task from a different accessible matter would be returned.
     // Mirrors the save_task pairing check.
     if (
-      input.matter_id !== undefined &&
-      input.matter_id !== owner.workspaceId
+      input.workspace_id !== undefined &&
+      input.workspace_id !== owner.workspaceId
     ) {
-      return errorResult("task_id does not belong to matter_id");
+      return errorResult("task_id does not belong to workspace_id");
     }
     const { taskRow, assigneeRows, linkRows } = await readTaskDetail({
       context,
@@ -1206,9 +1207,12 @@ const handleListTasksTool: TypedMcpToolHandler<
     };
   }
 
-  // List mode. matter_id is guaranteed present by the schema.
-  const matterId = input.matter_id ?? "";
-  const workspaceId = ensureWorkspaceAccess({ context, workspaceId: matterId });
+  // List mode. workspace_id is guaranteed present by the schema.
+  const requestedWorkspaceId = input.workspace_id ?? "";
+  const workspaceId = ensureWorkspaceAccess({
+    context,
+    workspaceId: requestedWorkspaceId,
+  });
   if (!workspaceId) {
     return notFoundResult("Matter not found or not accessible");
   }
@@ -1294,12 +1298,13 @@ const saveTaskArgsSchema = v.pipe(
         v.description("Task entity ID to update; omit to create"),
       ),
     ),
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
         v.description(
-          "Matter/workspace ID to create the task in; required when creating",
+          "Workspace ID to create the task in; required when creating. " +
+            "Deprecated input alias: matter_id.",
         ),
       ),
     ),
@@ -1403,15 +1408,15 @@ const saveTaskArgsSchema = v.pipe(
       ),
     ),
   }),
-  // Creating (no task_id) requires matter_id and name.
+  // Creating (no task_id) requires workspace_id and name.
   v.forward(
     v.partialCheck(
-      [["task_id"], ["matter_id"]],
-      ({ task_id, matter_id }) =>
-        task_id !== undefined || matter_id !== undefined,
-      "matter_id is required to create a task",
+      [["task_id"], ["workspace_id"]],
+      ({ task_id, workspace_id }) =>
+        task_id !== undefined || workspace_id !== undefined,
+      "workspace_id is required to create a task",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
   v.forward(
     v.partialCheck(
@@ -1421,7 +1426,7 @@ const saveTaskArgsSchema = v.pipe(
     ),
     ["name"],
   ),
-  // Assignee/link operations and matter_id only apply to an existing task.
+  // Assignee/link operations and workspace_id only apply to an existing task.
   v.partialCheck(
     [
       ["task_id"],
@@ -1429,7 +1434,7 @@ const saveTaskArgsSchema = v.pipe(
       ["remove_assignee_user_id"],
       ["link_entity_id"],
       ["unlink_link_id"],
-      ["matter_id"],
+      ["workspace_id"],
     ],
     (i) =>
       i.task_id !== undefined ||
@@ -1586,7 +1591,7 @@ const validateUnlinkTarget = async ({
 
 /**
  * Validate every failure-capable save_task target up front so no partial
- * mutation can commit before a later step fails. Covers the matter_id/task_id
+ * mutation can commit before a later step fails. Covers the workspace_id/task_id
  * pairing; the task's own read-only state, which every assignee and link
  * handler rejects on; the link target (via validateLinkTarget); assignee
  * membership; and the unlink target (via validateUnlinkTarget). Mirrors every
@@ -1608,9 +1613,9 @@ const validateSaveTaskTargets = async ({
   taskId: SafeId<"entity">;
   workspaceId: SafeId<"workspace">;
 }): Promise<ReturnType<typeof errorResult> | null> => {
-  // matter_id is optional on update; when given it must name the task's matter.
-  if (input.matter_id !== undefined && input.matter_id !== workspaceId) {
-    return errorResult("task_id does not belong to matter_id");
+  // workspace_id is optional on update; when given it must name the task's matter.
+  if (input.workspace_id !== undefined && input.workspace_id !== workspaceId) {
+    return errorResult("task_id does not belong to workspace_id");
   }
 
   // Every assignee/link handler rejects once the task itself is read-only
@@ -1690,7 +1695,7 @@ const handleSaveTaskTool: TypedMcpToolHandler<
     }
     const workspaceId = ensureActiveWorkspace({
       context,
-      workspaceId: input.matter_id ?? "",
+      workspaceId: input.workspace_id ?? "",
     });
     if (typeof workspaceId !== "string") {
       return workspaceId;
@@ -2174,10 +2179,10 @@ export const MATTER_TOOL_DEFINITIONS = [
       openWorldHint: false,
     },
     description:
-      "List tasks in a matter, or read one task in detail. Pass task_id to " +
+      "List tasks in a workspace, or read one task in detail. Pass task_id to " +
       "get a single task's fields, assignees, and linked entities. Otherwise " +
-      "pass matter_id to list the matter's tasks, optionally filtered by a " +
-      "due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. " +
+      "pass workspace_id to list the workspace's tasks, optionally filtered " +
+      "by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. " +
       "Returns each item's id, name, item type, status, priority, and due date.",
     inputSchema: listTasksArgsSchema,
     jsonSchemaProjectionWaiver: {
@@ -2196,7 +2201,7 @@ export const MATTER_TOOL_DEFINITIONS = [
   defineValibotMcpTool({
     description:
       "Create or update a task, and manage its assignees and entity links. " +
-      "Omit task_id to create a task (matter_id and name required). Pass " +
+      "Omit task_id to create a task (workspace_id and name required). Pass " +
       "task_id to update: set name, item_type, status, priority, or due_date (ISO " +
       "YYYY-MM-DD, null to clear); add or remove one assignee " +
       "(add_assignee_user_id / remove_assignee_user_id); link the task to " +

--- a/apps/api/src/mcp/null-tolerance.test.ts
+++ b/apps/api/src/mcp/null-tolerance.test.ts
@@ -246,7 +246,7 @@ describe("static tools reject explicit null on plain optional fields", () => {
     { tool: "save_matter", args: { name: null }, path: "name" },
     {
       tool: "list_documents",
-      args: { matter_id: "ws_1", mode: null },
+      args: { workspace_id: "ws_1", mode: null },
       path: "mode",
     },
   ];

--- a/apps/api/src/mcp/registry-quality.test.ts
+++ b/apps/api/src/mcp/registry-quality.test.ts
@@ -77,9 +77,13 @@ const TOOL_COUNT_CEILING: Record<SurfaceMode, number> = {
 // three keyword classes reproduces the previous payload byte for byte, so no
 // description, enum or property grew; the default surface still fits its
 // ceiling unchanged.
+// anonymized bumped 23_403 -> 23_557, exactly the measured growth from naming
+// the scoping input `workspace_id` and stating its deprecated `matter_id` alias
+// in one clause per field. The alias clause comes back out when the
+// deprecation window closes.
 const TOOLS_LIST_PAYLOAD_CHAR_CEILING: Record<SurfaceMode, number> = {
   default: 70_000,
-  anonymized: 23_403,
+  anonymized: 23_557,
 };
 
 // Longest description measured after plan 047: save_template at 724 chars
@@ -542,8 +546,9 @@ const collectOpenObjectSchemas = (
 
 // Advertised input property names: lowercase words joined by single
 // underscores. The name is the one part of a tool contract an agent has to
-// reproduce exactly, so a camelCase outlier (or a synonym like `workspace_id`
-// beside ten `matter_id`s) is a correctness cost, not a style preference.
+// reproduce exactly, so a camelCase outlier (or a synonym for a name the rest
+// of the surface already settled) is a correctness cost, not a style
+// preference. `input-vocabulary.test.ts` guards the scoping name specifically.
 const SNAKE_CASE_PROPERTY = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/u;
 
 /**

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -200,7 +200,7 @@ describe("manage_organization per-action validation", () => {
   test("requires user_id for a member action", async () => {
     expect(
       errorMessage(
-        await runManageOrg({ action: "add_member", matter_id: "ws_1" }),
+        await runManageOrg({ action: "add_member", workspace_id: "ws_1" }),
       ),
     ).toBe("user_id is required for add_member and remove_member");
   });
@@ -209,7 +209,7 @@ describe("manage_organization per-action validation", () => {
     const message = errorMessage(
       await runManageOrg({
         action: "remove_member",
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         user_id: "user_2",
         prompt_caching_enabled: false,
         document_processing_mode: "searchable-text",
@@ -292,7 +292,7 @@ describe("manage_organization remove_member confirm gate", () => {
       errorText(
         await runManageOrg({
           action: "remove_member",
-          matter_id: "ws_1",
+          workspace_id: "ws_1",
           user_id: "user_2",
         }),
       ),
@@ -307,7 +307,7 @@ describe("manage_organization remove_member confirm gate", () => {
     const text = errorText(
       await runManageOrg({
         action: "remove_member",
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         user_id: "user_2",
         confirm: true,
       }),

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -85,11 +85,13 @@ const MANAGE_ORG_ACTIONS = [
 
 const listAuditLogArgsSchema = v.pipe(
   v.strictObject({
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
-        v.description("Only entries scoped to this matter/workspace"),
+        v.description(
+          "Only entries scoped to this workspace. Deprecated input alias: matter_id.",
+        ),
       ),
     ),
     action: v.optional(
@@ -178,7 +180,7 @@ const LIST_AUDIT_LOG_TOOL_DEFINITION = defineValibotMcpTool({
   description:
     "Read the organization's audit trail (compliance view). Returns audit " +
     "entries newest first, each with its action, resource type and id, actor " +
-    "user id, workspace, timestamp, and change detail. Filter by matter_id, " +
+    "user id, workspace, timestamp, and change detail. Filter by workspace_id, " +
     "action, resource_type (with optional resource_id), user_id, and a " +
     "created-at range (from/to, ISO date-time). Paginate with limit and " +
     "cursor. Requires organization audit-log access.",
@@ -558,9 +560,9 @@ const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
   const input = parsed.output;
 
   const filter: AuditLogFilter = {
-    ...(input.matter_id === undefined
+    ...(input.workspace_id === undefined
       ? {}
-      : { workspaceId: brandPersistedWorkspaceId(input.matter_id) }),
+      : { workspaceId: brandPersistedWorkspaceId(input.workspace_id) }),
     ...(input.action === undefined ? {} : { action: input.action }),
     ...(input.resource_type === undefined
       ? {}
@@ -609,11 +611,14 @@ const manageOrganizationArgsSchema = v.pipe(
       v.picklist(MANAGE_ORG_ACTIONS),
       v.description("Administrative action to perform"),
     ),
-    matter_id: v.optional(
+    workspace_id: v.optional(
       v.pipe(
         v.string(),
         v.minLength(1),
-        v.description("Matter/workspace id for add_member and remove_member"),
+        v.description(
+          "Workspace id for add_member and remove_member. Deprecated input alias: " +
+            "matter_id.",
+        ),
       ),
     ),
     user_id: v.optional(
@@ -677,12 +682,12 @@ const manageOrganizationArgsSchema = v.pipe(
   // Member actions need a matter and a user.
   v.forward(
     v.partialCheck(
-      [["action"], ["matter_id"]],
-      ({ action, matter_id }) =>
-        action === "update_org_settings" || matter_id !== undefined,
-      "matter_id is required for add_member and remove_member",
+      [["action"], ["workspace_id"]],
+      ({ action, workspace_id }) =>
+        action === "update_org_settings" || workspace_id !== undefined,
+      "workspace_id is required for add_member and remove_member",
     ),
-    ["matter_id"],
+    ["workspace_id"],
   ),
   v.forward(
     v.partialCheck(
@@ -710,13 +715,13 @@ const manageOrganizationArgsSchema = v.pipe(
         i.document_processing_mode === undefined),
     "matter_number_pattern, matter_number_padding, prompt_caching_enabled, and document_processing_mode apply only to update_org_settings",
   ),
-  // matter_id/user_id are meaningless for an org-settings update.
+  // workspace_id/user_id are meaningless for an org-settings update.
   v.partialCheck(
-    [["action"], ["matter_id"], ["user_id"]],
+    [["action"], ["workspace_id"], ["user_id"]],
     (i) =>
       i.action !== "update_org_settings" ||
-      (i.matter_id === undefined && i.user_id === undefined),
-    "matter_id and user_id do not apply to update_org_settings",
+      (i.workspace_id === undefined && i.user_id === undefined),
+    "workspace_id and user_id do not apply to update_org_settings",
   ),
   // An org-settings update must change at least one field.
   v.partialCheck(
@@ -748,7 +753,7 @@ const manageOrganizationArgsSchema = v.pipe(
 const MANAGE_ORGANIZATION_TOOL_DEFINITION = defineValibotMcpTool({
   description:
     "Manage organization members and non-secret settings. Member actions " +
-    "require matter_id and user_id. update_org_settings controls matter " +
+    "require workspace_id and user_id. update_org_settings controls matter " +
     "numbering, prompt caching, and document processing. Manage provider " +
     "secrets in the dashboard.",
   inputSchema: manageOrganizationArgsSchema,
@@ -770,17 +775,20 @@ const MANAGE_ORGANIZATION_TOOL_DEFINITION = defineValibotMcpTool({
 
 const handleAddMember = async ({
   context,
-  matterId,
+  requestedWorkspaceId,
   userId,
 }: {
   context: McpRequestContext;
-  matterId: string;
+  requestedWorkspaceId: string;
   userId: string;
 }) => {
   if (!hasEffectiveAuthority(context, { workspace: ["update"] })) {
     return errorResult("Forbidden");
   }
-  const workspaceId = ensureActiveWorkspace({ context, workspaceId: matterId });
+  const workspaceId = ensureActiveWorkspace({
+    context,
+    workspaceId: requestedWorkspaceId,
+  });
   if (typeof workspaceId !== "string") {
     return workspaceId;
   }
@@ -803,17 +811,20 @@ const handleAddMember = async ({
 
 const handleRemoveMember = async ({
   context,
-  matterId,
+  requestedWorkspaceId,
   userId,
 }: {
   context: McpRequestContext;
-  matterId: string;
+  requestedWorkspaceId: string;
   userId: string;
 }) => {
   if (!hasEffectiveAuthority(context, { workspace: ["update"] })) {
     return errorResult("Forbidden");
   }
-  const workspaceId = ensureActiveWorkspace({ context, workspaceId: matterId });
+  const workspaceId = ensureActiveWorkspace({
+    context,
+    workspaceId: requestedWorkspaceId,
+  });
   if (typeof workspaceId !== "string") {
     return workspaceId;
   }
@@ -847,10 +858,10 @@ const handleManageOrganizationTool: TypedMcpToolHandler<
   const input = parsed.output;
 
   if (input.action === "add_member") {
-    // matter_id and user_id are guaranteed present by the schema.
+    // workspace_id and user_id are guaranteed present by the schema.
     return await handleAddMember({
       context,
-      matterId: input.matter_id ?? "",
+      requestedWorkspaceId: input.workspace_id ?? "",
       userId: input.user_id ?? "",
     });
   }
@@ -869,10 +880,10 @@ const handleManageOrganizationTool: TypedMcpToolHandler<
         hint: "Removing a member is irreversible. Confirm with the human user, then retry with confirm: true.",
       });
     }
-    // matter_id and user_id are guaranteed present by the schema.
+    // workspace_id and user_id are guaranteed present by the schema.
     return await handleRemoveMember({
       context: bindApprovedMcpAuditContext(context),
-      matterId: input.matter_id ?? "",
+      requestedWorkspaceId: input.workspace_id ?? "",
       userId: input.user_id ?? "",
     });
   }

--- a/apps/api/src/mcp/static-cli-metadata.ts
+++ b/apps/api/src/mcp/static-cli-metadata.ts
@@ -165,19 +165,24 @@ export const DEFAULT_MCP_CLI_ANNOTATIONS = defineMcpCliToolAnnotations(
             command: "new-document",
             include: [
               "template_id",
-              "matter_id",
+              "workspace_id",
               "idempotency_key",
               "parent_id",
               "name",
               "values",
             ],
-            required: ["template_id", "matter_id", "idempotency_key", "values"],
+            required: [
+              "template_id",
+              "workspace_id",
+              "idempotency_key",
+              "values",
+            ],
           },
           create_version: {
             command: "new-version",
             include: [
               "template_id",
-              "matter_id",
+              "workspace_id",
               "idempotency_key",
               "entity_id",
               "name",
@@ -185,7 +190,7 @@ export const DEFAULT_MCP_CLI_ANNOTATIONS = defineMcpCliToolAnnotations(
             ],
             required: [
               "template_id",
-              "matter_id",
+              "workspace_id",
               "entity_id",
               "idempotency_key",
               "values",
@@ -256,13 +261,13 @@ export const DEFAULT_MCP_CLI_ANNOTATIONS = defineMcpCliToolAnnotations(
         subcommands: {
           add_member: {
             command: "add-member",
-            include: ["matter_id", "user_id"],
-            required: ["matter_id", "user_id"],
+            include: ["workspace_id", "user_id"],
+            required: ["workspace_id", "user_id"],
           },
           remove_member: {
             command: "remove-member",
-            include: ["matter_id", "user_id"],
-            required: ["matter_id", "user_id"],
+            include: ["workspace_id", "user_id"],
+            required: ["workspace_id", "user_id"],
             destructive: true,
           },
           update_org_settings: {

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -960,7 +960,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "create-document-1",
         parent_id: FOLDER_ID,
         name: "Example Lease",
@@ -1030,7 +1030,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "create-document-missing-required",
         values: { "tenant.name": "ACME" },
       },
@@ -1068,7 +1068,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "disconnect-1",
         values: { "tenant.name": "ACME" },
       },
@@ -1109,7 +1109,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "create-document-retry",
         values: { "tenant.name": "ACME" },
       },
@@ -1138,7 +1138,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "concurrent-retry",
         values: { "tenant.name": "ACME" },
       },
@@ -1166,7 +1166,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "reused-key",
         values: { "tenant.name": "Different" },
       },
@@ -1212,7 +1212,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "create-version-1",
         entity_id: ENTITY_ID,
         values: { "tenant.name": "ACME" },
@@ -1261,7 +1261,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "missing-entity-1",
         values: {},
       },
@@ -1272,7 +1272,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "archived-1",
         values: {},
       },
@@ -1283,7 +1283,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "forbidden-1",
         values: {},
       },
@@ -1294,7 +1294,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: "not-a-uuid",
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "malformed-template-1",
         values: {},
       },
@@ -1305,7 +1305,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "malformed-parent-1",
         parent_id: "not-a-uuid",
         values: {},
@@ -1317,7 +1317,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "malformed-entity-1",
         entity_id: "not-a-uuid",
         values: {},
@@ -1374,7 +1374,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "missing-parent-1",
         parent_id: MISSING_FOLDER_ID,
         values: {},
@@ -1386,7 +1386,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "non-folder-1",
         parent_id: NON_FOLDER_ID,
         values: {},
@@ -1398,7 +1398,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "missing-version-1",
         entity_id: MISSING_VERSION_ID,
         values: {},
@@ -1410,7 +1410,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "read-only-1",
         entity_id: READ_ONLY_VERSION_ID,
         values: {},
@@ -1422,7 +1422,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "non-file-1",
         entity_id: NON_FILE_VERSION_ID,
         values: {},
@@ -1456,7 +1456,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        workspace_id: "ws_1",
         idempotency_key: "full-workspace-1",
         values: {},
       },

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -519,7 +519,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
   {
     description:
       "Fill a registered template and persist the generated DOCX directly in " +
-      "a matter, without requiring the client to upload bytes. Use " +
+      "a workspace, without requiring the client to upload bytes. Use " +
       "action='create_document' to create a new document (optionally inside " +
       "parent_id), or action='create_version' with entity_id to append a " +
       "version to an existing document. Call list_templates first to learn " +
@@ -536,7 +536,9 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
           "create_version",
         ]),
         template_id: stringProp("Template id, as returned by list_templates"),
-        matter_id: stringProp("Matter/workspace receiving the filled DOCX"),
+        workspace_id: stringProp(
+          "Workspace receiving the filled DOCX. Deprecated input alias: matter_id.",
+        ),
         entity_id: stringProp(
           "Existing document entity id; required only for create_version",
         ),
@@ -560,7 +562,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       required: [
         "action",
         "template_id",
-        "matter_id",
+        "workspace_id",
         "idempotency_key",
         "values",
       ],
@@ -971,7 +973,7 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
 const saveFilledTemplateArgsSchema = v.strictObject({
   action: v.picklist(["create_document", "create_version"]),
   template_id: v.pipe(v.string(), v.uuid()),
-  matter_id: v.pipe(v.string(), v.minLength(1)),
+  workspace_id: v.pipe(v.string(), v.minLength(1)),
   entity_id: v.optional(v.pipe(v.string(), v.uuid())),
   parent_id: v.optional(v.pipe(v.string(), v.uuid())),
   name: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(255))),
@@ -1129,7 +1131,7 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
 
   const workspaceId = ensureWorkspaceAccess({
     context,
-    workspaceId: input.matter_id,
+    workspaceId: input.workspace_id,
   });
   if (workspaceId === null) {
     return notFoundResult("Matter not found or not accessible");
@@ -1211,7 +1213,7 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
 
   const activeWorkspaceId = ensureActiveWorkspace({
     context,
-    workspaceId: input.matter_id,
+    workspaceId: input.workspace_id,
   });
   if (typeof activeWorkspaceId !== "string") {
     await releaseClaim();

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -2581,7 +2581,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_documents rejects flat mode combined with parent_id", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", mode: "flat", parent_id: "entity_folder" },
+      args: { workspace_id: "ws_1", mode: "flat", parent_id: "entity_folder" },
       context: createContext(),
       toolName: "list_documents",
     });
@@ -2591,9 +2591,9 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_documents surfaces a field-level issue with a dot-path", async () => {
     const result = await handleMcpToolCall({
-      // matter_id must be a string; a number fails the field validator, so the
+      // workspace_id must be a string; a number fails the field validator, so the
       // envelope carries a structured issue pinpointing the offending field.
-      args: { matter_id: 123 },
+      args: { workspace_id: 123 },
       context: createContext(),
       toolName: "list_documents",
     });
@@ -2601,7 +2601,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const error = validationEnvelope(result);
     expect(error["code"]).toBe("validation_error");
     expect(error["issues"]).toEqual([
-      { path: "matter_id", message: expect.any(String) },
+      { path: "workspace_id", message: expect.any(String) },
     ]);
   });
 
@@ -3385,7 +3385,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_properties declares how file and scalar properties are written", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1" },
+      args: { workspace_id: "ws_1" },
       context: createContext({
         scopedDb: createScopedDb([
           {
@@ -3490,16 +3490,16 @@ describe("OpenAI-compatible MCP tools", () => {
     expectValidationMessage(result, "label and description require version_id");
   });
 
-  test("save_document rejects matter_id (a create field) alongside entity_id", async () => {
+  test("save_document rejects workspace_id (a create field) alongside entity_id", async () => {
     const result = await handleMcpToolCall({
-      args: { entity_id: "entity_1", matter_id: "ws_1", name: "Renamed" },
+      args: { entity_id: "entity_1", workspace_id: "ws_1", name: "Renamed" },
       context: createContext(),
       toolName: "save_document",
     });
 
     expectValidationMessage(
       result,
-      "matter_id applies only when creating; omit it when updating a document",
+      "workspace_id applies only when creating; omit it when updating a document",
     );
   });
 
@@ -3816,14 +3816,17 @@ describe("OpenAI-compatible MCP tools", () => {
     ]);
   });
 
-  test("save_task rejects a create with no matter_id", async () => {
+  test("save_task rejects a create with no workspace_id", async () => {
     const result = await handleMcpToolCall({
       args: { name: "Draft motion" },
       context: createContext(),
       toolName: "save_task",
     });
 
-    expectValidationMessage(result, "matter_id is required to create a task");
+    expectValidationMessage(
+      result,
+      "workspace_id is required to create a task",
+    );
   });
 
   // list_tasks (detail) and save_task confine themselves to entities of kind
@@ -3880,27 +3883,29 @@ describe("OpenAI-compatible MCP tools", () => {
     });
   });
 
-  // save_task ignored matter_id on update, so a mismatched pair silently
+  // save_task ignored workspace_id on update, so a mismatched pair silently
   // updated a task under the wrong matter. The handler now rejects it.
-  test("save_task rejects a task whose matter_id does not match", async () => {
+  test("save_task rejects a task whose workspace_id does not match", async () => {
     const result = await handleMcpToolCall({
-      args: { task_id: "task_1", matter_id: "ws_2", name: "Renamed" },
+      args: { task_id: "task_1", workspace_id: "ws_2", name: "Renamed" },
       context: createContext({ scopedDb: createTaskKindScopedDb("task") }),
       toolName: "save_task",
     });
 
     expect(result).toEqual({
-      content: [{ type: "text", text: "task_id does not belong to matter_id" }],
+      content: [
+        { type: "text", text: "task_id does not belong to workspace_id" },
+      ],
       isError: true,
     });
   });
 
   // list_tasks detail resolved by task_id alone, so a task_id paired with a
-  // different accessible matter_id leaked a task from the wrong matter. The
+  // different accessible workspace_id leaked a task from the wrong matter. The
   // detail branch now enforces the same pairing check as save_task.
-  test("list_tasks detail rejects a task whose matter_id does not match", async () => {
+  test("list_tasks detail rejects a task whose workspace_id does not match", async () => {
     const result = await handleMcpToolCall({
-      args: { task_id: "task_1", matter_id: "ws_2" },
+      args: { task_id: "task_1", workspace_id: "ws_2" },
       context: createContext({
         accessibleWorkspaceIds: ["ws_1", "ws_2"],
         scopedDb: createTaskKindScopedDb("task"),
@@ -3909,7 +3914,9 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     expect(result).toEqual({
-      content: [{ type: "text", text: "task_id does not belong to matter_id" }],
+      content: [
+        { type: "text", text: "task_id does not belong to workspace_id" },
+      ],
       isError: true,
     });
   });
@@ -4206,7 +4213,7 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1" },
+      args: { workspace_id: "ws_1" },
       context: createContext({
         scopedDb: createSelectListScopedDb([
           {
@@ -4255,7 +4262,7 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1" },
+      args: { workspace_id: "ws_1" },
       context: createContext({
         scopedDb: createSelectListScopedDb([
           {
@@ -4390,7 +4397,7 @@ describe("OpenAI-compatible MCP tools", () => {
         const recordAuditEvent = createRecordAuditEventMock();
         const result = await handleMcpToolCall({
           args: {
-            matter_id: "ws_1",
+            workspace_id: "ws_1",
             entity_id: "entity_1",
             date_worked: "2026-02-01",
             timezone_id: "Europe/Prague",
@@ -4607,6 +4614,38 @@ describe("undeclared-argument backstop", () => {
       {
         path: "matterId",
         message: "Unknown parameter: matterId (did you mean matter_id?)",
+      },
+    ]);
+  });
+
+  test("dispatch rewrites the deprecated matter_id alias onto workspace_id", async () => {
+    // The rewrite runs before the unknown-key backstop, so the old name is not
+    // rejected as a typo: the call reaches the handler, which answers on the
+    // workspace it names.
+    const result = await handleMcpToolCall({
+      args: { matter_id: "ws_missing" },
+      context: createContext(),
+      toolName: "list_documents",
+    });
+
+    const error = validationEnvelope(result);
+    expect(error["message"]).toBe("Matter not found or not accessible");
+  });
+
+  test("dispatch refuses the alias and its replacement with different values", async () => {
+    const result = await handleMcpToolCall({
+      args: { matter_id: "ws_1", workspace_id: "ws_2" },
+      context: createContext(),
+      toolName: "list_documents",
+    });
+
+    const error = validationEnvelope(result);
+    expect(error["code"]).toBe("validation_error");
+    expect(error["issues"]).toEqual([
+      {
+        path: "matter_id",
+        message:
+          "matter_id is a deprecated alias for workspace_id; they were supplied with different values",
       },
     ]);
   });

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -15,6 +15,10 @@ import {
   bindApprovedMcpAuditContext,
   type McpRequestContext,
 } from "@/api/mcp/context";
+import {
+  applyDeprecatedInputAliases,
+  deprecatedInputAliasConflictMessage,
+} from "@/api/mcp/deprecated-input-aliases";
 import { finalizeToolEgress } from "@/api/mcp/egress";
 import { dispatchGatewayToolCall } from "@/api/mcp/gateway/dispatch-call";
 import {
@@ -216,8 +220,31 @@ export const handleMcpToolCall = async ({
     );
   }
 
-  const unknownArgs = findUndeclaredArguments({
+  // Deprecated input names are rewritten onto their canonical field before the
+  // unknown-key backstop, so a caller still sending the old name reaches the
+  // handler while the advertised schema names only the canonical field.
+  const aliased = applyDeprecatedInputAliases({
     args,
+    inputSchema: staticTool.inputSchema,
+  });
+  if (aliased.status === "conflict") {
+    const names = aliased.conflicts.map((entry) => entry.alias);
+    return serializeToolResult(
+      structuredErrorResult({
+        code: "validation_error",
+        message: `Conflicting values for ${names.join(", ")} and their replacements`,
+        issues: aliased.conflicts.map((entry) => ({
+          path: entry.alias,
+          message: deprecatedInputAliasConflictMessage(entry),
+        })),
+        hint: `Send only ${aliased.conflicts.map((entry) => `'${entry.canonical}'`).join(", ")}.`,
+      }),
+    );
+  }
+  const toolArgs = aliased.args;
+
+  const unknownArgs = findUndeclaredArguments({
+    args: toolArgs,
     inputSchema: staticTool.inputSchema,
   });
   if (unknownArgs) {
@@ -241,7 +268,7 @@ export const handleMcpToolCall = async ({
   // without the confirmation.
   if (
     staticTool.annotations.destructiveHint === true &&
-    args["confirm"] !== true
+    toolArgs["confirm"] !== true
   ) {
     return serializeToolResult(
       structuredErrorResult({
@@ -273,7 +300,10 @@ export const handleMcpToolCall = async ({
     // before windowing; this transport boundary then serializes. Both steps run
     // inside this try so an anonymization or windowing failure is captured like
     // any handler failure.
-    const response = await handler({ args, context: executionContext });
+    const response = await handler({
+      args: toolArgs,
+      context: executionContext,
+    });
     return serializeToolResult(
       await finalizeToolEgress(
         {

--- a/packages/cli/skills/stella-cli/SKILL.md
+++ b/packages/cli/skills/stella-cli/SKILL.md
@@ -71,7 +71,7 @@ session with `--scopes`; the default scopes are
   (windowed, so follow `--cursor`).
 - **MCP resources**: `stella reference list` enumerates static server resources;
   `stella reference show <name>` prints one.
-- **Uploading a file**: `stella upload --file <file> --matter-id <matter-id>` uploads a local file as a new document; add `--entity-id <id>` to upload it as a new version of an existing document instead — a CLI-native path (the CLI reads the file itself), separate from the MCP `upload_document_version`/`open_document_version_upload` tools (which take a host-supplied file reference and are excluded from the CLI).
+- **Uploading a file**: `stella upload --file <file> --workspace-id <workspace-id>` uploads a local file as a new document; add `--entity-id <id>` to upload it as a new version of an existing document instead — a CLI-native path (the CLI reads the file itself), separate from the MCP `upload_document_version`/`open_document_version_upload` tools (which take a host-supplied file reference and are excluded from the CLI).
 
 ## Command tree
 
@@ -136,7 +136,7 @@ Global flags (output/cursor/limit/all/yes/input; see Conventions above)
 are omitted here.
 
 - `stella audit-log list`
-  - optional: --matter-id, --action, --resource-type, --resource-id, --user-id, --from, --to
+  - optional: --workspace-id, --action, --resource-type, --resource-id, --user-id, --from, --to
 - `stella capability describe`
   - `--capability` — Capability id to describe, as returned by list_capabilities (e.g. "time-entries.create"). (string)
 - `stella capability invoke`
@@ -175,22 +175,22 @@ are omitted here.
   - `--entity-id` — Document entity ID whose cell to set (string)
   - `--property-id` — Property ID, as returned by list_properties (string)
 - `stella document list`
-  - `--matter-id` — Matter/workspace ID to list documents in (string)
+  - `--workspace-id` — Workspace ID to list documents in. Deprecated input alias: matter_id. (string)
   - optional: --mode (flat|children), --parent-id
 - `stella document properties list`
-  - `--matter-id` — Matter/workspace ID to list properties for (string)
+  - `--workspace-id` — Workspace ID to list properties for. Deprecated input alias: matter_id. (string)
 - `stella document read`
   - `--entity-id` — Document entity ID (string)
   - optional: --version-id, --compare-with-version-id, --include-versions, --versions-cursor
 - `stella document save`
-  - optional: --entity-id, --matter-id, --name, --parent-id, --kind (document|folder), --move-to-root, --version-id, --label, --description
+  - optional: --entity-id, --workspace-id, --name, --parent-id, --kind (document|folder), --move-to-root, --version-id, --label, --description
 - `stella feedback send`
   - `--kind` — Feedback category: bug, feature_request, docs, or other (enum: bug, feature_request, docs, other)
   - `--title` — Short one-line summary of the issue; no tenant data, ids, or secrets (string)
   - `--body` — Markdown details: reproduction steps, expected vs actual behavior, environment. Never include tenant data, client or matter names, ids, or secrets; they are redacted server-side. (string)
   - optional: --channel (github)
 - `stella invoice list`
-  - optional: --matter-id, --invoice-id
+  - optional: --workspace-id, --invoice-id
 - `stella legislation search`
   - optional: --query, --title, --department-code, --legal-range-code, --matter-code, --date-from, --date-to, --law-id, --block-id, --relation-type (modifies|modifiedBy|derogates|derogatedBy|all), --full-text
 - `stella matter delete`
@@ -203,10 +203,10 @@ are omitted here.
 - `stella matter save`
   - optional: --matter-id, --name, --client-id, --reference, --billing-reference, --status (active|archived)
 - `stella organization add-member`
-  - `--matter-id` — Matter/workspace id for add_member and remove_member (string)
+  - `--workspace-id` — Workspace id for add_member and remove_member. Deprecated input alias: matter_id. (string)
   - `--user-id` — User id to add or remove for the member actions (string)
 - `stella organization remove-member`
-  - `--matter-id` — Matter/workspace id for add_member and remove_member (string)
+  - `--workspace-id` — Workspace id for add_member and remove_member. Deprecated input alias: matter_id. (string)
   - `--user-id` — User id to add or remove for the member actions (string)
 - `stella organization set-jurisdictions` — no flags; pass `--input` with jurisdictions
 - `stella organization update-settings`
@@ -214,18 +214,18 @@ are omitted here.
 - `stella playbook list`
   - optional: --playbook-id
 - `stella playbook run`
-  - `--matter-id` — Matter/workspace id to run the playbook over (string)
+  - `--workspace-id` — Workspace id to run the playbook over. Deprecated input alias: matter_id. (string)
   - `--playbook-id` — Playbook id to run (string)
 - `stella rate resolve`
-  - `--matter-id` — Matter/workspace ID to resolve the rate in (string)
+  - `--workspace-id` — Workspace ID to resolve the rate in. Deprecated input alias: matter_id. (string)
   - `--user-id` — User ID to resolve the rate for (string)
   - `--date` — Date to resolve the rate on (ISO YYYY-MM-DD) (string)
 - `stella search matters`
   - `--query` — Search query (string)
 - `stella task list`
-  - optional: --matter-id, --task-id, --date-from, --date-to, --status
+  - optional: --workspace-id, --task-id, --date-from, --date-to, --status
 - `stella task save`
-  - optional: --task-id, --matter-id, --name, --status, --priority, --item-type (task|fact|issue|requirement|event), --list-id, --list-section-id, --list-description, --due-date, --workflow-reason, --add-assignee-user-id, --remove-assignee-user-id, --link-entity-id, --unlink-link-id
+  - optional: --task-id, --workspace-id, --name, --status, --priority, --item-type (task|fact|issue|requirement|event), --list-id, --list-section-id, --list-description, --due-date, --workflow-reason, --add-assignee-user-id, --remove-assignee-user-id, --link-entity-id, --unlink-link-id
 - `stella template fill`
   - `--template-id` — Template id, as returned by list_templates (string)
   - optional: --allow-unused-values, --completion-mode (require_complete|allow_partial)
@@ -235,21 +235,21 @@ are omitted here.
   - optional: --template-id, --name, --docx-base64
 - `stella template save-filled new-document`
   - `--template-id` — Template id, as returned by list_templates (string)
-  - `--matter-id` — Matter/workspace receiving the filled DOCX (string)
+  - `--workspace-id` — Workspace receiving the filled DOCX. Deprecated input alias: matter_id. (string)
   - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (string)
   - optional: --parent-id, --name
 - `stella template save-filled new-version`
   - `--template-id` — Template id, as returned by list_templates (string)
-  - `--matter-id` — Matter/workspace receiving the filled DOCX (string)
+  - `--workspace-id` — Workspace receiving the filled DOCX. Deprecated input alias: matter_id. (string)
   - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (string)
   - `--entity-id` — Existing document entity id; required only for create_version (string)
   - optional: --name
 - `stella time-entry delete`
   - `--time-entry-id` — Time entry ID to delete or write off (string)
 - `stella time-entry list`
-  - optional: --matter-id, --time-entry-id, --entity-id, --user-id, --date-from, --date-to, --status (draft|approved|billed|written_off)
+  - optional: --workspace-id, --time-entry-id, --entity-id, --user-id, --date-from, --date-to, --status (draft|approved|billed|written_off)
 - `stella time-entry save`
-  - optional: --time-entry-id, --matter-id, --entity-id, --date-worked, --timezone-id, --duration-minutes, --narrative, --invoice-narrative, --billable, --no-charge, --task-code, --activity-code
+  - optional: --time-entry-id, --workspace-id, --entity-id, --date-worked, --timezone-id, --duration-minutes, --narrative, --invoice-narrative, --billable, --no-charge, --task-code, --activity-code
 - `stella usage get` — no arguments
 
 ## Exit codes
@@ -305,7 +305,7 @@ generic capability path. Current domains: `audit-logs`, `billing-codes`, `case-l
 - Start workflow extraction: `stella capability workspaces workflow-start --workspace <workspace>`.
 - **`--input` casing is not uniform; never guess it.** A curated command's
   `--input` JSON (the table and flags above) uses the MCP tool schema's own
-  keys, snake_case (`matter_id`, `contact_id`). A capability command's
+  keys, snake_case (`workspace_id`, `contact_id`). A capability command's
   `--input` JSON uses the handler schema's own keys, camelCase (`fieldId`,
   `workspaceId`). Run `stella <command> --help` or `stella capability describe
 <id>` and copy the field paths it prints.

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -296,7 +296,7 @@ describe("one-command document upload", () => {
     const result = await runCli({
       args: [
         "upload",
-        "--matter-id",
+        "--workspace-id",
         "workspace-1",
         "--file",
         filePath,
@@ -347,7 +347,7 @@ describe("one-command document upload", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("--file");
-    expect(result.stdout).toContain("--matter-id");
+    expect(result.stdout).toContain("--workspace-id");
     expect(result.stdout).toContain("--json");
     expect(result.stdout).toContain("computes its SHA-256 checksum");
     expect(server.requests).toHaveLength(0);
@@ -380,7 +380,7 @@ describe("one-command document upload", () => {
     const result = await runCli({
       args: [
         "upload",
-        "--matter-id",
+        "--workspace-id",
         "workspace-1",
         "--file",
         filePath,
@@ -1083,8 +1083,8 @@ describe("template persistence discriminator split", () => {
         "new-version",
         "--template-id",
         "template_1",
-        "--matter-id",
-        "matter_1",
+        "--workspace-id",
+        "workspace_1",
         "--entity-id",
         "entity_1",
         "--idempotency-key",
@@ -1116,8 +1116,8 @@ describe("template persistence discriminator split", () => {
         "new-version",
         "--template-id",
         "template_1",
-        "--matter-id",
-        "matter_1",
+        "--workspace-id",
+        "workspace_1",
         "--entity-id",
         "entity_1",
         "--idempotency-key",
@@ -1135,7 +1135,7 @@ describe("template persistence discriminator split", () => {
     expect(server.requests.at(0)?.params.arguments).toEqual({
       action: "create_version",
       template_id: "template_1",
-      matter_id: "matter_1",
+      workspace_id: "workspace_1",
       entity_id: "entity_1",
       idempotency_key: "retry_1",
       values: { "tenant.name": "ACME" },
@@ -1150,8 +1150,8 @@ describe("organization discriminator split (S2/Phase 4)", () => {
       args: [
         "organization",
         "add-member",
-        "--matter-id",
-        "m1",
+        "--workspace-id",
+        "w1",
         "--user-id",
         "u1",
       ],
@@ -1163,7 +1163,7 @@ describe("organization discriminator split (S2/Phase 4)", () => {
     expect(server.requests.at(0)?.params.name).toBe("manage_organization");
     expect(server.requests.at(0)?.params.arguments).toEqual({
       action: "add_member",
-      matter_id: "m1",
+      workspace_id: "w1",
       user_id: "u1",
     });
   });
@@ -1174,8 +1174,8 @@ describe("organization discriminator split (S2/Phase 4)", () => {
       args: [
         "organization",
         "remove-member",
-        "--matter-id",
-        "m1",
+        "--workspace-id",
+        "w1",
         "--user-id",
         "u1",
       ],
@@ -1421,8 +1421,8 @@ describe("destructive confirm injection (S4)", () => {
       args: [
         "organization",
         "remove-member",
-        "--matter-id",
-        "m1",
+        "--workspace-id",
+        "w1",
         "--user-id",
         "u1",
         "--yes",
@@ -1435,7 +1435,7 @@ describe("destructive confirm injection (S4)", () => {
     expect(server.requests.at(0)?.params.name).toBe("manage_organization");
     expect(server.requests.at(0)?.params.arguments).toEqual({
       action: "remove_member",
-      matter_id: "m1",
+      workspace_id: "w1",
       user_id: "u1",
       confirm: true,
     });

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -60,7 +60,7 @@ type UploadFlags = CommonFlagValues & {
   readonly name: string | undefined;
   readonly parentId: string | undefined;
   readonly propertyId: string | undefined;
-  readonly matterId: string;
+  readonly workspaceId: string;
 };
 
 const renderNestedFailure = ({
@@ -103,7 +103,7 @@ const renderNestedFailure = ({
  */
 export const uploadSpecificFlags: {
   readonly file: RequiredStringFlagSpec;
-  readonly matterId: RequiredStringFlagSpec;
+  readonly workspaceId: RequiredStringFlagSpec;
   readonly propertyId: OptionalStringFlagSpec;
   readonly parentId: OptionalStringFlagSpec;
   readonly entityId: OptionalStringFlagSpec;
@@ -115,8 +115,8 @@ export const uploadSpecificFlags: {
     kind: "parsed",
     parse: parseString,
   },
-  matterId: {
-    brief: "Matter id that will own the document",
+  workspaceId: {
+    brief: "Workspace id that will own the document",
     kind: "parsed",
     parse: parseString,
   },
@@ -200,7 +200,7 @@ export const uploadCommand: Command<Context> = buildCommand<
         filePath: flags.file,
         mimeType: flags.mimeType,
         name: flags.name,
-        workspaceId: flags.matterId,
+        workspaceId: flags.workspaceId,
         ...(flags.entityId === undefined
           ? {
               target: "new_document" as const,
@@ -232,7 +232,7 @@ export const uploadCommand: Command<Context> = buildCommand<
     }
     renderNestedFailure({ context: this, failure: uploaded.error.failure });
     writers.stderr(
-      `hint: retry finalization with '${formatCapabilityCommand("uploads.update")} --workspace-id ${flags.matterId} --upload-id ${uploaded.error.uploadId}'\n`,
+      `hint: retry finalization with '${formatCapabilityCommand("uploads.update")} --workspace-id ${flags.workspaceId} --upload-id ${uploaded.error.uploadId}'\n`,
     );
   },
   parameters: {

--- a/packages/cli/src/deprecated-input-aliases.ts
+++ b/packages/cli/src/deprecated-input-aliases.ts
@@ -1,0 +1,78 @@
+import { MCP_DEPRECATED_INPUT_ALIASES } from "./generated/mcp-contract.js";
+
+/**
+ * The server accepts a deprecated tool-input name for one release and rewrites
+ * it onto its replacement at dispatch. The CLI validates `--input` against the
+ * baked schema BEFORE it ever contacts the server, so without the same rewrite
+ * here a caller following a field description (`Deprecated input alias:
+ * matter_id.`) would be rejected locally and never reach that server-side
+ * normalization.
+ *
+ * The alias table itself is generated from the API's own map
+ * (`generated/mcp-contract.ts`), so the two surfaces cannot disagree about
+ * WHICH names are aliased; only the (small) rewrite rule is stated twice, once
+ * per package. Both go when the deprecation window closes.
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Canonical name -> the deprecated name it replaced. */
+export const DEPRECATED_NAME_BY_CANONICAL_INPUT: Readonly<
+  Record<string, string>
+> = Object.fromEntries(
+  Object.entries(MCP_DEPRECATED_INPUT_ALIASES).map(([alias, canonical]) => [
+    canonical,
+    alias,
+  ]),
+);
+
+export type DeprecatedInputAliasResult =
+  | { status: "normalized"; args: Record<string, unknown> }
+  | { status: "conflict"; alias: string; canonical: string };
+
+/**
+ * Rewrites deprecated input names onto their canonical field. A deprecated name
+ * the schema still declares is left alone (the tool genuinely owns it), and
+ * supplying both names with different values is a conflict rather than a silent
+ * winner — the same three rules the server applies.
+ */
+export const applyDeprecatedInputAliases = ({
+  args,
+  inputSchema,
+}: {
+  args: Record<string, unknown>;
+  inputSchema: unknown;
+}): DeprecatedInputAliasResult => {
+  const rawProperties = isRecord(inputSchema)
+    ? inputSchema["properties"]
+    : undefined;
+  const properties = isRecord(rawProperties) ? rawProperties : {};
+  const renames = new Map<string, string>();
+
+  for (const [alias, canonical] of Object.entries(
+    MCP_DEPRECATED_INPUT_ALIASES,
+  )) {
+    const applies =
+      alias in args && !(alias in properties) && canonical in properties;
+    if (!applies) {
+      continue;
+    }
+    if (canonical in args && args[canonical] !== args[alias]) {
+      return { alias, canonical, status: "conflict" };
+    }
+    renames.set(alias, canonical);
+  }
+
+  if (renames.size === 0) {
+    return { args, status: "normalized" };
+  }
+  return {
+    args: Object.fromEntries(
+      Object.entries(args).map(([key, value]) => [
+        renames.get(key) ?? key,
+        value,
+      ]),
+    ),
+    status: "normalized",
+  };
+};

--- a/packages/cli/src/generate-route-map.test.ts
+++ b/packages/cli/src/generate-route-map.test.ts
@@ -22,6 +22,9 @@ const snapshotUrl = new URL(
 const snapshotListings: readonly RegistryToolListing[] =
   await Bun.file(snapshotUrl).json();
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const findLeaf = (
   node: RouteNode,
   path: readonly string[],
@@ -254,6 +257,44 @@ describe("generateRouteMap: discriminator split (S2)", () => {
     expect(flagFor(newVersion ?? errorSpec(), "--entity-id")?.required).toBe(
       true,
     );
+  });
+
+  test("a subcommand include list falls back to a schema's deprecated name", () => {
+    // This generator also runs at runtime over a `tools/list` refreshed from a
+    // self-hosted server still on the pre-rename registry. The Annotation Table
+    // names `workspace_id`; that schema still says `matter_id`. Without the
+    // alias fallback the subcommand would expose NEITHER, because the canonical
+    // prop is absent and the deprecated one is not in the include list.
+    const listing = snapshotListings.find(
+      (candidate) => candidate.name === "manage_organization",
+    );
+    if (listing === undefined) {
+      throw new Error("manage_organization missing from the snapshot");
+    }
+    const properties = listing.inputSchema["properties"];
+    if (!isRecord(properties)) {
+      throw new Error("manage_organization has no properties");
+    }
+    const { workspace_id: scoping, ...rest } = properties;
+    const olderTree = generateRouteMap(
+      [
+        {
+          ...listing,
+          inputSchema: {
+            ...listing.inputSchema,
+            properties: { ...rest, matter_id: scoping },
+          },
+        },
+      ],
+      TOOL_ANNOTATIONS,
+    );
+
+    const olderAdd = findLeaf(olderTree, ["organization", "add-member"]);
+    expect(olderAdd?.flags.map((f) => f.flag).sort()).toEqual([
+      "--matter-id",
+      "--user-id",
+    ]);
+    expect(olderAdd?.flags.every((f) => f.required)).toBe(true);
   });
 });
 

--- a/packages/cli/src/generate-route-map.test.ts
+++ b/packages/cli/src/generate-route-map.test.ts
@@ -176,8 +176,8 @@ describe("generateRouteMap: discriminator split (S2)", () => {
 
   test("per-subcommand flag sets and required sets match the table", () => {
     expect(add?.flags.map((f) => f.flag).sort()).toEqual([
-      "--matter-id",
       "--user-id",
+      "--workspace-id",
     ]);
     expect(add?.flags.every((f) => f.required)).toBe(true);
     expect(settings?.flags.map((f) => f.flag).sort()).toEqual([
@@ -478,7 +478,7 @@ describe("generateRouteMap: Phase 4 domains (S1/S3)", () => {
 
   test("run_playbook required[] props become required flags", () => {
     const run = findLeaf(tree, ["playbook", "run"]);
-    expect(flagFor(run ?? errorSpec(), "--matter-id")?.required).toBe(true);
+    expect(flagFor(run ?? errorSpec(), "--workspace-id")?.required).toBe(true);
     expect(flagFor(run ?? errorSpec(), "--playbook-id")?.required).toBe(true);
   });
 });

--- a/packages/cli/src/generate-route-map.ts
+++ b/packages/cli/src/generate-route-map.ts
@@ -8,6 +8,7 @@
 import { TaggedError, type TaggedErrorClass } from "better-result";
 
 import { RESERVED_FLAGS, RESERVED_TOP_LEVEL_NAMES } from "./annotations.js";
+import { DEPRECATED_NAME_BY_CANONICAL_INPUT } from "./deprecated-input-aliases.js";
 import { flagKey } from "./flag-name.js";
 import type {
   FlagSpec,
@@ -465,6 +466,31 @@ const resolvePaginationMode = (
   return hasLimit ? "full" : "cursor-only";
 };
 
+/**
+ * Resolve a property name the Annotation Table refers to against the schema
+ * actually in hand.
+ *
+ * The table names the CANONICAL field, but this generator also runs at runtime
+ * over a `tools/list` refreshed from a self-hosted server that may still be on
+ * the pre-rename registry, where the same field carries its deprecated name.
+ * Without this fallback a discriminated tool (`save_filled_template`,
+ * `manage_organization`) would expose NEITHER name against such a server:
+ * `buildFlags` skips the canonical prop as absent, and the deprecated one is
+ * not in the include list. Drop it with the alias table.
+ */
+const resolveAnnotatedProp = (
+  prop: string,
+  properties: Record<string, PropSchema>,
+): string => {
+  if (prop in properties) {
+    return prop;
+  }
+  const deprecated = DEPRECATED_NAME_BY_CANONICAL_INPUT[prop];
+  return deprecated !== undefined && deprecated in properties
+    ? deprecated
+    : prop;
+};
+
 type BuiltFlags = {
   flags: FlagSpec[];
   inputOnly: string[];
@@ -616,11 +642,18 @@ const leafSpecsForTool = ({
     for (const value of values) {
       const sub = annotation?.discriminator?.subcommands[value];
       const subCommandName = sub?.command ?? kebabCase(value);
-      const subRequired = new Set([...baseRequired, ...(sub?.required ?? [])]);
+      const subRequired = new Set([
+        ...baseRequired,
+        ...(sub?.required ?? []).map((prop) =>
+          resolveAnnotatedProp(prop, properties),
+        ),
+      ]);
       const { flags, inputOnly } = buildFlags({
         properties,
         required: subRequired,
-        includeProps: sub?.include,
+        includeProps: sub?.include?.map((prop) =>
+          resolveAnnotatedProp(prop, properties),
+        ),
         skipProps: skipWithDiscriminator,
       });
       specs.push({

--- a/packages/cli/src/generate-skill.ts
+++ b/packages/cli/src/generate-skill.ts
@@ -323,7 +323,7 @@ const renderCapabilitySection = (summary: CapabilitySkillSummary): string => {
     ...exampleLines,
     "- **`--input` casing is not uniform; never guess it.** A curated command's",
     "  `--input` JSON (the table and flags above) uses the MCP tool schema's own",
-    "  keys, snake_case (`matter_id`, `contact_id`). A capability command's",
+    "  keys, snake_case (`workspace_id`, `contact_id`). A capability command's",
     "  `--input` JSON uses the handler schema's own keys, camelCase (`fieldId`,",
     "  `workspaceId`). Run `stella <command> --help` or `stella capability describe",
     "  <id>` and copy the field paths it prints.",
@@ -339,7 +339,7 @@ const isOptionalUploadFlag = (flag: UploadFlagEntry): boolean =>
 const uploadFlagName = (key: string): string => `--${kebabCase(key)}`;
 
 /** `stella upload`'s required flags, in invocation order (spec upload-note). */
-const REQUIRED_UPLOAD_KEYS = ["file", "matterId"] as const;
+const REQUIRED_UPLOAD_KEYS = ["file", "workspaceId"] as const;
 
 /**
  * Documents the real `stella upload` invocation, including uploading a new

--- a/packages/cli/src/generated/mcp-contract.ts
+++ b/packages/cli/src/generated/mcp-contract.ts
@@ -72,3 +72,7 @@ export const MCP_CLI_TOOL_SCOPES = [
   "feedback",
 ] as const;
 export type McpCliToolScope = (typeof MCP_CLI_TOOL_SCOPES)[number];
+/** Deprecated tool-input names the server still accepts, keyed to their replacement. */
+export const MCP_DEPRECATED_INPUT_ALIASES = {
+  matter_id: "workspace_id",
+} as const;

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -686,7 +686,7 @@
             "command": "new-document",
             "include": [
               "template_id",
-              "matter_id",
+              "workspace_id",
               "idempotency_key",
               "parent_id",
               "name",
@@ -694,7 +694,7 @@
             ],
             "required": [
               "template_id",
-              "matter_id",
+              "workspace_id",
               "idempotency_key",
               "values"
             ]
@@ -703,7 +703,7 @@
             "command": "new-version",
             "include": [
               "template_id",
-              "matter_id",
+              "workspace_id",
               "idempotency_key",
               "entity_id",
               "name",
@@ -711,7 +711,7 @@
             ],
             "required": [
               "template_id",
-              "matter_id",
+              "workspace_id",
               "entity_id",
               "idempotency_key",
               "values"
@@ -721,7 +721,7 @@
       }
     },
     "name": "save_filled_template",
-    "description": "Fill a registered template and persist the generated DOCX directly in a matter, without requiring the client to upload bytes. Use action='create_document' to create a new document (optionally inside parent_id), or action='create_version' with entity_id to append a version to an existing document. Call list_templates first to learn the field paths and which are required. A required field that is not AI-fillable must be provided, or the fill fails with the exact list of missing fields; ask the user for those values instead of guessing. Returns the entity and version identifiers plus any unmatched placeholders or unused values.",
+    "description": "Fill a registered template and persist the generated DOCX directly in a workspace, without requiring the client to upload bytes. Use action='create_document' to create a new document (optionally inside parent_id), or action='create_version' with entity_id to append a version to an existing document. Call list_templates first to learn the field paths and which are required. A required field that is not AI-fillable must be provided, or the fill fails with the exact list of missing fields; ask the user for those values instead of guessing. Returns the entity and version identifiers plus any unmatched placeholders or unused values.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -734,9 +734,9 @@
           "type": "string",
           "description": "Template id, as returned by list_templates"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
-          "description": "Matter/workspace receiving the filled DOCX"
+          "description": "Workspace receiving the filled DOCX. Deprecated input alias: matter_id."
         },
         "entity_id": {
           "type": "string",
@@ -765,7 +765,7 @@
       "required": [
         "action",
         "template_id",
-        "matter_id",
+        "workspace_id",
         "idempotency_key",
         "values"
       ],
@@ -1165,21 +1165,21 @@
       "itemsKey": "documents"
     },
     "name": "list_documents",
-    "description": "List the documents and folders in a matter. Use 'flat' mode to enumerate every document and folder in the matter, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the matter root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
+    "description": "List the documents and folders in a workspace. Use 'flat' mode to enumerate every document and folder in the workspace, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the workspace root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
     "inputSchema": {
       "type": "object",
-      "required": ["matter_id"],
+      "required": ["workspace_id"],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list documents in"
+          "description": "Workspace ID to list documents in. Deprecated input alias: matter_id."
         },
         "mode": {
           "enum": ["flat", "children"],
           "type": "string",
-          "description": "'flat' lists every document and folder in the matter; 'children' lists only the direct children of parent_id (or the matter root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected."
+          "description": "'flat' lists every document and folder in the workspace; 'children' lists only the direct children of parent_id (or the workspace root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected."
         },
         "parent_id": {
           "type": "string",
@@ -1255,7 +1255,7 @@
       "scope": "documents_write"
     },
     "name": "save_document",
-    "description": "Create a document or folder, or update an existing one. Omit entity_id to create: pass matter_id and name, optionally a parent_id folder and kind ('document' by default, or 'folder'). Creating makes an empty named entity; uploading file content is a separate step. Pass entity_id to update: set name to rename; parent_id to move it into a folder or move_to_root to move it to the matter root; version_id with label and/or description to annotate a version. An update needs at least one change. Returns the entity ID.",
+    "description": "Create a document or folder, or update an existing one. Omit entity_id to create: pass workspace_id and name, optionally a parent_id folder and kind ('document' by default, or 'folder'). Creating makes an empty named entity; uploading file content is a separate step. Pass entity_id to update: set name to rename; parent_id to move it into a folder or move_to_root to move it to the workspace root; version_id with label and/or description to annotate a version. An update needs at least one change. Returns the entity ID.",
     "inputSchema": {
       "type": "object",
       "required": [],
@@ -1266,10 +1266,10 @@
           "minLength": 1,
           "description": "Document entity ID to update; omit to create"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to create the entity in; required when creating"
+          "description": "Workspace ID to create the entity in; required when creating. Deprecated input alias: matter_id."
         },
         "name": {
           "type": "string",
@@ -1452,13 +1452,13 @@
     "description": "List the property (column) definitions of a matter. Returns each property's id, name, value type (text, single-select, multi-select, date, int, or file), status, and writeMethod. Use set_field_value for scalar properties. Arbitrary file-property cells are not writable; document upload/version tools replace only a document's primary file.",
     "inputSchema": {
       "type": "object",
-      "required": ["matter_id"],
+      "required": ["workspace_id"],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list properties for"
+          "description": "Workspace ID to list properties for. Deprecated input alias: matter_id."
         },
         "limit": {
           "type": "integer",
@@ -1920,16 +1920,16 @@
       "singleReadWhen": "task_id"
     },
     "name": "list_tasks",
-    "description": "List tasks in a matter, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass matter_id to list the matter's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each item's id, name, item type, status, priority, and due date.",
+    "description": "List tasks in a workspace, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass workspace_id to list the workspace's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each item's id, name, item type, status, priority, and due date.",
     "inputSchema": {
       "type": "object",
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list tasks in; required unless task_id is given"
+          "description": "Workspace ID to list tasks in; required unless task_id is given. Deprecated input alias: matter_id."
         },
         "task_id": {
           "type": "string",
@@ -1979,7 +1979,7 @@
       "scope": "matters_write"
     },
     "name": "save_task",
-    "description": "Create or update a task, and manage its assignees and entity links. Omit task_id to create a task (matter_id and name required). Pass task_id to update: set name, item_type, status, priority, or due_date (ISO YYYY-MM-DD, null to clear); add or remove one assignee (add_assignee_user_id / remove_assignee_user_id); link the task to another entity (link_entity_id) or remove a link (unlink_link_id). Returns the task ID.",
+    "description": "Create or update a task, and manage its assignees and entity links. Omit task_id to create a task (workspace_id and name required). Pass task_id to update: set name, item_type, status, priority, or due_date (ISO YYYY-MM-DD, null to clear); add or remove one assignee (add_assignee_user_id / remove_assignee_user_id); link the task to another entity (link_entity_id) or remove a link (unlink_link_id). Returns the task ID.",
     "inputSchema": {
       "type": "object",
       "required": [],
@@ -1990,10 +1990,10 @@
           "minLength": 1,
           "description": "Task entity ID to update; omit to create"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to create the task in; required when creating"
+          "description": "Workspace ID to create the task in; required when creating. Deprecated input alias: matter_id."
         },
         "name": {
           "type": "string",
@@ -2433,16 +2433,16 @@
       "scope": "knowledge_write"
     },
     "name": "run_playbook",
-    "description": "Run a review playbook over a matter's documents. Materializes the playbook's extraction and verdict columns onto the matter's table and starts the AI review; findings populate asynchronously. Pass matter_id and playbook_id. Returns the number of columns queued for review.",
+    "description": "Run a review playbook over a workspace's documents. Materializes the playbook's extraction and verdict columns onto the workspace's table and starts the AI review; findings populate asynchronously. Pass workspace_id and playbook_id. Returns the number of columns queued for review.",
     "inputSchema": {
       "type": "object",
-      "required": ["matter_id", "playbook_id"],
+      "required": ["workspace_id", "playbook_id"],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace id to run the playbook over"
+          "description": "Workspace id to run the playbook over. Deprecated input alias: matter_id."
         },
         "playbook_id": {
           "type": "string",
@@ -2465,16 +2465,16 @@
       "singleReadWhen": "time_entry_id"
     },
     "name": "list_time_entries",
-    "description": "List time entries in a matter, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass matter_id to list the matter's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status. The response includes visibility: all_entries for billing reviewers, or own_entries when the caller can see only their own time; own_entries is not a matter total.",
+    "description": "List time entries in a workspace, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass workspace_id to list the workspace's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status. The response includes visibility: all_entries for billing reviewers, or own_entries when the caller can see only their own time; own_entries is not a matter total.",
     "inputSchema": {
       "type": "object",
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list time entries in; required unless time_entry_id is given"
+          "description": "Workspace ID to list time entries in; required unless time_entry_id is given. Deprecated input alias: matter_id."
         },
         "time_entry_id": {
           "type": "string",
@@ -2533,7 +2533,7 @@
       "scope": "billing_write"
     },
     "name": "save_time_entry",
-    "description": "Create or update a time entry. Omit time_entry_id to create (matter_id, date_worked, timezone_id, duration_minutes, and narrative required; entity_id is optional context). Pass time_entry_id to update: set date_worked (with timezone_id), duration_minutes, narrative, invoice_narrative, billable, no_charge, entity_id (move the entry), task_code, and/or activity_code. The timekeeper's effective rate is resolved server-side. Durations are whole minutes. Returns the time entry ID.",
+    "description": "Create or update a time entry. Omit time_entry_id to create (workspace_id, date_worked, timezone_id, duration_minutes, and narrative required; entity_id is optional context). Pass time_entry_id to update: set date_worked (with timezone_id), duration_minutes, narrative, invoice_narrative, billable, no_charge, entity_id (move the entry), task_code, and/or activity_code. The timekeeper's effective rate is resolved server-side. Durations are whole minutes. Returns the time entry ID.",
     "inputSchema": {
       "type": "object",
       "required": [],
@@ -2544,10 +2544,10 @@
           "minLength": 1,
           "description": "Time entry ID to update; omit to create"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to create the entry in; required when creating"
+          "description": "Workspace ID to create the entry in; required when creating. Deprecated input alias: matter_id."
         },
         "entity_id": {
           "anyOf": [
@@ -2672,16 +2672,16 @@
       "scope": "read"
     },
     "name": "resolve_rate",
-    "description": "Resolve the effective hourly rate for a user on a given date in a matter, using the matter's default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
+    "description": "Resolve the effective hourly rate for a user on a given date in a workspace, using its default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
     "inputSchema": {
       "type": "object",
-      "required": ["matter_id", "user_id", "date"],
+      "required": ["workspace_id", "user_id", "date"],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to resolve the rate in"
+          "description": "Workspace ID to resolve the rate in. Deprecated input alias: matter_id."
         },
         "user_id": {
           "type": "string",
@@ -2710,16 +2710,16 @@
       "singleReadWhen": "invoice_id"
     },
     "name": "list_invoices",
-    "description": "List invoices in a matter, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass matter_id to list the matter's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
+    "description": "List invoices in a workspace, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass workspace_id to list the workspace's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
     "inputSchema": {
       "type": "object",
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace ID to list invoices in; required unless invoice_id is given"
+          "description": "Workspace ID to list invoices in; required unless invoice_id is given. Deprecated input alias: matter_id."
         },
         "invoice_id": {
           "type": "string",
@@ -2862,16 +2862,16 @@
       "itemsKey": "items"
     },
     "name": "list_audit_log",
-    "description": "Read the organization's audit trail (compliance view). Returns audit entries newest first, each with its action, resource type and id, actor user id, workspace, timestamp, and change detail. Filter by matter_id, action, resource_type (with optional resource_id), user_id, and a created-at range (from/to, ISO date-time). Paginate with limit and cursor. Requires organization audit-log access.",
+    "description": "Read the organization's audit trail (compliance view). Returns audit entries newest first, each with its action, resource type and id, actor user id, workspace, timestamp, and change detail. Filter by workspace_id, action, resource_type (with optional resource_id), user_id, and a created-at range (from/to, ISO date-time). Paginate with limit and cursor. Requires organization audit-log access.",
     "inputSchema": {
       "type": "object",
       "required": [],
       "additionalProperties": false,
       "properties": {
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Only entries scoped to this matter/workspace"
+          "description": "Only entries scoped to this workspace. Deprecated input alias: matter_id."
         },
         "action": {
           "type": "string",
@@ -2932,13 +2932,13 @@
         "subcommands": {
           "add_member": {
             "command": "add-member",
-            "include": ["matter_id", "user_id"],
-            "required": ["matter_id", "user_id"]
+            "include": ["workspace_id", "user_id"],
+            "required": ["workspace_id", "user_id"]
           },
           "remove_member": {
             "command": "remove-member",
-            "include": ["matter_id", "user_id"],
-            "required": ["matter_id", "user_id"],
+            "include": ["workspace_id", "user_id"],
+            "required": ["workspace_id", "user_id"],
             "destructive": true
           },
           "update_org_settings": {
@@ -2954,7 +2954,7 @@
       }
     },
     "name": "manage_organization",
-    "description": "Manage organization members and non-secret settings. Member actions require matter_id and user_id. update_org_settings controls matter numbering, prompt caching, and document processing. Manage provider secrets in the dashboard.",
+    "description": "Manage organization members and non-secret settings. Member actions require workspace_id and user_id. update_org_settings controls matter numbering, prompt caching, and document processing. Manage provider secrets in the dashboard.",
     "inputSchema": {
       "type": "object",
       "required": ["action"],
@@ -2965,10 +2965,10 @@
           "type": "string",
           "description": "Administrative action to perform"
         },
-        "matter_id": {
+        "workspace_id": {
           "type": "string",
           "minLength": 1,
-          "description": "Matter/workspace id for add_member and remove_member"
+          "description": "Workspace id for add_member and remove_member. Deprecated input alias: matter_id."
         },
         "user_id": {
           "type": "string",

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -630,11 +630,12 @@ export const generatedRouteMap: RouteNode = {
             toolName: "list_documents",
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
-                description: "Matter/workspace ID to list documents in",
+                description:
+                  "Workspace ID to list documents in. Deprecated input alias: matter_id.",
                 required: true,
               },
               {
@@ -644,7 +645,7 @@ export const generatedRouteMap: RouteNode = {
                 enum: ["flat", "children"],
                 repeatable: false,
                 description:
-                  "'flat' lists every document and folder in the matter; 'children' lists only the direct children of parent_id (or the matter root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected.",
+                  "'flat' lists every document and folder in the workspace; 'children' lists only the direct children of parent_id (or the workspace root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected.",
                 required: false,
               },
               {
@@ -665,19 +666,20 @@ export const generatedRouteMap: RouteNode = {
             scope: "read",
             inputSchema: {
               type: "object",
-              required: ["matter_id"],
+              required: ["workspace_id"],
               additionalProperties: false,
               properties: {
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
-                  description: "Matter/workspace ID to list documents in",
+                  description:
+                    "Workspace ID to list documents in. Deprecated input alias: matter_id.",
                 },
                 mode: {
                   enum: ["flat", "children"],
                   type: "string",
                   description:
-                    "'flat' lists every document and folder in the matter; 'children' lists only the direct children of parent_id (or the matter root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected.",
+                    "'flat' lists every document and folder in the workspace; 'children' lists only the direct children of parent_id (or the workspace root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected.",
                 },
                 parent_id: {
                   type: "string",
@@ -807,12 +809,12 @@ export const generatedRouteMap: RouteNode = {
                 required: false,
               },
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace ID to create the entity in; required when creating",
+                  "Workspace ID to create the entity in; required when creating. Deprecated input alias: matter_id.",
                 required: false,
               },
               {
@@ -895,11 +897,11 @@ export const generatedRouteMap: RouteNode = {
                   minLength: 1,
                   description: "Document entity ID to update; omit to create",
                 },
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace ID to create the entity in; required when creating",
+                    "Workspace ID to create the entity in; required when creating. Deprecated input alias: matter_id.",
                 },
                 name: {
                   type: "string",
@@ -1027,11 +1029,12 @@ export const generatedRouteMap: RouteNode = {
                 toolName: "list_properties",
                 flags: [
                   {
-                    flag: "--matter-id",
-                    prop: "matter_id",
+                    flag: "--workspace-id",
+                    prop: "workspace_id",
                     kind: "string",
                     repeatable: false,
-                    description: "Matter/workspace ID to list properties for",
+                    description:
+                      "Workspace ID to list properties for. Deprecated input alias: matter_id.",
                     required: true,
                   },
                 ],
@@ -1043,13 +1046,14 @@ export const generatedRouteMap: RouteNode = {
                 scope: "read",
                 inputSchema: {
                   type: "object",
-                  required: ["matter_id"],
+                  required: ["workspace_id"],
                   additionalProperties: false,
                   properties: {
-                    matter_id: {
+                    workspace_id: {
                       type: "string",
                       minLength: 1,
-                      description: "Matter/workspace ID to list properties for",
+                      description:
+                        "Workspace ID to list properties for. Deprecated input alias: matter_id.",
                     },
                     limit: {
                       type: "integer",
@@ -1916,12 +1920,12 @@ export const generatedRouteMap: RouteNode = {
             },
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace id for add_member and remove_member",
+                  "Workspace id for add_member and remove_member. Deprecated input alias: matter_id.",
                 required: true,
               },
               {
@@ -1948,11 +1952,11 @@ export const generatedRouteMap: RouteNode = {
                   type: "string",
                   description: "Administrative action to perform",
                 },
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace id for add_member and remove_member",
+                    "Workspace id for add_member and remove_member. Deprecated input alias: matter_id.",
                 },
                 user_id: {
                   type: "string",
@@ -2004,12 +2008,12 @@ export const generatedRouteMap: RouteNode = {
             },
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace id for add_member and remove_member",
+                  "Workspace id for add_member and remove_member. Deprecated input alias: matter_id.",
                 required: true,
               },
               {
@@ -2036,11 +2040,11 @@ export const generatedRouteMap: RouteNode = {
                   type: "string",
                   description: "Administrative action to perform",
                 },
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace id for add_member and remove_member",
+                    "Workspace id for add_member and remove_member. Deprecated input alias: matter_id.",
                 },
                 user_id: {
                   type: "string",
@@ -2146,11 +2150,11 @@ export const generatedRouteMap: RouteNode = {
                   type: "string",
                   description: "Administrative action to perform",
                 },
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace id for add_member and remove_member",
+                    "Workspace id for add_member and remove_member. Deprecated input alias: matter_id.",
                 },
                 user_id: {
                   type: "string",
@@ -2328,11 +2332,12 @@ export const generatedRouteMap: RouteNode = {
                     required: true,
                   },
                   {
-                    flag: "--matter-id",
-                    prop: "matter_id",
+                    flag: "--workspace-id",
+                    prop: "workspace_id",
                     kind: "string",
                     repeatable: false,
-                    description: "Matter/workspace receiving the filled DOCX",
+                    description:
+                      "Workspace receiving the filled DOCX. Deprecated input alias: matter_id.",
                     required: true,
                   },
                   {
@@ -2382,9 +2387,10 @@ export const generatedRouteMap: RouteNode = {
                       type: "string",
                       description: "Template id, as returned by list_templates",
                     },
-                    matter_id: {
+                    workspace_id: {
                       type: "string",
-                      description: "Matter/workspace receiving the filled DOCX",
+                      description:
+                        "Workspace receiving the filled DOCX. Deprecated input alias: matter_id.",
                     },
                     entity_id: {
                       type: "string",
@@ -2417,7 +2423,7 @@ export const generatedRouteMap: RouteNode = {
                   required: [
                     "action",
                     "template_id",
-                    "matter_id",
+                    "workspace_id",
                     "idempotency_key",
                     "values",
                   ],
@@ -2443,11 +2449,12 @@ export const generatedRouteMap: RouteNode = {
                     required: true,
                   },
                   {
-                    flag: "--matter-id",
-                    prop: "matter_id",
+                    flag: "--workspace-id",
+                    prop: "workspace_id",
                     kind: "string",
                     repeatable: false,
-                    description: "Matter/workspace receiving the filled DOCX",
+                    description:
+                      "Workspace receiving the filled DOCX. Deprecated input alias: matter_id.",
                     required: true,
                   },
                   {
@@ -2497,9 +2504,10 @@ export const generatedRouteMap: RouteNode = {
                       type: "string",
                       description: "Template id, as returned by list_templates",
                     },
-                    matter_id: {
+                    workspace_id: {
                       type: "string",
-                      description: "Matter/workspace receiving the filled DOCX",
+                      description:
+                        "Workspace receiving the filled DOCX. Deprecated input alias: matter_id.",
                     },
                     entity_id: {
                       type: "string",
@@ -2532,7 +2540,7 @@ export const generatedRouteMap: RouteNode = {
                   required: [
                     "action",
                     "template_id",
-                    "matter_id",
+                    "workspace_id",
                     "idempotency_key",
                     "values",
                   ],
@@ -2964,12 +2972,12 @@ export const generatedRouteMap: RouteNode = {
             toolName: "list_tasks",
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace ID to list tasks in; required unless task_id is given",
+                  "Workspace ID to list tasks in; required unless task_id is given. Deprecated input alias: matter_id.",
                 required: false,
               },
               {
@@ -3018,11 +3026,11 @@ export const generatedRouteMap: RouteNode = {
               required: [],
               additionalProperties: false,
               properties: {
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace ID to list tasks in; required unless task_id is given",
+                    "Workspace ID to list tasks in; required unless task_id is given. Deprecated input alias: matter_id.",
                 },
                 task_id: {
                   type: "string",
@@ -3080,12 +3088,12 @@ export const generatedRouteMap: RouteNode = {
                 required: false,
               },
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace ID to create the task in; required when creating",
+                  "Workspace ID to create the task in; required when creating. Deprecated input alias: matter_id.",
                 required: false,
               },
               {
@@ -3212,11 +3220,11 @@ export const generatedRouteMap: RouteNode = {
                   minLength: 1,
                   description: "Task entity ID to update; omit to create",
                 },
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace ID to create the task in; required when creating",
+                    "Workspace ID to create the task in; required when creating. Deprecated input alias: matter_id.",
                 },
                 name: {
                   type: "string",
@@ -3764,11 +3772,12 @@ export const generatedRouteMap: RouteNode = {
             toolName: "run_playbook",
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
-                description: "Matter/workspace id to run the playbook over",
+                description:
+                  "Workspace id to run the playbook over. Deprecated input alias: matter_id.",
                 required: true,
               },
               {
@@ -3787,13 +3796,14 @@ export const generatedRouteMap: RouteNode = {
             scope: "knowledge_write",
             inputSchema: {
               type: "object",
-              required: ["matter_id", "playbook_id"],
+              required: ["workspace_id", "playbook_id"],
               additionalProperties: false,
               properties: {
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
-                  description: "Matter/workspace id to run the playbook over",
+                  description:
+                    "Workspace id to run the playbook over. Deprecated input alias: matter_id.",
                 },
                 playbook_id: {
                   type: "string",
@@ -3816,12 +3826,12 @@ export const generatedRouteMap: RouteNode = {
             toolName: "list_time_entries",
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace ID to list time entries in; required unless time_entry_id is given",
+                  "Workspace ID to list time entries in; required unless time_entry_id is given. Deprecated input alias: matter_id.",
                 required: false,
               },
               {
@@ -3888,11 +3898,11 @@ export const generatedRouteMap: RouteNode = {
               required: [],
               additionalProperties: false,
               properties: {
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace ID to list time entries in; required unless time_entry_id is given",
+                    "Workspace ID to list time entries in; required unless time_entry_id is given. Deprecated input alias: matter_id.",
                 },
                 time_entry_id: {
                   type: "string",
@@ -3960,12 +3970,12 @@ export const generatedRouteMap: RouteNode = {
                 required: false,
               },
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace ID to create the entry in; required when creating",
+                  "Workspace ID to create the entry in; required when creating. Deprecated input alias: matter_id.",
                 required: false,
               },
               {
@@ -4071,11 +4081,11 @@ export const generatedRouteMap: RouteNode = {
                   minLength: 1,
                   description: "Time entry ID to update; omit to create",
                 },
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace ID to create the entry in; required when creating",
+                    "Workspace ID to create the entry in; required when creating. Deprecated input alias: matter_id.",
                 },
                 entity_id: {
                   anyOf: [
@@ -4218,11 +4228,12 @@ export const generatedRouteMap: RouteNode = {
             toolName: "resolve_rate",
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
-                description: "Matter/workspace ID to resolve the rate in",
+                description:
+                  "Workspace ID to resolve the rate in. Deprecated input alias: matter_id.",
                 required: true,
               },
               {
@@ -4249,13 +4260,14 @@ export const generatedRouteMap: RouteNode = {
             scope: "read",
             inputSchema: {
               type: "object",
-              required: ["matter_id", "user_id", "date"],
+              required: ["workspace_id", "user_id", "date"],
               additionalProperties: false,
               properties: {
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
-                  description: "Matter/workspace ID to resolve the rate in",
+                  description:
+                    "Workspace ID to resolve the rate in. Deprecated input alias: matter_id.",
                 },
                 user_id: {
                   type: "string",
@@ -4284,12 +4296,12 @@ export const generatedRouteMap: RouteNode = {
             toolName: "list_invoices",
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Matter/workspace ID to list invoices in; required unless invoice_id is given",
+                  "Workspace ID to list invoices in; required unless invoice_id is given. Deprecated input alias: matter_id.",
                 required: false,
               },
               {
@@ -4312,11 +4324,11 @@ export const generatedRouteMap: RouteNode = {
               required: [],
               additionalProperties: false,
               properties: {
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
                   description:
-                    "Matter/workspace ID to list invoices in; required unless invoice_id is given",
+                    "Workspace ID to list invoices in; required unless invoice_id is given. Deprecated input alias: matter_id.",
                 },
                 invoice_id: {
                   type: "string",
@@ -4588,11 +4600,12 @@ export const generatedRouteMap: RouteNode = {
             toolName: "list_audit_log",
             flags: [
               {
-                flag: "--matter-id",
-                prop: "matter_id",
+                flag: "--workspace-id",
+                prop: "workspace_id",
                 kind: "string",
                 repeatable: false,
-                description: "Only entries scoped to this matter/workspace",
+                description:
+                  "Only entries scoped to this workspace. Deprecated input alias: matter_id.",
                 required: false,
               },
               {
@@ -4658,10 +4671,11 @@ export const generatedRouteMap: RouteNode = {
               required: [],
               additionalProperties: false,
               properties: {
-                matter_id: {
+                workspace_id: {
                   type: "string",
                   minLength: 1,
-                  description: "Only entries scoped to this matter/workspace",
+                  description:
+                    "Only entries scoped to this workspace. Deprecated input alias: matter_id.",
                 },
                 action: {
                   type: "string",

--- a/packages/cli/src/generated/tool-annotations.ts
+++ b/packages/cli/src/generated/tool-annotations.ts
@@ -78,19 +78,24 @@ export const generatedToolAnnotations: Readonly<
           command: "new-document",
           include: [
             "template_id",
-            "matter_id",
+            "workspace_id",
             "idempotency_key",
             "parent_id",
             "name",
             "values",
           ],
-          required: ["template_id", "matter_id", "idempotency_key", "values"],
+          required: [
+            "template_id",
+            "workspace_id",
+            "idempotency_key",
+            "values",
+          ],
         },
         create_version: {
           command: "new-version",
           include: [
             "template_id",
-            "matter_id",
+            "workspace_id",
             "idempotency_key",
             "entity_id",
             "name",
@@ -98,7 +103,7 @@ export const generatedToolAnnotations: Readonly<
           ],
           required: [
             "template_id",
-            "matter_id",
+            "workspace_id",
             "entity_id",
             "idempotency_key",
             "values",
@@ -257,14 +262,14 @@ export const generatedToolAnnotations: Readonly<
       subcommands: {
         add_member: {
           command: "add-member",
-          include: ["matter_id", "user_id"],
-          required: ["matter_id", "user_id"],
+          include: ["workspace_id", "user_id"],
+          required: ["workspace_id", "user_id"],
         },
         remove_member: {
           command: "remove-member",
           destructive: true,
-          include: ["matter_id", "user_id"],
-          required: ["matter_id", "user_id"],
+          include: ["workspace_id", "user_id"],
+          required: ["workspace_id", "user_id"],
         },
         update_org_settings: {
           command: "update-settings",

--- a/packages/cli/src/run-leaf-command.test.ts
+++ b/packages/cli/src/run-leaf-command.test.ts
@@ -473,6 +473,72 @@ describe("--input composes with flags before schema validation (S5.5)", () => {
   });
 });
 
+describe("--input honors a deprecated tool-input alias", () => {
+  // The schema names the replacement, and no flag is generated for the old
+  // name, so `--input` is the only way the alias reaches the CLI. Local
+  // validation runs before the request, so the rewrite has to happen here too.
+  const RENAMED_SPEC: LeafCommandSpec = {
+    commandPath: ["document", "list"],
+    toolName: "list_documents",
+    flags: [
+      {
+        flag: "--workspace-id",
+        prop: "workspace_id",
+        kind: "string",
+        required: true,
+        repeatable: false,
+      },
+    ],
+    inputOnly: [],
+    paginated: false,
+    windowedText: false,
+    destructive: false,
+    inputSchema: {
+      type: "object",
+      properties: { workspace_id: { type: "string" } },
+      required: ["workspace_id"],
+      additionalProperties: false,
+    },
+  };
+
+  test("the deprecated name is rewritten onto the canonical field", async () => {
+    const server = startConfirmGateServer();
+    const tty = makeTtyContext({
+      serverUrl: server.url,
+      stdinData: "",
+      isTTY: false,
+    });
+    await runLeafCommand({
+      context: tty.context,
+      flags: { input: '{"matter_id":"m1"}' },
+      spec: RENAMED_SPEC,
+    });
+    server.stop();
+    // The request is made at all (no local "missing required flag" or schema
+    // rejection) and carries the canonical name.
+    expect(server.calls[0]?.args).toEqual({ workspace_id: "m1" });
+  });
+
+  test("both names with different values fail locally", async () => {
+    const server = startConfirmGateServer();
+    const tty = makeTtyContext({
+      serverUrl: server.url,
+      stdinData: "",
+      isTTY: false,
+    });
+    await runLeafCommand({
+      context: tty.context,
+      flags: { input: '{"matter_id":"m1","workspace_id":"m2"}' },
+      spec: RENAMED_SPEC,
+    });
+    server.stop();
+    expect(tty.stderrText()).toContain(
+      "--input invalid at matter_id: deprecated alias for workspace_id",
+    );
+    expect(server.calls).toHaveLength(0);
+  });
+});
+
 describe("confirm passthrough (capability invoke)", () => {
   test("--yes injects confirm: true upfront (single call)", async () => {
     const server = startConfirmGateServer();

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -386,7 +386,7 @@ export const parseInputObject = async ({
   // Parse only: schema validation runs on the COMPOSED args (after value flags
   // overlay their paths), never on the raw `--input` alone. Validating here would
   // reject a `--input` that legitimately omits a required flag-backed path (e.g.
-  // a `matter_id` supplied by `--matter-id`), defeating the compose semantics.
+  // a `workspace_id` supplied by `--workspace-id`), defeating the compose semantics.
   return parsed.value;
 };
 

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -13,6 +13,7 @@ import { text as readStreamText } from "node:stream/consumers";
 import { decodeAccessTokenClaims } from "./auth/jwt.js";
 import { RESOURCE_SCOPE_PREFIX } from "./auth/scopes.js";
 import type { Context } from "./context.js";
+import { applyDeprecatedInputAliases } from "./deprecated-input-aliases.js";
 import { flagKey } from "./flag-name.js";
 import { validateAgainstSchema } from "./json-schema-validate.js";
 import {
@@ -1089,7 +1090,25 @@ export const runLeafCommand = async ({
     setExit(context, EXIT_CODES.validation);
     return;
   }
-  const built = await buildArgsFromFlags(spec, flags, argsBase);
+
+  // A deprecated input name reaches the CLI only through `--input` (no flag is
+  // generated for it), and both the required-flag check and local schema
+  // validation read the baked schema, which names the replacement. Rewrite the
+  // JSON base before either runs, so the alias each field description
+  // advertises is honored here exactly as it is on the server.
+  const aliased = applyDeprecatedInputAliases({
+    args: argsBase,
+    inputSchema: spec.inputSchema,
+  });
+  if (aliased.status === "conflict") {
+    writers.stderr(
+      `--input invalid at ${aliased.alias}: deprecated alias for ${aliased.canonical}; they were supplied with different values\n`,
+    );
+    setExit(context, EXIT_CODES.validation);
+    return;
+  }
+
+  const built = await buildArgsFromFlags(spec, flags, aliased.args);
   if (!built.ok) {
     writers.stderr(`${built.message}\n`);
     setExit(context, EXIT_CODES.validation);


### PR DESCRIPTION
- Rename the workspace-scoping MCP tool input from `matter_id` to `workspace_id` on the 13 tools where it names the container (`list_documents`, `save_document`, `list_properties`, `list_tasks`, `save_task`, `run_playbook`, `list_time_entries`, `save_time_entry`, `resolve_rate`, `list_invoices`, `list_audit_log`, `manage_organization`, `save_filled_template`), and update their descriptions to say workspace. `save_matter`, `delete_matter`, `list_matters` and `link_matter_contact` keep `matter_id`: there the matter record is the subject. The generated CLI leaves take `--workspace-id`, and `stella upload`'s own `--matter-id` moves with them.
- `matter_id` stays accepted as a deprecated alias for one release: `deprecated-input-aliases.ts` rewrites it onto `workspace_id` at dispatch, before the unknown-key backstop, and refuses the two names supplied with different values. The advertised schema names only `workspace_id`, and each renamed field's description states the alias in one clause.
- Add `input-vocabulary.test.ts` as the class guard: no static tool definition may declare `matter_id` outside an explicit matter-entity allowlist (each entry with its reason, and a stale entry fails too), no input may use another spelling of the container, and the set of tools declaring `workspace_id` is pinned. Regenerated the registry snapshot, CLI route map, and skill; changeset for `@stll/cli`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-scoped MCP tools now consistently use `workspace_id`.
  * CLI commands, including `stella upload`, now use `--workspace-id`.
  * The previous `matter_id` input remains supported as a deprecated alias for one release, including JSON supplied with `--input`.
* **Bug Fixes**
  * Conflicting `matter_id` and `workspace_id` values now return a clear validation error.
  * Matter-specific commands continue to use `matter_id` and `--matter-id`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->