### PR TITLE
fix(landing): render changelog screenshots as images

### DIFF
--- a/apps/landing/src/lib/changelog-markdown.test.ts
+++ b/apps/landing/src/lib/changelog-markdown.test.ts
@@ -25,7 +25,7 @@ describe("changelog Markdown paragraphs", () => {
     ]);
   });
 
-  test("keeps prose separate from headings, lists, and videos", () => {
+  test("keeps prose separate from headings, lists, images, and videos", () => {
     expect(
       parseChangelogMarkdown(
         [
@@ -34,6 +34,7 @@ describe("changelog Markdown paragraphs", () => {
           "across two lines.",
           "- First change",
           "- Second change",
+          "![The fork action on an answer](https://example.com/fork.png)",
           '<video controls src="https://example.com/demo.mp4"></video>',
         ].join("\n"),
       ),
@@ -41,7 +42,25 @@ describe("changelog Markdown paragraphs", () => {
       { level: 1, text: "Release title", type: "heading" },
       { text: "A summary wrapped across two lines.", type: "paragraph" },
       { items: ["First change", "Second change"], type: "list" },
+      {
+        alt: "The fork action on an answer",
+        src: "https://example.com/fork.png",
+        type: "image",
+      },
       { src: "https://example.com/demo.mp4", type: "video" },
+    ]);
+  });
+
+  test("does not reinterpret a pasted screenshot as a video", () => {
+    const screenshot =
+      "![Chat fork](https://github.com/user-attachments/assets/82f63bcb-5f22-487e-a018-c60745244447)";
+
+    expect(parseChangelogMarkdown(screenshot)).toEqual([
+      {
+        alt: "Chat fork",
+        src: "https://github.com/user-attachments/assets/82f63bcb-5f22-487e-a018-c60745244447",
+        type: "image",
+      },
     ]);
   });
 });

--- a/apps/landing/src/lib/changelog-markdown.ts
+++ b/apps/landing/src/lib/changelog-markdown.ts
@@ -1,12 +1,13 @@
 export type ChangelogMarkdownBlock =
   | { level: 1 | 2 | 3; text: string; type: "heading" }
+  | { alt: string; src: string; type: "image" }
   | { items: string[]; type: "list" }
   | { text: string; type: "paragraph" }
   | { src: string; type: "video" };
 
 const HTML_VIDEO_PATTERN =
   /^<video\b[^>]*\bsrc=["']([^"']+)["'][^>]*><\/video>$/iu;
-const MARKDOWN_VIDEO_PATTERN = /^!\[[^\]]*\]\((https:\/\/[^)\s]+)\)$/u;
+const MARKDOWN_IMAGE_PATTERN = /^!\[([^\]]*)\]\((https:\/\/[^)\s]+)\)$/u;
 
 const parseHeading = (line: string) => {
   if (line.startsWith("### ")) {
@@ -52,13 +53,20 @@ export const parseChangelogMarkdown = (body: string) => {
       continue;
     }
 
-    const htmlVideoSrc = HTML_VIDEO_PATTERN.exec(line)?.[1];
-    const markdownVideoSrc = MARKDOWN_VIDEO_PATTERN.exec(line)?.[1];
-    const videoSrc = htmlVideoSrc ?? markdownVideoSrc;
+    const videoSrc = HTML_VIDEO_PATTERN.exec(line)?.[1];
     if (videoSrc) {
       closeParagraph();
       closeList();
       blocks.push({ src: videoSrc, type: "video" });
+      continue;
+    }
+
+    const imageMatch = MARKDOWN_IMAGE_PATTERN.exec(line);
+    const imageSrc = imageMatch?.[2];
+    if (imageMatch && imageSrc) {
+      closeParagraph();
+      closeList();
+      blocks.push({ alt: imageMatch[1], src: imageSrc, type: "image" });
       continue;
     }
 

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -461,8 +461,21 @@ const formatReleaseDate = (publishedAt: string) =>
       width: 100%;
     }
 
+    :global(.changelog-body img) {
+      background: var(--muted);
+      border-radius: 0.5rem;
+      display: block;
+      height: auto;
+      margin-top: 1rem;
+      max-height: 42rem;
+      object-fit: contain;
+      outline: 1px solid color-mix(in srgb, var(--foreground) 6%, transparent);
+      width: 100%;
+    }
+
     @media (max-width: 640px) {
-      :global(.changelog-body video) {
+      :global(.changelog-body video),
+      :global(.changelog-body img) {
         border-radius: 0.375rem;
         margin-inline: -0.5rem;
         max-width: calc(100% + 1rem);
@@ -655,6 +668,21 @@ const formatReleaseDate = (publishedAt: string) =>
       const fragment = document.createDocumentFragment();
 
       for (const block of parseChangelogMarkdown(body)) {
+        if (block.type === "image") {
+          const safeSrc = safeHttpsUrl(block.src);
+          if (!safeSrc) {
+            continue;
+          }
+
+          const image = document.createElement("img");
+          image.alt = block.alt;
+          image.decoding = "async";
+          image.loading = "lazy";
+          image.src = safeSrc;
+          fragment.append(image);
+          continue;
+        }
+
         if (block.type === "video") {
           const safeSrc = safeHttpsUrl(block.src);
           if (!safeSrc) {

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -31,18 +31,23 @@ Example:
 
 ## We are shipping faster table editing, cleaner sorting, and smoother bulk actions.
 
+![A table with the updated sorting controls](https://github.com/user-attachments/assets/example-image-id)
+
 <video controls src="https://github.com/user-attachments/assets/example-video-id"></video>
 ```
 
 The changelog page renders `#` as the manual heading, `##` as the subheading,
-and safe `https://` video URLs as embedded videos. Generated commit entries keep
-their clickable pull request links under a collapsed `Full release notes`
-section.
+Markdown images with safe `https://` URLs as responsive screenshots, and
+`<video controls src="https://..."></video>` as an embedded video. Generated
+commit entries keep their clickable pull request links under a collapsed
+`Full release notes` section.
 
-Use GitHub user attachments for short videos: drag an `.mp4` into a GitHub issue,
-PR comment, or release description draft, then copy the generated
-`https://github.com/user-attachments/assets/...` URL into the changelog note.
-Keep videos short and compressed; the website embeds the file responsively.
+Use GitHub user attachments for screenshots and short videos. Paste an image
+into a GitHub issue, PR comment, or release description draft, then copy its
+generated Markdown into the changelog note. For a video, drag in an `.mp4` and
+put its `https://github.com/user-attachments/assets/...` URL in the `<video>`
+element shown above. Keep videos short and compressed; the website embeds the
+file responsively.
 
 Stable releases (`vX.Y.Z`) generate their commit list from the previous stable
 tag, so the stable release includes the changes shipped through earlier


### PR DESCRIPTION
Markdown screenshot embeds in release notes are now parsed as images instead of video players. The renderer preserves alt text, loads images lazily, and keeps screenshots responsive with a bounded, outlined presentation on desktop and mobile.

The changelog authoring guide now documents both pasted screenshots and video embeds. Reverting the image classification makes the focused regression fail.