### PR TITLE
fix(kanban): the column header takes the shared chrome row height

### DIFF
--- a/.changeset/kanban-column-header-toolbar-row-height.md
+++ b/.changeset/kanban-column-header-toolbar-row-height.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+The kanban column header takes the shared chrome row height so column tops align with the rows above them.

--- a/packages/ui/src/kanban/column-header.test.tsx
+++ b/packages/ui/src/kanban/column-header.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { KanbanColumnHeader } from "./column-header";
+
+// Static markup carries no layout; this test pins the classes that keep the
+// column top on the shared chrome row height and stop a long title from
+// growing it.
+
+describe("KanbanColumnHeader", () => {
+  test("carries the toolbar row height and truncates the title", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanColumnHeader title="A very long column name" />,
+    );
+    const rootClass = /class="([^"]*)"/u.exec(markup)?.[1] ?? "";
+
+    expect(rootClass.split(" ")).toEqual(
+      expect.arrayContaining(["h-12", "items-center", "px-3"]),
+    );
+    expect(rootClass).not.toContain("py-2");
+    expect(markup).toContain("truncate");
+  });
+});

--- a/packages/ui/src/kanban/column-header.tsx
+++ b/packages/ui/src/kanban/column-header.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
 
+import { TOOLBAR_ROW_HEIGHT } from "../inspector/layout-tokens";
+import { cn } from "../lib/utils";
+
 export type KanbanColumnHeaderProps = {
   /** Colour swatch, or the control that changes it. */
   swatch?: ReactNode;
@@ -13,11 +16,18 @@ export type KanbanColumnHeaderProps = {
   dragHandle?: ReactNode;
   /** Column menu. */
   actions?: ReactNode;
+  /** Extra classes, e.g. to opt a caller out of the default row height. */
+  className?: string;
 };
 
 /**
  * The column header row: one rhythm for the swatch, the name, the count, the
  * calculation, and the column's controls, so every board's header lines up.
+ *
+ * Fixed at `TOOLBAR_ROW_HEIGHT`, the same height as the page header, the view
+ * switcher, and the inspector rail's cells, so a column's top edge lines up
+ * with every other chrome row above the board. The title clips instead of
+ * wrapping so a long name can never grow the row past that height.
  */
 export const KanbanColumnHeader = ({
   swatch,
@@ -26,8 +36,15 @@ export const KanbanColumnHeader = ({
   calculation,
   dragHandle,
   actions,
+  className,
 }: KanbanColumnHeaderProps) => (
-  <div className="flex items-center gap-2 px-3 py-2">
+  <div
+    className={cn(
+      "flex items-center gap-2 px-3",
+      TOOLBAR_ROW_HEIGHT,
+      className,
+    )}
+  >
     {swatch}
     <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate">
       {title}


### PR DESCRIPTION
## Summary

`KanbanColumnHeader` used `py-2` with a content-driven height, the one chrome row on a board that did not share `TOOLBAR_ROW_HEIGHT` (48px) with the page header, view switcher, and inspector rail cells. It now takes the shared token (`flex items-center gap-2 px-3 h-12`), keeps its truncating title, and accepts `className`. The band caption stays a 28px caption line.

No changes were needed in the app's consumers: `kanban-column.tsx` and `kanban-subgroup-board.tsx` render the header directly, and their menu trigger (`size-7`) and drag handle center inside the row.

## Verification

`packages/ui` typecheck and the new `column-header.test.tsx`; web typecheck; kanban unit suite (45 pass); type-aware oxlint and oxfmt clean. Changeset: `@stll/ui` patch.
