### PR TITLE
fix(case-law): keep body text an Aspose page header is glued to

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -278,6 +278,38 @@ describe("parseNssDecisionHtml", () => {
       // The page-one header carries the case number, which is content.
       expect(texts).toContain("58 A 65/2012-46");
     });
+
+    /**
+     * The letter-first registers carry no leading panel number at all
+     * (`Konf`, `Nad`), so a running header built around one leaves the header
+     * in the AST and hides the numbered-paragraph prefix behind it.
+     */
+    const letterFirstHtml = `<html><body>
+      <p style="text-align:center">
+        <span style="font-weight:bold">ROZSUDEK</span>
+      </p>
+      <p style="text-align:center">
+        <span style="font-weight:bold">Odůvodnění:</span>
+      </p>
+      <p>[OBRÁZEK][OBRÁZEK]pokračování 2 Konf 4/2011 [3] Zvláštní senát rozhodl o kompetenčním sporu.</p>
+      <p>[OBRÁZEK][OBRÁZEK]pokračování 3 Nad 224/2014-53 [4] Věc byla přikázána jinému soudu.</p>
+      <p>[OBRÁZEK][OBRÁZEK]pokračování 4 Konf 4/2011</p>
+    </body></html>`;
+
+    test("peels a running header whose docket is letter-first", () => {
+      const { documentAst, fulltext } = parseNssDecisionHtml(
+        baseInput(letterFirstHtml),
+      );
+      const texts = documentAst.blocks.map((b) => b.plainText);
+
+      // Body text survives, and with the header peeled the numbered-paragraph
+      // prefix behind it is recognised, so "[3]" becomes the block's number
+      // rather than staying in its text.
+      expect(fulltext).toContain("Zvláštní senát rozhodl o kompetenčním sporu");
+      expect(fulltext).toContain("Věc byla přikázána jinému soudu");
+      expect(texts.some((t) => t.includes("pokračování"))).toBe(false);
+      expect(texts.some((t) => t.includes("Konf 4/2011"))).toBe(false);
+    });
   });
 
   describe("section separators", () => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -232,6 +232,52 @@ describe("parseNssDecisionHtml", () => {
       const texts = documentAst.blocks.map((b) => b.plainText);
       expect(texts.some((t) => t === "pokračování")).toBe(false);
     });
+
+    /**
+     * Aspose sets a page's emblem and running header inside the first
+     * paragraph of that page's body rather than as their own paragraph, so a
+     * page opening mid-sentence carries the whole of that paragraph behind
+     * the furniture. Dropping the chunk for starting with "[OBRÁZEK]" lost
+     * every such page: whole reasoning paragraphs absent from the AST while
+     * present in the source.
+     */
+    const pagedHtml = `<html><body>
+      <p style="text-align:center">[OBRÁZEK]58 A 65/2012-46</p>
+      <p style="text-align:center">
+        <span style="font-weight:bold">ROZSUDEK</span>
+      </p>
+      <p style="text-align:center">
+        <span style="font-weight:bold">Odůvodnění:</span>
+      </p>
+      <p>[OBRÁZEK][OBRÁZEK]pokračování 3 58 A 65/2012 [3] Žalovaný ve svém
+      vyjádření k žalobě popřel oprávněnost žaloby.</p>
+      <p>[OBRÁZEK][OBRÁZEK]pokračování 4 58 A 65/2012</p>
+      <p>[OBRÁZEK][OBRÁZEK]Státní hranici překročil v úkrytu.</p>
+      <p>[OBRÁZEK]ČESKÁ REPUBLIKA</p>
+    </body></html>`;
+
+    test("keeps body text a page header is glued to", () => {
+      const { documentAst, fulltext } = parseNssDecisionHtml(
+        baseInput(pagedHtml),
+      );
+      const texts = documentAst.blocks.map((b) => b.plainText);
+
+      expect(fulltext).toContain("popřel oprávněnost žaloby");
+      expect(fulltext).toContain("Státní hranici překročil v úkrytu");
+      // The furniture itself is peeled off the text it was glued to.
+      expect(texts.some((t) => t.includes("[OBRÁZEK]"))).toBe(false);
+      expect(texts.some((t) => t.includes("pokračování"))).toBe(false);
+    });
+
+    test("still drops a chunk holding nothing but page furniture", () => {
+      const { documentAst } = parseNssDecisionHtml(baseInput(pagedHtml));
+      const texts = documentAst.blocks.map((b) => b.plainText);
+
+      expect(texts).not.toContain("pokračování 4 58 A 65/2012");
+      expect(texts).not.toContain("ČESKÁ REPUBLIKA");
+      // The page-one header carries the case number, which is content.
+      expect(texts).toContain("58 A 65/2012-46");
+    });
   });
 
   describe("section separators", () => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -561,9 +561,14 @@ const parseFontSize = (style: string): number => {
  * its own paragraph, so the furniture is peeled off the chunk instead of the
  * chunk being dropped for starting with it. Every part is optional, so an
  * ordinary paragraph matches the empty string and is left alone.
+ *
+ * The docket's leading panel number is optional because the letter-first
+ * registers have none: `Konf 4/2011`, `Nad 224/2014`. Same shape the citation
+ * extractor accepts, and the `pokračování` literal is what keeps the optional
+ * digits from reaching ordinary prose.
  */
 const PAGE_FURNITURE_RE =
-  /^(?:\[OBRÁZEK\]\s*)*(?:pokračování\s+\d+\s+\d+\s*\p{Lu}\p{L}*\s+\d+\/\d{4}(?:\s*-\s*\d+)?)?\s*/u;
+  /^(?:\[OBRÁZEK\]\s*)*(?:pokračování\s+\d+\s+(?:\d+\s*)?\p{Lu}\p{L}*\s+\d+\/\d{4}(?:\s*-\s*\d+)?)?\s*/u;
 
 /** Decorative lines carrying no content once the furniture is peeled. */
 const DECORATIVE_LINE_RE = /^(?:pokračování|ČESKÁ REPUBLIKA)$/u;

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -41,6 +41,7 @@ import {
 } from "./cz-patterns";
 import {
   inlinesToPlainText,
+  stripFurniturePrefix,
   stripInlinePrefix,
   walkInlines as walkInlinesShared,
 } from "./shared-inlines";
@@ -552,11 +553,39 @@ const parseFontSize = (style: string): number => {
 // ── Patterns ───────────────────────────────────────────────
 
 /**
- * Lines to skip entirely (decorative/header content).
- * [OBRÁZEK] is always dropped regardless of suffix
- * (e.g. "[OBRÁZEK]ČESKÁ REPUBLIKA" in one <p>).
+ * Page furniture Aspose repeats at the top of every page: image placeholders
+ * for the court emblem, then the running header "pokračování <page> <case
+ * number>" on every page after the first.
+ *
+ * It is glued to the first paragraph of the page's body rather than set as
+ * its own paragraph, so the furniture is peeled off the chunk instead of the
+ * chunk being dropped for starting with it. Every part is optional, so an
+ * ordinary paragraph matches the empty string and is left alone.
  */
-const SKIP_RE = /^\[OBRÁZEK\]|^pokračování$|^ČESKÁ REPUBLIKA$/u;
+const PAGE_FURNITURE_RE =
+  /^(?:\[OBRÁZEK\]\s*)*(?:pokračování\s+\d+\s+\d+\s*\p{Lu}\p{L}*\s+\d+\/\d{4}(?:\s*-\s*\d+)?)?\s*/u;
+
+/** Decorative lines carrying no content once the furniture is peeled. */
+const DECORATIVE_LINE_RE = /^(?:pokračování|ČESKÁ REPUBLIKA)$/u;
+
+type ChunkContent = { plainText: string; inlines: Inline[] };
+
+/**
+ * Peel page furniture off a chunk, or report it as wholly decorative.
+ *
+ * Null means nothing but furniture was in the chunk. Anything else is body
+ * text that shared a paragraph with the header, which is the common case: a
+ * page opening mid-sentence carries the whole of that page's first paragraph
+ * behind the emblem.
+ */
+const stripPageFurniture = (chunk: PChunk): ChunkContent | null => {
+  const inlines = stripFurniturePrefix(chunk.inlines, PAGE_FURNITURE_RE);
+  const plainText = inlinesToPlainText(inlines).trim();
+
+  return plainText && !DECORATIVE_LINE_RE.test(plainText)
+    ? { plainText, inlines }
+    : null;
+};
 
 /**
  * Decision titles keyed by their semantic letters. Older Aspose exports split
@@ -659,18 +688,13 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
   let sawTitle = false;
 
   for (const chunk of chunks) {
-    const {
-      plainText,
-      inlines,
-      centered,
-      bold,
-      letterSpacing: _letterSpacing,
-    } = chunk;
+    const { centered, bold, letterSpacing: _letterSpacing } = chunk;
 
-    // Skip decorative lines
-    if (SKIP_RE.test(plainText)) {
+    const content = stripPageFurniture(chunk);
+    if (content === null) {
       continue;
     }
+    const { plainText, inlines } = content;
 
     if (chunk.footnote !== null) {
       // A footnote the publisher set over several paragraphs arrives as

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.test.ts
@@ -437,6 +437,33 @@ describe("parseUsDecisionHtml", () => {
       expect(texts).not.toContain("Česká republika");
     });
 
+    test("keeps text the emblem placeholder is glued to", () => {
+      const rtf = [
+        "[OBRÁZEK]Česká republika",
+        "\\par",
+        "[OBRÁZEK][OBRÁZEK]Ústavní soud návrhu vyhověl.",
+        "\\par",
+        "V Brně dne 1. ledna 2025",
+      ].join("\n");
+
+      const html = `
+        <html><body>
+          <span id="lblDecisionForm">NÁLEZ</span>
+          <input id="docContentHidden" value="${rtf}" />
+          <input id="docIdHidden" value="12345" />
+          <div class="DocContent"><p>Text</p></div>
+        </body></html>
+      `;
+
+      const { documentAst, fulltext } = parseUsDecisionHtml(baseInput(html));
+      const texts = documentAst.blocks.map((b) => b.plainText);
+
+      expect(fulltext).toContain("Ústavní soud návrhu vyhověl");
+      expect(texts.some((t) => t.includes("[OBRÁZEK]"))).toBe(false);
+      // The emblem glued to a decorative line leaves nothing to keep.
+      expect(texts).not.toContain("Česká republika");
+    });
+
     test("skips ČESKÁ REPUBLIKA decorative line", () => {
       const rtf = [
         "ČESKÁ REPUBLIKA",

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
@@ -60,7 +60,11 @@ import {
   CZ_JUDGE_NAME_RE as JUDGE_NAME_RE,
   CZ_JUDGE_TITLE_RE as SIGNATURE_RE,
 } from "./cz-patterns";
-import { inlinesToPlainText, stripInlinePrefix } from "./shared-inlines";
+import {
+  inlinesToPlainText,
+  stripFurniturePrefix,
+  stripInlinePrefix,
+} from "./shared-inlines";
 
 // ── Public API ─────────────────────────────────────────────
 
@@ -436,8 +440,14 @@ const extractLines = ($: cheerio.CheerioAPI): ParsedLine[] => {
 
 // ── Patterns ───────────────────────────────────────────────
 
-/** Decorative lines to skip entirely. */
-const SKIP_RE = /^\[OBRÁZEK\]|^Česká republika$|^ČESKÁ REPUBLIKA$/u;
+/**
+ * Image placeholders for the court emblem, which the export glues to the
+ * start of whatever line follows them rather than setting on their own.
+ */
+const EMBLEM_PREFIX_RE = /^(?:\[OBRÁZEK\]\s*)*/u;
+
+/** Decorative lines carrying no content once the emblem is peeled. */
+const DECORATIVE_LINE_RE = /^(?:Česká republika|ČESKÁ REPUBLIKA)$/u;
 
 /** Decision title (level 1). */
 const TITLE_RE =
@@ -501,15 +511,16 @@ const classifyLines = (lines: readonly ParsedLine[]): Block[] => {
     if (consumedLines.has(line)) {
       continue;
     }
-    const { plainText, inlines } = line;
-
     // Skip empty sentinel lines (paragraph breaks)
-    if (!plainText) {
+    if (!line.plainText) {
       continue;
     }
 
-    // Skip decorative lines
-    if (SKIP_RE.test(plainText)) {
+    // Peel the emblem rather than dropping the line it is glued to, then skip
+    // what turns out to have been decoration and nothing else.
+    const inlines = stripFurniturePrefix(line.inlines, EMBLEM_PREFIX_RE);
+    const plainText = inlinesToPlainText(inlines).trim();
+    if (!plainText || DECORATIVE_LINE_RE.test(plainText)) {
       continue;
     }
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
@@ -379,3 +379,28 @@ export const stripInlinePrefix = (
 
   return trimLeadingWhitespace(result);
 };
+
+/**
+ * Strip a leading run of presentational page furniture, matched by `pattern`
+ * against the chunk's own plain text.
+ *
+ * Aspose glues a page's running header onto the first paragraph of that
+ * page's body, so a chunk that *starts* with furniture usually carries body
+ * text behind it. Peeling the prefix and letting the caller judge the
+ * remainder keeps that text, where testing the whole chunk against the same
+ * pattern and dropping it loses the page. `pattern` is matched from the first
+ * non-whitespace character, so it anchors with `^` and needs no allowance for
+ * the leading whitespace an inline walk may leave.
+ */
+export const stripFurniturePrefix = (
+  inlines: readonly Inline[],
+  pattern: RegExp,
+): Inline[] => {
+  const text = inlinesToPlainText(inlines);
+  const lead = text.length - text.trimStart().length;
+  const match = pattern.exec(text.slice(lead))?.at(0);
+
+  return match === undefined || match.length === 0
+    ? [...inlines]
+    : stripInlinePrefix(inlines, lead + match.length);
+};

--- a/bun.lock
+++ b/bun.lock
@@ -966,7 +966,7 @@
     "expo-modules-core": "57.0.14",
     "fast-uri": "3.1.6",
     "fast-xml-parser": "5.10.1",
-    "ip-address": "10.5.0",
+    "ip-address": "10.7.0",
     "lucide-react": "1.30.0",
     "nanoid": "3.3.18",
     "postcss": "8.5.25",
@@ -3860,7 +3860,7 @@
 
     "ioredis": ["ioredis@6.0.0", "", { "dependencies": { "@ioredis/commands": "2.0.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "standard-as-callback": "2.1.0" } }, "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w=="],
 
-    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
+    "ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "expo-modules-core": "57.0.14",
     "fast-uri": "3.1.6",
     "fast-xml-parser": "5.10.1",
-    "ip-address": "10.5.0",
+    "ip-address": "10.7.0",
     "lucide-react": "1.30.0",
     "nanoid": "3.3.18",
     "postcss": "8.5.25",


### PR DESCRIPTION
## What

The Czech Aspose exports do not set a page's furniture as its own paragraph. The court emblem arrives as one or more `[OBRÁZEK]` image placeholders, and on NSS pages after the first the running header `pokračování {page} {case number}` follows it, both inside the *first paragraph of that page's body*. A page that opens mid-sentence therefore carries the whole of that paragraph behind the furniture.

Both parsers tested the entire chunk against a skip pattern whose `[OBRÁZEK]` branch is anchored only at the start:

```ts
// cz-nss.ts
const SKIP_RE = /^\[OBRÁZEK\]|^pokračování$|^ČESKÁ REPUBLIKA$/u;
// cz-us.ts
const SKIP_RE = /^\[OBRÁZEK\]|^Česká republika$|^ČESKÁ REPUBLIKA$/u;
```

so every such paragraph was dropped whole. The comment above the cz-nss one records the intent — *"[OBRÁZEK] is always dropped regardless of suffix (e.g. `[OBRÁZEK]ČESKÁ REPUBLIKA` in one `<p>`)"* — which is right for a decorative suffix and wrong for a paragraph of reasoning. On a multi-page judgment that is most of the document: absent from the AST while present in the source, which is exactly what rule 10 forbids.

A worked example, one paragraph from a ten-page judgment, dropped in full today:

```
[OBRÁZEK][OBRÁZEK]pokračování 3 58 A 65/2012 [3] Žalovaný ve svém vyjádření
k žalobě popřel oprávněnost žaloby, odkázal na svůj správní spis. …
```

## How

`stripFurniturePrefix` peels the furniture off the chunk; the caller then judges what is left and drops the chunk only when nothing else was in it. It lives in `shared-inlines` next to `stripInlinePrefix`, which it delegates to, because the prefix has to come off the inline tree as well as the plain text.

- **cz-nss** matches emblem placeholders plus the optional running header as one prefix. Every part is optional, so an ordinary paragraph matches the empty string and is left alone. The docket's leading panel number is optional too, because the letter-first registers have none (`Konf 4/2011`, `Nad 224/2014`) — the same shape `citation-extractor.ts` already accepts.
- **cz-us** matches the emblem placeholders alone; its RTF source has no running header.
- Both keep the decorative-line check for what remains, so `[OBRÁZEK]ČESKÁ REPUBLIKA` and a chunk holding only `pokračování 4 58 A 65/2012` are still dropped.

One behaviour change beyond the recovered text: the page-one header carries the case number, which is content, so it now reaches the case-number branch instead of being discarded.

## Tests

Four regression tests, each verified to fail without the corresponding change:

- `cz-nss` keeps body text a page header is glued to, and the furniture itself does not reach the AST
- `cz-nss` still drops a chunk holding nothing but furniture, while keeping the page-one case number
- `cz-nss` peels a running header whose docket is letter-first, including the header-only chunk
- `cz-us` keeps text the emblem placeholder is glued to

Checked against real published documents rather than only synthetic fixtures: on two NSS-hosted regional judgments the pattern drops 11 of 72 and 8 of 48 chunks, 4,173 and 10,488 characters, and the words the AST validator reports missing appear verbatim inside the dropped chunks.

`typecheck`, `oxlint` and `format` clean; parser, `shared-inlines` and `oxlint-guardrails` suites pass (155 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwDP3nmzffCU1yYxSNS6Jw