### PR TITLE
fix(canary): give the budget-edge probe its own deadline

### DIFF
--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -38,9 +38,9 @@ import { CANARY_PROVIDERS } from "./ai-provider-canary-config";
 
 describe("AI provider canary probe deadlines", () => {
   test("gives the budget-edge probe the extended structured-output deadline", () => {
-    expect(
-      canaryCapabilityProbeTimeout("structured-output-budget-edge"),
-    ).toBe(45_000);
+    expect(canaryCapabilityProbeTimeout("structured-output-budget-edge")).toBe(
+      45_000,
+    );
     expect(canaryCapabilityProbeTimeout("structured-output")).toBe(20_000);
     expect(canaryCapabilityProbeTimeout("unknown-probe")).toBeUndefined();
   });

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -16,6 +16,7 @@ import {
   CanaryCredentialRejectedError,
   CanaryProviderRunError,
   CATALOG_SWEEP_BUDGET_MS,
+  canaryCapabilityProbeTimeout,
   catalogModelIds,
   classifyCanaryFailure,
   createPdfCanaryMessages,
@@ -34,6 +35,16 @@ import {
   toolRoundTripPromptForProvider,
 } from "./ai-provider-canary";
 import { CANARY_PROVIDERS } from "./ai-provider-canary-config";
+
+describe("AI provider canary probe deadlines", () => {
+  test("gives the budget-edge probe the extended structured-output deadline", () => {
+    expect(
+      canaryCapabilityProbeTimeout("structured-output-budget-edge"),
+    ).toBe(45_000);
+    expect(canaryCapabilityProbeTimeout("structured-output")).toBe(20_000);
+    expect(canaryCapabilityProbeTimeout("unknown-probe")).toBeUndefined();
+  });
+});
 
 describe("AI provider catalog canary coverage", () => {
   test("declares every selectable model id of a provider exactly once", () => {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -51,6 +51,13 @@ const TOOL_CALL_ROLE = "chat" satisfies ModelRole;
 const CAPABILITY_PROBE_TIMEOUT_MS = 20_000;
 const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
+// The budget-edge probe sends the largest schema the canary knows how to
+// build and asks for one answer per property in it (~4K output tokens at
+// OpenAI's documented 100 000-byte budget), against a grammar the provider
+// compiles for that schema. Every other capability probe answers in one
+// line, so the deadline they share aborts this one mid-generation; it gets
+// the longest deadline the canary already waits on a single call.
+const BUDGET_EDGE_PROBE_TIMEOUT_MS = TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS;
 // A provider's overload response ("high demand", 503) or a slow first
 // answer must not read as a capability regression: three attempts, with the
 // wait growing from 5s to 20s so a short capacity spike has time to pass.
@@ -950,7 +957,7 @@ const capabilityProbes = [
     // constrained-decoding grammar limits here, not in a user's workflow run.
     type: "capability",
     name: "structured-output-budget-edge",
-    timeoutMs: CAPABILITY_PROBE_TIMEOUT_MS,
+    timeoutMs: BUDGET_EDGE_PROBE_TIMEOUT_MS,
     run: async ({ config, provider }, signal) => {
       const modelId = DEFAULT_MODELS[provider][CAPABILITY_ROLE];
       const edge = buildBudgetEdgeSchema({ provider, modelId });

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1052,6 +1052,11 @@ const capabilityProbes = [
   },
 ] as const satisfies readonly CapabilityProbe[];
 
+export const canaryCapabilityProbeTimeout = (
+  name: string,
+): number | undefined =>
+  capabilityProbes.find((probe) => probe.name === name)?.timeoutMs;
+
 const probes = [
   ...modelRoleProbes,
   ...structuredOutputModelRoleProbes,


### PR DESCRIPTION
## Proposed change

`structured-output-budget-edge` (#2811) runs on the 20s deadline the capability probes share, and those probes answer in one line. This one sends the largest schema the canary knows how to build and asks for one answer per property in it: against OpenAI's documented budget that is 74 properties, 99 993 bytes and roughly 4K output tokens, on a grammar the provider compiles for that schema.

In the scheduled run at https://github.com/stella/stella/actions/runs/33715994050 the OpenAI job's three attempts all ended at the deadline (04:42:33, 04:42:58, 04:43:38, each 20s of work plus the 5s and 20s backoff between them), and the probe reported `failed after 3 attempts (timeout)` without learning whether the provider accepts the schema at all.

The probe now gets the 45s the tool round trip probe already waits, the longest deadline the script spends on a single provider call. Nothing else about the probe changes, so a provider that really does reject the schema still fails it.

The same run has unrelated failures this does not touch: Bedrock rejecting the budget-edge schema with "Model produced invalid sequence as part of ToolUse", and several catalog probes.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun --env-file=.env.example test scripts/ai-provider-canary.test.ts scripts/ai-provider-canary-config.test.ts` (50 pass), plus the `tsconfig.scripts.json` typecheck, oxlint and oxfmt on the changed file. The probe itself needs provider credentials, so it is exercised by the next canary run.
- [ ] DARK MODE SUPPORT | Not applicable, no UI in this change.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6pXFFwgMFmWEfj4rq7cwS

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6pXFFwgMFmWEfj4rq7cwS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the timeout for the structured-output budget-edge check to 45 seconds.
  - This allows slower checks more time to complete and reduces the likelihood of false failures during AI provider capability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->