### PR TITLE
fix(web): validate mapped sourcemap chunks

### DIFF
--- a/apps/web/scripts/publish-sourcemaps.test.ts
+++ b/apps/web/scripts/publish-sourcemaps.test.ts
@@ -118,6 +118,23 @@ describe("source map removal", () => {
 });
 
 describe("source-map injection coverage", () => {
+  test("rejects a client build with no mapped JavaScript chunks", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "stella-sourcemaps-empty-"));
+    const clientRoot = path.join(root, "client");
+    await mkdir(path.join(clientRoot, "assets"), { recursive: true });
+
+    let failure: unknown;
+    try {
+      await assertChunksInjected(clientRoot);
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure instanceof Error ? failure.message : "").toMatch(
+      /no mapped client chunks/u,
+    );
+  });
+
   test("validates mapped chunks without rejecting emitted mapless assets", async () => {
     const root = await createDist();
     const clientRoot = path.join(root, "client");

--- a/apps/web/scripts/publish-sourcemaps.test.ts
+++ b/apps/web/scripts/publish-sourcemaps.test.ts
@@ -117,15 +117,25 @@ describe("source map removal", () => {
   });
 });
 
-describe("assertChunksInjected", () => {
-  test("counts injected chunks and names the ones the CLI skipped", async () => {
+describe("source-map injection coverage", () => {
+  test("validates mapped chunks without rejecting emitted mapless assets", async () => {
     const root = await createDist();
     const clientRoot = path.join(root, "client");
     expect(await assertChunksInjected(clientRoot)).toBe(1);
 
     await writeFile(
-      path.join(clientRoot, "assets/vendor-XyZw5678.js"),
+      path.join(clientRoot, "assets/render-worker-XyZw5678.js"),
+      'console.log("worker");\n',
+    );
+    expect(await assertChunksInjected(clientRoot)).toBe(1);
+
+    await writeFile(
+      path.join(clientRoot, "assets/vendor-QrSt9012.js"),
       'console.log("vendor");\n',
+    );
+    await writeFile(
+      path.join(clientRoot, "assets/vendor-QrSt9012.js.map"),
+      "{}",
     );
     let failure: unknown;
     try {
@@ -135,7 +145,7 @@ describe("assertChunksInjected", () => {
     }
     expect(failure).toBeInstanceOf(Error);
     expect(failure instanceof Error ? failure.message : "").toMatch(
-      /vendor-XyZw5678\.js/u,
+      /vendor-QrSt9012\.js/u,
     );
   });
 });

--- a/apps/web/scripts/publish-sourcemaps.ts
+++ b/apps/web/scripts/publish-sourcemaps.ts
@@ -121,17 +121,20 @@ export const removeSourcemaps = async (root: string): Promise<number> => {
   return files.length;
 };
 
-/** Every client chunk must carry the injected id, or the upload was partial. */
+/** Every mapped client chunk must carry the injected id, or the upload was partial. */
 export const assertChunksInjected = async (
   clientRoot: string,
 ): Promise<number> => {
   const missing: string[] = [];
   let count = 0;
-  for await (const file of new Bun.Glob("assets/*.js").scan({
+  // PostHog only injects JavaScript/source-map pairs. Vite may also copy
+  // prebuilt JavaScript assets that have no map and cannot be uploaded.
+  for await (const mapFile of new Bun.Glob("assets/*.js.map").scan({
     absolute: true,
     cwd: clientRoot,
   })) {
     count += 1;
+    const file = mapFile.slice(0, -".map".length);
     const source = await readFile(file, "utf-8");
     if (!source.includes(CHUNK_ID_MARKER)) {
       missing.push(path.relative(clientRoot, file));

--- a/apps/web/scripts/publish-sourcemaps.ts
+++ b/apps/web/scripts/publish-sourcemaps.ts
@@ -140,6 +140,9 @@ export const assertChunksInjected = async (
       missing.push(path.relative(clientRoot, file));
     }
   }
+  if (count === 0) {
+    return panic("no mapped client chunks found after source-map publication");
+  }
   if (missing.length > 0) {
     return panic(
       `chunks without an injected id: ${missing.toSorted().join(", ")}`,


### PR DESCRIPTION
## Summary

- validate PostHog injection against JavaScript/source-map pairs
- allow emitted JavaScript assets that have no source map and cannot be uploaded
- retain a hard failure when PostHog skips a mapped chunk
- cover both cases with the source-map publication regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved publication validation for client-side source maps.
  - Builds are now rejected when published source maps do not correspond to injected JavaScript chunks.
  - Validation now correctly distinguishes client chunks from other assets, reducing false positives for unmapped worker files.
  - Error messages identify the specific asset that failed validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->