### PR TITLE
fix(landing): record the v0.8.9 and v0.8.10 release dates

### DIFF
--- a/apps/landing/src/data/changelog-release-dates.json
+++ b/apps/landing/src/data/changelog-release-dates.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Publication timestamps for stable releases, keyed by tag. Sourced from the GitHub releases API (published_at; v0.3.0 has no GitHub release, so its tag commit date is used). The server-rendered changelog list reads these at build time; the client-side live feed replaces it with fresh GitHub data. A release missing here renders without a date until the entry is added.",
+  "_note": "Publication timestamps for stable releases, keyed by tag. Sourced from the GitHub releases API (published_at; v0.3.0 and v0.8.9 have no GitHub release, so their tag dates are used). The server-rendered changelog list reads these at build time; the client-side live feed replaces it with fresh GitHub data. A release missing here renders without a date until the entry is added.",
   "v0.1.2": "2026-05-06T10:46:08Z",
   "v0.1.3": "2026-05-06T13:39:55Z",
   "v0.1.4": "2026-05-09T11:29:13Z",
@@ -93,5 +93,7 @@
   "v0.8.5": "2026-09-01T14:08:45Z",
   "v0.8.6": "2026-09-01T21:39:26Z",
   "v0.8.7": "2026-09-01T23:11:53Z",
-  "v0.8.8": "2026-09-02T11:19:32Z"
+  "v0.8.8": "2026-09-02T11:19:32Z",
+  "v0.8.9": "2026-09-02T20:52:44Z",
+  "v0.8.10": "2026-09-02T22:00:33Z"
 }


### PR DESCRIPTION
- `changelog-release-dates.json`: v0.8.9 (tag date; no GitHub release exists because its Release Artifacts run failed at the web image's sourcemap publish step) and v0.8.10 (`published_at`).
- Unblocks the landing changelog test on every PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog metadata notes to clarify release-date sources for versions 0.3.0 and 0.8.9.
  - Added publication timestamps for versions 0.8.9 and 0.8.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->