### PR TITLE
feat(ui): context menu in the kit, centred rail icons, denser lanes

### DIFF
--- a/.changeset/context-menu-rail-density.md
+++ b/.changeset/context-menu-rail-density.md
@@ -1,0 +1,7 @@
+---
+"@stll/ui": minor
+---
+
+- `@stll/ui/context-menu`: the right-click `ContextMenu` (actions with icons, submenus, separators, a `checked` mark, and `closeOnClick` for toggles) moves from the app into the kit.
+- `SidebarMenuButton` `size="rail"` centres its icon while the sidebar is collapsed: the label leaves the flow instead of only fading out.
+- `KanbanSubgroupBoard` spends one row on an open lane's chrome instead of two: the per-column count row now renders only while a lane is collapsed (an open lane shows its cells, and a folded band's slot carries its own count), and the header and lane paddings tighten.

--- a/apps/web/src/components/catalogue/catalogue-row.tsx
+++ b/apps/web/src/components/catalogue/catalogue-row.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "use-intl";
 
+import { ContextMenu, type ContextMenuAction } from "@stll/ui/context-menu";
 import { cn } from "@stll/ui/utils";
 
 import {
@@ -9,7 +10,6 @@ import {
 } from "@/components/catalogue/catalogue-badges";
 import { CatalogueEntryIcon } from "@/components/catalogue/catalogue-entry-icon";
 import { nativeToolLabelKey } from "@/components/catalogue/native-tool-label";
-import { ContextMenu, type ContextMenuAction } from "@/components/context-menu";
 
 /**
  * Minimal display fields shared by onboarding (`LoadedCatalogueEntry`)

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -17,6 +17,7 @@ import { useTranslations } from "use-intl";
 
 import { EU_MEMBER_STATES } from "@stll/catalogue";
 import { Button } from "@stll/ui/button";
+import type { ContextMenuAction } from "@stll/ui/context-menu";
 import {
   InputGroup,
   InputGroupAddon,
@@ -32,7 +33,6 @@ import {
   type CatalogueRowDisplay,
 } from "@/components/catalogue/catalogue-row";
 import { nativeToolLabelKey } from "@/components/catalogue/native-tool-label";
-import type { ContextMenuAction } from "@/components/context-menu";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
 import { useInspectorView } from "@/components/inspector/use-inspector-view";
 import { McpIcon } from "@/components/mcp-icon";

--- a/apps/web/src/routes/_protected.knowledge/-components/category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/category-sidebar.tsx
@@ -19,6 +19,8 @@ import {
   AlertDialogTitle,
 } from "@stll/ui/alert-dialog";
 import { Button } from "@stll/ui/button";
+import { ContextMenu } from "@stll/ui/context-menu";
+import type { ContextMenuAction } from "@stll/ui/context-menu";
 import {
   Dialog,
   DialogClose,
@@ -37,8 +39,6 @@ import {
 } from "@stll/ui/menu";
 import { cn } from "@stll/ui/utils";
 
-import { ContextMenu } from "@/components/context-menu";
-import type { ContextMenuAction } from "@/components/context-menu";
 import { detached } from "@/lib/detached";
 
 // ── Types ────────────────────────────────────────────

--- a/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
@@ -37,6 +37,8 @@ import {
   ComboboxList,
   ComboboxPopup,
 } from "@stll/ui/combobox";
+import { ContextMenu } from "@stll/ui/context-menu";
+import type { ContextMenuAction } from "@stll/ui/context-menu";
 import {
   Dialog,
   DialogClose,
@@ -62,8 +64,6 @@ import { Textarea } from "@stll/ui/textarea";
 import { stellaToast } from "@stll/ui/toast";
 import { cn } from "@stll/ui/utils";
 
-import { ContextMenu } from "@/components/context-menu";
-import type { ContextMenuAction } from "@/components/context-menu";
 import Tooltip from "@/components/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
 import { EntityKindIcon } from "@/components/workspaces/entity-kind-icon";

--- a/apps/web/src/routes/onboarding/-components/steps/catalogue-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/catalogue-step.tsx
@@ -18,6 +18,7 @@ import {
   type LoadedCatalogueEntry,
 } from "@stll/catalogue";
 import { Button } from "@stll/ui/button";
+import type { ContextMenuAction } from "@stll/ui/context-menu";
 import { Form } from "@stll/ui/form";
 import {
   InputGroup,
@@ -33,7 +34,6 @@ import {
   type CatalogueRowDisplay,
 } from "@/components/catalogue/catalogue-row";
 import { nativeToolLabelKey } from "@/components/catalogue/native-tool-label";
-import type { ContextMenuAction } from "@/components/context-menu";
 import { useLocale } from "@/i18n/formatting-context";
 import { compareByLocale } from "@/lib/collation";
 import type { PracticeJurisdiction } from "@/lib/jurisdictions";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
     "./combobox": "./src/components/combobox.tsx",
     "./command": "./src/components/command.tsx",
     "./composer": "./src/components/composer.tsx",
+    "./context-menu": "./src/components/context-menu.tsx",
     "./control-size": "./src/lib/control-size.ts",
     "./calendar": "./src/calendar/index.ts",
     "./data-table": "./src/data-table/index.ts",

--- a/packages/ui/src/components/context-menu.test.tsx
+++ b/packages/ui/src/components/context-menu.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { ContextMenu } from "./context-menu";
+
+describe("ContextMenu", () => {
+  test("renders only its children when there are no actions", () => {
+    const markup = renderToStaticMarkup(
+      <ContextMenu actions={[]}>
+        <span data-testid="content">content</span>
+      </ContextMenu>,
+    );
+
+    expect(markup).toBe('<span data-testid="content">content</span>');
+  });
+
+  test("wraps the children in a right-click trigger when there are actions", () => {
+    const markup = renderToStaticMarkup(
+      <ContextMenu actions={[{ label: "Rename", onClick: () => undefined }]}>
+        <span data-testid="content">content</span>
+      </ContextMenu>,
+    );
+
+    expect(markup).toContain('data-slot="context-menu-trigger"');
+    expect(markup).toContain('data-testid="content"');
+  });
+});

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -1,16 +1,19 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
 
+import { cn } from "../lib/utils";
 import {
+  MenuCheckboxItem,
   MenuItem,
   MenuPopup,
   MenuSeparator,
   MenuSub,
   MenuSubPopup,
   MenuSubTrigger,
-} from "@stll/ui/menu";
-import { cn } from "@stll/ui/utils";
+} from "./menu";
 
 export type ContextMenuAction = {
   label: string;
@@ -18,14 +21,19 @@ export type ContextMenuAction = {
   onClick?: () => void;
   variant?: "default" | "destructive";
   disabled?: boolean;
+  /** Set on a toggle-style action: it renders as a checkbox item whose
+   *  state assistive technology can read. `onClick` flips it. */
   checked?: boolean;
   submenu?: readonly ContextMenuAction[];
   /** Draw a divider above this item — e.g. to set a trailing "New …" action
    *  apart from the list of existing choices above it. */
   separatorBefore?: boolean;
+  /** Keep the menu open after the click, for a toggle the user may flip
+   *  several of in a row. */
+  closeOnClick?: boolean;
 };
 
-type ContextMenuProps = {
+export type ContextMenuProps = {
   actions: readonly ContextMenuAction[];
   children: ReactNode;
 };
@@ -47,17 +55,20 @@ type ContextMenuProps = {
 export const ContextMenu = ({
   actions,
   children,
-}: ContextMenuProps): React.ReactNode => {
+}: ContextMenuProps): ReactNode => {
   if (actions.length === 0) {
     return children;
   }
 
   return (
     <ContextMenuPrimitive.Root>
-      <ContextMenuPrimitive.Trigger render={<div className="contents" />}>
+      <ContextMenuPrimitive.Trigger
+        data-slot="context-menu-trigger"
+        render={<div className="contents" />}
+      >
         {children}
       </ContextMenuPrimitive.Trigger>
-      <MenuPopup>
+      <MenuPopup data-slot="context-menu-popup">
         {actions.map((action) => (
           <ContextMenuActionItem action={action} key={action.label} />
         ))}
@@ -88,11 +99,31 @@ const ContextMenuActionItem = ({ action }: { action: ContextMenuAction }) => {
     );
   }
 
+  if (action.checked !== undefined) {
+    // A toggle is a checkbox item, so assistive technology reads its state
+    // (`menuitemcheckbox` with `aria-checked`) rather than a bare glyph.
+    return (
+      <>
+        {separator}
+        <MenuCheckboxItem
+          checked={action.checked}
+          closeOnClick={action.closeOnClick ?? true}
+          disabled={action.disabled === true}
+          onCheckedChange={() => action.onClick?.()}
+        >
+          {action.icon}
+          {action.label}
+        </MenuCheckboxItem>
+      </>
+    );
+  }
+
   return (
     <>
       {separator}
       <MenuItem
         className={cn(action.variant === "destructive" && "text-destructive")}
+        closeOnClick={action.closeOnClick ?? true}
         disabled={action.disabled === true}
         onClick={action.onClick}
       >

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -580,7 +580,10 @@ const sidebarMenuButtonVariants = cva(
         lg: "h-12 text-sm",
         /** A 44px target in both states, for a sidebar that stands in for
          * the application rail on touch and hybrid devices. */
-        rail: "h-11 text-sm group-data-[collapsible=icon]:size-11! group-data-[collapsible=icon]:justify-center",
+        // Collapsed, the label leaves the layout flow (not just its
+        // opacity) so the icon centres in the 44px cell, while `sr-only`
+        // keeps it as the button's accessible name.
+        rail: "h-11 text-sm group-data-[collapsible=icon]:size-11! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:[&>span:last-child]:sr-only",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -100,13 +100,17 @@ describe("KanbanSubgroupBoard", () => {
     const expanded = renderBoard(matrix, true);
 
     expect(collapsed).toContain("lane:lin:0");
-    expect(collapsed).toContain('data-kanban-lane-column-count="1"');
+    // Only the collapsed (empty) lanes carry a count row; the open lane
+    // shows its cells instead.
     expect(collapsed).toContain('data-kanban-lane-column-count="0"');
+    expect(collapsed).not.toContain('data-kanban-lane-column-count="1"');
     expect(collapsed).not.toContain("cell:lin:open:0");
     expect(collapsed).toContain('aria-expanded="false"');
     expect(expanded).toContain("cell:lin:open:0");
     expect(expanded).toContain("cell:lin:done:0");
-    expect(expanded).toContain('data-kanban-lane-column-count="0"');
+    // An open lane shows its cells; the count row stands in only while
+    // the lane is collapsed.
+    expect(expanded).not.toContain("data-kanban-lane-column-count");
   });
 
   test("renders one board row when subgrouping is absent", () => {
@@ -302,9 +306,10 @@ describe("KanbanSubgroupBoard with column bands", () => {
     // The band's column headers and cells are gone from the flow...
     expect(markup).not.toContain("column:open:1");
     expect(markup).not.toContain("cell:ada:open:1");
-    // ...replaced by one folded slot per lane carrying both hidden cells.
+    // ...replaced by one folded slot per lane carrying both hidden cells;
+    // the slot carries its own count, so the open lane adds no count row.
     expect(markup).toContain("folded:ada:todo:2:2");
-    expect(markup).toContain('data-kanban-lane-column-count="2"');
+    expect(markup).not.toContain("data-kanban-lane-column-count");
     // Columns outside the band are untouched.
     expect(markup).toContain("column:done:1");
     expect(markup).toContain("cell:ada:done:1");

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -551,12 +551,9 @@ export const KanbanSubgroupBoard = <TRow,>({
   return (
     <div className={cn("h-full overflow-auto px-4 pb-4", className)}>
       <div className="min-w-max">
-        <div className="bg-background sticky top-0 z-20 pt-4 pb-3">
+        <div className="bg-background sticky top-0 z-20 pt-2 pb-2">
           {hasBands ? (
-            <div
-              className="flex items-end gap-3 pb-1.5"
-              data-kanban-band-row=""
-            >
+            <div className="flex items-end gap-3 pb-1" data-kanban-band-row="">
               {spans.map((span) => {
                 const band = span.band;
                 if (band === null) {
@@ -664,7 +661,7 @@ export const KanbanSubgroupBoard = <TRow,>({
 
           return (
             <section
-              className="border-border/60 border-b py-2 first:pt-0 last:border-b-0"
+              className="border-border/60 border-b py-1 first:pt-0 last:border-b-0"
               key={groupValueKey(group.value)}
             >
               <div className="bg-background/95 sticky start-0 z-10 flex min-h-11 items-center backdrop-blur-sm">
@@ -689,23 +686,28 @@ export const KanbanSubgroupBoard = <TRow,>({
                 </button>
               </div>
 
-              {renderRow({
-                label: "Lane column counts",
-                renderColumn: (column) => {
-                  const columnRows = cellFor(column)?.rows.length ?? 0;
-                  return (
-                    <div
-                      className="px-3"
-                      data-kanban-lane-column-count={columnRows}
-                    >
-                      <span className="text-muted-foreground text-xs tabular-nums">
-                        {formatCount(columnRows)}
-                      </span>
-                    </div>
-                  );
-                },
-                renderFoldedBand: (_band, span) => foldedCount(span, cells),
-              })}
+              {/* Per-column counts stand in for the cells only while the
+               * lane is collapsed. An open lane shows its cells, and a
+               * folded band's slot already carries its own count, so the
+               * extra row would only push the cards down. */}
+              {collapsed &&
+                renderRow({
+                  label: "Lane column counts",
+                  renderColumn: (column) => {
+                    const columnRows = cellFor(column)?.rows.length ?? 0;
+                    return (
+                      <div
+                        className="px-3"
+                        data-kanban-lane-column-count={columnRows}
+                      >
+                        <span className="text-muted-foreground text-xs tabular-nums">
+                          {formatCount(columnRows)}
+                        </span>
+                      </div>
+                    );
+                  },
+                  renderFoldedBand: (_band, span) => foldedCount(span, cells),
+                })}
 
               {!collapsed &&
                 renderRow({


### PR DESCRIPTION
- `@stll/ui/context-menu`: the app's `ContextMenu` lifted into the kit (plus `checked` mark and `closeOnClick` for toggles); app imports repointed.
- `SidebarMenuButton` `size="rail"`: label leaves the flow when collapsed, so the icon is centred in the 44px cell.
- `KanbanSubgroupBoard`: lane caption and per-column counts share one row; header and lane paddings tightened.
- `@stll/ui` minor.
