### PR TITLE
chore(deps): raise the ip-address resolution pin to 10.7.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -966,7 +966,7 @@
     "expo-modules-core": "57.0.14",
     "fast-uri": "3.1.6",
     "fast-xml-parser": "5.10.1",
-    "ip-address": "10.5.0",
+    "ip-address": "10.7.0",
     "lucide-react": "1.30.0",
     "nanoid": "3.3.18",
     "postcss": "8.5.25",
@@ -3860,7 +3860,7 @@
 
     "ioredis": ["ioredis@6.0.0", "", { "dependencies": { "@ioredis/commands": "2.0.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "standard-as-callback": "2.1.0" } }, "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w=="],
 
-    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
+    "ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "expo-modules-core": "57.0.14",
     "fast-uri": "3.1.6",
     "fast-xml-parser": "5.10.1",
-    "ip-address": "10.5.0",
+    "ip-address": "10.7.0",
     "lucide-react": "1.30.0",
     "nanoid": "3.3.18",
     "postcss": "8.5.25",


### PR DESCRIPTION
- Raise the root `resolutions` pin for `ip-address` from 10.5.0 to 10.7.0 so it satisfies apps/api's `^10.7.0` floor.
- Reinstalled to refresh `bun.lock`; `check-resolution-ranges.ts` and `check-lockfile-workspace-versions.ts` both pass.
