### PR TITLE
fix(ci): publish the release and advance latest aliases only after promotion

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -40,11 +40,12 @@ concurrency:
 jobs:
   resolve:
     # Only a successful Release Artifacts run may trigger the desktop
-    # publication path. Release Artifacts creates the GitHub Release before
-    # promotion, so accepting `failure` here would let a failed production
-    # promotion reach the latest and CDN publication steps below. Manual
-    # dispatch remains available for recovery, but its stable path is gated
-    # by the post-build production verification job.
+    # publication path. Release Artifacts publishes the GitHub Release only
+    # after production promotion is verified, so a failed run leaves a draft;
+    # accepting `failure` here would attach installers to that draft and
+    # reach the CDN publication steps below. Manual dispatch remains
+    # available for recovery, but its stable path is gated by the post-build
+    # production verification job.
     #
     # Skip `cancelled` (a newer release.yml run replaced it; that newer run
     # will trigger us instead) and `skipped` (release.yml never actually ran,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -655,6 +655,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [resolve, build, prepare-web-image, smoke]
+    outputs:
+      api-image-digest: ${{ steps.manifest.outputs.digest }}
     permissions:
       contents: write
       packages: write
@@ -883,27 +885,27 @@ jobs:
           } > NOTES.with-manual.md
           mv NOTES.with-manual.md NOTES.md
 
-      - name: Publish GitHub release manifest
+      - name: Create draft GitHub release with the manifest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: |
+          # A draft: absent from /releases, the public API and
+          # /releases/latest until the promote job for its channel has
+          # verified that the environment serves this commit and publishes
+          # it. A failed promotion therefore leaves an immutable tag,
+          # immutable images and a draft, and the previous release stays
+          # what users see. `gh` resolves a draft by its tag, so a rerun
+          # reuses the object; a release already published by an earlier
+          # run is left as it is. Beta and alpha tags promote nowhere, so
+          # nothing would publish their draft: they are published here.
           if ! gh release view "$RELEASE_REF" >/dev/null 2>&1; then
             extra_args=()
-            if [[ "$RELEASE_REF" == *-* ]]; then
-              extra_args+=(--prerelease)
-            else
-              # Defer the "latest" flag until release-desktop.yml has
-              # uploaded the signed installers. Without this, GitHub
-              # auto-promotes the new stable release on creation, but
-              # the desktop build runs as a workflow_run trigger and
-              # takes another ~25 min — during that window
-              # /releases/latest/download/Stella-macos-universal.dmg
-              # 404s for end users. release-desktop.yml flips the
-              # flag in its final step, after both Mac + Windows
-              # signed installers are attached to the release.
-              extra_args+=(--latest=false)
-            fi
+            case "$RELEASE_REF" in
+              *-rc.*) extra_args+=(--draft --prerelease) ;;
+              *-*) extra_args+=(--prerelease) ;;
+              *) extra_args+=(--draft) ;;
+            esac
             gh release create "$RELEASE_REF" \
               --title "$RELEASE_REF" \
               --notes-file NOTES.md \
@@ -911,21 +913,6 @@ jobs:
               "${extra_args[@]}"
           fi
           gh release upload "$RELEASE_REF" release-manifest.json --clobber
-
-      - name: Advance stable image tags
-        if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
-        env:
-          API_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          API_IMAGE_DIGEST: ${{ steps.manifest.outputs.digest }}
-          WEB_IMAGE: ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}
-          WEB_IMAGE_DIGEST: ${{ needs.prepare-web-image.outputs.digest }}
-        run: |
-          docker buildx imagetools create \
-            --tag "${API_IMAGE}:latest" \
-            "${API_IMAGE}@${API_IMAGE_DIGEST}"
-          docker buildx imagetools create \
-            --tag "${WEB_IMAGE}:latest" \
-            "${WEB_IMAGE}@${WEB_IMAGE_DIGEST}"
 
   promote:
     # Auto-promote stable releases (vX.Y.Z) to production. Any tag
@@ -939,7 +926,8 @@ jobs:
     needs: [resolve, manifest, prepare-web-image, smoke]
     if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
     permissions:
-      contents: read
+      contents: write # publish the draft release
+      packages: write # advance the mutable image aliases
     # Release App key lives in this environment (main and v* tags only).
     environment: release-app
     steps:
@@ -994,6 +982,51 @@ jobs:
           API_DEPLOYMENT_URL: https://my.stll.app
         run: bun scripts/check-api-deployment.ts
 
+      # Everything below is the publication: it runs only once production
+      # verifiably serves the release, so nothing users can reach moves on a
+      # failed promotion. Each step is idempotent for a rerun.
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+        run: |
+          # Not "latest" yet: release-desktop.yml flips that in its final
+          # step, after the signed installers are attached, so
+          # /releases/latest/download/Stella-* never 404s in between.
+          # Publishing a draft would otherwise make it latest by default.
+          gh release edit "$RELEASE_REF" --draft=false --latest=false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Advance stable image tags
+        env:
+          API_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          API_IMAGE_DIGEST: ${{ needs.manifest.outputs.api-image-digest }}
+          WEB_IMAGE: ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}
+          WEB_IMAGE_DIGEST: ${{ needs.prepare-web-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for digest in "$API_IMAGE_DIGEST" "$WEB_IMAGE_DIGEST"; do
+            if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "::error::A release image digest was not resolved from the manifest jobs."
+              exit 1
+            fi
+          done
+          docker buildx imagetools create \
+            --tag "${API_IMAGE}:latest" \
+            "${API_IMAGE}@${API_IMAGE_DIGEST}"
+          docker buildx imagetools create \
+            --tag "${WEB_IMAGE}:latest" \
+            "${WEB_IMAGE}@${WEB_IMAGE_DIGEST}"
+
   promote-staging:
     # Auto-promote release-candidate tags (vX.Y.Z-rc.N) to staging.
     # Same dispatch pattern as `promote` above; the infra workflow
@@ -1004,7 +1037,7 @@ jobs:
     needs: [resolve, manifest, prepare-web-image, smoke]
     if: ${{ contains(needs.resolve.outputs.release_ref, '-rc.') }}
     permissions:
-      contents: read
+      contents: write # publish the draft prerelease
     environment: release-app
     steps:
       # The workflow's own revision, not the release's: this job can be
@@ -1025,3 +1058,9 @@ jobs:
           release-ref: ${{ needs.resolve.outputs.release_ref }}
           target-environment: staging
           web-image-digest: ${{ needs.prepare-web-image.outputs.digest }}
+
+      - name: Publish GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+        run: gh release edit "$RELEASE_REF" --draft=false --prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -990,10 +990,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: |
-          # Not "latest" yet: release-desktop.yml flips that in its final
-          # step, after the signed installers are attached, so
-          # /releases/latest/download/Stella-* never 404s in between.
-          # Publishing a draft would otherwise make it latest by default.
+          # Only a draft is published here. A rerun against a release that
+          # an earlier run already published (and that release-desktop.yml
+          # may since have made Latest) must leave it exactly as it is:
+          # `--latest=false` on a published release would clear Latest.
+          # Not "latest" at publication: release-desktop.yml flips that in
+          # its final step, after the signed installers are attached, so
+          # /releases/latest/download/Stella-* never 404s in between, and
+          # publishing a draft would otherwise make it Latest by default.
+          is_draft="$(gh release view "$RELEASE_REF" --json isDraft --jq '.isDraft')"
+          if [[ "$is_draft" != "true" ]]; then
+            echo "Release $RELEASE_REF is already published; leaving it unchanged."
+            exit 0
+          fi
           gh release edit "$RELEASE_REF" --draft=false --latest=false
 
       - name: Set up Docker Buildx
@@ -1063,4 +1072,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-        run: gh release edit "$RELEASE_REF" --draft=false --prerelease
+        run: |
+          # Same rerun rule as the production publish: only a draft changes.
+          is_draft="$(gh release view "$RELEASE_REF" --json isDraft --jq '.isDraft')"
+          if [[ "$is_draft" != "true" ]]; then
+            echo "Release $RELEASE_REF is already published; leaving it unchanged."
+            exit 0
+          fi
+          gh release edit "$RELEASE_REF" --draft=false --prerelease

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -71,10 +71,14 @@ marketing:reshoot` re-records only the stale captures (see
 5. Merge the commit to `main`. The `tag-on-version-bump.yml` workflow pushes
    the matching `vX.Y.Z` tag automatically. The tag then triggers
    `release.yml`.
-6. Wait for the release workflow to publish the image, manifest, and GitHub
-   release notes. Stable releases are promoted automatically; the workflow does
-   not succeed until `https://api.stll.app/health` reports the exact release
-   commit. RCs continue to target staging.
+6. Wait for the release workflow. It builds and attests the immutable
+   images, creates the GitHub release as a draft with the manifest attached,
+   and promotes stable releases automatically; the release is published and
+   the `latest` image aliases advance only after `https://api.stll.app/ready`
+   and the web origin report the exact release commit. A failed promotion
+   leaves the tag, the immutable images, and the draft; rerunning the
+   workflow for the same tag reuses them. RCs continue to target staging and
+   are published as prereleases once the staging promotion finishes.
 7. After a stable release succeeds, `publish-npm.yml` checks out the same
    release commit, packs the CLI, installs that exact tarball under plain Node,
    and runs its unauthenticated compatibility canary against production. Only

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -248,11 +248,21 @@ describe("API deployment health receipt", () => {
     expect(releasePublished).toBeGreaterThan(productionVerified);
     expect(aliasesAdvanced).toBeGreaterThan(releasePublished);
     expect(promoteJob).toContain("--draft=false --latest=false");
+    // A rerun against an already published release must not touch it: the
+    // publish is gated on the draft state, so Latest is never cleared.
+    const publishStep = promoteJob.slice(releasePublished, aliasesAdvanced);
+    expect(publishStep.indexOf("--json isDraft")).toBeGreaterThan(-1);
+    expect(publishStep.indexOf("--json isDraft")).toBeLessThan(
+      publishStep.indexOf("--draft=false --latest=false"),
+    );
     const stagingJob = releaseWorkflow.slice(stagingJobStart);
     expect(stagingJob.indexOf("Publish GitHub prerelease")).toBeGreaterThan(
       stagingJob.indexOf("Promote to staging"),
     );
     expect(stagingJob).toContain("--draft=false --prerelease");
+    expect(stagingJob.indexOf("--json isDraft")).toBeLessThan(
+      stagingJob.indexOf("--draft=false --prerelease"),
+    );
     expect(releaseWorkflow).toContain(
       `group: release-\${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}`,
     );

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -229,9 +229,30 @@ describe("API deployment health receipt", () => {
       `Immutable image tag \${image}:\${tag} points to a different digest.`,
     );
     expect(manifestJob).toContain('"STELLA_COMMIT_SHA=" + $commit');
-    expect(manifestJob.indexOf("Publish GitHub release manifest")).toBeLessThan(
-      manifestJob.indexOf("Advance stable image tags"),
+    // Publication is the promote job's last act: the release object is a
+    // draft and the mutable image aliases stay put until production
+    // verifiably serves the release.
+    expect(manifestJob).toContain("gh release create");
+    expect(manifestJob).toContain(
+      "*-rc.*) extra_args+=(--draft --prerelease) ;;",
     );
+    expect(manifestJob).toContain("*) extra_args+=(--draft) ;;");
+    expect(manifestJob).not.toContain("Advance stable image tags");
+    expect(manifestJob).not.toContain(":latest");
+    const productionVerified = promoteJob.indexOf(
+      "Verify production web serves the release commit",
+    );
+    const releasePublished = promoteJob.indexOf("Publish GitHub release");
+    const aliasesAdvanced = promoteJob.indexOf("Advance stable image tags");
+    expect(productionVerified).toBeGreaterThan(-1);
+    expect(releasePublished).toBeGreaterThan(productionVerified);
+    expect(aliasesAdvanced).toBeGreaterThan(releasePublished);
+    expect(promoteJob).toContain("--draft=false --latest=false");
+    const stagingJob = releaseWorkflow.slice(stagingJobStart);
+    expect(stagingJob.indexOf("Publish GitHub prerelease")).toBeGreaterThan(
+      stagingJob.indexOf("Promote to staging"),
+    );
+    expect(stagingJob).toContain("--draft=false --prerelease");
     expect(releaseWorkflow).toContain(
       `group: release-\${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}`,
     );


### PR DESCRIPTION
## What

`release.yml` published the GitHub release and advanced the mutable `:latest` image aliases in the `manifest` job, before the `promote` job had deployed anything. A failed production promotion therefore left a visible release object and `:latest` images for a version production did not serve.

Publication now happens last:

- `manifest` creates the GitHub release as a draft (stable and rc tags) with the manifest attached; drafts are absent from `/releases`, the public API, and `/releases/latest`. Beta and alpha tags promote nowhere, so they are still published directly as prereleases.
- `promote`, after both production verification probes pass, publishes the draft with `--latest=false` (release-desktop.yml keeps flipping Latest after the installers are attached) and then advances the `:latest` API and web aliases from the digests the manifest jobs resolved.
- `promote-staging` publishes the rc draft as a prerelease after the staging promotion finishes.

A failed promotion leaves the immutable tag, the immutable images, and a draft; rerunning the workflow for the same tag reuses all three (`gh` resolves a draft by its tag). Nothing users can reach moves until production serves the release.

`release-desktop.yml` only needed its comment updated: it already refuses to run on a failed upstream, which now also means it never attaches installers to a draft.

## Checks

- `check-api-deployment.test.ts` asserts the new ordering: no `:latest` in `manifest`, publish after production verification in `promote`, aliases after publish, prerelease publish after the staging dispatch.
- Both workflows parse; `docs/releases.md` describes the new sequence.
