### PR TITLE
refactor(api): fill templates through one service pipeline

### DIFF
--- a/apps/api/evals/template-fill.ts
+++ b/apps/api/evals/template-fill.ts
@@ -293,6 +293,7 @@ const createFixtureTools = ({
       values,
       scopedDb,
       organizationId,
+      requiredFields: "enforce",
     });
     if ("usageRejection" in filled) {
       // No usage check is configured for this call, so this branch is

--- a/apps/api/src/handlers/chat/tools/template-tools.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools.ts
@@ -193,6 +193,7 @@ export const createTemplateTools = ({
       async ({ templateId }) =>
         await describeStoredTemplate({
           templateId: brandPersistedTemplateId(templateId),
+          organizationId,
           scopedDb,
         }),
     ),

--- a/apps/api/src/handlers/chat/tools/template-tools.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools.ts
@@ -119,40 +119,33 @@ export const createTemplateTools = ({
   orgAIConfig,
   recordAuditEvent,
 }: CreateTemplateToolsArgs) => {
-  const aiAnalytics = buildTemplateAiAnalytics({
-    safeDb,
-    organizationId,
-    userId,
-    orgAIConfig,
-    feature: "templates.fill",
-  });
-  // Model-backed generator for AI-fillable fields (FieldMeta.aiPrompt); shared
-  // with the web fill routes so AI placeholders behave identically. A failed or
+  // Model-backed collaborators for the manifest's AI fields, shared with the
+  // web fill routes so AI placeholders behave identically: a generator for
+  // AI-fillable fields (FieldMeta.aiPrompt), a decider for AI-decided boolean
+  // conditions, and a per-occurrence adapter for aiAdapt stubs. A failed or
   // unavailable model just leaves the field unfilled rather than erroring.
+  // The fill service builds these only when the manifest declares an AI field.
   // tenantWorkspaceIds is empty: a chat-driven template action is org-scoped,
-  // not bound to a matter (see buildTemplateAiAnalytics above).
-  const generateAiValue = buildAiFieldGenerator({
-    orgAIConfig: orgAIConfig ?? null,
-    organizationId,
-    aiAnalytics,
-    tenantWorkspaceIds: [],
-  });
-  // Decider for AI-decided boolean conditions (a boolean field with an
-  // aiPrompt); same fallback semantics as generateAiValue.
-  const decideAiCondition = buildAiConditionDecider({
-    orgAIConfig: orgAIConfig ?? null,
-    organizationId,
-    aiAnalytics,
-    tenantWorkspaceIds: [],
-  });
-  // Per-occurrence adapter for aiAdapt fields (stub rewritten to fit each
-  // marker's surrounding text); same fallback semantics as generateAiValue.
-  const adaptAiValue = buildAiOccurrenceAdapter({
-    orgAIConfig: orgAIConfig ?? null,
-    organizationId,
-    aiAnalytics,
-    tenantWorkspaceIds: [],
-  });
+  // not bound to a matter (see buildTemplateAiAnalytics below).
+  const aiCollaborators = () => {
+    const shared = {
+      orgAIConfig: orgAIConfig ?? null,
+      organizationId,
+      aiAnalytics: buildTemplateAiAnalytics({
+        safeDb,
+        organizationId,
+        userId,
+        orgAIConfig,
+        feature: "templates.fill",
+      }),
+      tenantWorkspaceIds: [],
+    };
+    return {
+      generateAiValue: buildAiFieldGenerator(shared),
+      decideAiCondition: buildAiConditionDecider(shared),
+      adaptAiValue: buildAiOccurrenceAdapter(shared),
+    };
+  };
 
   return {
     [LIST_TEMPLATES_TOOL_NAME]: toolDefinition({
@@ -226,9 +219,8 @@ export const createTemplateTools = ({
         values,
         scopedDb,
         organizationId,
-        generateAiValue,
-        decideAiCondition,
-        adaptAiValue,
+        requiredFields: "enforce",
+        aiCollaborators,
       });
       if ("requiredFieldsRejection" in result) {
         // A required, non-AI-fillable field was omitted or empty: reject

--- a/apps/api/src/handlers/reports/report-export-queue.ts
+++ b/apps/api/src/handlers/reports/report-export-queue.ts
@@ -63,7 +63,10 @@ import {
 } from "@/api/lib/safe-id-boundaries";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { hasTanStackInstanceProvider } from "@/api/lib/tanstack-ai-models";
-import type { MissingRequiredField } from "@/api/lib/templates/template-fill-service";
+import type {
+  AiFillCollaborators,
+  MissingRequiredField,
+} from "@/api/lib/templates/template-fill-service";
 import {
   fillStoredTemplateDocx,
   fillTemplateDocx,
@@ -626,11 +629,16 @@ const renderSpecReport = async ({
       return { usageRejection };
     }
   }
+  // A spec report renders its narrative directly rather than through the fill
+  // service, so it resolves the collaborators itself — and only when the
+  // narrative is actually requested.
   const rendered = await renderReportSpec({
     spec: builtin.spec,
     report,
     prompts: builtin.prompts,
-    generateAiValue: generators.generateAiValue,
+    generateAiValue: aiNarrative
+      ? (await generators.aiCollaborators?.())?.generateAiValue
+      : undefined,
     aiNarrative,
     linkBase,
   });
@@ -644,12 +652,12 @@ const renderSpecReport = async ({
   };
 };
 
-/** The AI generator bundle passed into the fill pipeline; every field is
- *  optional so a deterministic export can pass `{}`. */
+/** The AI hooks passed into the fill pipeline; both are optional so a
+ *  deterministic export can pass `{}`. */
 type ReportAiGenerators = {
-  generateAiValue?: ReturnType<typeof buildAiFieldGenerator> | undefined;
-  decideAiCondition?: ReturnType<typeof buildAiConditionDecider> | undefined;
-  adaptAiValue?: ReturnType<typeof buildAiOccurrenceAdapter> | undefined;
+  aiCollaborators?:
+    | (() => AiFillCollaborators | Promise<AiFillCollaborators>)
+    | undefined;
   assertUsageAvailable?: (() => Promise<unknown>) | undefined;
 };
 
@@ -690,32 +698,24 @@ const buildReportAiGenerators = ({
           })
       : undefined;
 
-  const skillContext = {
+  const shared = {
+    orgAIConfig,
     organizationId: actor.organizationId,
-    safeDb: actor.safeDb,
-    userId: actor.userId,
+    skillContext: {
+      organizationId: actor.organizationId,
+      safeDb: actor.safeDb,
+      userId: actor.userId,
+    },
+    aiAnalytics,
+    tenantWorkspaceIds: [actor.workspaceId],
   };
   return {
-    generateAiValue: buildAiFieldGenerator({
-      orgAIConfig,
-      organizationId: actor.organizationId,
-      skillContext,
-      aiAnalytics,
-      tenantWorkspaceIds: [actor.workspaceId],
-    }),
-    decideAiCondition: buildAiConditionDecider({
-      orgAIConfig,
-      organizationId: actor.organizationId,
-      skillContext,
-      aiAnalytics,
-      tenantWorkspaceIds: [actor.workspaceId],
-    }),
-    adaptAiValue: buildAiOccurrenceAdapter({
-      orgAIConfig,
-      organizationId: actor.organizationId,
-      skillContext,
-      aiAnalytics,
-      tenantWorkspaceIds: [actor.workspaceId],
+    // The fill service builds these only when the manifest declares an AI
+    // field, so a deterministic export never reaches the model layer.
+    aiCollaborators: () => ({
+      generateAiValue: buildAiFieldGenerator(shared),
+      decideAiCondition: buildAiConditionDecider(shared),
+      adaptAiValue: buildAiOccurrenceAdapter(shared),
     }),
     assertUsageAvailable,
   };
@@ -740,6 +740,7 @@ const fillReportDocx = async ({
       values,
       scopedDb: actor.scopedDb,
       organizationId: actor.organizationId,
+      requiredFields: "enforce",
       ...generators,
     });
   }
@@ -758,6 +759,7 @@ const fillReportDocx = async ({
     values,
     scopedDb: actor.scopedDb,
     organizationId: actor.organizationId,
+    requiredFields: "enforce",
     ...generators,
   });
 };

--- a/apps/api/src/handlers/templates/fill-preview.ts
+++ b/apps/api/src/handlers/templates/fill-preview.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { t } from "elysia";
 
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -34,14 +35,17 @@ const config = {
 const fillTemplatePreview = createSafeRootHandler(
   config,
   async function* ({ safeDb, scopedDb, session, user, params, body }) {
-    return yield* fillPreviewLogic({
-      safeDb,
-      scopedDb,
-      organizationId: session.activeOrganizationId,
-      userId: user.id,
-      templateId: params.templateId,
-      body,
-    });
+    const preview = yield* Result.await(
+      fillPreviewLogic({
+        safeDb,
+        scopedDb,
+        organizationId: session.activeOrganizationId,
+        userId: user.id,
+        templateId: params.templateId,
+        body,
+      }),
+    );
+    return Result.ok(preview);
   },
 );
 

--- a/apps/api/src/handlers/templates/fill-to-workspace.ts
+++ b/apps/api/src/handlers/templates/fill-to-workspace.ts
@@ -147,21 +147,37 @@ const fillTemplateToWorkspace = createSafeHandler(
       }
     }
 
-    const aiAnalytics = createTanStackAIAnalyticsCallbacks({
-      usageMetering: {
-        actionType: "chat",
+    // Built only when the manifest declares an AI field: the fill service
+    // defers this, so a deterministic fill opens no metered trace.
+    const aiCollaborators = () => {
+      const aiAnalytics = createTanStackAIAnalyticsCallbacks({
+        usageMetering: {
+          actionType: "chat",
+          organizationId,
+          safeDb,
+          serviceTier: "standard",
+          userId: user.id,
+          workspaceId,
+        },
+        feature: "templates.fill",
+        modelRole: "fast",
+        orgAIConfig,
+        properties: { organization_id: organizationId },
+        traceId: Bun.randomUUIDv7(),
+      });
+      const shared = {
+        orgAIConfig,
         organizationId,
-        safeDb,
-        serviceTier: "standard",
-        userId: user.id,
-        workspaceId,
-      },
-      feature: "templates.fill",
-      modelRole: "fast",
-      orgAIConfig,
-      properties: { organization_id: organizationId },
-      traceId: Bun.randomUUIDv7(),
-    });
+        skillContext: { organizationId, safeDb, userId: user.id },
+        aiAnalytics,
+        tenantWorkspaceIds: [workspaceId],
+      };
+      return {
+        generateAiValue: buildAiFieldGenerator(shared),
+        decideAiCondition: buildAiConditionDecider(shared),
+        adaptAiValue: buildAiOccurrenceAdapter(shared),
+      };
+    };
 
     // The fill service runs this only when the manifest declares AI fields,
     // before any model call, so a deterministic fill never spends AI quota.
@@ -191,29 +207,10 @@ const fillTemplateToWorkspace = createSafeHandler(
             scopedDb,
             organizationId,
             workspaceId,
+            requiredFields: "enforce",
             clauseOverrides: body.clauseOverrides,
             assertUsageAvailable,
-            generateAiValue: buildAiFieldGenerator({
-              orgAIConfig,
-              organizationId,
-              skillContext: { organizationId, safeDb, userId: user.id },
-              aiAnalytics,
-              tenantWorkspaceIds: [workspaceId],
-            }),
-            decideAiCondition: buildAiConditionDecider({
-              orgAIConfig,
-              organizationId,
-              skillContext: { organizationId, safeDb, userId: user.id },
-              aiAnalytics,
-              tenantWorkspaceIds: [workspaceId],
-            }),
-            adaptAiValue: buildAiOccurrenceAdapter({
-              orgAIConfig,
-              organizationId,
-              skillContext: { organizationId, safeDb, userId: user.id },
-              aiAnalytics,
-              tenantWorkspaceIds: [workspaceId],
-            }),
+            aiCollaborators,
           }),
         catch: (cause) =>
           new HandlerError({

--- a/apps/api/src/handlers/templates/fill.ts
+++ b/apps/api/src/handlers/templates/fill.ts
@@ -3,35 +3,19 @@ import { t } from "elysia";
 
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
 import { templateFills } from "@/api/db/schema";
-import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
 import { captureError } from "@/api/lib/analytics/capture";
-import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
-import { adaptAiFields } from "@/api/lib/docx/adapt-ai-fields";
-import {
-  buildAiConditionDecider,
-  buildAiFieldGenerator,
-  buildAiOccurrenceAdapter,
-} from "@/api/lib/docx/ai-field-generator";
-import { documentTextForAiFields } from "@/api/lib/docx/extract-text";
-import { createDispatchLookupResolver } from "@/api/lib/docx/lookup-fields";
-import { applyManifestFillSteps } from "@/api/lib/docx/manifest-fill-steps";
-import { fillTemplate } from "@/api/lib/docx/patch-template";
-import { buildIsRegistryEnabledForOrg } from "@/api/lib/docx/registry-org-gate";
-import { resolveAiConditions } from "@/api/lib/docx/resolve-ai-conditions";
-import { resolveAiFields } from "@/api/lib/docx/resolve-ai-fields";
-import { readManifest } from "@/api/lib/docx/template-manifest";
-import { isTemplateData, type TemplateData } from "@/api/lib/docx/types";
+import { isTemplateData } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { convertToPdf } from "@/api/lib/files/gotenberg";
 import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
 import { DOCX_EXT_RE, sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { secureDocumentResponse } from "@/api/lib/secure-document-response";
 import { containsNull } from "@/api/lib/templates/template-data";
-import { assertTemplateFillUsage } from "@/api/lib/templates/template-fill-usage";
-import { collectMissingRequiredFields } from "@/api/lib/templates/template-optional-defaults";
+import { fillTemplateDocx } from "@/api/lib/templates/template-fill-service";
+import { buildTemplateFillAiWiring } from "@/api/lib/templates/template-fill-usage";
 import { isTemplateOutputValid } from "@/api/lib/templates/validate-template-output";
 import { isRecord } from "@/api/lib/type-guards";
 import { DOCX_MIME_TYPE, OCTET_STREAM_MIME_TYPE } from "@/api/mime-types";
@@ -134,160 +118,44 @@ export const fillHandler = async ({
   }
 
   const buffer = Buffer.from(await file.arrayBuffer());
+  const sourceName = sanitizeFilename(file.name);
 
-  // Draft any AI-fillable fields (manifest fields with an aiPrompt) before fill,
-  // so an AI placeholder like "the scope of this power of attorney" is filled on
-  // download just as the chat fill tool fills it. A user-supplied value wins.
-  let fillData: TemplateData = parsed;
-  let fillBuffer: Buffer = buffer;
-  let adaptedPaths: readonly string[] = [];
-  const manifest = await readManifest(buffer);
-
-  // Reject before any AI/registry work runs: a required, user-entered field
-  // left absent or empty must never download as an invented value or a raw
-  // `{{marker}}`. This route always enforces the full contract (unlike
-  // fill-preview, whose live typing preview legitimately allows partial
-  // values).
-  if (manifest) {
-    const missingRequiredFields = collectMissingRequiredFields({
-      fields: manifest.fields,
-      policy: "enforce",
-      values: fillData,
-    });
-    if (missingRequiredFields.length > 0) {
-      return new Response(
-        JSON.stringify({
-          error: "missing_required_fields",
-          missingFields: missingRequiredFields,
-        }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
-    }
-  }
-
-  const hasAiDraftFields = manifest?.fields.some((field) => field.aiPrompt);
-  const hasAiAdaptFields = manifest?.fields.some((field) => field.aiAdapt);
-  // Loaded once for the AI draft/adapt steps below.
-  const orgAIConfig =
-    manifest && (hasAiDraftFields || hasAiAdaptFields)
-      ? await loadOrgAIConfig(organizationId)
-      : null;
-
-  // This download route streams its own Response, so a usage rejection is
-  // serialized to the same body the framework preflight emits (message plus
-  // usage detail) here.
-  const usageRejection = await assertTemplateFillUsage({
-    orgAIConfig,
-    hasAiFields: Boolean(hasAiDraftFields) || Boolean(hasAiAdaptFields),
+  const result = await fillTemplateDocx({
+    source: { name: sourceName, fileName: sourceName, buffer },
+    values: parsed,
+    scopedDb,
     organizationId,
-    userId,
-    safeDb,
-  });
-  if (usageRejection !== null) {
-    return usageRejectionResponse(usageRejection);
-  }
-
-  // Resolve registry lookups, assemble composite (multipart) values,
-  // evaluate formula (derived) fields, and check dependent (optionsFrom)
-  // selects before any AI step or substitution sees them (in place: a
-  // resolved value is a plain string, so the data stays valid TemplateData);
-  // a failing step rejects naming the field.
-  const stepError = await applyManifestFillSteps({
-    values: fillData,
-    manifest,
-    resolveLookup: createDispatchLookupResolver({
-      isRegistryEnabledForOrg: await buildIsRegistryEnabledForOrg({
-        organizationId,
-        scopedDb,
-      }),
+    // A required, user-entered field left absent or empty must never download
+    // as an invented value or a raw `{{marker}}`.
+    requiredFields: "enforce",
+    ...buildTemplateFillAiWiring({
+      organizationId,
+      userId,
+      safeDb,
+      feature: "templates.fill",
     }),
   });
-  if (stepError !== null) {
-    return new Response(JSON.stringify({ error: stepError }), {
+
+  if ("requiredFieldsRejection" in result) {
+    return new Response(
+      JSON.stringify({
+        error: "missing_required_fields",
+        missingFields: result.requiredFieldsRejection,
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  if ("usageRejection" in result) {
+    return usageRejectionResponse(result.usageRejection);
+  }
+  if ("error" in result) {
+    return new Response(JSON.stringify({ error: result.error }), {
       status: 400,
       headers: { "Content-Type": "application/json" },
     });
   }
 
-  if (manifest && (hasAiDraftFields || hasAiAdaptFields)) {
-    const aiAnalytics = createTanStackAIAnalyticsCallbacks({
-      usageMetering: {
-        actionType: "chat",
-        organizationId,
-        safeDb,
-        serviceTier: "standard",
-        userId,
-        workspaceId: null,
-      },
-      feature: "templates.fill",
-      modelRole: "fast",
-      orgAIConfig,
-      properties: { organization_id: organizationId },
-      traceId: Bun.randomUUIDv7(),
-    });
-    if (hasAiDraftFields) {
-      const documentText = await documentTextForAiFields(
-        new Uint8Array(buffer),
-        manifest.fields,
-      );
-      const resolved = await resolveAiFields({
-        values: parsed,
-        fields: manifest.fields,
-        documentText,
-        // This route fills a raw uploaded DOCX via a root handler, so there is
-        // no workspace/matter scope to redact tenant ids against.
-        generate: buildAiFieldGenerator({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      // Decide AI-decided boolean conditions (a boolean field with an aiPrompt)
-      // alongside the string drafts; resolveAiFields skips boolean fields.
-      const decided = await resolveAiConditions({
-        values: resolved,
-        fields: manifest.fields,
-        decide: buildAiConditionDecider({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      if (isTemplateData(decided)) {
-        fillData = decided;
-      }
-    }
-    if (hasAiAdaptFields) {
-      // Rewrite each aiAdapt marker occurrence to fit its surrounding text
-      // (declension); the stub stays in fillData so uncovered occurrences
-      // still get the plain global substitution below.
-      const adapted = await adaptAiFields({
-        buffer,
-        fields: manifest.fields,
-        values: fillData,
-        adapt: buildAiOccurrenceAdapter({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      fillBuffer = adapted.buffer;
-      adaptedPaths = adapted.adaptedPaths;
-    }
-  }
-
-  const result = await fillTemplate(fillBuffer, fillData);
-  // Adapted stubs no longer match a marker (each occurrence was already
-  // substituted), so they are not "unused" in any user-meaningful sense.
-  const unusedValues = result.unusedValues.filter(
-    (name) => !adaptedPaths.includes(name),
-  );
+  const { unusedValues } = result;
 
   const fillStatus =
     result.unmatchedPlaceholders.length > 0 ? "partial" : "success";
@@ -322,7 +190,7 @@ export const fillHandler = async ({
     if (
       !(await isTemplateOutputValid({
         buffer: docxBytes,
-        fileName: sanitizeFilename(file.name),
+        fileName: sourceName,
       }))
     ) {
       return new Response(
@@ -338,7 +206,7 @@ export const fillHandler = async ({
         docxBytes.byteOffset,
         docxBytes.byteOffset + docxBytes.byteLength,
       ),
-      sanitizeFilename(file.name),
+      sourceName,
       DOCX_MIME_TYPE,
     );
     if (Result.isError(pdfResult)) {
@@ -348,10 +216,9 @@ export const fillHandler = async ({
       });
     }
 
-    const sanitized = sanitizeFilename(file.name);
-    const pdfName = DOCX_EXT_RE.test(sanitized)
-      ? sanitized.replace(DOCX_EXT_RE, ".pdf")
-      : `${sanitized}.pdf`;
+    const pdfName = DOCX_EXT_RE.test(sourceName)
+      ? sourceName.replace(DOCX_EXT_RE, ".pdf")
+      : `${sourceName}.pdf`;
     return secureDocumentResponse({
       body: new Uint8Array(pdfResult.value.buffer),
       // Octet-stream, not application/pdf: see OCTET_STREAM_MIME_TYPE.

--- a/apps/api/src/lib/templates/fill-by-id-logic.test.ts
+++ b/apps/api/src/lib/templates/fill-by-id-logic.test.ts
@@ -66,7 +66,12 @@ const stubDb = (fileName: string) =>
   createScopedDbMock({
     query: {
       templates: {
-        findFirst: async () => ({ s3Key, fileName, languages: null }),
+        findFirst: async () => ({
+          name: "Template",
+          fileName,
+          s3Key,
+          languages: [],
+        }),
       },
       organizationSettings: { findFirst: async () => undefined },
     },

--- a/apps/api/src/lib/templates/fill-by-id-logic.ts
+++ b/apps/api/src/lib/templates/fill-by-id-logic.ts
@@ -82,7 +82,11 @@ export const fillByIdLogic = async function* ({
     );
   }
 
-  const source = await loadStoredTemplateSource({ templateId, scopedDb });
+  const source = await loadStoredTemplateSource({
+    templateId,
+    organizationId,
+    scopedDb,
+  });
   if (!source) {
     return Result.err(
       new HandlerError({ status: 404, message: "Template not found" }),

--- a/apps/api/src/lib/templates/fill-by-id-logic.ts
+++ b/apps/api/src/lib/templates/fill-by-id-logic.ts
@@ -8,40 +8,21 @@ import { Result } from "better-result";
 
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
 import { templateFills } from "@/api/db/schema";
-import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
-import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
-import { clauseBodyToRichPatch } from "@/api/lib/clauses/clause-to-patch";
 import type { ClauseBody } from "@/api/lib/clauses/types";
-import { adaptAiFields } from "@/api/lib/docx/adapt-ai-fields";
-import {
-  buildAiConditionDecider,
-  buildAiFieldGenerator,
-  buildAiOccurrenceAdapter,
-} from "@/api/lib/docx/ai-field-generator";
-import { discoverClauseSlots } from "@/api/lib/docx/discover-clause-slots";
-import { documentTextForAiFields } from "@/api/lib/docx/extract-text";
-import { createDispatchLookupResolver } from "@/api/lib/docx/lookup-fields";
-import { applyManifestFillSteps } from "@/api/lib/docx/manifest-fill-steps";
-import { fillTemplate } from "@/api/lib/docx/patch-template";
-import { buildIsRegistryEnabledForOrg } from "@/api/lib/docx/registry-org-gate";
-import { resolveAiConditions } from "@/api/lib/docx/resolve-ai-conditions";
-import { resolveAiFields } from "@/api/lib/docx/resolve-ai-fields";
-import { resolveClauseSlots } from "@/api/lib/docx/resolve-clause-slots";
-import { readManifest } from "@/api/lib/docx/template-manifest";
-import { isTemplateData } from "@/api/lib/docx/types";
-import type { RichPatchValue } from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { convertToPdf } from "@/api/lib/files/gotenberg";
-import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { DOCX_EXT_RE, sanitizeFilename } from "@/api/lib/sanitize-filename";
 import type { SecureDocumentResponseOptions } from "@/api/lib/secure-document-response";
 import { recordTemplateUse } from "@/api/lib/templates/record-use";
 import { containsNull } from "@/api/lib/templates/template-data";
-import { assertTemplateFillUsage } from "@/api/lib/templates/template-fill-usage";
-import { collectMissingRequiredFields } from "@/api/lib/templates/template-optional-defaults";
+import {
+  fillTemplateDocx,
+  loadStoredTemplateSource,
+} from "@/api/lib/templates/template-fill-service";
+import { buildTemplateFillAiWiring } from "@/api/lib/templates/template-fill-usage";
 import { isTemplateOutputValid } from "@/api/lib/templates/validate-template-output";
 import { isRecord } from "@/api/lib/type-guards";
 import { DOCX_MIME_TYPE, OCTET_STREAM_MIME_TYPE } from "@/api/mime-types";
@@ -57,47 +38,9 @@ export type FillByIdLogicProps = {
   recordAuditEvent: AuditRecorder;
 };
 
-type ResolveClausePatchesArgs = {
-  buffer: Buffer;
-  templateId: SafeId<"template">;
-  clauseOverrides: Record<string, ClauseBody> | undefined;
-  scopedDb: ScopedDb;
-  organizationId: SafeId<"organization">;
-};
-
-/** Resolve the template's clause slots to rich patches, with any per-fill
- *  override taking precedence over the linked clause body. */
-const resolveClausePatches = async ({
-  buffer,
-  templateId,
-  clauseOverrides,
-  scopedDb,
-  organizationId,
-}: ResolveClausePatchesArgs): Promise<Record<string, RichPatchValue>> => {
-  const slots = await discoverClauseSlots(buffer);
-  if (slots.length === 0) {
-    return {};
-  }
-  const patches = await resolveClauseSlots(
-    templateId,
-    slots,
-    scopedDb,
-    organizationId,
-  );
-  if (clauseOverrides) {
-    const slotKeys = new Set(slots.map((slot) => slot.patchKey));
-    for (const [key, overrideBody] of Object.entries(clauseOverrides)) {
-      if (slotKeys.has(key)) {
-        patches[key] = clauseBodyToRichPatch(overrideBody);
-      }
-    }
-  }
-  return patches;
-};
-
-/** `templates.fill-by-id`'s fill logic. Mirrors `fillHandler` (the raw-upload
- *  route) with a stored template's clause-slot resolution, AI drafting, and
- *  audit/use bookkeeping layered on top.
+/** `templates.fill-by-id`'s fill logic: the shared fill pipeline plus this
+ *  route's download shaping (PDF conversion, diagnostic headers) and its
+ *  use/fill/audit bookkeeping, written in one transaction.
  *
  * @yields safeDb/scopedDb errors out to the parent safe-handler. */
 export const fillByIdLogic = async function* ({
@@ -110,28 +53,6 @@ export const fillByIdLogic = async function* ({
   query: { format = "docx" },
   recordAuditEvent,
 }: FillByIdLogicProps) {
-  const template = yield* Result.await(
-    safeDb((tx) =>
-      tx.query.templates.findFirst({
-        where: {
-          id: { eq: templateId },
-          organizationId: { eq: organizationId },
-        },
-        columns: {
-          s3Key: true,
-          fileName: true,
-          languages: true,
-        },
-      }),
-    ),
-  );
-
-  if (!template) {
-    return Result.err(
-      new HandlerError({ status: 404, message: "Template not found" }),
-    );
-  }
-
   const parseResult = Result.try((): unknown => JSON.parse(valuesJson));
   if (Result.isError(parseResult)) {
     return Result.err(
@@ -161,181 +82,56 @@ export const fillByIdLogic = async function* ({
     );
   }
 
-  const arrayBuf = await readS3ArrayBuffer(template.s3Key);
-  const buffer = Buffer.from(arrayBuf);
-
-  // Discover/resolve clause slots ({{@clause:...}}) and apply per-fill overrides.
-  const clausePatches = await resolveClausePatches({
-    buffer,
-    templateId,
-    clauseOverrides,
-    scopedDb,
-    organizationId,
-  });
-  for (const [key, value] of Object.entries(clausePatches)) {
-    parsed[key] = value;
-  }
-
-  // Draft AI-fillable fields so the downloaded document matches the preview
-  // (fill-preview resolves them too); without this an AI-drafted placeholder
-  // shown in the preview would download unresolved.
-  let fillBuffer: Buffer = buffer;
-  let adaptedPaths: readonly string[] = [];
-  const manifest = await readManifest(buffer);
-
-  // Reject before any AI/registry work runs: a required, user-entered field
-  // left absent or empty must never download as an invented value or a raw
-  // `{{marker}}`. This route always enforces the full contract (unlike
-  // fill-preview, whose live typing preview legitimately allows partial
-  // values).
-  if (manifest) {
-    const missingRequiredFields = collectMissingRequiredFields({
-      fields: manifest.fields,
-      policy: "enforce",
-      values: parsed,
-    });
-    if (missingRequiredFields.length > 0) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: `Missing required template values: ${missingRequiredFields
-            .map((field) => field.label ?? field.path)
-            .join(", ")}`,
-          requiredFields: missingRequiredFields,
-        }),
-      );
-    }
-  }
-
-  const hasAiDraftFields = manifest?.fields.some((field) => field.aiPrompt);
-  const hasAiAdaptFields = manifest?.fields.some((field) => field.aiAdapt);
-  // Loaded once for the AI draft/adapt steps below.
-  const orgAIConfig =
-    manifest && (hasAiDraftFields || hasAiAdaptFields)
-      ? await loadOrgAIConfig(organizationId)
-      : null;
-
-  const usageRejection = await assertTemplateFillUsage({
-    orgAIConfig,
-    hasAiFields: Boolean(hasAiDraftFields) || Boolean(hasAiAdaptFields),
-    organizationId,
-    userId,
-    safeDb,
-  });
-  if (usageRejection !== null) {
-    return Result.err(usageRejection);
-  }
-
-  // Resolve registry lookups, assemble composite (multipart) values,
-  // evaluate formula (derived) fields, and check dependent (optionsFrom)
-  // selects before any AI step or substitution sees them; a failing step
-  // rejects the request naming the field.
-  const stepError = await applyManifestFillSteps({
-    values: parsed,
-    manifest,
-    resolveLookup: createDispatchLookupResolver({
-      isRegistryEnabledForOrg: await buildIsRegistryEnabledForOrg({
-        organizationId,
-        scopedDb,
-      }),
-    }),
-  });
-  if (stepError !== null) {
-    return Result.err(new HandlerError({ status: 400, message: stepError }));
-  }
-
-  if (manifest && (hasAiDraftFields || hasAiAdaptFields)) {
-    const aiAnalytics = createTanStackAIAnalyticsCallbacks({
-      usageMetering: {
-        actionType: "chat",
-        organizationId,
-        safeDb,
-        serviceTier: "standard",
-        userId,
-        workspaceId: null,
-      },
-      feature: "templates.fill",
-      modelRole: "fast",
-      orgAIConfig,
-      properties: { organization_id: organizationId },
-      traceId: Bun.randomUUIDv7(),
-    });
-    if (hasAiDraftFields) {
-      const documentText = await documentTextForAiFields(
-        new Uint8Array(buffer),
-        manifest.fields,
-      );
-      const aiResolved = await resolveAiFields({
-        values: parsed,
-        fields: manifest.fields,
-        documentText,
-        // Root-scoped route (template selected by id, no matter binding), so
-        // there is no workspace scope to redact tenant ids against.
-        generate: buildAiFieldGenerator({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      // Decide AI-decided boolean conditions (a boolean field with an aiPrompt)
-      // so the downloaded document matches the preview.
-      const aiDecided = await resolveAiConditions({
-        values: aiResolved,
-        fields: manifest.fields,
-        decide: buildAiConditionDecider({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      for (const [key, value] of Object.entries(aiDecided)) {
-        parsed[key] = value;
-      }
-    }
-    if (hasAiAdaptFields) {
-      // Rewrite each aiAdapt marker occurrence to fit its surrounding text;
-      // the stub stays in `parsed` so uncovered occurrences still get the
-      // plain global substitution below.
-      const adapted = await adaptAiFields({
-        buffer,
-        fields: manifest.fields,
-        values: parsed,
-        adapt: buildAiOccurrenceAdapter({
-          orgAIConfig,
-          organizationId,
-          documentLanguages: template.languages,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      fillBuffer = adapted.buffer;
-      adaptedPaths = adapted.adaptedPaths;
-    }
-  }
-
-  if (!isTemplateData(parsed)) {
+  const source = await loadStoredTemplateSource({ templateId, scopedDb });
+  if (!source) {
     return Result.err(
-      new HandlerError({
-        status: 400,
-        message:
-          "'values' must contain only strings, numbers, booleans, " +
-          "arrays, nested objects, or rich-text patch values.",
-      }),
+      new HandlerError({ status: 404, message: "Template not found" }),
     );
   }
 
-  const result = await fillTemplate(fillBuffer, parsed);
-  // Adapted stubs no longer match a marker (each occurrence was already
-  // substituted), so they are not "unused" in any user-meaningful sense.
-  const unusedValues = result.unusedValues.filter(
-    (name) => !adaptedPaths.includes(name),
-  );
+  const result = await fillTemplateDocx({
+    source,
+    values: parsed,
+    scopedDb,
+    organizationId,
+    clauseOverrides,
+    // A required, user-entered field left absent or empty must never download
+    // as an invented value or a raw `{{marker}}`.
+    requiredFields: "enforce",
+    // The use count is written below, inside this route's own bookkeeping
+    // transaction, alongside the fill row and the audit event.
+    useRecording: "caller",
+    ...buildTemplateFillAiWiring({
+      organizationId,
+      userId,
+      safeDb,
+      feature: "templates.fill",
+      documentLanguages: source.documentLanguages,
+    }),
+  });
 
+  if ("requiredFieldsRejection" in result) {
+    return Result.err(
+      new HandlerError({
+        status: 400,
+        message: `Missing required template values: ${result.requiredFieldsRejection
+          .map((field) => field.label ?? field.path)
+          .join(", ")}`,
+        // The message alone loses each field's input type/options; carry the
+        // full rejection so a client can render the right control per field
+        // and retry with all of them at once.
+        requiredFields: result.requiredFieldsRejection,
+      }),
+    );
+  }
+  if ("usageRejection" in result) {
+    return Result.err(result.usageRejection);
+  }
+  if ("error" in result) {
+    return Result.err(new HandlerError({ status: 400, message: result.error }));
+  }
+
+  const { unusedValues } = result;
   const fillStatus =
     result.unmatchedPlaceholders.length > 0 ? "partial" : "success";
 
@@ -377,7 +173,7 @@ export const fillByIdLogic = async function* ({
     }),
   );
 
-  const baseName = template.fileName;
+  const baseName = result.fileName;
 
   // PDF conversion via Gotenberg
   if (format === "pdf") {

--- a/apps/api/src/lib/templates/fill-preview-logic.test.ts
+++ b/apps/api/src/lib/templates/fill-preview-logic.test.ts
@@ -63,7 +63,12 @@ const stubDb = () =>
   createScopedDbMock({
     query: {
       templates: {
-        findFirst: async () => ({ s3Key }),
+        findFirst: async () => ({
+          name: "Template",
+          fileName: "template.docx",
+          s3Key,
+          languages: [],
+        }),
       },
       organizationSettings: { findFirst: async () => undefined },
     },
@@ -79,16 +84,14 @@ describe("fillPreviewLogic required fields (allow-partial)", () => {
       fakeS3.put("stella", s3Key, buffer);
       const { safeDb, scopedDb } = stubDb();
 
-      const result = await Result.gen(() =>
-        fillPreviewLogic({
-          safeDb,
-          scopedDb,
-          organizationId,
-          userId,
-          templateId,
-          body: { values: "{}" },
-        }),
-      );
+      const result = await fillPreviewLogic({
+        safeDb,
+        scopedDb,
+        organizationId,
+        userId,
+        templateId,
+        body: { values: "{}" },
+      });
 
       expect(Result.isOk(result)).toBe(true);
       if (Result.isOk(result)) {
@@ -110,16 +113,14 @@ describe("fillPreviewLogic required fields (allow-partial)", () => {
       fakeS3.put("stella", s3Key, buffer);
       const { safeDb, scopedDb } = stubDb();
 
-      const result = await Result.gen(() =>
-        fillPreviewLogic({
-          safeDb,
-          scopedDb,
-          organizationId,
-          userId,
-          templateId,
-          body: { values: '{"governing_law": "Czech"}' },
-        }),
-      );
+      const result = await fillPreviewLogic({
+        safeDb,
+        scopedDb,
+        organizationId,
+        userId,
+        templateId,
+        body: { values: '{"governing_law": "Czech"}' },
+      });
 
       expect(Result.isOk(result)).toBe(true);
       if (Result.isOk(result)) {

--- a/apps/api/src/lib/templates/fill-preview-logic.ts
+++ b/apps/api/src/lib/templates/fill-preview-logic.ts
@@ -86,7 +86,11 @@ export const fillPreviewLogic = async ({
     );
   }
 
-  const source = await loadStoredTemplateSource({ templateId, scopedDb });
+  const source = await loadStoredTemplateSource({
+    templateId,
+    organizationId,
+    scopedDb,
+  });
   if (!source) {
     return Result.err(
       new HandlerError({ status: 404, message: "Template not found" }),

--- a/apps/api/src/lib/templates/fill-preview-logic.ts
+++ b/apps/api/src/lib/templates/fill-preview-logic.ts
@@ -1,41 +1,26 @@
 /**
  * `templates.fill-preview`'s fill logic, factored out of the endpoint module
  * (`handlers/templates/fill-preview.ts`) so that module can keep to one
- * default `{ config, handler }` export while this generator stays directly
- * testable.
+ * default `{ config, handler }` export while this stays directly testable.
  */
 
+import type { Result as ResultType } from "better-result";
 import { Result } from "better-result";
 
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
-import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
-import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
-import { adaptAiFields } from "@/api/lib/docx/adapt-ai-fields";
-import {
-  buildAiConditionDecider,
-  buildAiFieldGenerator,
-  buildAiOccurrenceAdapter,
-} from "@/api/lib/docx/ai-field-generator";
-import { discoverClauseSlots } from "@/api/lib/docx/discover-clause-slots";
-import {
-  documentTextForAiFields,
-  extractText,
-} from "@/api/lib/docx/extract-text";
-import { createDispatchLookupResolver } from "@/api/lib/docx/lookup-fields";
-import { applyManifestFillSteps } from "@/api/lib/docx/manifest-fill-steps";
-import { fillTemplate } from "@/api/lib/docx/patch-template";
-import { buildIsRegistryEnabledForOrg } from "@/api/lib/docx/registry-org-gate";
-import { resolveAiConditions } from "@/api/lib/docx/resolve-ai-conditions";
-import { resolveAiFields } from "@/api/lib/docx/resolve-ai-fields";
-import { resolveClauseSlots } from "@/api/lib/docx/resolve-clause-slots";
-import { readManifest } from "@/api/lib/docx/template-manifest";
-import { isTemplateData } from "@/api/lib/docx/types";
+import { extractText } from "@/api/lib/docx/extract-text";
+import type {
+  ExtractedParagraph,
+  TemplateStructureError,
+} from "@/api/lib/docx/types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { containsNull } from "@/api/lib/templates/template-data";
-import { assertTemplateFillUsage } from "@/api/lib/templates/template-fill-usage";
-import { collectMissingRequiredFields } from "@/api/lib/templates/template-optional-defaults";
+import {
+  fillTemplateDocx,
+  loadStoredTemplateSource,
+} from "@/api/lib/templates/template-fill-service";
+import { buildTemplateFillAiWiring } from "@/api/lib/templates/template-fill-usage";
 import { isRecord } from "@/api/lib/type-guards";
 
 export type FillPreviewLogicProps = {
@@ -47,37 +32,31 @@ export type FillPreviewLogicProps = {
   body: { values: string };
 };
 
-/** `templates.fill-preview`'s fill logic: the same pipeline as
- *  `fillByIdLogic`, minus the download/PDF/audit steps, returning the
- *  rendered paragraphs and diagnostics for a live preview instead.
- *
- * @yields safeDb errors out to the parent safe-handler. */
-export const fillPreviewLogic = async function* ({
+/** What the preview renders: the filled text plus the same diagnostics a
+ *  download reports. */
+type FillPreviewResult = {
+  paragraphs: ExtractedParagraph[];
+  charCount: number;
+  unmatchedPlaceholders: string[];
+  unusedValues: string[];
+  structureErrors: TemplateStructureError[];
+};
+
+/** `templates.fill-preview`'s fill logic: the shared fill pipeline in its
+ *  `"allow-partial"` mode, returning the rendered paragraphs and diagnostics
+ *  for a live preview instead of a downloadable file. The error status is
+ *  annotated because the branches below would otherwise infer as a union of
+ *  differently-parameterised `HandlerError`s the caller cannot consume. */
+export const fillPreviewLogic = async ({
   safeDb,
   scopedDb,
   organizationId,
   userId,
   templateId,
   body: { values: valuesJson },
-}: FillPreviewLogicProps) {
-  const template = yield* Result.await(
-    safeDb((tx) =>
-      tx.query.templates.findFirst({
-        where: {
-          id: { eq: templateId },
-          organizationId: { eq: organizationId },
-        },
-        columns: { s3Key: true },
-      }),
-    ),
-  );
-
-  if (!template) {
-    return Result.err(
-      new HandlerError({ status: 404, message: "Template not found" }),
-    );
-  }
-
+}: FillPreviewLogicProps): Promise<
+  ResultType<FillPreviewResult, HandlerError<400 | 402 | 404 | 500>>
+> => {
   const parseResult = Result.try((): unknown => JSON.parse(valuesJson));
   if (Result.isError(parseResult)) {
     return Result.err(
@@ -98,8 +77,7 @@ export const fillPreviewLogic = async function* ({
     );
   }
 
-  const record = parsed;
-  if (Object.values(record).some(containsNull)) {
+  if (Object.values(parsed).some(containsNull)) {
     return Result.err(
       new HandlerError({
         status: 400,
@@ -108,190 +86,63 @@ export const fillPreviewLogic = async function* ({
     );
   }
 
-  const arrayBuf = await readS3ArrayBuffer(template.s3Key);
-  const buffer = Buffer.from(arrayBuf);
-
-  // Resolve clause slots before filling
-  const slots = await discoverClauseSlots(buffer);
-  if (slots.length > 0) {
-    const clausePatches = await resolveClauseSlots(
-      templateId,
-      slots,
-      scopedDb,
-      organizationId,
+  const source = await loadStoredTemplateSource({ templateId, scopedDb });
+  if (!source) {
+    return Result.err(
+      new HandlerError({ status: 404, message: "Template not found" }),
     );
-    for (const [key, value] of Object.entries(clausePatches)) {
-      record[key] = value;
-    }
   }
 
-  // Draft AI-fillable fields so the preview reflects what download produces.
-  let fillBuffer: Buffer = buffer;
-  let adaptedPaths: readonly string[] = [];
-  const manifest = await readManifest(buffer);
-
-  // Live preview: the values are typically still in progress (the person is
-  // mid-typing in the fill form), so partial values are explicitly allowed
-  // here — the one deliberate exception to the required-fields gate every
-  // other fill route (download, chat/MCP tool, workspace persistence)
-  // enforces. Named at the call site (`"allow-partial"`) rather than simply
-  // never calling the gate, so the exception stays visible and this route
-  // keeps tracking the gate's contract if it ever grows beyond a no-op for
-  // that policy.
-  if (manifest) {
-    const missingRequiredFields = collectMissingRequiredFields({
-      fields: manifest.fields,
-      policy: "allow-partial",
-      values: record,
-    });
-    if (missingRequiredFields.length > 0) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: `Missing required template values: ${missingRequiredFields
-            .map((field) => field.label ?? field.path)
-            .join(", ")}`,
-          requiredFields: missingRequiredFields,
-        }),
-      );
-    }
-  }
-
-  const hasAiDraftFields = manifest?.fields.some((field) => field.aiPrompt);
-  const hasAiAdaptFields = manifest?.fields.some((field) => field.aiAdapt);
-  // Loaded once for the AI draft/adapt steps below.
-  const orgAIConfig =
-    manifest && (hasAiDraftFields || hasAiAdaptFields)
-      ? await loadOrgAIConfig(organizationId)
-      : null;
-
-  const usageRejection = await assertTemplateFillUsage({
-    orgAIConfig,
-    hasAiFields: Boolean(hasAiDraftFields) || Boolean(hasAiAdaptFields),
+  const result = await fillTemplateDocx({
+    source,
+    values: parsed,
+    scopedDb,
     organizationId,
-    userId,
-    safeDb,
-  });
-  if (usageRejection !== null) {
-    return Result.err(usageRejection);
-  }
-
-  // Resolve registry lookups, assemble composite (multipart) values,
-  // evaluate formula (derived) fields, and check dependent (optionsFrom)
-  // selects before any AI step or substitution sees them; a failing step
-  // rejects the request naming the field.
-  const stepError = await applyManifestFillSteps({
-    values: record,
-    manifest,
-    resolveLookup: createDispatchLookupResolver({
-      isRegistryEnabledForOrg: await buildIsRegistryEnabledForOrg({
-        organizationId,
-        scopedDb,
-      }),
+    // Live preview: the values are typically still in progress (the person is
+    // mid-typing in the fill form), so partial values are explicitly allowed
+    // here — the one deliberate exception to the required-fields gate every
+    // other fill boundary (download, chat/MCP tool, workspace persistence)
+    // enforces. Everything else, AI drafting included, runs exactly as it does
+    // on download, so the preview shows what a download would produce.
+    requiredFields: "allow-partial",
+    // Rendering a preview is not a use of the template; nothing is recorded.
+    useRecording: "caller",
+    ...buildTemplateFillAiWiring({
+      organizationId,
+      userId,
+      safeDb,
+      feature: "templates.fill_preview",
+      documentLanguages: source.documentLanguages,
     }),
   });
-  if (stepError !== null) {
-    return Result.err(new HandlerError({ status: 400, message: stepError }));
-  }
 
-  if (manifest && (hasAiDraftFields || hasAiAdaptFields)) {
-    const aiAnalytics = createTanStackAIAnalyticsCallbacks({
-      usageMetering: {
-        actionType: "chat",
-        organizationId,
-        safeDb,
-        serviceTier: "standard",
-        userId,
-        workspaceId: null,
-      },
-      feature: "templates.fill_preview",
-      modelRole: "fast",
-      orgAIConfig,
-      properties: { organization_id: organizationId },
-      traceId: Bun.randomUUIDv7(),
-    });
-    if (hasAiDraftFields) {
-      const documentText = await documentTextForAiFields(
-        new Uint8Array(buffer),
-        manifest.fields,
-      );
-      const aiResolved = await resolveAiFields({
-        values: record,
-        fields: manifest.fields,
-        documentText,
-        // Root-scoped route (template selected by id, no matter binding), so
-        // there is no workspace scope to redact tenant ids against.
-        generate: buildAiFieldGenerator({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      // Decide AI-decided boolean conditions (a boolean field with an aiPrompt)
-      // so the preview reflects which {{#if field_path}} blocks resolve.
-      const aiDecided = await resolveAiConditions({
-        values: aiResolved,
-        fields: manifest.fields,
-        decide: buildAiConditionDecider({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      for (const [key, value] of Object.entries(aiDecided)) {
-        record[key] = value;
-      }
-    }
-    if (hasAiAdaptFields) {
-      // Rewrite each aiAdapt marker occurrence to fit its surrounding text;
-      // the stub stays in `record` so uncovered occurrences still get the
-      // plain global substitution below.
-      const adapted = await adaptAiFields({
-        buffer,
-        fields: manifest.fields,
-        values: record,
-        adapt: buildAiOccurrenceAdapter({
-          orgAIConfig,
-          organizationId,
-          skillContext: { organizationId, safeDb, userId },
-          aiAnalytics,
-          tenantWorkspaceIds: [],
-        }),
-      });
-      fillBuffer = adapted.buffer;
-      adaptedPaths = adapted.adaptedPaths;
-    }
-  }
-
-  if (!isTemplateData(record)) {
+  if ("requiredFieldsRejection" in result) {
+    // Unreachable under "allow-partial": the gate reports nothing. Surfaced
+    // rather than dropped so the union stays exhaustively handled.
     return Result.err(
       new HandlerError({
         status: 400,
-        message:
-          "'values' must contain only strings, numbers, booleans, " +
-          "arrays, nested objects, or rich-text patch values.",
+        message: `Missing required template values: ${result.requiredFieldsRejection
+          .map((field) => field.label ?? field.path)
+          .join(", ")}`,
+        requiredFields: result.requiredFieldsRejection,
       }),
     );
   }
+  if ("usageRejection" in result) {
+    return Result.err(result.usageRejection);
+  }
+  if ("error" in result) {
+    return Result.err(new HandlerError({ status: 400, message: result.error }));
+  }
 
-  const result = await fillTemplate(fillBuffer, record);
-
-  // Extract text from the filled document
   const { paragraphs, charCount } = await extractText(result.buffer);
 
   return Result.ok({
     paragraphs,
     charCount,
     unmatchedPlaceholders: result.unmatchedPlaceholders,
-    // Adapted stubs no longer match a marker (each occurrence was already
-    // substituted), so they are not "unused" in any user-meaningful sense.
-    unusedValues: result.unusedValues.filter(
-      (name) => !adaptedPaths.includes(name),
-    ),
+    unusedValues: result.unusedValues,
     structureErrors: result.structureErrors,
   });
 };

--- a/apps/api/src/lib/templates/fill-required-fields-parity.test.ts
+++ b/apps/api/src/lib/templates/fill-required-fields-parity.test.ts
@@ -1,0 +1,271 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { fillHandler } from "@/api/handlers/templates/fill";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { toSafeId } from "@/api/lib/branded-types";
+import { writeManifest } from "@/api/lib/docx/template-manifest";
+import type { TemplateManifest } from "@/api/lib/docx/types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+import { startFakeS3 } from "@/api/tests/helpers/fake-s3";
+import { readTestJson } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import { fillByIdLogic } from "./fill-by-id-logic";
+import { fillPreviewLogic } from "./fill-preview-logic";
+import type { MissingRequiredField } from "./template-fill-service";
+import { fillTemplateDocx } from "./template-fill-service";
+
+// Every fill boundary runs one pipeline (template-fill-service). This suite
+// pins what motivated collapsing the route copies into it: a template whose
+// required field the caller omitted is rejected identically everywhere — the
+// same structured MissingRequiredField list, carrying each field's input type
+// and options, whether the caller is an agent (the tools read the service's
+// `requiredFieldsRejection` directly), the raw-upload download route, or the
+// by-id download route. A route drifting back to its own copy of the sequence
+// shows up here as a differing payload, not as a silently invented value.
+// fill-to-workspace and the MCP save tool consume the same
+// `requiredFieldsRejection` this suite asserts on the service itself.
+
+// ── DOCX fixture helpers (mirrors templates.test.ts / patch-template.test.ts:
+// no shared fixture module exists yet) ──────────────────────────────────────
+
+const WRAP = (body: string) =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<w:document xmlns:w="http://schemas.openxmlformats.org` +
+  `/wordprocessingml/2006/main">` +
+  `<w:body>${body}</w:body></w:document>`;
+
+const P = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+const makeDocx = async (documentXml: string): Promise<Buffer> => {
+  const zip = new JSZip();
+  zip.file("word/document.xml", documentXml);
+  zip.file(
+    "[Content_Types].xml",
+    [
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+      '<Types xmlns="http://schemas.openxmlformats.org',
+      '/package/2006/content-types">',
+      '<Default Extension="xml" ContentType="application/xml"/>',
+      '<Default Extension="rels"',
+      ' ContentType="application/vnd.openxmlformats',
+      '-package.relationships+xml"/>',
+      "</Types>",
+    ].join(""),
+  );
+  const buf = await zip.generateAsync({ type: "nodebuffer" });
+  return Buffer.from(buf);
+};
+
+const organizationId = toSafeId<"organization">("org_1");
+const userId = toSafeId<"user">("user_1");
+const templateId = toSafeId<"template">("tmpl_1");
+const s3Key = "fake-key-fill-required-fields-parity";
+
+const recordAuditEvent: AuditRecorder = async () => {
+  await Promise.resolve();
+};
+
+/** A select carries the metadata a plain path would lose: the caller has to
+ *  learn the input type and allowed values from the rejection to ask the right
+ *  question, so every boundary must report them. */
+const manifest: TemplateManifest = {
+  version: 1,
+  fields: [
+    {
+      path: "governing_law",
+      label: "Governing law",
+      inputType: "select",
+      options: ["Czech", "Polish"],
+      required: true,
+    },
+  ],
+};
+
+const expectedMissingFields: MissingRequiredField[] = [
+  {
+    path: "governing_law",
+    label: "Governing law",
+    inputType: "select",
+    options: ["Czech", "Polish"],
+  },
+];
+
+const buildTemplate = async (): Promise<Buffer> =>
+  await writeManifest(
+    await makeDocx(WRAP(P("Governed by {{governing_law}} law."))),
+    manifest,
+  );
+
+const stubDb = () =>
+  createScopedDbMock({
+    query: {
+      templates: {
+        findFirst: async () => ({
+          name: "NDA",
+          fileName: "nda.docx",
+          s3Key,
+          languages: [],
+        }),
+      },
+      organizationSettings: { findFirst: async () => undefined },
+    },
+  });
+
+/** Serve the fixture from the fake object store for the stored-template
+ *  boundaries, which load their source through S3. */
+const withStoredTemplate = async <T>(
+  buffer: Buffer,
+  run: () => Promise<T>,
+): Promise<T> => {
+  const fakeS3 = startFakeS3();
+  try {
+    fakeS3.put("stella", s3Key, buffer);
+    return await run();
+  } finally {
+    fakeS3.stop();
+  }
+};
+
+describe("required-fields rejection is identical at every enforcing fill boundary", () => {
+  test("the fill service reports the full structured rejection the tools return", async () => {
+    const buffer = await buildTemplate();
+    const { scopedDb } = stubDb();
+
+    const result = await fillTemplateDocx({
+      source: { name: "NDA", fileName: "nda.docx", buffer },
+      values: {},
+      scopedDb,
+      organizationId,
+      requiredFields: "enforce",
+    });
+
+    expect(result).toEqual({ requiredFieldsRejection: expectedMissingFields });
+  });
+
+  test("the raw-upload download route returns that same list as missingFields", async () => {
+    const buffer = await buildTemplate();
+    const { safeDb, scopedDb } = stubDb();
+
+    const response = await fillHandler({
+      safeDb,
+      scopedDb,
+      organizationId,
+      userId,
+      query: {},
+      body: {
+        file: new File([new Uint8Array(buffer)], "nda.docx", {
+          type: DOCX_MIME_TYPE,
+        }),
+        values: "{}",
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect(
+      await readTestJson<{
+        error: string;
+        missingFields: MissingRequiredField[];
+      }>(response),
+    ).toEqual({
+      error: "missing_required_fields",
+      missingFields: expectedMissingFields,
+    });
+  });
+
+  test("the by-id download route carries that same list on its HandlerError", async () => {
+    const buffer = await buildTemplate();
+    const { safeDb, scopedDb } = stubDb();
+
+    const result = await withStoredTemplate(
+      buffer,
+      async () =>
+        await Result.gen(() =>
+          fillByIdLogic({
+            safeDb,
+            scopedDb,
+            organizationId,
+            userId,
+            templateId,
+            body: { values: "{}" },
+            query: {},
+            recordAuditEvent,
+          }),
+        ),
+    );
+
+    if (!Result.isError(result)) {
+      throw new TypeError("Expected the fill to be rejected");
+    }
+    if (!HandlerError.is(result.error)) {
+      throw new TypeError("Expected a HandlerError rejection");
+    }
+    expect(result.error.status).toBe(400);
+    expect(result.error.requiredFields).toEqual(expectedMissingFields);
+  });
+
+  test("the live preview renders the same values instead of rejecting them", async () => {
+    const buffer = await buildTemplate();
+    const { safeDb, scopedDb } = stubDb();
+
+    const result = await withStoredTemplate(
+      buffer,
+      async () =>
+        await fillPreviewLogic({
+          safeDb,
+          scopedDb,
+          organizationId,
+          userId,
+          templateId,
+          body: { values: "{}" },
+        }),
+    );
+
+    if (!Result.isOk(result)) {
+      throw new TypeError("Expected the preview to render");
+    }
+    // Still an unfilled marker, as any in-progress preview has; the point is
+    // that the shared gate lets it through under "allow-partial".
+    expect(result.value.unmatchedPlaceholders).toContain("governing_law");
+  });
+
+  test("the preview keeps a partially filled document renderable field by field", async () => {
+    const buffer = await writeManifest(
+      await makeDocx(
+        WRAP(P("Governed by {{governing_law}} law, signed {{signing_date}}.")),
+      ),
+      {
+        version: 1,
+        fields: [
+          ...manifest.fields,
+          { path: "signing_date", label: "Signing date", required: true },
+        ],
+      },
+    );
+    const { safeDb, scopedDb } = stubDb();
+
+    const result = await withStoredTemplate(
+      buffer,
+      async () =>
+        await fillPreviewLogic({
+          safeDb,
+          scopedDb,
+          organizationId,
+          userId,
+          templateId,
+          body: { values: '{"governing_law": "Czech"}' },
+        }),
+    );
+
+    if (!Result.isOk(result)) {
+      throw new TypeError("Expected the preview to render");
+    }
+    expect(
+      result.value.paragraphs.map((paragraph) => paragraph.text).join("\n"),
+    ).toContain("Governed by Czech law");
+    expect(result.value.unmatchedPlaceholders).toEqual(["signing_date"]);
+  });
+});

--- a/apps/api/src/lib/templates/template-fill-service.test.ts
+++ b/apps/api/src/lib/templates/template-fill-service.test.ts
@@ -10,6 +10,7 @@ import { startFakeS3 } from "@/api/tests/helpers/fake-s3";
 
 import {
   describeStoredTemplate,
+  fillStoredTemplateDocx,
   fillTemplateDocx,
 } from "./template-fill-service";
 
@@ -272,6 +273,29 @@ describe("fillTemplateDocx required-field rejection", () => {
     expect("requiredFieldsRejection" in result).toBe(false);
   });
 
+  // The collaborator factory costs an org AI config read and a metered trace,
+  // so the service must not resolve it for a manifest that declares no AI
+  // field. A factory that throws proves it was never called.
+  test("never resolves the AI collaborators for a deterministic manifest", async () => {
+    const buffer = await makeManifestDocx([requiredTextField]);
+
+    const result = await fillTemplateDocx({
+      source: { name: "NDA", fileName: "nda.docx", buffer },
+      values: { governing_law: "Czech" },
+      scopedDb: stubScopedDb(),
+      organizationId,
+      requiredFields: "enforce",
+      aiCollaborators: () =>
+        panic("deterministic fill resolved the AI collaborators"),
+    });
+
+    if (!("buffer" in result)) {
+      throw new Error("expected a filled document");
+    }
+    const texts = await extractTexts(result.buffer);
+    expect(texts.join("")).toContain("Governed by Czech law.");
+  });
+
   test("does not check required fields on a manifest-less template", async () => {
     const buffer = await makeDocx(WRAP(P("Hello {{name}}.")));
 
@@ -289,20 +313,49 @@ describe("fillTemplateDocx required-field rejection", () => {
 
 // The service owns the use counter, but a persistence caller that writes its
 // own atomic transaction (fill-by-id, save_filled_template) takes it over with
-// `useRecording: "caller"`. That option was silently dropped on the
-// stored-template path, so those callers bumped the counter twice per fill.
+// `useRecording: "caller"`. `fillStoredTemplateDocx` dropped that option while
+// forwarding, so those callers bumped the counter twice per fill; these run
+// through that wrapper, the one that was broken.
 
-describe("template use recording", () => {
+describe("fillStoredTemplateDocx use recording", () => {
   const usedTemplateId = toSafeId<"template">("tmpl_use");
+  const storedS3Key = "fake-key-use-recording";
+  const storedRow = {
+    name: "NDA",
+    fileName: "nda.docx",
+    s3Key: storedS3Key,
+    languages: [],
+  };
 
-  /** ScopedDb stub that counts the `templates` use-counter update. */
-  const countingScopedDb = (): {
+  /** ScopedDb stub serving the stored template row and counting the
+   *  `templates` use-counter update. `findFirst` honours the organization
+   *  predicate the loader sends, so a mismatch reads as "not found" exactly as
+   *  the query would in Postgres. */
+  const storedTemplateScopedDb = (): {
     scopedDb: ScopedDb;
     updates: () => number;
   } => {
     let updates = 0;
     const fakeTx = {
       query: {
+        templates: {
+          findFirst: async ({
+            where,
+          }: {
+            where: {
+              id: { eq: string };
+              organizationId?: { eq: string } | undefined;
+            };
+          }) =>
+            // An absent predicate returns the row: that is what the query
+            // looked like before, so the cross-organization case below fails
+            // if the predicate is ever dropped again.
+            where.id.eq === usedTemplateId &&
+            (where.organizationId === undefined ||
+              where.organizationId.eq === organizationId)
+              ? storedRow
+              : undefined,
+        },
         organizationSettings: { findFirst: async () => undefined },
       },
       update: () => {
@@ -310,53 +363,65 @@ describe("template use recording", () => {
         return { set: () => ({ where: async () => undefined }) };
       },
     };
-    // SAFETY: test stub; this fill touches only the registry-gate read and the
-    // use-counter update counted above.
+    // SAFETY: test stub; this fill touches only the template row, the
+    // registry-gate read, and the use-counter update counted above.
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     const scopedDb = (async (fn: (tx: unknown) => Promise<unknown>) =>
       fn(fakeTx)) as unknown as ScopedDb;
     return { scopedDb, updates: () => updates };
   };
 
-  test("bumps the use counter once by default", async () => {
+  const fillStored = async (
+    options: Pick<
+      Parameters<typeof fillStoredTemplateDocx>[0],
+      "organizationId" | "useRecording"
+    >,
+  ) => {
     const buffer = await makeManifestDocx([requiredTextField]);
-    const { scopedDb, updates } = countingScopedDb();
-
-    await fillTemplateDocx({
-      source: {
-        name: "NDA",
-        fileName: "nda.docx",
-        buffer,
+    const { scopedDb, updates } = storedTemplateScopedDb();
+    const fakeS3 = startFakeS3();
+    try {
+      fakeS3.put("stella", storedS3Key, buffer);
+      const result = await fillStoredTemplateDocx({
         templateId: usedTemplateId,
-      },
-      values: { governing_law: "Czech" },
-      scopedDb,
-      organizationId,
-      requiredFields: "enforce",
-    });
+        values: { governing_law: "Czech" },
+        scopedDb,
+        requiredFields: "enforce",
+        ...options,
+      });
+      return { result, updates: updates() };
+    } finally {
+      fakeS3.stop();
+    }
+  };
 
-    expect(updates()).toBe(1);
+  test("bumps the use counter once by default", async () => {
+    const { result, updates } = await fillStored({ organizationId });
+
+    expect("buffer" in result).toBe(true);
+    expect(updates).toBe(1);
   });
 
   test("leaves the counter to the caller under useRecording: caller", async () => {
-    const buffer = await makeManifestDocx([requiredTextField]);
-    const { scopedDb, updates } = countingScopedDb();
-
-    await fillTemplateDocx({
-      source: {
-        name: "NDA",
-        fileName: "nda.docx",
-        buffer,
-        templateId: usedTemplateId,
-      },
-      values: { governing_law: "Czech" },
-      scopedDb,
+    const { result, updates } = await fillStored({
       organizationId,
-      requiredFields: "enforce",
       useRecording: "caller",
     });
 
-    expect(updates()).toBe(0);
+    expect("buffer" in result).toBe(true);
+    expect(updates).toBe(0);
+  });
+
+  // Tenant isolation on a cross-tenant-addressable id must not rest on RLS
+  // alone: the loader's own predicate has to reject a template that belongs to
+  // another organization even when the session role does not.
+  test("does not load a template belonging to another organization", async () => {
+    const { result, updates } = await fillStored({
+      organizationId: toSafeId<"organization">("org_other"),
+    });
+
+    expect(result).toEqual({ error: "Template not found." });
+    expect(updates).toBe(0);
   });
 });
 
@@ -412,6 +477,7 @@ describe("describeStoredTemplate array shape", () => {
       fakeS3.put("stella", s3Key, buffer);
       const result = await describeStoredTemplate({
         templateId,
+        organizationId,
         scopedDb: stubDescribeScopedDb(),
       });
 
@@ -455,6 +521,7 @@ describe("describeStoredTemplate array shape", () => {
       fakeS3.put("stella", s3Key, buffer);
       const result = await describeStoredTemplate({
         templateId,
+        organizationId,
         scopedDb: stubDescribeScopedDb(),
       });
 

--- a/apps/api/src/lib/templates/template-fill-service.test.ts
+++ b/apps/api/src/lib/templates/template-fill-service.test.ts
@@ -95,6 +95,7 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: {},
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     expect(result).toEqual({
@@ -117,6 +118,7 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: { governing_law: "" },
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     expect("requiredFieldsRejection" in result).toBe(true);
@@ -130,6 +132,7 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: { governing_law: "   " },
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     expect("requiredFieldsRejection" in result).toBe(true);
@@ -153,6 +156,7 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: { persons: [{ member: "Alice" }, { member: "" }] },
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     expect(result).toEqual({
@@ -185,6 +189,7 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: { persons: [{ member: "Alice" }, { member: "Bob" }] },
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     expect("requiredFieldsRejection" in result).toBe(false);
@@ -204,6 +209,7 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: { governing_law: "Czech" },
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     expect("requiredFieldsRejection" in result).toBe(false);
@@ -230,7 +236,8 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: {},
       scopedDb: stubScopedDb(),
       organizationId,
-      generateAiValue: async () => "Slovak",
+      requiredFields: "enforce",
+      aiCollaborators: async () => ({ generateAiValue: async () => "Slovak" }),
     });
 
     expect("requiredFieldsRejection" in result).toBe(false);
@@ -257,6 +264,7 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: {},
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     // No matter is bound (no workspaceId), so the source field simply stays
@@ -272,9 +280,83 @@ describe("fillTemplateDocx required-field rejection", () => {
       values: {},
       scopedDb: stubScopedDb(),
       organizationId,
+      requiredFields: "enforce",
     });
 
     expect("requiredFieldsRejection" in result).toBe(false);
+  });
+});
+
+// The service owns the use counter, but a persistence caller that writes its
+// own atomic transaction (fill-by-id, save_filled_template) takes it over with
+// `useRecording: "caller"`. That option was silently dropped on the
+// stored-template path, so those callers bumped the counter twice per fill.
+
+describe("template use recording", () => {
+  const usedTemplateId = toSafeId<"template">("tmpl_use");
+
+  /** ScopedDb stub that counts the `templates` use-counter update. */
+  const countingScopedDb = (): {
+    scopedDb: ScopedDb;
+    updates: () => number;
+  } => {
+    let updates = 0;
+    const fakeTx = {
+      query: {
+        organizationSettings: { findFirst: async () => undefined },
+      },
+      update: () => {
+        updates += 1;
+        return { set: () => ({ where: async () => undefined }) };
+      },
+    };
+    // SAFETY: test stub; this fill touches only the registry-gate read and the
+    // use-counter update counted above.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    const scopedDb = (async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn(fakeTx)) as unknown as ScopedDb;
+    return { scopedDb, updates: () => updates };
+  };
+
+  test("bumps the use counter once by default", async () => {
+    const buffer = await makeManifestDocx([requiredTextField]);
+    const { scopedDb, updates } = countingScopedDb();
+
+    await fillTemplateDocx({
+      source: {
+        name: "NDA",
+        fileName: "nda.docx",
+        buffer,
+        templateId: usedTemplateId,
+      },
+      values: { governing_law: "Czech" },
+      scopedDb,
+      organizationId,
+      requiredFields: "enforce",
+    });
+
+    expect(updates()).toBe(1);
+  });
+
+  test("leaves the counter to the caller under useRecording: caller", async () => {
+    const buffer = await makeManifestDocx([requiredTextField]);
+    const { scopedDb, updates } = countingScopedDb();
+
+    await fillTemplateDocx({
+      source: {
+        name: "NDA",
+        fileName: "nda.docx",
+        buffer,
+        templateId: usedTemplateId,
+      },
+      values: { governing_law: "Czech" },
+      scopedDb,
+      organizationId,
+      requiredFields: "enforce",
+      useRecording: "caller",
+    });
+
+    expect(updates()).toBe(0);
   });
 });
 

--- a/apps/api/src/lib/templates/template-fill-service.ts
+++ b/apps/api/src/lib/templates/template-fill-service.ts
@@ -107,20 +107,30 @@ export type FillTemplateSource = {
 };
 
 /**
- * Resolve a stored template into a fill source: its row (organization-scoped
- * by RLS on `scopedDb`) plus the DOCX bytes from S3. Null when no such
- * template exists for the caller, which every boundary reports as not found.
+ * Resolve a stored template into a fill source: its row plus the DOCX bytes
+ * from S3. Null when no such template exists for the caller, which every
+ * boundary reports as not found.
+ *
+ * The organization predicate is redundant with RLS on `scopedDb` and stays
+ * anyway: tenant isolation on a cross-tenant-addressable id should not rest on
+ * a single mechanism, and a session whose RLS role is ever misconfigured must
+ * still not read another organization's template.
  */
 export const loadStoredTemplateSource = async ({
   templateId,
+  organizationId,
   scopedDb,
 }: {
   templateId: SafeId<"template">;
+  organizationId: SafeId<"organization">;
   scopedDb: ScopedDb;
 }): Promise<FillTemplateSource | null> => {
   const template = await scopedDb((tx) =>
     tx.query.templates.findFirst({
-      where: { id: { eq: templateId } },
+      where: {
+        id: { eq: templateId },
+        organizationId: { eq: organizationId },
+      },
       columns: { name: true, fileName: true, s3Key: true, languages: true },
     }),
   );
@@ -245,12 +255,18 @@ export type DescribeTemplateResult =
 
 export const describeStoredTemplate = async ({
   templateId,
+  organizationId,
   scopedDb,
 }: {
   templateId: SafeId<"template">;
+  organizationId: SafeId<"organization">;
   scopedDb: ScopedDb;
 }): Promise<DescribeTemplateResult> => {
-  const loaded = await loadStoredTemplateSource({ templateId, scopedDb });
+  const loaded = await loadStoredTemplateSource({
+    templateId,
+    organizationId,
+    scopedDb,
+  });
   if (!loaded) {
     return { error: "Template not found." };
   }
@@ -699,6 +715,7 @@ export const fillStoredTemplateDocx = async <TRejection = never>({
 > => {
   const loaded = await loadStoredTemplateSource({
     templateId,
+    organizationId: options.organizationId,
     scopedDb: options.scopedDb,
   });
   if (!loaded) {
@@ -782,6 +799,7 @@ export const fillStoredTemplateWithTextStrict = async <TRejection = never>({
 > => {
   const loaded = await loadStoredTemplateSource({
     templateId,
+    organizationId: options.organizationId,
     scopedDb: options.scopedDb,
   });
   if (!loaded) {

--- a/apps/api/src/lib/templates/template-fill-service.ts
+++ b/apps/api/src/lib/templates/template-fill-service.ts
@@ -1,9 +1,13 @@
 /**
- * Shared template orchestration for the chat (MCP) tools: load a stored
- * template's DOCX from S3, then either describe its fields or fill it and
- * return the assembled text. Mirrors the fill-preview route's recipe
- * (discover clause slots → fill → extractText), reusing the same underlying,
- * already-tested functions.
+ * The single template fill pipeline. Every fill boundary — the REST routes
+ * (raw upload, by-id download, live preview, fill-to-workspace), the chat and
+ * MCP tools, and the report exporter — resolves its source through here and
+ * runs exactly one sequence: required-fields gate → clause slots → AI usage
+ * preflight → manifest fill steps (lookups, composites, formulas, dependent
+ * selects) → AI drafting/adaptation → substitution. Route-specific concerns
+ * (request parsing, usage metering wiring, response shaping, audit rows, S3
+ * writes) stay with the caller; only genuinely different fill semantics are
+ * options here (see `requiredFields`).
  */
 
 import { panic } from "better-result";
@@ -59,7 +63,10 @@ import {
   collectMissingRequiredFields,
   isTemplateFieldRequired,
 } from "./template-optional-defaults";
-import type { MissingRequiredField } from "./template-optional-defaults";
+import type {
+  MissingRequiredField,
+  RequiredFieldsPolicy,
+} from "./template-optional-defaults";
 
 export type { MissingRequiredField } from "./template-optional-defaults";
 
@@ -82,22 +89,52 @@ type FillRejection<TUsageRejection> =
   | { requiredFieldsRejection: MissingRequiredField[] }
   | { usageRejection: TUsageRejection };
 
-const loadTemplate = async (
-  templateId: SafeId<"template">,
-  scopedDb: ScopedDb,
-): Promise<{ name: string; fileName: string; buffer: Buffer } | null> => {
-  // RLS on scopedDb scopes this to the caller's organization.
+/**
+ * An already-resolved DOCX to fill: the loaded bytes plus display metadata.
+ * A stored template also carries its `templateId`, which enables clause-slot
+ * resolution and use recording; a built-in / in-memory template (e.g. the
+ * report layout) omits it — it has no linked clauses and no row to increment.
+ */
+export type FillTemplateSource = {
+  name: string;
+  fileName: string;
+  buffer: Buffer;
+  templateId?: SafeId<"template"> | undefined;
+  /** The template's declared document languages. The aiAdapt rewriter
+   *  conjugates its per-occurrence rendering in them, so a caller that builds
+   *  that collaborator passes these through. */
+  documentLanguages?: readonly string[] | undefined;
+};
+
+/**
+ * Resolve a stored template into a fill source: its row (organization-scoped
+ * by RLS on `scopedDb`) plus the DOCX bytes from S3. Null when no such
+ * template exists for the caller, which every boundary reports as not found.
+ */
+export const loadStoredTemplateSource = async ({
+  templateId,
+  scopedDb,
+}: {
+  templateId: SafeId<"template">;
+  scopedDb: ScopedDb;
+}): Promise<FillTemplateSource | null> => {
   const template = await scopedDb((tx) =>
     tx.query.templates.findFirst({
       where: { id: { eq: templateId } },
-      columns: { name: true, fileName: true, s3Key: true },
+      columns: { name: true, fileName: true, s3Key: true, languages: true },
     }),
   );
   if (!template) {
     return null;
   }
   const buffer = Buffer.from(await readS3ArrayBuffer(template.s3Key));
-  return { name: template.name, fileName: template.fileName, buffer };
+  return {
+    name: template.name,
+    fileName: template.fileName,
+    buffer,
+    templateId,
+    documentLanguages: template.languages,
+  };
 };
 
 type DescribedField = {
@@ -213,7 +250,7 @@ export const describeStoredTemplate = async ({
   templateId: SafeId<"template">;
   scopedDb: ScopedDb;
 }): Promise<DescribeTemplateResult> => {
-  const loaded = await loadTemplate(templateId, scopedDb);
+  const loaded = await loadStoredTemplateSource({ templateId, scopedDb });
   if (!loaded) {
     return { error: "Template not found." };
   }
@@ -301,22 +338,45 @@ export const describeStoredTemplate = async ({
  */
 type FillUsagePreflight<TRejection> = () => Promise<TRejection | null>;
 
+/** The model-backed collaborators a manifest's AI fields need: a generator for
+ *  AI-fillable fields (`aiPrompt`), a decider for AI-decided boolean fields (a
+ *  boolean field with an `aiPrompt`), and a per-occurrence adapter for
+ *  `aiAdapt` fields. Each is optional; an absent one leaves its fields
+ *  unresolved rather than failing the fill. */
+export type AiFillCollaborators = {
+  generateAiValue?: AiFieldGenerator | undefined;
+  decideAiCondition?: AiConditionDecider | undefined;
+  adaptAiValue?: AiOccurrenceAdapter | undefined;
+};
+
+/**
+ * Builds {@link AiFillCollaborators}, invoked once and only when the manifest
+ * declares an AI-drafted or AI-adapted field. Deferred because building them
+ * costs the caller an org AI config read and a metered analytics trace: a
+ * deterministic fill must pay neither.
+ */
+type AiFillCollaboratorProvider = () =>
+  | AiFillCollaborators
+  | Promise<AiFillCollaborators>;
+
 type FillServiceOptions<TRejection = never> = {
   templateId: SafeId<"template">;
   values: FillValues;
   scopedDb: ScopedDb;
   organizationId: SafeId<"organization">;
+  /** Whether a required, user-entered field left absent or empty rejects the
+   *  fill. `"enforce"` is the contract for every real fill; `"allow-partial"`
+   *  is the live preview's deliberate exception (see
+   *  {@link RequiredFieldsPolicy}). Mandatory so each boundary names its
+   *  stance. */
+  requiredFields: RequiredFieldsPolicy;
   /** Per-fill clause edits keyed by slot patch key (`@clause:Name`). When a
    *  key matches a discovered slot, the override body is inserted for that slot
    *  instead of the linked clause's resolved body (mirrors fill-by-id). */
   clauseOverrides?: Record<string, ClauseBody> | undefined;
-  /** Optional model-backed generator for AI-fillable fields (aiPrompt). */
-  generateAiValue?: AiFieldGenerator | undefined;
-  /** Optional model-backed decider for AI-decided boolean fields (a boolean
-   *  field with an aiPrompt). */
-  decideAiCondition?: AiConditionDecider | undefined;
-  /** Optional model-backed per-occurrence adapter for aiAdapt fields. */
-  adaptAiValue?: AiOccurrenceAdapter | undefined;
+  /** Deferred builder for the AI collaborators; omitted by a caller that never
+   *  drafts (the fill then leaves AI fields unresolved). */
+  aiCollaborators?: AiFillCollaboratorProvider | undefined;
   /** Optional usage preflight run only when the manifest declares AI fields,
    *  before any model call. A non-null return aborts the fill with a
    *  `{ usageRejection }` result the caller surfaces as its own response. */
@@ -341,19 +401,6 @@ type FilledDocx = {
   structureErrors: Awaited<ReturnType<typeof fillTemplate>>["structureErrors"];
 };
 
-/**
- * An already-resolved DOCX to fill: the loaded bytes plus display metadata.
- * A stored template also carries its `templateId`, which enables clause-slot
- * resolution and use recording; a built-in / in-memory template (e.g. the
- * report layout) omits it — it has no linked clauses and no row to increment.
- */
-export type FillTemplateSource = {
-  name: string;
-  fileName: string;
-  buffer: Buffer;
-  templateId?: SafeId<"template"> | undefined;
-};
-
 type FillDocxOptions<TRejection = never> = Omit<
   FillServiceOptions<TRejection>,
   "templateId"
@@ -367,22 +414,20 @@ type FillDocxWithPolicyOptions<TRejection = never> =
   };
 
 /**
- * Shared fill recipe over an already-loaded DOCX: resolve clause slots (stored
- * templates only), run the manifest fill steps (lookups, composites, formulas,
- * dependent selects), draft/adapt AI fields, then substitute. Records the
- * template use when a `templateId` is present. Backs both the stored-template
- * fill below and the built-in report export, so a template fills identically at
- * every boundary.
+ * Shared fill recipe over an already-loaded DOCX: gate required fields,
+ * resolve clause slots (stored templates only), run the manifest fill steps
+ * (lookups, composites, formulas, dependent selects), draft/adapt AI fields,
+ * then substitute. Records the template use when a `templateId` is present.
+ * Backs every fill boundary, so a template fills identically at each of them.
  */
 const fillTemplateDocxWithPolicy = async <TRejection = never>({
   source,
   values,
   scopedDb,
   organizationId,
+  requiredFields,
   clauseOverrides,
-  generateAiValue,
-  decideAiCondition,
-  adaptAiValue,
+  aiCollaborators,
   assertUsageAvailable,
   useRecording = "after-fill",
   workspaceId,
@@ -449,12 +494,12 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
   // field (not AI-fillable, not formula/condition/source-derived) that is
   // absent or empty must never be silently invented or left as a raw
   // `{{marker}}` in the output. Ask the caller for exactly these fields
-  // instead of guessing. Every real fill enforces this; only the live
-  // fill-preview route (not this service) legitimately allows partial values.
+  // instead of guessing. Every real fill passes "enforce" here; the live
+  // fill-preview route names its exception with "allow-partial".
   if (manifest) {
     const missingRequiredFields = collectMissingRequiredFields({
       fields: manifest.fields,
-      policy: "enforce",
+      policy: requiredFields,
       values: record,
     });
     if (missingRequiredFields.length > 0) {
@@ -491,6 +536,23 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
   let fillBuffer = loaded.buffer;
   let adaptedPaths: readonly string[] = [];
   if (manifest) {
+    // Gate the AI usage preflight and the collaborator build on a model call
+    // actually running: both cost the caller quota or an org AI config read,
+    // and a deterministic fill must spend neither. Runs before the manifest
+    // fill steps so an over-quota fill rejects without first calling out to a
+    // registry for its lookup fields.
+    const hasAiFields = manifest.fields.some(
+      (field) => Boolean(field.aiPrompt) || field.aiAdapt === true,
+    );
+    if (assertUsageAvailable && hasAiFields) {
+      const usageRejection = await assertUsageAvailable();
+      if (usageRejection !== null) {
+        return { usageRejection };
+      }
+    }
+    const { generateAiValue, decideAiCondition, adaptAiValue } =
+      aiCollaborators && hasAiFields ? await aiCollaborators() : {};
+
     // Resolve the data-binding context only when this fill targets a matter and
     // the manifest actually declares a bound field, so a transient fill or a
     // template with no bindings fires no extra queries.
@@ -522,21 +584,6 @@ const fillTemplateDocxWithPolicy = async <TRejection = never>({
     });
     if (stepError !== null) {
       return { error: stepError };
-    }
-
-    // Gate the AI usage preflight on a model call actually running: the
-    // generators below are no-ops unless the manifest declares AI fields, so a
-    // deterministic fill spends no quota and must not be rejected for it.
-    if (assertUsageAvailable) {
-      const hasAiFields = manifest.fields.some(
-        (field) => Boolean(field.aiPrompt) || field.aiAdapt === true,
-      );
-      if (hasAiFields) {
-        const usageRejection = await assertUsageAvailable();
-        if (usageRejection !== null) {
-          return { usageRejection };
-        }
-      }
     }
 
     const documentText = await documentTextForAiFields(
@@ -638,43 +685,27 @@ export const fillTemplateDocxStrict = async <TRejection = never>(
 
 /**
  * Load a stored template's DOCX from S3 and fill it via {@link fillTemplateDocx}.
- * Mirrors the fill-by-id route's pipeline so a stored template fills identically
- * at every boundary. Backs the fill-to-workspace route and the chat tools.
+ * Backs the fill-by-id and fill-to-workspace routes, the chat tools, and the
+ * report exporter.
  */
 export const fillStoredTemplateDocx = async <TRejection = never>({
   templateId,
-  values,
-  scopedDb,
-  organizationId,
-  clauseOverrides,
-  generateAiValue,
-  decideAiCondition,
-  adaptAiValue,
-  assertUsageAvailable,
-  workspaceId,
+  ...options
 }: FillServiceOptions<TRejection>): Promise<
   | FilledDocx
   | { error: string }
   | { requiredFieldsRejection: MissingRequiredField[] }
   | { usageRejection: TRejection }
 > => {
-  const loaded = await loadTemplate(templateId, scopedDb);
+  const loaded = await loadStoredTemplateSource({
+    templateId,
+    scopedDb: options.scopedDb,
+  });
   if (!loaded) {
     return { error: "Template not found." };
   }
 
-  return await fillTemplateDocx({
-    source: { ...loaded, templateId },
-    values,
-    scopedDb,
-    organizationId,
-    clauseOverrides,
-    generateAiValue,
-    decideAiCondition,
-    adaptAiValue,
-    assertUsageAvailable,
-    workspaceId,
-  });
+  return await fillTemplateDocx({ ...options, source: loaded });
 };
 
 export type FillTemplateResult =
@@ -740,21 +771,25 @@ export const fillStoredTemplateWithText = async <TRejection = never>(
   return await withExtractedText(filled);
 };
 
-export const fillStoredTemplateWithTextStrict = async <TRejection = never>(
-  options: FillServiceOptions<TRejection>,
-): Promise<
+export const fillStoredTemplateWithTextStrict = async <TRejection = never>({
+  templateId,
+  ...options
+}: FillServiceOptions<TRejection>): Promise<
   | FillTemplateWithDocxResult
   | { inputRejection: TemplateInputRejection }
   | { requiredFieldsRejection: MissingRequiredField[] }
   | { usageRejection: TRejection }
 > => {
-  const loaded = await loadTemplate(options.templateId, options.scopedDb);
+  const loaded = await loadStoredTemplateSource({
+    templateId,
+    scopedDb: options.scopedDb,
+  });
   if (!loaded) {
     return { error: "Template not found." };
   }
   const filled = await fillTemplateDocxStrict({
     ...options,
-    source: { ...loaded, templateId: options.templateId },
+    source: loaded,
   });
   if (
     "usageRejection" in filled ||

--- a/apps/api/src/lib/templates/template-fill-usage.ts
+++ b/apps/api/src/lib/templates/template-fill-usage.ts
@@ -1,50 +1,57 @@
 /**
- * Shared AI-usage preflight for every template-fill route (raw upload,
- * by-id download, fill-preview): gated on a model call actually running (an
- * org AI config plus a manifest AI field), so a deterministic fill spends no
- * AI quota. Lives in `lib/templates` (not an endpoint module) so every route
- * — and the lib-level fill logic each route wraps — can depend on it without
- * an endpoint-module-to-endpoint-module import.
+ * The AI wiring every REST template-fill route hands to the fill service: a
+ * usage preflight and a collaborator builder over one lazily-loaded org AI
+ * config. The service invokes both only when the manifest declares an AI
+ * field, so a deterministic fill neither reads the config nor spends quota.
+ * Lives in `lib/templates` (not an endpoint module) so every route — and the
+ * lib-level fill logic each route wraps — can depend on it without an
+ * endpoint-module-to-endpoint-module import.
  */
 
 import type { SafeDb } from "@/api/db/safe-db";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
+import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
+import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import { assertUsageAvailableForHandler } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  buildAiConditionDecider,
+  buildAiFieldGenerator,
+  buildAiOccurrenceAdapter,
+} from "@/api/lib/docx/ai-field-generator";
 import type { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { hasTanStackInstanceProvider } from "@/api/lib/tanstack-ai-models";
+
+import type { AiFillCollaborators } from "./template-fill-service";
 
 type TemplateFillUsageArgs = {
   /** Org AI (BYOK) config; null when the org has no usable AI config, in which
    *  case the generators are no-ops and no model call (or quota) occurs. */
   orgAIConfig: OrgAIConfig | null;
-  /** Whether the manifest declares any AI-drafted/adapted field. */
-  hasAiFields: boolean;
   organizationId: SafeId<"organization">;
   userId: SafeId<"user">;
   safeDb: SafeDb;
 };
 
 /**
- * Usage preflight for the template-fill routes, gated on a model call actually
- * running (an org AI config plus a manifest AI field). A deterministic fill
- * spends no AI quota, so the static `requiresUsage` config is omitted and this
- * runs in-handler instead. Returns the framework's 402/500 `HandlerError` (the
- * caller returns it as `Result.err`) or `null` to proceed.
+ * Usage preflight for the template-fill routes. The fill service runs it only
+ * once the manifest is known to declare an AI field, so the static
+ * `requiresUsage` config is omitted and this runs in-handler instead. Returns
+ * the framework's 402/500 `HandlerError` (the caller returns it as
+ * `Result.err`) or `null` to proceed.
  */
-export const assertTemplateFillUsage = async ({
+const assertTemplateFillUsage = async ({
   orgAIConfig,
-  hasAiFields,
   organizationId,
   userId,
   safeDb,
 }: TemplateFillUsageArgs): Promise<HandlerError<402 | 500> | null> => {
-  // Skip only when there is no AI field to bill, or no provider could run a
-  // model at all. With an instance provider but no org BYOK, the fill still
-  // calls the fast model (the instance provider resolves it), so the quota
-  // check must apply — a null org config is not "no model call". The metering
-  // layer prices the instance-provider call (non-BYOK rate).
-  if (!hasAiFields || (!orgAIConfig && !hasTanStackInstanceProvider())) {
+  // Skip only when no provider could run a model at all. With an instance
+  // provider but no org BYOK, the fill still calls the fast model (the
+  // instance provider resolves it), so the quota check must apply — a null
+  // org config is not "no model call". The metering layer prices the
+  // instance-provider call (non-BYOK rate).
+  if (!orgAIConfig && !hasTanStackInstanceProvider()) {
     return null;
   }
   return await assertUsageAvailableForHandler({
@@ -55,4 +62,88 @@ export const assertTemplateFillUsage = async ({
     userId,
     safeDb,
   });
+};
+
+type TemplateFillAiWiringArgs = {
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  safeDb: SafeDb;
+  /** Analytics feature label: the download/upload fill routes bill as
+   *  `templates.fill`, the live preview as `templates.fill_preview`. */
+  feature: "templates.fill" | "templates.fill_preview";
+  /** The template's declared languages, so the aiAdapt rewriter conjugates in
+   *  them. Absent for a raw upload, which has no stored template row. */
+  documentLanguages?: readonly string[] | undefined;
+};
+
+type TemplateFillAiWiring = {
+  assertUsageAvailable: () => Promise<HandlerError<402 | 500> | null>;
+  aiCollaborators: () => Promise<AiFillCollaborators>;
+};
+
+/**
+ * Build the two AI hooks the fill service takes. Both share a single org AI
+ * config read, resolved on first use: the service calls the preflight before
+ * any model call and the collaborator builder just after, and calls neither
+ * when the template declares no AI field.
+ *
+ * The routes are root-scoped (a raw upload, or a template chosen by id with no
+ * matter binding), so there is no workspace scope to redact tenant ids
+ * against.
+ */
+export const buildTemplateFillAiWiring = ({
+  organizationId,
+  userId,
+  safeDb,
+  feature,
+  documentLanguages,
+}: TemplateFillAiWiringArgs): TemplateFillAiWiring => {
+  let configPromise: Promise<OrgAIConfig | null> | undefined;
+  const orgAIConfig = async (): Promise<OrgAIConfig | null> => {
+    configPromise ??= loadOrgAIConfig(organizationId);
+    return await configPromise;
+  };
+
+  return {
+    assertUsageAvailable: async () =>
+      await assertTemplateFillUsage({
+        orgAIConfig: await orgAIConfig(),
+        organizationId,
+        userId,
+        safeDb,
+      }),
+    aiCollaborators: async () => {
+      const config = await orgAIConfig();
+      const shared = {
+        orgAIConfig: config,
+        organizationId,
+        skillContext: { organizationId, safeDb, userId },
+        aiAnalytics: createTanStackAIAnalyticsCallbacks({
+          usageMetering: {
+            actionType: "chat",
+            organizationId,
+            safeDb,
+            serviceTier: "standard",
+            userId,
+            workspaceId: null,
+          },
+          feature,
+          modelRole: "fast",
+          orgAIConfig: config,
+          properties: { organization_id: organizationId },
+          traceId: Bun.randomUUIDv7(),
+        }),
+        tenantWorkspaceIds: [],
+      };
+      return {
+        generateAiValue: buildAiFieldGenerator(shared),
+        decideAiCondition: buildAiConditionDecider(shared),
+        adaptAiValue: buildAiOccurrenceAdapter(
+          documentLanguages === undefined
+            ? shared
+            : { ...shared, documentLanguages },
+        ),
+      };
+    },
+  };
 };

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -813,41 +813,37 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
   const orgAIConfig = await (
     context.testDependencies?.loadOrgAIConfig ?? loadOrgAIConfig
   )(context.organizationId);
-  const aiAnalytics = createTanStackAIAnalyticsCallbacks({
-    usageMetering: {
-      actionType: "chat",
+  // Built only when the manifest declares an AI field: the fill service defers
+  // this, so a deterministic fill opens no metered trace. fill_template is
+  // org-scoped (no matter binding), so there is no workspace id to redact
+  // tenant ids against.
+  const aiCollaborators = () => {
+    const shared = {
+      orgAIConfig,
       organizationId: context.organizationId,
-      safeDb: context.safeDb,
-      serviceTier: "standard",
-      userId: context.userId,
-      workspaceId: null,
-    },
-    feature: "templates.fill",
-    modelRole: "fast",
-    orgAIConfig,
-    properties: { organization_id: context.organizationId },
-    traceId: Bun.randomUUIDv7(),
-  });
-  // fill_template is org-scoped (no matter binding), so there is no
-  // workspace id to redact tenant ids against.
-  const generateAiValue = buildAiFieldGenerator({
-    orgAIConfig,
-    organizationId: context.organizationId,
-    aiAnalytics,
-    tenantWorkspaceIds: [],
-  });
-  const decideAiCondition = buildAiConditionDecider({
-    orgAIConfig,
-    organizationId: context.organizationId,
-    aiAnalytics,
-    tenantWorkspaceIds: [],
-  });
-  const adaptAiValue = buildAiOccurrenceAdapter({
-    orgAIConfig,
-    organizationId: context.organizationId,
-    aiAnalytics,
-    tenantWorkspaceIds: [],
-  });
+      aiAnalytics: createTanStackAIAnalyticsCallbacks({
+        usageMetering: {
+          actionType: "chat",
+          organizationId: context.organizationId,
+          safeDb: context.safeDb,
+          serviceTier: "standard",
+          userId: context.userId,
+          workspaceId: null,
+        },
+        feature: "templates.fill",
+        modelRole: "fast",
+        orgAIConfig,
+        properties: { organization_id: context.organizationId },
+        traceId: Bun.randomUUIDv7(),
+      }),
+      tenantWorkspaceIds: [],
+    };
+    return {
+      generateAiValue: buildAiFieldGenerator(shared),
+      decideAiCondition: buildAiConditionDecider(shared),
+      adaptAiValue: buildAiOccurrenceAdapter(shared),
+    };
+  };
 
   // Gate AI quota the same way the web/chat fill paths do: the service runs
   // this only when the manifest declares AI fields, before any model call, so a
@@ -879,10 +875,9 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
     values: parsed.output.values,
     scopedDb: context.scopedDb,
     organizationId: context.organizationId,
+    requiredFields: "enforce",
     assertUsageAvailable,
-    generateAiValue,
-    decideAiCondition,
-    adaptAiValue,
+    aiCollaborators,
   });
   if ("usageRejection" in filled) {
     return errorResult(filled.usageRejection.message);
@@ -1233,26 +1228,6 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
   const orgAIConfig = await (
     context.testDependencies?.loadOrgAIConfig ?? loadOrgAIConfig
   )(context.organizationId);
-  const aiAnalytics = createTanStackAIAnalyticsCallbacks({
-    usageMetering: {
-      actionType: "chat",
-      organizationId: context.organizationId,
-      safeDb: context.safeDb,
-      serviceTier: "standard",
-      userId: context.userId,
-      workspaceId,
-    },
-    feature: "templates.fill",
-    modelRole: "fast",
-    orgAIConfig,
-    properties: { organization_id: context.organizationId },
-    traceId: Bun.randomUUIDv7(),
-  });
-  const skillContext = {
-    organizationId: context.organizationId,
-    safeDb: context.safeDb,
-    userId: context.userId,
-  };
   const assertUsageAvailable =
     orgAIConfig || hasTanStackInstanceProvider()
       ? async () =>
@@ -1273,6 +1248,41 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
     context.request === undefined
       ? renderDeadline
       : AbortSignal.any([context.request.signal, renderDeadline]);
+  // Built only when the manifest declares an AI field: the fill service defers
+  // this, so a deterministic fill opens no metered trace.
+  const aiCollaborators = () => {
+    const shared = {
+      orgAIConfig,
+      organizationId: context.organizationId,
+      skillContext: {
+        organizationId: context.organizationId,
+        safeDb: context.safeDb,
+        userId: context.userId,
+      },
+      aiAnalytics: createTanStackAIAnalyticsCallbacks({
+        usageMetering: {
+          actionType: "chat",
+          organizationId: context.organizationId,
+          safeDb: context.safeDb,
+          serviceTier: "standard",
+          userId: context.userId,
+          workspaceId,
+        },
+        feature: "templates.fill",
+        modelRole: "fast",
+        orgAIConfig,
+        properties: { organization_id: context.organizationId },
+        traceId: Bun.randomUUIDv7(),
+      }),
+      operationSignal,
+      tenantWorkspaceIds: [workspaceId],
+    };
+    return {
+      generateAiValue: buildAiFieldGenerator(shared),
+      decideAiCondition: buildAiConditionDecider(shared),
+      adaptAiValue: buildAiOccurrenceAdapter(shared),
+    };
+  };
   const filledResult = await Result.tryPromise(
     async () =>
       await withTimeout(
@@ -1286,32 +1296,10 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
             scopedDb: context.scopedDb,
             organizationId: context.organizationId,
             workspaceId,
+            requiredFields: "enforce",
             useRecording: "caller",
             assertUsageAvailable,
-            generateAiValue: buildAiFieldGenerator({
-              orgAIConfig,
-              organizationId: context.organizationId,
-              skillContext,
-              aiAnalytics,
-              operationSignal,
-              tenantWorkspaceIds: [workspaceId],
-            }),
-            decideAiCondition: buildAiConditionDecider({
-              orgAIConfig,
-              organizationId: context.organizationId,
-              skillContext,
-              aiAnalytics,
-              operationSignal,
-              tenantWorkspaceIds: [workspaceId],
-            }),
-            adaptAiValue: buildAiOccurrenceAdapter({
-              orgAIConfig,
-              organizationId: context.organizationId,
-              skillContext,
-              aiAnalytics,
-              operationSignal,
-              tenantWorkspaceIds: [workspaceId],
-            }),
+            aiCollaborators,
           }),
         {
           label: "save filled template render",

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -6,10 +6,12 @@ import type { Transaction } from "@/api/db/root";
 import { entities, templates } from "@/api/db/schema";
 import type { TemplatePersistenceResult } from "@/api/db/schema";
 import { configureTemplateFields } from "@/api/handlers/templates/configure-template-fields-service";
+import type { OrgAIConfig } from "@/api/lib/ai-config";
 import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import { assertUsageAvailableForHandler } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import type {
   AssertNoExtraFields,
   LIST_TEMPLATES_LIST_PROJECTION,
@@ -718,6 +720,7 @@ const describeTemplateDetail: TypedMcpToolHandler<
     context.testDependencies?.describeStoredTemplate ?? describeStoredTemplate
   )({
     templateId: brandPersistedTemplateId(parsed.output.template_id),
+    organizationId: context.organizationId,
     scopedDb: context.scopedDb,
   });
   if ("error" in result) {
@@ -784,6 +787,52 @@ const requiredFieldsRejectionResult = (
   });
 };
 
+/**
+ * Read the org AI config at most once, and only when the fill service actually
+ * asks for a usage preflight or AI collaborators. A deterministic template
+ * declares no AI field, so it must not pay for that read.
+ */
+const deferOrgAIConfig = (context: McpRequestContext) => {
+  let pending: Promise<OrgAIConfig | null> | undefined;
+  return async (): Promise<OrgAIConfig | null> => {
+    pending ??= (context.testDependencies?.loadOrgAIConfig ?? loadOrgAIConfig)(
+      context.organizationId,
+    );
+    return await pending;
+  };
+};
+
+/**
+ * Usage preflight for a template fill, invoked by the fill service only once
+ * the manifest is known to declare an AI field, before any model call, so a
+ * deterministic fill never spends quota. Skips only when no provider could run
+ * a model at all: with an instance provider but no org BYOK the fill still
+ * calls the fast model (the metering layer prices it at the non-BYOK rate), so
+ * the quota check must still apply.
+ */
+const assertTemplateFillUsage = async ({
+  context,
+  readOrgAIConfig,
+  workspaceId,
+}: {
+  context: McpRequestContext;
+  readOrgAIConfig: () => Promise<OrgAIConfig | null>;
+  workspaceId: SafeId<"workspace"> | null;
+}) => {
+  const orgAIConfig = await readOrgAIConfig();
+  if (!orgAIConfig && !hasTanStackInstanceProvider()) {
+    return null;
+  }
+  return await assertUsageAvailableForHandler({
+    metering: { actionType: "chat", modelRole: "fast" },
+    organizationId: context.organizationId,
+    orgAIConfig,
+    workspaceId,
+    userId: context.userId,
+    safeDb: context.safeDb,
+  });
+};
+
 const fillTemplateArgsSchema = v.strictObject({
   template_id: v.pipe(v.string(), v.minLength(1)),
   values: v.record(v.string(), v.unknown()),
@@ -807,17 +856,16 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
     return validationErrorResult(parsed.issues);
   }
 
-  // Load the org's AI config so AI-fillable / aiAdapt fields behave exactly as
+  // The org's AI config makes AI-fillable / aiAdapt fields behave exactly as
   // they do in the chat tools and web fill routes; a missing config simply
-  // leaves those fields unfilled rather than erroring.
-  const orgAIConfig = await (
-    context.testDependencies?.loadOrgAIConfig ?? loadOrgAIConfig
-  )(context.organizationId);
-  // Built only when the manifest declares an AI field: the fill service defers
-  // this, so a deterministic fill opens no metered trace. fill_template is
-  // org-scoped (no matter binding), so there is no workspace id to redact
-  // tenant ids against.
-  const aiCollaborators = () => {
+  // leaves those fields unfilled rather than erroring. Read lazily: the fill
+  // service asks for it only when the manifest declares an AI field.
+  const readOrgAIConfig = deferOrgAIConfig(context);
+  // Built only when the manifest declares an AI field, so a deterministic fill
+  // opens no metered trace. fill_template is org-scoped (no matter binding),
+  // so there is no workspace id to redact tenant ids against.
+  const aiCollaborators = async () => {
+    const orgAIConfig = await readOrgAIConfig();
     const shared = {
       orgAIConfig,
       organizationId: context.organizationId,
@@ -845,24 +893,12 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
     };
   };
 
-  // Gate AI quota the same way the web/chat fill paths do: the service runs
-  // this only when the manifest declares AI fields, before any model call, so a
-  // deterministic fill never spends quota. Gated on a usable provider — org
-  // BYOK or the deployment's instance provider — since the generators run the
-  // fast model in either case; a null org config flows through to the metering
-  // layer (instance-provider rate).
-  const assertUsageAvailable =
-    orgAIConfig || hasTanStackInstanceProvider()
-      ? async () =>
-          await assertUsageAvailableForHandler({
-            metering: { actionType: "chat", modelRole: "fast" },
-            organizationId: context.organizationId,
-            orgAIConfig,
-            workspaceId: null,
-            userId: context.userId,
-            safeDb: context.safeDb,
-          })
-      : undefined;
+  const assertUsageAvailable = async () =>
+    await assertTemplateFillUsage({
+      context,
+      readOrgAIConfig,
+      workspaceId: null,
+    });
 
   const fillStoredTemplate =
     parsed.output.allow_unused_values === true
@@ -1225,21 +1261,9 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
     return errorResult(destinationError);
   }
 
-  const orgAIConfig = await (
-    context.testDependencies?.loadOrgAIConfig ?? loadOrgAIConfig
-  )(context.organizationId);
-  const assertUsageAvailable =
-    orgAIConfig || hasTanStackInstanceProvider()
-      ? async () =>
-          await assertUsageAvailableForHandler({
-            metering: { actionType: "chat", modelRole: "fast" },
-            organizationId: context.organizationId,
-            orgAIConfig,
-            workspaceId,
-            userId: context.userId,
-            safeDb: context.safeDb,
-          })
-      : undefined;
+  const readOrgAIConfig = deferOrgAIConfig(context);
+  const assertUsageAvailable = async () =>
+    await assertTemplateFillUsage({ context, readOrgAIConfig, workspaceId });
 
   const renderDeadline = AbortSignal.timeout(
     SAVE_FILLED_TEMPLATE_RENDER_TIMEOUT_MS,
@@ -1250,7 +1274,8 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
       : AbortSignal.any([context.request.signal, renderDeadline]);
   // Built only when the manifest declares an AI field: the fill service defers
   // this, so a deterministic fill opens no metered trace.
-  const aiCollaborators = () => {
+  const aiCollaborators = async () => {
+    const orgAIConfig = await readOrgAIConfig();
     const shared = {
       orgAIConfig,
       organizationId: context.organizationId,
@@ -1608,6 +1633,7 @@ const configureExistingTemplate = async ({
     context.testDependencies?.describeStoredTemplate ?? describeStoredTemplate
   )({
     templateId,
+    organizationId: context.organizationId,
     scopedDb: context.scopedDb,
   });
   if ("error" in described) {


### PR DESCRIPTION
- The raw-upload, by-id download and live-preview fill routes now run `template-fill-service` instead of each carrying its own copy of the manifest → required-fields → clause → lookup → AI → substitute sequence; usage metering, response shaping, audit rows and S3 writes stay in the routes. Required-fields policy is a mandatory service option, so the preview's `allow-partial` is one named argument rather than a second code path.
- AI collaborators are built through a deferred provider the service calls only when the manifest declares an AI field, so a deterministic fill loads no org AI config and opens no metered trace; the usage preflight now runs before the manifest fill steps instead of after them.
- Fixes `fillStoredTemplateDocx` dropping `useRecording`, which made `save_filled_template` bump a template's use counter twice per fill. New tests pin that contract and pin that every enforcing boundary rejects a missing required field with the identical structured `missingFields` payload while the preview still renders partial values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Template filling now consistently checks that required fields are completed before generating documents.
  - Missing required fields are reported with structured details to help resolve incomplete templates.
  - AI-assisted template fields are handled consistently across document filling, previews, reports, and integrations.

- **Bug Fixes**
  - Improved consistency between live previews and completed template fills.
  - Template previews continue to support partial content while preserving unmatched placeholders and diagnostics.
  - Template usage tracking is now recorded correctly across fill workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->