### PR TITLE
fix(kanban): a folded band peeks open only under a dragged card

### DIFF
--- a/.changeset/kanban-band-peek-drag-only.md
+++ b/.changeset/kanban-band-peek-drag-only.md
@@ -2,4 +2,4 @@
 "@stll/ui": patch
 ---
 
-A folded kanban band peeks open only while a card is being dragged over it; a plain hover no longer opens it.
+A folded kanban band peeks open only while a card is being dragged over it: a plain hover, a column reorder drag, or any other native drag passing over the board no longer opens it, and a board that drives its own drag-and-drop (for example dnd-kit) can now report its drag directly to open the peek instead of relying on native drag events.

--- a/.changeset/kanban-band-peek-drag-only.md
+++ b/.changeset/kanban-band-peek-drag-only.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+A folded kanban band peeks open only while a card is being dragged over it; a plain hover no longer opens it.

--- a/packages/ui/src/kanban/band-peek.test.ts
+++ b/packages/ui/src/kanban/band-peek.test.ts
@@ -62,22 +62,6 @@ describe("band peek controller", () => {
     expect(changes).toEqual([]);
   });
 
-  // The defect this guards: folding a band from its caption left the new
-  // slot under the cursor, the first movement peeked it straight back open,
-  // and leaving the caption folded it again, over and over.
-  test("a band folded under the pointer does not peek until the pointer leaves its slot", () => {
-    const { clock, changes, peek } = setup();
-    peek.foldedUnderPointer("todo");
-    peek.slotDragOver("todo");
-    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
-    expect(changes).toEqual([]);
-
-    peek.slotDragLeave("todo");
-    peek.slotDragOver("todo");
-    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
-    expect(changes).toEqual(["todo"]);
-  });
-
   test("moving between the parts of an open band keeps the peek", () => {
     const { clock, changes, peek } = setup();
     peek.slotDragOver("todo");
@@ -109,17 +93,6 @@ describe("band peek controller", () => {
     expect(changes).toEqual(["todo", null]);
   });
 
-  test("folding a peeked band from its caption ends the peek and suppresses the slot", () => {
-    const { clock, changes, peek } = setup();
-    peek.slotDragOver("todo");
-    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
-    peek.foldedUnderPointer("todo");
-    expect(changes).toEqual(["todo", null]);
-    peek.slotDragOver("todo");
-    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
-    expect(changes).toEqual(["todo", null]);
-  });
-
   test("a slot that unmounts mid-delay cancels its pending peek", () => {
     const { clock, changes, peek } = setup();
     peek.slotDragOver("todo");
@@ -128,16 +101,7 @@ describe("band peek controller", () => {
     expect(changes).toEqual([]);
   });
 
-  test("a slot that unmounts drops its suppression", () => {
-    const { clock, changes, peek } = setup();
-    peek.foldedUnderPointer("todo");
-    peek.slotUnmounted("todo");
-    peek.slotDragOver("todo");
-    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
-    expect(changes).toEqual(["todo"]);
-  });
-
-  test("a fold without a pointer ends the peek but does not suppress the slot", () => {
+  test("folding a band ends its peek and lets the slot peek again on the next hover", () => {
     const { clock, changes, peek } = setup();
     peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);

--- a/packages/ui/src/kanban/band-peek.test.ts
+++ b/packages/ui/src/kanban/band-peek.test.ts
@@ -45,9 +45,9 @@ const setup = () => {
 };
 
 describe("band peek controller", () => {
-  test("a pointer resting on a folded slot peeks the band open after the delay", () => {
+  test("a dragged card resting on a folded slot peeks the band open after the delay", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS - 1);
     expect(changes).toEqual([]);
     clock.advance(1);
@@ -56,8 +56,8 @@ describe("band peek controller", () => {
 
   test("leaving the slot before the delay cancels the peek", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
-    peek.slotPointerLeave("todo");
+    peek.slotDragOver("todo");
+    peek.slotDragLeave("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual([]);
   });
@@ -68,42 +68,42 @@ describe("band peek controller", () => {
   test("a band folded under the pointer does not peek until the pointer leaves its slot", () => {
     const { clock, changes, peek } = setup();
     peek.foldedUnderPointer("todo");
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual([]);
 
-    peek.slotPointerLeave("todo");
-    peek.slotPointerMove("todo");
+    peek.slotDragLeave("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual(["todo"]);
   });
 
   test("moving between the parts of an open band keeps the peek", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual(["todo"]);
 
     // Caption to column: leave fires, then enter, within the linger.
-    peek.openPointerLeave("todo");
+    peek.openDragLeave("todo");
     clock.advance(KANBAN_BAND_PEEK_LINGER_MS - 1);
-    peek.openPointerEnter("todo");
+    peek.openDragEnter("todo");
     clock.advance(KANBAN_BAND_PEEK_LINGER_MS * 2);
     expect(changes).toEqual(["todo"]);
   });
 
   test("leaving an open band for longer than the linger ends the peek", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
-    peek.openPointerLeave("todo");
+    peek.openDragLeave("todo");
     clock.advance(KANBAN_BAND_PEEK_LINGER_MS);
     expect(changes).toEqual(["todo", null]);
   });
 
   test("pinning a peeked band open ends the peek without a linger", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     peek.bandExpanded("todo");
     expect(changes).toEqual(["todo", null]);
@@ -111,18 +111,18 @@ describe("band peek controller", () => {
 
   test("folding a peeked band from its caption ends the peek and suppresses the slot", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     peek.foldedUnderPointer("todo");
     expect(changes).toEqual(["todo", null]);
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual(["todo", null]);
   });
 
   test("a slot that unmounts mid-delay cancels its pending peek", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     peek.slotUnmounted("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual([]);
@@ -132,28 +132,44 @@ describe("band peek controller", () => {
     const { clock, changes, peek } = setup();
     peek.foldedUnderPointer("todo");
     peek.slotUnmounted("todo");
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual(["todo"]);
   });
 
   test("a fold without a pointer ends the peek but does not suppress the slot", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     peek.bandFolded("todo");
     expect(changes).toEqual(["todo", null]);
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual(["todo", null, "todo"]);
   });
 
+  test("the end of the drag ends the peek at once", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotDragOver("todo");
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    peek.dragEnded();
+    expect(changes).toEqual(["todo", null]);
+  });
+
+  test("the end of the drag cancels a pending peek", () => {
+    const { clock, changes, peek } = setup();
+    peek.slotDragOver("todo");
+    peek.dragEnded();
+    clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
+    expect(changes).toEqual([]);
+  });
+
   test("a second band's slot takes over a pending peek", () => {
     const { clock, changes, peek } = setup();
-    peek.slotPointerMove("todo");
+    peek.slotDragOver("todo");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS / 2);
-    peek.slotPointerLeave("todo");
-    peek.slotPointerMove("done");
+    peek.slotDragLeave("todo");
+    peek.slotDragOver("done");
     clock.advance(KANBAN_BAND_PEEK_DELAY_MS);
     expect(changes).toEqual(["done"]);
   });

--- a/packages/ui/src/kanban/band-peek.ts
+++ b/packages/ui/src/kanban/band-peek.ts
@@ -1,26 +1,27 @@
 /**
- * The peek a collapsed band opens while a pointer rests on its folded slot,
- * as a state machine with an injectable scheduler so its timing rules can be
- * tested without a DOM.
+ * The peek a collapsed band opens while a dragged card rests on its folded
+ * slot, as a state machine with an injectable scheduler so its timing rules
+ * can be tested without a DOM. A plain hover never peeks: the peek exists so
+ * a drag can still land on a specific column inside a folded band, and the
+ * board only feeds the controller drag events.
  *
- * Two rules keep a peek from fighting the pointer:
+ * Two rules keep a peek from fighting the drag:
  *
- *  - A slot that appeared under the pointer does not peek. Folding a band
- *    from its caption leaves the new slot right under the cursor; the first
- *    movement there must not reopen what was just closed. The band is
- *    suppressed until the pointer leaves the slot once.
- *  - A peek ends only after the pointer has left every part of the open
- *    band for a short linger. The band renders as separate elements (its
- *    caption, then its columns in each lane), so moving from the caption
- *    down into a column crosses an element boundary; without the linger the
- *    band would fold under the pointer and the slot would peek it straight
- *    back open.
+ *  - A slot that appeared under the dragged card does not peek. Folding a
+ *    band from its caption leaves the new slot right under the cursor; the
+ *    band is suppressed until the pointer leaves the slot once.
+ *  - A peek ends only after the drag has left every part of the open band
+ *    for a short linger. The band renders as separate elements (its caption,
+ *    then its columns in each lane), so moving from the caption down into a
+ *    column crosses an element boundary; without the linger the band would
+ *    fold under the card and the slot would peek it straight back open.
+ *  - The end of the drag, wherever it lands, ends the peek at once.
  */
 
-/** How long a pointer rests on a folded slot before the band peeks open. */
+/** How long a dragged card rests on a folded slot before the band peeks open. */
 export const KANBAN_BAND_PEEK_DELAY_MS = 400;
 
-/** How long the pointer may be outside an open band before the peek ends. */
+/** How long the drag may be outside an open band before the peek ends. */
 export const KANBAN_BAND_PEEK_LINGER_MS = 150;
 
 /** Runs `callback` after `ms`; the returned function cancels it. */
@@ -44,14 +45,16 @@ export type BandPeekControllerOptions = {
 };
 
 export type BandPeekController = {
-  /** The pointer moved inside a band's folded slot. */
-  slotPointerMove: (bandId: string) => void;
-  /** The pointer left a band's folded slot. */
-  slotPointerLeave: (bandId: string) => void;
-  /** The pointer entered a part of a band that is rendered open. */
-  openPointerEnter: (bandId: string) => void;
-  /** The pointer left a part of a band that is rendered open. */
-  openPointerLeave: (bandId: string) => void;
+  /** A dragged card moved over a band's folded slot. */
+  slotDragOver: (bandId: string) => void;
+  /** The drag left a band's folded slot. */
+  slotDragLeave: (bandId: string) => void;
+  /** The drag entered a part of a band that is rendered open. */
+  openDragEnter: (bandId: string) => void;
+  /** The drag left a part of a band that is rendered open. */
+  openDragLeave: (bandId: string) => void;
+  /** The drag ended (dropped or cancelled), wherever it was. */
+  dragEnded: () => void;
   /**
    * The band was folded by a pointer on its caption, so its slot now sits
    * under the pointer; it must not peek until the pointer leaves the slot.
@@ -118,7 +121,7 @@ export const createBandPeekController = ({
   };
 
   return {
-    slotPointerMove: (bandId) => {
+    slotDragOver: (bandId) => {
       if (
         suppressedBandId === bandId ||
         peekingBandId === bandId ||
@@ -135,7 +138,7 @@ export const createBandPeekController = ({
         setPeeking(bandId);
       }, delayMs);
     },
-    slotPointerLeave: (bandId) => {
+    slotDragLeave: (bandId) => {
       if (openingBandId === bandId) {
         clearOpenTimer();
       }
@@ -143,12 +146,12 @@ export const createBandPeekController = ({
         suppressedBandId = null;
       }
     },
-    openPointerEnter: (bandId) => {
+    openDragEnter: (bandId) => {
       if (peekingBandId === bandId) {
         clearEndTimer();
       }
     },
-    openPointerLeave: (bandId) => {
+    openDragLeave: (bandId) => {
       if (peekingBandId !== bandId || cancelEnd !== null) {
         return;
       }
@@ -181,6 +184,11 @@ export const createBandPeekController = ({
       if (suppressedBandId === bandId) {
         suppressedBandId = null;
       }
+    },
+    dragEnded: () => {
+      clearOpenTimer();
+      clearEndTimer();
+      setPeeking(null);
     },
     dispose: () => {
       clearOpenTimer();

--- a/packages/ui/src/kanban/band-peek.ts
+++ b/packages/ui/src/kanban/band-peek.ts
@@ -5,17 +5,13 @@
  * a drag can still land on a specific column inside a folded band, and the
  * board only feeds the controller drag events.
  *
- * Two rules keep a peek from fighting the drag:
- *
- *  - A slot that appeared under the dragged card does not peek. Folding a
- *    band from its caption leaves the new slot right under the cursor; the
- *    band is suppressed until the pointer leaves the slot once.
- *  - A peek ends only after the drag has left every part of the open band
- *    for a short linger. The band renders as separate elements (its caption,
- *    then its columns in each lane), so moving from the caption down into a
- *    column crosses an element boundary; without the linger the band would
- *    fold under the card and the slot would peek it straight back open.
- *  - The end of the drag, wherever it lands, ends the peek at once.
+ * One rule keeps a peek from fighting the drag: it ends only after the drag
+ * has left every part of the open band for a short linger. The band renders
+ * as separate elements (its caption, then its columns in each lane), so
+ * moving from the caption down into a column crosses an element boundary;
+ * without the linger the band would fold under the card and the slot would
+ * peek it straight back open. The end of the drag, wherever it lands, ends
+ * the peek at once.
  */
 
 /** How long a dragged card rests on a folded slot before the band peeks open. */
@@ -56,12 +52,7 @@ export type BandPeekController = {
   /** The drag ended (dropped or cancelled), wherever it was. */
   dragEnded: () => void;
   /**
-   * The band was folded by a pointer on its caption, so its slot now sits
-   * under the pointer; it must not peek until the pointer leaves the slot.
-   */
-  foldedUnderPointer: (bandId: string) => void;
-  /**
-   * The band was folded without a pointer on it (keyboard, or a controlled
+   * The band was folded (from its caption, the keyboard, or a controlled
    * caller): any peek ends, and the slot may peek on the next hover.
    */
   bandFolded: (bandId: string) => void;
@@ -69,8 +60,7 @@ export type BandPeekController = {
   bandExpanded: (bandId: string) => void;
   /**
    * A band's folded slot left the DOM (the band expanded or disappeared) so
-   * a peek it was about to open, or a suppression it carried, no longer
-   * applies.
+   * a peek it was about to open no longer applies.
    */
   slotUnmounted: (bandId: string) => void;
   /** Ends any pending timer, for unmount. */
@@ -84,7 +74,6 @@ export const createBandPeekController = ({
   schedule = hostScheduler,
 }: BandPeekControllerOptions): BandPeekController => {
   let peekingBandId: string | null = null;
-  let suppressedBandId: string | null = null;
   let cancelOpen: (() => void) | null = null;
   let openingBandId: string | null = null;
   let cancelEnd: (() => void) | null = null;
@@ -122,11 +111,7 @@ export const createBandPeekController = ({
 
   return {
     slotDragOver: (bandId) => {
-      if (
-        suppressedBandId === bandId ||
-        peekingBandId === bandId ||
-        openingBandId === bandId
-      ) {
+      if (peekingBandId === bandId || openingBandId === bandId) {
         return;
       }
       clearOpenTimer();
@@ -141,9 +126,6 @@ export const createBandPeekController = ({
     slotDragLeave: (bandId) => {
       if (openingBandId === bandId) {
         clearOpenTimer();
-      }
-      if (suppressedBandId === bandId) {
-        suppressedBandId = null;
       }
     },
     openDragEnter: (bandId) => {
@@ -160,17 +142,10 @@ export const createBandPeekController = ({
         setPeeking(null);
       }, lingerMs);
     },
-    foldedUnderPointer: (bandId) => {
-      bandFolded(bandId);
-      suppressedBandId = bandId;
-    },
     bandFolded,
     bandExpanded: (bandId) => {
       if (openingBandId === bandId) {
         clearOpenTimer();
-      }
-      if (suppressedBandId === bandId) {
-        suppressedBandId = null;
       }
       if (peekingBandId === bandId) {
         clearEndTimer();
@@ -180,9 +155,6 @@ export const createBandPeekController = ({
     slotUnmounted: (bandId) => {
       if (openingBandId === bandId) {
         clearOpenTimer();
-      }
-      if (suppressedBandId === bandId) {
-        suppressedBandId = null;
       }
     },
     dragEnded: () => {

--- a/packages/ui/src/kanban/drag-interactions.test.ts
+++ b/packages/ui/src/kanban/drag-interactions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// The real `draggable` reaches into DOM APIs (addEventListener, dataset, ...)
+// that this bun:test process has no DOM for. It is replaced with a stand-in
+// that only records the arguments it was called with, before importing the
+// module under test. Every other export is passed through untouched so
+// unrelated kanban tests sharing this bun:test process are unaffected.
+const realAdapter =
+  await import("@atlaskit/pragmatic-drag-and-drop/element/adapter");
+
+type DraggableArgs = Parameters<typeof realAdapter.draggable>[0];
+
+let capturedArgs: DraggableArgs | undefined;
+
+void mock.module("@atlaskit/pragmatic-drag-and-drop/element/adapter", () => ({
+  ...realAdapter,
+  draggable: (args: DraggableArgs) => {
+    capturedArgs = args;
+    return () => undefined;
+  },
+}));
+
+const { KANBAN_CARD_DRAG_MIME, registerKanbanCardDrag } =
+  await import("./drag-interactions");
+
+// SAFETY: the mocked `draggable` above only stores `element` without ever
+// touching a real DOM API on it, so a plain object stands in for it here.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double for a DOM element; see the SAFETY note above.
+const stubElement = (): HTMLElement => ({}) as unknown as HTMLElement;
+
+// SAFETY: `getInitialDataForExternal` ignores the feedback args entirely
+// (see drag-interactions.ts), so this stub only needs to satisfy the call
+// signature, never to be read.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double for feedback args; see the SAFETY note above.
+const stubFeedbackArgs = {} as Parameters<
+  NonNullable<DraggableArgs["getInitialDataForExternal"]>
+>[0];
+
+describe("registerKanbanCardDrag", () => {
+  test("marks the drag with the kanban card MIME type for the board's native listeners", () => {
+    registerKanbanCardDrag({
+      element: stubElement(),
+      getInitialData: () => ({}),
+    });
+
+    expect(capturedArgs?.getInitialDataForExternal?.(stubFeedbackArgs)).toEqual(
+      { [KANBAN_CARD_DRAG_MIME]: "" },
+    );
+  });
+});

--- a/packages/ui/src/kanban/drag-interactions.ts
+++ b/packages/ui/src/kanban/drag-interactions.ts
@@ -7,6 +7,16 @@ import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/el
 
 type AtlaskitDraggableOptions = Parameters<typeof draggable>[0];
 
+/**
+ * Marks a card drag on the native `DataTransfer` so the board's native
+ * `dragover`/`dragenter`/`dragleave` listeners (which also see reorders,
+ * file drops, and any other native drag passing over the board) can tell a
+ * kanban card drag from everything else. Pragmatic's `getInitialData` never
+ * reaches those native events; only data attached this way does.
+ */
+export const KANBAN_CARD_DRAG_MIME =
+  "application/x-stella-kanban-card" as const;
+
 export type RegisterKanbanCardDragOptions = {
   /** The drag wrapper rendered by `KanbanCardShell`. */
   element: AtlaskitDraggableOptions["element"];
@@ -35,6 +45,7 @@ export const registerKanbanCardDrag = ({
   draggable({
     element,
     getInitialData,
+    getInitialDataForExternal: () => ({ [KANBAN_CARD_DRAG_MIME]: "" }),
     ...(canDrag === undefined ? {} : { canDrag }),
     ...(onDragStart === undefined ? {} : { onDragStart }),
     ...(onDrop === undefined ? {} : { onDrop }),

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -78,6 +78,7 @@ export type {
 } from "./drag-interactions";
 export {
   KANBAN_BOARD_AUTO_SCROLL_SOURCES,
+  KANBAN_CARD_DRAG_MIME,
   registerKanbanBoardAutoScroll,
   registerKanbanCardDrag,
 } from "./drag-interactions";

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -457,7 +457,19 @@ export type KanbanSortableBoardProps = {
   sensors?: DndContextProps["sensors"] | undefined;
   /** Overrides dnd-kit's screen-reader announcements when supplied. */
   accessibility?: DndContextProps["accessibility"] | undefined;
+  /**
+   * Fires on drag start and on every drag end or cancel; a board over a
+   * `KanbanSubgroupBoard` combines the two into that board's `isDragging`
+   * (`true` here, `false` on `onDragEnd`/`onDragCancel`).
+   */
   onDragStart?: ((event: KanbanDragStartEvent) => void) | undefined;
+  /**
+   * Fires whenever dnd-kit's collision detection changes the drop target
+   * the drag is over, `event.over` included when it becomes none. A board
+   * over a `KanbanSubgroupBoard` maps `event.over?.id ?? null` to a band id
+   * (via `KanbanSubgroupCellContext.band`, or a droppable registered for a
+   * folded band's slot) to drive that board's `dragOverBandId`.
+   */
   onDragOver?: ((event: KanbanDragOverEvent) => void) | undefined;
   onDragCancel?: ((event: KanbanDragCancelEvent) => void) | undefined;
   /** Called once mounted child drop targets can safely receive input. */

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { DragEvent, ReactElement, ReactNode } from "react";
 
 import { ChevronDownIcon } from "lucide-react";
@@ -17,6 +17,7 @@ import {
   resolveKanbanColumnBands,
 } from "./column-bands";
 import type { KanbanColumnBandSpan } from "./column-bands";
+import { KANBAN_CARD_DRAG_MIME } from "./drag-interactions";
 import type { KanbanColumnBand, KanbanGroup } from "./grouping";
 import type {
   KanbanBoardCell,
@@ -54,6 +55,12 @@ export type KanbanSubgroupCellContext<TRow> = {
   /** Number of rows in this lane/column intersection, including zero. */
   count: number;
   laneValue: string | null;
+  /**
+   * The band this cell's column belongs to, or `null` outside any band. Lets
+   * a host that drives its own drag-and-drop (see `dragOverBandId` on the
+   * board) map a cell's droppable id back to the band it should report.
+   */
+  band: KanbanColumnBand | null;
 };
 
 export type KanbanSubgroupBandHeaderContext = {
@@ -70,9 +77,9 @@ export type KanbanSubgroupBandHeaderContext = {
    */
   folded: boolean;
   /**
-   * A custom caption reports which way it was activated; omitting the
-   * activation is read as a pointer fold, the conservative choice for the
-   * peek that follows.
+   * A custom caption may report which way it was activated (pointer vs.
+   * keyboard); the board itself has no use for the distinction and passes
+   * it through unread, purely as information for a host's own header.
    */
   onCollapsedChange: (
     collapsed: boolean,
@@ -137,6 +144,27 @@ export type KanbanSubgroupBoardProps<TRow> = {
   formatCount?: ((count: number) => ReactNode) | undefined;
   footer?: ReactNode;
   className?: string | undefined;
+  /**
+   * The band whose folded slot (or, for a peeked band, whose open part) the
+   * host's own drag is currently over, or `null` when it is over neither.
+   * Omit (`undefined`) when the host does not drive drags itself — the
+   * board's native `dragover`/`dragenter`/`dragleave` listeners already feed
+   * the peek controller in that case. A host drives its own drag when it
+   * builds the drop targets itself (for example a `KanbanSortableBoard`,
+   * whose `onDragOver` reports the active `over` droppable); it maps that
+   * droppable back to a band id — a folded cell's context and an open
+   * cell's context (see `KanbanSubgroupCellContext.band`) both carry the
+   * band — and passes it here. The controller treats "over the band" as
+   * entering the open band when it is already peeked, and as hovering its
+   * folded slot otherwise; leaving it is reported the same way.
+   */
+  dragOverBandId?: string | null | undefined;
+  /**
+   * Whether the host's own drag (see `dragOverBandId`) is in progress.
+   * Flipping to `false` ends any peek immediately, mirroring the native
+   * `dragend`/`drop` listeners the board installs for its own drags.
+   */
+  isDragging?: boolean | undefined;
 } & KanbanSubgroupCollapseControl;
 
 /**
@@ -166,6 +194,8 @@ export const KanbanSubgroupBoard = <TRow,>({
   onBandCollapsedChange,
   footer,
   className,
+  dragOverBandId,
+  isDragging,
 }: KanbanSubgroupBoardProps<TRow>) => {
   const [collapsedLaneValues, setCollapsedLaneValues] = useState(
     () => new Set<string | null>(),
@@ -194,6 +224,41 @@ export const KanbanSubgroupBoard = <TRow,>({
       window.removeEventListener("drop", end);
     };
   }, [peek]);
+  // A host that drives its own drag (dnd-kit, rather than the board's native
+  // listeners) reports the band its drag is over directly. `undefined` means
+  // the host does not drive drags at all, so no comparison against the
+  // previous id ever runs.
+  const previousDragOverBandId = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      dragOverBandId === undefined ||
+      dragOverBandId === previousDragOverBandId.current
+    ) {
+      return;
+    }
+    const previous = previousDragOverBandId.current;
+    previousDragOverBandId.current = dragOverBandId;
+    if (previous !== null) {
+      if (peekingBandId === previous) {
+        peek.openDragLeave(previous);
+      } else {
+        peek.slotDragLeave(previous);
+      }
+    }
+    if (dragOverBandId !== null) {
+      if (peekingBandId === dragOverBandId) {
+        peek.openDragEnter(dragOverBandId);
+      } else {
+        peek.slotDragOver(dragOverBandId);
+      }
+    }
+  }, [dragOverBandId, peek, peekingBandId]);
+  useEffect(() => {
+    if (isDragging === false) {
+      previousDragOverBandId.current = null;
+      peek.dragEnded();
+    }
+  }, [isDragging, peek]);
 
   const { cellsByLaneValue, countByColumnValue, ungroupedCells } =
     useMemo(() => {
@@ -287,21 +352,14 @@ export const KanbanSubgroupBoard = <TRow,>({
       peek.bandExpanded(staleBandId);
     }
   }, [peek, staleBandId]);
-  const setBandCollapsed = (
-    band: KanbanColumnBand,
-    collapsed: boolean,
-    activation?: KanbanBandToggleActivation,
-  ) => {
-    const viaPointer = activation === undefined ? true : activation.viaPointer;
-    // A pointer fold from the caption leaves the new slot under the pointer;
-    // the controller keeps it from peeking straight back open. A keyboard
-    // fold leaves no pointer there, so the next hover may peek as usual.
-    if (!collapsed) {
-      peek.bandExpanded(band.id);
-    } else if (viaPointer) {
-      peek.foldedUnderPointer(band.id);
-    } else {
+  // `activation` (pointer vs. keyboard) only ever mattered to a suppression
+  // rule the drag-only peek lifecycle can no longer support, so the board
+  // itself ignores it now; it stays informational, for a host's own header.
+  const setBandCollapsed = (band: KanbanColumnBand, collapsed: boolean) => {
+    if (collapsed) {
       peek.bandFolded(band.id);
+    } else {
+      peek.bandExpanded(band.id);
     }
     if (onBandCollapsedChange) {
       onBandCollapsedChange(band, collapsed);
@@ -345,7 +403,10 @@ export const KanbanSubgroupBoard = <TRow,>({
   }: {
     className?: string;
     label?: string;
-    renderColumn: (column: KanbanBoardColumn) => Rendered;
+    renderColumn: (
+      column: KanbanBoardColumn,
+      band: KanbanColumnBand | null,
+    ) => Rendered;
     renderFoldedBand: (
       band: KanbanColumnBand,
       span: KanbanColumnBandSpan,
@@ -372,13 +433,19 @@ export const KanbanSubgroupBoard = <TRow,>({
             data-kanban-band={band?.id}
             key={spanKey(span)}
             onDragEnter={
-              band === null ? undefined : () => peek.openDragEnter(band.id)
+              band === null
+                ? undefined
+                : (event) => {
+                    if (isKanbanCardDragEvent(event)) {
+                      peek.openDragEnter(band.id);
+                    }
+                  }
             }
             onDragLeave={
               band === null
                 ? undefined
                 : (event) => {
-                    if (leavesElement(event)) {
+                    if (leavesElement(event) && isKanbanCardDragEvent(event)) {
                       peek.openDragLeave(band.id);
                     }
                   }
@@ -389,7 +456,7 @@ export const KanbanSubgroupBoard = <TRow,>({
                 className={KANBAN_COLUMN_WIDTH_CLASS}
                 key={columnKey(column)}
               >
-                {renderColumn(column)}
+                {renderColumn(column, band)}
               </div>
             ))}
           </div>
@@ -410,8 +477,7 @@ export const KanbanSubgroupBoard = <TRow,>({
       columns: span.columns,
       count: span.columns.reduce((sum, column) => sum + columnCount(column), 0),
       folded,
-      onCollapsedChange: (next, activation) =>
-        setBandCollapsed(band, next, activation),
+      onCollapsedChange: (next) => setBandCollapsed(band, next),
     };
     if (renderBandHeader) {
       return <>{renderBandHeader(context)}</>;
@@ -523,9 +589,16 @@ export const KanbanSubgroupBoard = <TRow,>({
                     data-kanban-band={band.id}
                     key={spanKey(span)}
                     style={{ width: `${String(spanWidth(span))}px` }}
-                    onDragEnter={() => peek.openDragEnter(band.id)}
+                    onDragEnter={(event) => {
+                      if (isKanbanCardDragEvent(event)) {
+                        peek.openDragEnter(band.id);
+                      }
+                    }}
                     onDragLeave={(event) => {
-                      if (leavesElement(event)) {
+                      if (
+                        leavesElement(event) &&
+                        isKanbanCardDragEvent(event)
+                      ) {
                         peek.openDragLeave(band.id);
                       }
                     }}
@@ -548,7 +621,7 @@ export const KanbanSubgroupBoard = <TRow,>({
           ? null
           : renderRow({
               className: "pb-1",
-              renderColumn: (column) => {
+              renderColumn: (column, band) => {
                 const cell = ungroupedCells.find(
                   (candidate) =>
                     columnKey(candidate.coordinate.column) ===
@@ -557,6 +630,7 @@ export const KanbanSubgroupBoard = <TRow,>({
                 return cell === undefined ? null : (
                   <>
                     {renderCell({
+                      band,
                       cell,
                       count: cell.rows.length,
                       laneValue: null,
@@ -636,11 +710,12 @@ export const KanbanSubgroupBoard = <TRow,>({
               {!collapsed &&
                 renderRow({
                   className: "pb-1",
-                  renderColumn: (column) => {
+                  renderColumn: (column, band) => {
                     const cell = cellFor(column);
                     return cell === undefined ? null : (
                       <>
                         {renderCell({
+                          band,
                           cell,
                           count: cell.rows.length,
                           laneValue: group.value,
@@ -671,6 +746,14 @@ const leavesElement = (event: DragEvent<HTMLElement>): boolean =>
     event.currentTarget.contains(event.relatedTarget)
   );
 
+/**
+ * Whether a native drag event is a kanban card drag, rather than some other
+ * native drag (a column reorder, a file, text) passing over the board. Only
+ * a card drag should ever open or hold a band's peek.
+ */
+const isKanbanCardDragEvent = (event: DragEvent<HTMLElement>): boolean =>
+  event.dataTransfer.types.includes(KANBAN_CARD_DRAG_MIME);
+
 type FoldedBandSlotProps = {
   band: KanbanColumnBand;
   children: ReactNode;
@@ -681,7 +764,7 @@ type FoldedBandSlotProps = {
 /**
  * The narrow slot a folded band occupies in a row. Its drag events go to
  * the board's peek controller, which decides when a resting drag peeks the
- * band open and keeps a slot that appeared under the pointer folded.
+ * band open.
  */
 const FoldedBandSlot = ({
   band,
@@ -690,16 +773,20 @@ const FoldedBandSlot = ({
   peek,
 }: FoldedBandSlotProps) => {
   // A slot that leaves the DOM mid-delay (its band expanded or disappeared)
-  // takes its pending peek and its suppression with it.
+  // takes its pending peek with it.
   useEffect(() => () => peek.slotUnmounted(band.id), [peek, band.id]);
   return (
     <div
       className={className}
       data-kanban-band={band.id}
       data-kanban-band-collapsed=""
-      onDragOver={() => peek.slotDragOver(band.id)}
+      onDragOver={(event) => {
+        if (isKanbanCardDragEvent(event)) {
+          peek.slotDragOver(band.id);
+        }
+      }}
       onDragLeave={(event) => {
-        if (leavesElement(event)) {
+        if (leavesElement(event) && isKanbanCardDragEvent(event)) {
           peek.slotDragLeave(band.id);
         }
       }}

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import type { ReactElement, ReactNode } from "react";
+import type { DragEvent, ReactElement, ReactNode } from "react";
 
 import { ChevronDownIcon } from "lucide-react";
 
@@ -145,8 +145,8 @@ export type KanbanSubgroupBoardProps<TRow> = {
  * Columns that carry band metadata render under a one-line band caption and
  * can be collapsed as a run: the band folds into one narrow slot in every
  * row, whose cells stay reachable (a host renders its drop target in them),
- * and peeks open while a pointer rests on it, so a drag can still land on a
- * specific column inside. Every row is laid out span by span with the same
+ * and peeks open while a dragged card rests on it, so a drag can still land
+ * on a specific column inside; a plain hover never opens it. Every row is laid out span by span with the same
  * widths, which is what keeps captions, headers, counts, and cells aligned
  * in every state; the caption line never grows past its own height, so a
  * folded band costs no vertical space.
@@ -183,6 +183,17 @@ export const KanbanSubgroupBoard = <TRow,>({
     createBandPeekController({ onChange: setPeekingBandId }),
   );
   useEffect(() => () => peek.dispose(), [peek]);
+  // A drop or a cancelled drag ends the peek wherever the card was; the
+  // open band may never see a leave for it.
+  useEffect(() => {
+    const end = () => peek.dragEnded();
+    window.addEventListener("dragend", end);
+    window.addEventListener("drop", end);
+    return () => {
+      window.removeEventListener("dragend", end);
+      window.removeEventListener("drop", end);
+    };
+  }, [peek]);
 
   const { cellsByLaneValue, countByColumnValue, ungroupedCells } =
     useMemo(() => {
@@ -360,11 +371,17 @@ export const KanbanSubgroupBoard = <TRow,>({
             className="flex gap-3"
             data-kanban-band={band?.id}
             key={spanKey(span)}
-            onPointerEnter={
-              band === null ? undefined : () => peek.openPointerEnter(band.id)
+            onDragEnter={
+              band === null ? undefined : () => peek.openDragEnter(band.id)
             }
-            onPointerLeave={
-              band === null ? undefined : () => peek.openPointerLeave(band.id)
+            onDragLeave={
+              band === null
+                ? undefined
+                : (event) => {
+                    if (leavesElement(event)) {
+                      peek.openDragLeave(band.id);
+                    }
+                  }
             }
           >
             {span.columns.map((column) => (
@@ -506,8 +523,12 @@ export const KanbanSubgroupBoard = <TRow,>({
                     data-kanban-band={band.id}
                     key={spanKey(span)}
                     style={{ width: `${String(spanWidth(span))}px` }}
-                    onPointerEnter={() => peek.openPointerEnter(band.id)}
-                    onPointerLeave={() => peek.openPointerLeave(band.id)}
+                    onDragEnter={() => peek.openDragEnter(band.id)}
+                    onDragLeave={(event) => {
+                      if (leavesElement(event)) {
+                        peek.openDragLeave(band.id);
+                      }
+                    }}
                   >
                     {bandHeader(band, span)}
                   </div>
@@ -640,6 +661,16 @@ export const KanbanSubgroupBoard = <TRow,>({
   );
 };
 
+/**
+ * Whether a drag-leave event actually leaves `currentTarget` rather than
+ * moving between its descendants, which fire leave/enter pairs of their own.
+ */
+const leavesElement = (event: DragEvent<HTMLElement>): boolean =>
+  !(
+    event.relatedTarget instanceof Node &&
+    event.currentTarget.contains(event.relatedTarget)
+  );
+
 type FoldedBandSlotProps = {
   band: KanbanColumnBand;
   children: ReactNode;
@@ -648,9 +679,9 @@ type FoldedBandSlotProps = {
 };
 
 /**
- * The narrow slot a folded band occupies in a row. Its pointer events go to
- * the board's peek controller, which decides when a resting pointer peeks
- * the band open and keeps a slot that appeared under the pointer folded.
+ * The narrow slot a folded band occupies in a row. Its drag events go to
+ * the board's peek controller, which decides when a resting drag peeks the
+ * band open and keeps a slot that appeared under the pointer folded.
  */
 const FoldedBandSlot = ({
   band,
@@ -666,8 +697,12 @@ const FoldedBandSlot = ({
       className={className}
       data-kanban-band={band.id}
       data-kanban-band-collapsed=""
-      onPointerMove={() => peek.slotPointerMove(band.id)}
-      onPointerLeave={() => peek.slotPointerLeave(band.id)}
+      onDragOver={() => peek.slotDragOver(band.id)}
+      onDragLeave={(event) => {
+        if (leavesElement(event)) {
+          peek.slotDragLeave(band.id);
+        }
+      }}
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary

Follow-up to #2832. A folded band still peeked open on a plain hover once the pointer re-entered its slot, which is never what a user wants from a hover. The peek's only purpose is to let a dragged card land on a specific column inside a folded band, and during a native HTML5 drag the browser fires drag events, not the pointer events the slot listened to, so the hover peek never even served that purpose.

- `FoldedBandSlot` arms the peek on `dragover` and cancels on a `dragleave` that actually leaves the slot (leaves between descendants are ignored); the open band's caption and columns report `dragenter` / `dragleave` the same way.
- A `dragend` or `drop` anywhere ends the peek immediately (`dragEnded`), since the open band may never see a leave for it.
- Controller methods renamed to the drag vocabulary (`slotDragOver`, `slotDragLeave`, `openDragEnter`, `openDragLeave`, `dragEnded`); timing and the fold suppression are unchanged. Two controller tests added (69 kanban tests pass).
- Changeset: `@stll/ui` patch.
