### PR TITLE
fix(api): reject a cancelled text generation instead of returning partial output

### DIFF
--- a/apps/api/src/lib/tanstack-ai-generate.canary.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.canary.test.ts
@@ -1,0 +1,122 @@
+import { EventType } from "@tanstack/ai";
+import type { AnyTextAdapter, StreamChunk } from "@tanstack/ai";
+import { describe, expect, test } from "bun:test";
+
+import type { CachingDecision } from "@/api/lib/ai-config";
+import { generateTanStackTextForRole } from "@/api/lib/tanstack-ai-generate";
+import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
+
+// Real `chat()` runtime, no module mocks. `generateTanStackTextForRole`
+// compensates for the chat loop leaving a cancelled provider stream silently
+// (a plain `break`, no terminal event, nothing thrown). That shape belongs to
+// the SDK, so it is exercised here through the SDK itself: a change to its
+// cancellation ordering or terminal events fails this file, not a caller.
+
+const noCaching = {
+  enabled: false,
+  reason: "org-disabled",
+} satisfies CachingDecision;
+
+type CancellationPoint = "mid-stream" | "after-finish";
+
+const createCancellingAdapter = (
+  controller: AbortController,
+  cancelAt: CancellationPoint,
+): AnyTextAdapter => ({
+  kind: "text",
+  name: "cancelling",
+  model: "cancelling",
+  "~types": {
+    providerOptions: {},
+    inputModalities: ["text"],
+    messageMetadataByModality: {},
+    toolCapabilities: [],
+    toolCallMetadata: {},
+    systemPromptMetadata: undefined,
+  },
+  async *chatStream({ runId, threadId }) {
+    const resolvedRunId = runId ?? "run-1";
+    const resolvedThreadId = threadId ?? "thread-1";
+    const messageId = "provider-message-1";
+    yield {
+      type: EventType.RUN_STARTED,
+      runId: resolvedRunId,
+      threadId: resolvedThreadId,
+    } satisfies StreamChunk;
+    yield {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId,
+      role: "assistant",
+    } satisfies StreamChunk;
+    yield {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId,
+      delta: "half an",
+    } satisfies StreamChunk;
+    if (cancelAt === "mid-stream") {
+      controller.abort();
+    }
+    yield {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId,
+      delta: " answer",
+    } satisfies StreamChunk;
+    yield { type: EventType.TEXT_MESSAGE_END, messageId } satisfies StreamChunk;
+    yield {
+      type: EventType.RUN_FINISHED,
+      finishReason: "stop",
+      runId: resolvedRunId,
+      threadId: resolvedThreadId,
+    } satisfies StreamChunk;
+    if (cancelAt === "after-finish") {
+      controller.abort();
+    }
+  },
+  structuredOutput: () => {
+    throw new Error("Structured output is not part of this fixture");
+  },
+});
+
+const generateWithCancellation = async (cancelAt: CancellationPoint) => {
+  const controller = new AbortController();
+  // SAFETY: the adapter is the only part of the resolved model the real chat
+  // loop reads on this path; the rest is bookkeeping this canary never routes
+  // through a provider.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  const model = {
+    adapter: createCancellingAdapter(controller, cancelAt),
+    keySource: "instance",
+    modelId: "cancelling",
+    modelOptions: {},
+    provider: "openai",
+  } as ResolvedTanStackTextModel;
+
+  return await generateTanStackTextForRole({
+    abortSignal: controller.signal,
+    caching: noCaching,
+    organizationId: null,
+    orgAIConfig: null,
+    prompt: "Rewrite it.",
+    resolveTextModel: () => model,
+    role: "chat",
+    serviceTier: "standard",
+    tenantWorkspaceIds: [],
+  });
+};
+
+describe("TanStack cancellation canary", () => {
+  test("a run cancelled mid-stream rejects instead of returning its prefix", async () => {
+    const caught = await generateWithCancellation("mid-stream").then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({ status: 502 });
+  });
+
+  test("a run that finished before the cancellation keeps its output", async () => {
+    expect(await generateWithCancellation("after-finish")).toBe(
+      "half an answer",
+    );
+  });
+});

--- a/apps/api/src/lib/tanstack-ai-generate.canary.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.canary.test.ts
@@ -82,7 +82,6 @@ const generateWithCancellation = async (cancelAt: CancellationPoint) => {
   // SAFETY: the adapter is the only part of the resolved model the real chat
   // loop reads on this path; the rest is bookkeeping this canary never routes
   // through a provider.
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const model = {
     adapter: createCancellingAdapter(controller, cancelAt),
     keySource: "instance",

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -804,6 +804,51 @@ describe("TanStack AI text generation", () => {
     expect(caught).toMatchObject({ status: 502 });
   });
 
+  test("rejects a cancelled run instead of returning its truncated text", async () => {
+    capturedChatOptions.length = 0;
+    const controller = new AbortController();
+    nextChatResult = createCancelledTextStream(["half an ans"], controller);
+
+    const caught = await generateTextForTestModel({
+      abortSignal: controller.signal,
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Rewrite it.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({ status: 502 });
+  });
+
+  test("keeps the output of a run that finished before the cancellation", async () => {
+    capturedChatOptions.length = 0;
+    const controller = new AbortController();
+    nextChatResult = createCancelledTextStream(
+      ["a whole answer"],
+      controller,
+      "stop",
+    );
+
+    const output = await generateTextForTestModel({
+      abortSignal: controller.signal,
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Rewrite it.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    });
+
+    expect(output).toBe("a whole answer");
+  });
+
   test("collects text through the error-aware streaming boundary", async () => {
     capturedChatOptions.length = 0;
     nextChatResult = createTextStream(["hello", " world"]);
@@ -1040,6 +1085,19 @@ const createTextStream = async function* (
       finishReason,
     };
   }
+};
+
+// The chat loop's cancellation shape: it breaks out of the provider stream on
+// the next chunk, so the deltas already collected stand, no `RUN_FINISHED`
+// follows, and nothing is thrown. Pass a finish reason to model the run
+// reporting completion before the signal fires.
+const createCancelledTextStream = async function* (
+  deltas: string[],
+  controller: AbortController,
+  finishReason?: "stop" | "length",
+) {
+  yield* createTextStream(deltas, finishReason);
+  controller.abort();
 };
 
 const createRunErrorStream = async function* ({

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -849,6 +849,28 @@ describe("TanStack AI text generation", () => {
     expect(output).toBe("a whole answer");
   });
 
+  test("keeps the output of a run that finished without a reason before the cancellation", async () => {
+    capturedChatOptions.length = 0;
+    const controller = new AbortController();
+    nextChatResult = createCancelledUnreasonedFinishStream(
+      ["a whole answer"],
+      controller,
+    );
+
+    const output = await generateTextForTestModel({
+      abortSignal: controller.signal,
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Rewrite it.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    });
+
+    expect(output).toBe("a whole answer");
+  });
+
   test("collects text through the error-aware streaming boundary", async () => {
     capturedChatOptions.length = 0;
     nextChatResult = createTextStream(["hello", " world"]);
@@ -1097,6 +1119,16 @@ const createCancelledTextStream = async function* (
   finishReason?: "stop" | "length",
 ) {
   yield* createTextStream(deltas, finishReason);
+  controller.abort();
+};
+
+// `RUN_FINISHED` may carry no finish reason at all; the run still finished.
+const createCancelledUnreasonedFinishStream = async function* (
+  deltas: string[],
+  controller: AbortController,
+) {
+  yield* createTextStream(deltas);
+  yield { type: realTanStackAI.EventType.RUN_FINISHED };
   controller.abort();
 };
 

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -153,7 +153,10 @@ export const generateTanStackTextForRole = async (
   const abortController = options.abortSignal
     ? abortControllerFromSignal(options.abortSignal)
     : undefined;
-  const state: { finishReason: TanStackTextFinishReason } = {
+  // `finished` records that the run reported its end at all; the reason is
+  // optional on that event, so it cannot stand in for the event itself.
+  const state: { finished: boolean; finishReason: TanStackTextFinishReason } = {
+    finished: false,
     finishReason: null,
   };
   let output = "";
@@ -169,6 +172,7 @@ export const generateTanStackTextForRole = async (
     system: guardedSystemPrompt(options),
     temperature: options.temperature,
     onFinishReason: (value) => {
+      state.finished = true;
       state.finishReason = value;
     },
   })) {
@@ -179,9 +183,9 @@ export const generateTanStackTextForRole = async (
   // chunk: no `RUN_FINISHED`, nothing thrown. Whether a cancellation instead
   // surfaces as an adapter rejection races the provider stream, so without
   // this the same cancellation is sometimes an error and sometimes a truncated
-  // answer the caller cannot tell from a whole one. A reported finish reason
+  // answer the caller cannot tell from a whole one. A reported finish
   // separates the two: that run completed before the signal fired.
-  if (state.finishReason === null && options.abortSignal?.aborted === true) {
+  if (!state.finished && options.abortSignal?.aborted === true) {
     throw new HandlerError({
       status: 502,
       message: "AI generation was cancelled",

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -175,6 +175,19 @@ export const generateTanStackTextForRole = async (
     output += delta;
   }
 
+  // A cancelled run leaves the chat loop through a plain `break` on the next
+  // chunk: no `RUN_FINISHED`, nothing thrown. Whether a cancellation instead
+  // surfaces as an adapter rejection races the provider stream, so without
+  // this the same cancellation is sometimes an error and sometimes a truncated
+  // answer the caller cannot tell from a whole one. A reported finish reason
+  // separates the two: that run completed before the signal fired.
+  if (state.finishReason === null && options.abortSignal?.aborted === true) {
+    throw new HandlerError({
+      status: 502,
+      message: "AI generation was cancelled",
+    });
+  }
+
   if (
     options.finishPolicy === "require-complete" &&
     state.finishReason !== "stop"


### PR DESCRIPTION
## Proposed change

`generateTanStackTextForRole` accumulates deltas until the chat stream ends, then returns the collected text. The chat loop, however, leaves the provider stream through a plain `break` when the run is cancelled (`@tanstack/ai` checks `isCancelled()` inside the adapter loop): it emits no `RUN_FINISHED` and throws nothing. A cancelled run therefore came back as an ordinary return value, handing the caller whatever deltas had arrived as if the model had answered in full. Whether a cancellation surfaced as an error at all depended on whether the abort won the race and rejected the adapter's fetch first, so the same cancellation was sometimes a 502 and sometimes a truncated answer indistinguishable from a whole one.

Callers pass `AbortSignal.any([request.signal, AbortSignal.timeout(...)])`, so a caller-side deadline and a disconnected client both take this path. `finishPolicy: "require-complete"` is the only existing check that catches a missing finish reason, and one of the collected-text callers opts into it.

This rejects a run that reported no finish reason and whose abort signal has fired. Placing it in the shared helper rather than at each call site means a caller cannot opt back into partial output by omission. A run that did report a finish reason completed before the signal fired, so its output still stands and is returned unchanged; the two cases are covered by new tests.

`generateTanStackObjectForRole` uses the promise form of `chat()` and already rejects a cancelled run (the structured result is missing, so `v.parse` throws), so it is unchanged here.

## Verification

`@stll/api` typecheck, type-aware oxlint and oxfmt; the `tanstack-ai-generate`, `improve-prompt` and `polish-narrative` suites. The cancellation test fails on the unpatched helper and passes with it. Two unrelated test failures on this checkout (`generateImageThumbnail`, `scripts/env-tool.test.ts`) reproduce identically on `main` and are local toolchain differences, not this diff.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: server-side change, no UI surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-visible surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxLDW6GNyoTMza7wuvhhH7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxLDW6GNyoTMza7wuvhhH7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - AI-generated responses now correctly report an error when generation is cancelled before completion.
  - Responses that finish before cancellation are preserved and returned in full, including runs without a specified finish reason.
  - Cancelled generation requests now return a clear error response instead of appearing to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->