### PR TITLE
fix(ai-catalog): offer Gemini 3.8 Flash

### DIFF
--- a/.changeset/offer-gemini-3-8-flash.md
+++ b/.changeset/offer-gemini-3-8-flash.md
@@ -1,0 +1,5 @@
+---
+"@stll/ai-catalog": patch
+---
+
+Offer Gemini 3.8 Flash with its upstream rates, 1M context window, and generated capabilities.

--- a/packages/ai-catalog/src/capabilities.gen.ts
+++ b/packages/ai-catalog/src/capabilities.gen.ts
@@ -23,6 +23,7 @@ import type {
  */
 export const MODEL_DOCUMENT_INPUT_OPTIONS = {
   google: [
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
@@ -33,6 +34,7 @@ export const MODEL_DOCUMENT_INPUT_OPTIONS = {
   openrouter: [
     "openai/gpt-5.6-luna",
     "openai/gpt-5.6-terra",
+    "google/gemini-3.8-flash",
     "google/gemini-3.7-flash",
     "google/gemini-3.6-flash",
     "google/gemini-3.5-flash-lite",
@@ -90,6 +92,7 @@ export const MODEL_DOCUMENT_INPUT_OPTIONS = {
  * through `resolveReasoningEffort`.
  */
 export const MODEL_REASONING_EFFORTS = {
+  "gemini-3.8-flash": ["low", "medium", "high"],
   "gemini-3.7-flash": ["low", "medium", "high"],
   "gemini-3.6-flash": ["minimal", "low", "medium", "high"],
   "gemini-3.5-flash-lite": ["minimal", "low", "medium", "high"],
@@ -98,6 +101,7 @@ export const MODEL_REASONING_EFFORTS = {
   "gemini-3.1-flash-lite": ["minimal", "low", "medium", "high"],
   "openai/gpt-5.6-luna": ["none", "low", "medium", "high", "xhigh", "max"],
   "openai/gpt-5.6-terra": ["none", "low", "medium", "high", "xhigh", "max"],
+  "google/gemini-3.8-flash": ["low", "medium", "high"],
   "google/gemini-3.7-flash": ["low", "medium", "high"],
   "google/gemini-3.6-flash": ["minimal", "low", "medium", "high"],
   "google/gemini-3.5-flash-lite": ["minimal", "low", "medium", "high"],
@@ -155,6 +159,7 @@ export const MODEL_REASONING_EFFORTS = {
  * a truthful named default, so clients must retain a separate Default choice.
  */
 export const MODEL_DEFAULT_REASONING_EFFORTS = {
+  "gemini-3.8-flash": null,
   "gemini-3.7-flash": null,
   "gemini-3.6-flash": null,
   "gemini-3.5-flash-lite": null,
@@ -163,6 +168,7 @@ export const MODEL_DEFAULT_REASONING_EFFORTS = {
   "gemini-3.1-flash-lite": null,
   "openai/gpt-5.6-luna": "medium",
   "openai/gpt-5.6-terra": "medium",
+  "google/gemini-3.8-flash": "medium",
   "google/gemini-3.7-flash": "medium",
   "google/gemini-3.6-flash": "medium",
   "google/gemini-3.5-flash-lite": "minimal",
@@ -217,6 +223,7 @@ export const MODEL_DEFAULT_REASONING_EFFORTS = {
  * parameters. Consumers must go through `shouldEmitTemperature`.
  */
 export const MODEL_TEMPERATURE_POLICIES = {
+  "gemini-3.8-flash": "omit",
   "gemini-3.7-flash": "omit",
   "gemini-3.6-flash": "omit",
   "gemini-3.5-flash-lite": "omit",
@@ -225,6 +232,7 @@ export const MODEL_TEMPERATURE_POLICIES = {
   "gemini-3.1-flash-lite": "emit",
   "openai/gpt-5.6-luna": "omit",
   "openai/gpt-5.6-terra": "omit",
+  "google/gemini-3.8-flash": "omit",
   "google/gemini-3.7-flash": "omit",
   "google/gemini-3.6-flash": "omit",
   "google/gemini-3.5-flash-lite": "omit",

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -308,6 +308,9 @@ describe("MODEL_RATES economic ordering", () => {
     expect(getModelRate("google/gemini-3.7-flash")).toBe(
       getModelRate("gemini-3.7-flash"),
     );
+    expect(getModelRate("google/gemini-3.8-flash")).toBe(
+      getModelRate("gemini-3.8-flash"),
+    );
   });
 
   test("floating provider pointers do not inherit fixed-model metadata", () => {
@@ -323,6 +326,12 @@ describe("MODEL_RATES economic ordering", () => {
 
   test("canonical model rates match expected amounts", () => {
     expect(getModelRate("gemini-3.6-flash")).toEqual({
+      kind: "flat",
+      inputPerMTok: 75_000,
+      outputPerMTok: 375_000,
+      cachedInputPerMTok: 7500,
+    });
+    expect(getModelRate("gemini-3.8-flash")).toEqual({
       kind: "flat",
       inputPerMTok: 75_000,
       outputPerMTok: 375_000,

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -214,6 +214,7 @@ export const DEFAULT_MODELS = {
  */
 export const BYOK_MODEL_OPTIONS = {
   google: [
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
@@ -245,6 +246,7 @@ export const BYOK_MODEL_OPTIONS = {
   openrouter: [
     "openai/gpt-5.6-luna",
     "openai/gpt-5.6-terra",
+    "google/gemini-3.8-flash",
     "google/gemini-3.7-flash",
     "google/gemini-3.6-flash",
     "google/gemini-3.5-flash-lite",
@@ -307,6 +309,10 @@ export type ModelDisplayMetadata = {
  * creator's icon while their routing provider remains available separately.
  */
 export const MODEL_DISPLAY_METADATA = {
+  "gemini-3.8-flash": {
+    displayName: "Gemini 3.8 Flash",
+    iconProvider: "google",
+  },
   "gemini-3.7-flash": {
     displayName: "Gemini 3.7 Flash",
     iconProvider: "google",
@@ -390,6 +396,10 @@ export const MODEL_DISPLAY_METADATA = {
   "openai/gpt-5.6-terra": {
     displayName: "GPT-5.6 Terra",
     iconProvider: "openai",
+  },
+  "google/gemini-3.8-flash": {
+    displayName: "Gemini 3.8 Flash",
+    iconProvider: "google",
   },
   "google/gemini-3.7-flash": {
     displayName: "Gemini 3.7 Flash",
@@ -975,6 +985,12 @@ export const MODEL_RATES = {
     outputPerMTok: 375_000,
     cachedInputPerMTok: 7500,
   },
+  "gemini-3.8-flash": {
+    kind: "flat",
+    inputPerMTok: 75_000,
+    outputPerMTok: 375_000,
+    cachedInputPerMTok: 7500,
+  },
   "gemini-3.1-pro-preview": {
     kind: "input-token-tiered",
     inputTokenThreshold: 200_000,
@@ -1289,6 +1305,7 @@ export const CONTEXT_WINDOW_TOKENS = {
   "gemini-3.5-flash-lite": 1_048_576,
   "gemini-3.6-flash": 1_048_576,
   "gemini-3.7-flash": 1_048_576,
+  "gemini-3.8-flash": 1_048_576,
   "gemini-3.1-pro-preview": 1_048_576,
   // OpenAI: GPT-4o family 128K; GPT-5 varies by generation.
   "gpt-4o-mini": 128_000,
@@ -1322,6 +1339,7 @@ export const CONTEXT_WINDOW_TOKENS = {
   "magistral-small": 128_000,
   "pixtral-large-latest": 128_000,
   // OpenRouter provider-prefixed slugs mirror their upstream windows.
+  "google/gemini-3.8-flash": 1_048_576,
   "google/gemini-3.7-flash": 1_048_576,
   "google/gemini-3.6-flash": 1_048_576,
   "google/gemini-3.5-flash-lite": 1_048_576,


### PR DESCRIPTION
## Proposed change

The scheduled Model Catalog Upstream Check is red on main
([run](https://github.com/stella/stella/actions/runs/33718992860)):

```
✗ [NEW] google / gemini-3.8-flash — released 2026-09-02; not offered or reviewed
```

`gemini-3.8-flash` is Google's first-party successor to the already offered
`gemini-3.7-flash`: the same `gemini-flash` family, the same 1M input / 64K
output limits, the same published rates ($0.75 input, $3.75 output, $0.075
cache read per MTok), stable rather than preview, and listed by both
models.dev and OpenRouter. Its disposition is therefore to offer it rather
than to record a reviewed exclusion.

- offer it for the `google` and `openrouter` providers, with display metadata
- add its rates and its 1M context window
- regenerate `capabilities.gen.ts` (document input, reasoning efforts,
  temperature policy) from live models.dev and OpenRouter metadata

Role defaults stay on `gemini-3.7-flash`; promoting a default is a separate
decision from offering the model.

Verified with `bun run check:model-catalog` (45 offered IDs, green) and
`bun --filter @stll/ai-catalog test`.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: catalogue data, no UI change.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no visible change beyond a new picker entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvCvrR6A7j5USNiEyTZ84w

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvCvrR6A7j5USNiEyTZ84w)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Gemini 3.8 Flash model in the AI catalogue.
  * Gemini 3.8 Flash is available through Google BYOK and OpenRouter.
  * Added model details including pricing, capabilities, and a context window of up to 1 million tokens.

* **Documentation**
  * Added release metadata documenting Gemini 3.8 Flash and its upstream rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->