### PR TITLE
feat(kanban): optional accent tint on the cell surface

### DIFF
--- a/.changeset/kanban-cell-accent-tint.md
+++ b/.changeset/kanban-cell-accent-tint.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Add an optional `accent` prop to `KanbanVirtualCell` (`@stll/ui/kanban`) so a host can carry a column's option colour onto the cell surface itself, not just its header swatch. With no `accent`, the surface renders exactly as before. With an `accent`, the resting surface gets a faint colour-derived tint, and while `active` is also set (a card dragged over the cell) the tint strengthens into an accent-coloured wash and ring, replacing the generic highlight instead of layering under it.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -243,13 +243,30 @@ export const KanbanColumn = ({
     onChangeColor?.(value);
   };
 
+  // Drag-over emphasis reads the column's own colour when it has one, so the
+  // frame that says "drop here" carries the same identity as the swatch
+  // instead of a generic highlight; a colourless column keeps that generic
+  // highlight unchanged.
+  const isColumnActive = isFileDragOver || isEntityDragOver;
+  const restingBackground = colorBg
+    ? `color-mix(in srgb, ${colorBg} 50%, transparent)`
+    : undefined;
+  const activeAccentBackground =
+    isColumnActive && color
+      ? `color-mix(in srgb, ${color} 22%, var(--background))`
+      : undefined;
+  const activeAccentRing =
+    isColumnActive && color
+      ? `0 0 0 2px color-mix(in srgb, ${color} 55%, transparent)`
+      : undefined;
+  const columnBackground = activeAccentBackground ?? restingBackground;
+
   return (
     <div
       className={cn(
         "group/column relative flex w-[300px] max-w-[320px] min-w-[280px] shrink-0 flex-col rounded-lg transition-[opacity,background-color,outline-color]",
         !colorBg && "bg-muted/50",
-        (isFileDragOver || isEntityDragOver) &&
-          "bg-primary/5 ring-primary/50 ring-2",
+        isColumnActive && !color && "bg-primary/5 ring-primary/50 ring-2",
         isDragging && "opacity-40",
       )}
       // A stable hook for the card drag-over state that does not depend on
@@ -257,9 +274,14 @@ export const KanbanColumn = ({
       data-drag-over={isEntityDragOver ? "true" : "false"}
       ref={columnRef}
       style={
-        colorBg
+        columnBackground || activeAccentRing
           ? {
-              backgroundColor: `color-mix(in srgb, ${colorBg} 50%, transparent)`,
+              ...(columnBackground
+                ? { backgroundColor: columnBackground }
+                : undefined),
+              ...(activeAccentRing
+                ? { boxShadow: activeAccentRing }
+                : undefined),
             }
           : undefined
       }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
@@ -209,13 +209,12 @@ const WorkspaceKanbanSubgroupCell = ({
 
   return (
     <KanbanVirtualCell
-      active={isDragOver}
-      backgroundColor={
-        cell.coordinate.column.type === "group" &&
-        cell.coordinate.column.group.colorBg
-          ? `color-mix(in srgb, ${cell.coordinate.column.group.colorBg} 26%, transparent)`
+      accent={
+        cell.coordinate.column.type === "group"
+          ? cell.coordinate.column.group.optionColor
           : undefined
       }
+      active={isDragOver}
       containerRef={cellRef}
       footer={
         columnValue !== null && canCreateTask ? (

--- a/packages/ui/src/kanban/virtual-cell.test.tsx
+++ b/packages/ui/src/kanban/virtual-cell.test.tsx
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { KanbanVirtualCell } from "./virtual-cell";
+import type { KanbanVirtualCellProps } from "./virtual-cell";
+
+// Static markup carries no layout; these tests pin the neutral surface's
+// default output and the optional accent tint layered on top of it.
+
+const readCell = (markup: string) => {
+  const match = /<div[^>]*>/u.exec(markup);
+
+  if (!match) {
+    throw new Error("no cell surface in the rendered markup");
+  }
+
+  return match[0];
+};
+
+const renderCell = (overrides: Partial<KanbanVirtualCellProps<string>> = {}) =>
+  readCell(
+    renderToStaticMarkup(
+      <KanbanVirtualCell
+        getRowKey={(row) => row}
+        pagination={{ type: "none" }}
+        renderRow={(row) => <span>{row}</span>}
+        rows={["one"]}
+        {...overrides}
+      />,
+    ),
+  );
+
+describe("KanbanVirtualCell", () => {
+  test("renders the plain neutral surface with no accent", () => {
+    const cell = renderCell();
+
+    expect(cell).not.toContain("data-kanban-cell-accent");
+    expect(cell).not.toContain("--kanban-cell-accent");
+  });
+
+  test("keeps the generic drag-over highlight when active without an accent", () => {
+    const cell = renderCell({ active: true });
+
+    expect(cell).toContain("bg-primary/5");
+    expect(cell).toContain("ring-primary/50");
+    expect(cell).not.toContain("--kanban-cell-accent");
+  });
+
+  test("layers a faint accent tint on the resting surface", () => {
+    const cell = renderCell({ accent: "blue" });
+
+    expect(cell).toContain('data-kanban-cell-accent="true"');
+    expect(cell).toContain("--kanban-cell-accent:var(--option-blue)");
+    expect(cell).toContain(
+      "background-color:color-mix(in srgb, var(--kanban-cell-accent) 12%, var(--background))",
+    );
+    // The resting tint never reaches for a ring or the generic highlight.
+    expect(cell).not.toContain("box-shadow");
+    expect(cell).not.toContain("ring-primary/50");
+  });
+
+  test("strengthens the accent into an active wash and ring while a card is over the cell", () => {
+    const cell = renderCell({ accent: "blue", active: true });
+
+    expect(cell).toContain('data-kanban-cell-accent="true"');
+    expect(cell).toContain(
+      "background-color:color-mix(in srgb, var(--kanban-cell-accent) 22%, var(--background))",
+    );
+    expect(cell).toContain(
+      "box-shadow:0 0 0 2px color-mix(in srgb, var(--kanban-cell-accent) 55%, transparent)",
+    );
+    // The active accent frame replaces the generic primary-coloured one.
+    expect(cell).not.toContain("bg-primary/5");
+    expect(cell).not.toContain("ring-primary/50");
+  });
+});

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -1,4 +1,5 @@
 import {
+  type CSSProperties,
   type Key,
   type ReactNode,
   type RefObject,
@@ -20,6 +21,7 @@ import {
   useVirtualizer,
 } from "@tanstack/react-virtual";
 
+import { type OptionColor, resolveOptionColor } from "../lib/option-color";
 import { cn } from "../lib/utils";
 import {
   useKanbanDropTarget,
@@ -30,6 +32,24 @@ import {
 const DEFAULT_ESTIMATE_SIZE_PX = 128;
 const DEFAULT_OVERSCAN = 8;
 const DEFAULT_LOAD_MORE_THRESHOLD_PX = 200;
+
+/** The CSS custom property every accent tint and the active accent ring are
+ *  derived from, so both stay in lockstep with the resolved colour token. */
+const KANBAN_CELL_ACCENT_VAR = "--kanban-cell-accent" as const;
+
+/** Faint resting wash: matches the alpha `option-color` already uses for its
+ *  own subtle background token, so a tinted cell reads at the same weight as
+ *  the swatch and badges that carry the same colour. */
+const KANBAN_CELL_ACCENT_RESTING_ALPHA = 12;
+/** Stronger wash while a card is dragged over an accented cell. */
+const KANBAN_CELL_ACCENT_ACTIVE_ALPHA = 22;
+/** Ring alpha for the active accent frame, well above the wash so the frame
+ *  still reads as the drag-over affordance rather than more background tint. */
+const KANBAN_CELL_ACCENT_ACTIVE_RING_ALPHA = 55;
+
+type KanbanCellStyle = CSSProperties & {
+  [KANBAN_CELL_ACCENT_VAR]?: string;
+};
 
 const retainActiveSortableIndex = (
   range: Range,
@@ -82,6 +102,14 @@ export type KanbanVirtualCellProps<TRow> = {
   containerRef?: RefObject<HTMLDivElement | null> | undefined;
   active?: boolean | undefined;
   backgroundColor?: string | undefined;
+  /**
+   * Optional colour identity for the cell surface: a faint resting tint at
+   * the same alpha as `option-color`'s own subtle background, with a
+   * stronger accent-coloured wash and ring while `active` is also set. Omit
+   * for the plain neutral surface; `backgroundColor` still wins outright
+   * when both are given, since that prop is the caller's explicit override.
+   */
+  accent?: OptionColor | undefined;
   footer?: ReactNode;
   estimateSize?: number | undefined;
   overscan?: number | undefined;
@@ -99,6 +127,7 @@ export const KanbanVirtualCell = <TRow,>({
   containerRef,
   active = false,
   backgroundColor,
+  accent,
   footer,
   estimateSize = DEFAULT_ESTIMATE_SIZE_PX,
   overscan = DEFAULT_OVERSCAN,
@@ -172,17 +201,48 @@ export const KanbanVirtualCell = <TRow,>({
     dropTarget.setNodeRef(element);
   };
 
+  const accentVariants =
+    accent === undefined ? undefined : resolveOptionColor(accent);
+  const accentAlpha = active
+    ? KANBAN_CELL_ACCENT_ACTIVE_ALPHA
+    : KANBAN_CELL_ACCENT_RESTING_ALPHA;
+  const accentBackground =
+    accentVariants === undefined
+      ? undefined
+      : `color-mix(in srgb, var(${KANBAN_CELL_ACCENT_VAR}) ${accentAlpha}%, var(--background))`;
+  const activeAccentRing =
+    active && accentVariants !== undefined
+      ? `0 0 0 2px color-mix(in srgb, var(${KANBAN_CELL_ACCENT_VAR}) ${KANBAN_CELL_ACCENT_ACTIVE_RING_ALPHA}%, transparent)`
+      : undefined;
+  const style: KanbanCellStyle | undefined =
+    backgroundColor === undefined && accentVariants === undefined
+      ? undefined
+      : {
+          backgroundColor: backgroundColor ?? accentBackground,
+          ...(activeAccentRing === undefined
+            ? undefined
+            : { boxShadow: activeAccentRing }),
+          ...(accentVariants === undefined
+            ? undefined
+            : { [KANBAN_CELL_ACCENT_VAR]: accentVariants.color }),
+        };
+
   const content = (
     <div
       className={cn(
         "bg-muted/20 max-h-[min(60vh,40rem)] min-h-20 overflow-y-auto overscroll-y-contain rounded-xl p-2 transition-[background-color,outline-color]",
-        active && "bg-primary/5 ring-primary/50 ring-2",
+        active &&
+          accentVariants === undefined &&
+          "bg-primary/5 ring-primary/50 ring-2",
         className,
       )}
       data-kanban-cell={sortable?.dropTarget.id}
+      data-kanban-cell-accent={
+        accentVariants === undefined ? undefined : "true"
+      }
       onScroll={handleScroll}
       ref={setScrollElement}
-      style={backgroundColor ? { backgroundColor } : undefined}
+      style={style}
     >
       <div className="relative" style={{ height: virtualizer.getTotalSize() }}>
         {virtualizer.getVirtualItems().map((virtualRow) => {


### PR DESCRIPTION
- `KanbanVirtualCell` gains `accent?: OptionColor`: 12% wash at rest, 22% wash plus an accent ring while a card is over it; no accent keeps the current output and the generic highlight.
- The app's subgrouped columns pass `group.optionColor`; the flat column's drag-over highlight takes its colour too.
- `@stll/ui` minor.
