### PR TITLE
perf(api): settle a corpus-index search page within one scan round

### DIFF
--- a/apps/api/src/handlers/case-law/decisions/search-identity.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-identity.db.test.ts
@@ -82,46 +82,46 @@ afterAll(async () => {
 });
 
 test("a docket resolves by its citation key however the reader spaces it", async () => {
-  const spaced = await findDecisionIdsByIdentity(
+  const spaced = await findDecisionIdsByIdentity({
     caseLawDb,
-    { type: "identifier", kind: "docket", value: "Pl. ÚS 24/10" },
-    "CZE",
-  );
+    country: "CZE",
+    identity: { type: "identifier", kind: "docket", value: "Pl. ÚS 24/10" },
+  });
   expect(spaced).toEqual([plenaryId]);
 
-  const unscoped = await findDecisionIdsByIdentity(
+  const unscoped = await findDecisionIdsByIdentity({
     caseLawDb,
-    { type: "identifier", kind: "docket", value: "23 Cdo 1572/2012" },
-    undefined,
-  );
+    country: undefined,
+    identity: { type: "identifier", kind: "docket", value: "23 Cdo 1572/2012" },
+  });
   expect(unscoped).toEqual([supremeId]);
 });
 
 test("an ECLI resolves by equality regardless of the reader's case", async () => {
-  const ids = await findDecisionIdsByIdentity(
+  const ids = await findDecisionIdsByIdentity({
     caseLawDb,
-    {
+    country: "CZE",
+    identity: {
       type: "identifier",
       kind: "ecli",
       value: "ecli:cz:ns:2012:23.cdo.1572.2012.1",
     },
-    "CZE",
-  );
+  });
   expect(ids).toEqual([supremeId]);
 });
 
 test("an identifier nobody holds, or held in another jurisdiction, resolves to nothing", async () => {
-  const unknown = await findDecisionIdsByIdentity(
+  const unknown = await findDecisionIdsByIdentity({
     caseLawDb,
-    { type: "identifier", kind: "docket", value: "22 Cdo 1/2026" },
-    "CZE",
-  );
+    country: "CZE",
+    identity: { type: "identifier", kind: "docket", value: "22 Cdo 1/2026" },
+  });
   expect(unknown).toEqual([]);
 
-  const elsewhere = await findDecisionIdsByIdentity(
+  const elsewhere = await findDecisionIdsByIdentity({
     caseLawDb,
-    { type: "identifier", kind: "docket", value: "Pl. ÚS 24/10" },
-    "SVK",
-  );
+    country: "SVK",
+    identity: { type: "identifier", kind: "docket", value: "Pl. ÚS 24/10" },
+  });
   expect(elsewhere).toEqual([]);
 });

--- a/apps/api/src/handlers/case-law/decisions/search-telemetry.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-telemetry.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { parseDecisionQuery } from "@stll/api-contract/decision-query-intent";
+
+import {
+  DECISION_QUERY_CLASS,
+  decisionQueryClass,
+  reportCaseLawSearchCompleted,
+} from "@/api/handlers/case-law/decisions/search-telemetry";
+import type { RecordingLogger } from "@/api/tests/helpers/recording-telemetry";
+import { installRecordingLogger } from "@/api/tests/helpers/recording-telemetry";
+
+/** The class the handler derives from the intent it already parsed. */
+const classOf = (query: string) =>
+  decisionQueryClass(parseDecisionQuery(query));
+
+describe("what a search reports about the entry", () => {
+  test("a docket and an ECLI are identifier entries", () => {
+    expect(classOf("22 Cdo 2653/2012")).toBe(DECISION_QUERY_CLASS.identifier);
+    expect(classOf("ECLI:EU:C:2014:317")).toBe(DECISION_QUERY_CLASS.identifier);
+  });
+
+  test("a quoted entry is a phrase, an unquoted one is terms", () => {
+    expect(classOf('"náhrada škody"')).toBe(DECISION_QUERY_CLASS.phrase);
+    expect(classOf("náhrada škody")).toBe(DECISION_QUERY_CLASS.term);
+  });
+
+  test("a phrase in the quotes the jurisdictions print is a phrase", () => {
+    // The entry ran as a phrase against the engine, so it is recorded as one:
+    // the class comes from the tokenizer, not from a search for ASCII quotes.
+    expect(classOf("„náhrada škody“")).toBe(DECISION_QUERY_CLASS.phrase);
+    expect(classOf("«náhrada škody»")).toBe(DECISION_QUERY_CLASS.phrase);
+  });
+
+  test("a quote that opens no span is terms, as it ran", () => {
+    expect(classOf('"náhrada škody')).toBe(DECISION_QUERY_CLASS.term);
+  });
+
+  test("an entry the tokenizer finds nothing in is empty", () => {
+    expect(classOf("   ")).toBe(DECISION_QUERY_CLASS.empty);
+    // Punctuation only: no searchable token, and the handler answers with an
+    // empty page rather than querying the engine.
+    expect(classOf("!!! ???")).toBe(DECISION_QUERY_CLASS.empty);
+  });
+});
+
+describe("the completed-search record", () => {
+  let recording: RecordingLogger;
+
+  beforeEach(() => {
+    recording = installRecordingLogger();
+  });
+
+  afterEach(() => {
+    recording.restore();
+  });
+
+  const emit = (country: string | undefined) => {
+    reportCaseLawSearchCompleted({
+      candidatesHydrated: 42,
+      country,
+      db: {
+        reads: 3,
+        msByRead: {
+          alternates: 3.2,
+          candidates: 8.4,
+          identity: 0,
+          servingGeneration: 0.8,
+        },
+      },
+      earlyStopped: true,
+      hitsReturned: 20,
+      indexMs: 88.6,
+      passagesScanned: 300,
+      queryClass: classOf('"náhrada škody"'),
+      roundCapHit: false,
+      rounds: 1,
+      totalMs: 130.2,
+    });
+    const record = recording.records.at(0);
+    if (record === undefined) {
+      throw new Error("the search must emit exactly one record");
+    }
+    return record;
+  };
+
+  test("carries what the scan cost", () => {
+    const record = emit("cz");
+
+    expect(record.severityText).toBe("INFO");
+    expect(record.message).toBe("case_law.search.completed");
+    expect(record.attributes).toEqual({
+      queryClass: "phrase",
+      country: "cz",
+      rounds: 1,
+      passagesScanned: 300,
+      candidatesHydrated: 42,
+      hitsReturned: 20,
+      indexMs: 89,
+      dbReads: 3,
+      dbMs: 12,
+      dbAlternatesMs: 3,
+      dbCandidatesMs: 8,
+      dbIdentityMs: 0,
+      dbServingGenerationMs: 1,
+      totalMs: 130,
+      roundCapHit: false,
+      earlyStopped: true,
+    });
+    expect(recording.records).toHaveLength(1);
+  });
+
+  test("the database total is what its breakdown adds up to", () => {
+    const attributes = emit("cz").attributes ?? {};
+
+    const parts = Object.entries(attributes).filter(
+      ([key]) => key.startsWith("db") && key.endsWith("Ms") && key !== "dbMs",
+    );
+    // A read that grows has to show up in one of these, and a read nobody
+    // named would make the two disagree.
+    expect(parts).toHaveLength(4);
+    const breakdown = parts.reduce((total, [, ms]) => total + Number(ms), 0);
+    expect(Number(attributes["dbMs"])).toBe(breakdown);
+  });
+
+  test("carries no entry text and nothing the sanitizer had to drop", () => {
+    const record = emit("cz");
+
+    // The class is all the record knows about the entry, and a dropped
+    // attribute would mean a key the record should never have carried.
+    for (const value of Object.values(record.attributes ?? {})) {
+      expect(String(value)).not.toContain("náhrada");
+    }
+    expect(record.attributes).not.toHaveProperty("log.attributes_dropped");
+  });
+
+  test("omits the country an unscoped search does not have", () => {
+    const record = emit(undefined);
+
+    expect(record.attributes).not.toHaveProperty("country");
+  });
+});

--- a/apps/api/src/handlers/case-law/decisions/search-telemetry.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-telemetry.ts
@@ -1,0 +1,204 @@
+import { panic } from "better-result";
+
+import type { DecisionQueryIntent } from "@stll/api-contract/decision-query-intent";
+
+import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
+import type { LoggerAttributes } from "@/api/lib/observability/logger";
+import { logger } from "@/api/lib/observability/logger";
+
+/**
+ * What a case-law search cost, per request. Latency here is dominated by how
+ * many times the scan went back to the index, which nothing outside the
+ * request could otherwise see: the response carries a page either way.
+ *
+ * The entry itself is never an attribute. Its shape is: a docket or an ECLI
+ * is answered from identity columns, a quoted phrase and loose terms hit the
+ * index differently, and that is as much as telemetry needs to explain a
+ * slow request.
+ *
+ * Which of those an entry is comes from the same tokenizer that builds the
+ * engine query, never from a second scan of the raw text: the quote
+ * conventions a phrase may be written in are the tokenizer's to know, and a
+ * quote that opens no span is not a phrase at all.
+ */
+export const DECISION_QUERY_CLASS = {
+  empty: "empty",
+  identifier: "identifier",
+  phrase: "phrase",
+  term: "term",
+} as const;
+
+export type DecisionQueryClass =
+  (typeof DECISION_QUERY_CLASS)[keyof typeof DECISION_QUERY_CLASS];
+
+export const decisionQueryClass = (
+  intent: DecisionQueryIntent,
+): DecisionQueryClass => {
+  switch (intent.type) {
+    case "empty":
+      return DECISION_QUERY_CLASS.empty;
+    case "identifier":
+      return DECISION_QUERY_CLASS.identifier;
+    case "text": {
+      const tokens = tokenizeCorpusFreeText(intent.text);
+      if (tokens.length === 0) {
+        return DECISION_QUERY_CLASS.empty;
+      }
+      return tokens.some((token) => token.type === "phrase")
+        ? DECISION_QUERY_CLASS.phrase
+        : DECISION_QUERY_CLASS.term;
+    }
+    default: {
+      const exhaustive: never = intent;
+      return panic(`Unhandled decision query intent: ${String(exhaustive)}`);
+    }
+  }
+};
+
+/**
+ * The Postgres reads one corpus-index search makes, named so a record can say
+ * which one a slow request waited on rather than only how long it waited in
+ * total.
+ */
+export const CASE_LAW_SEARCH_DB_READ = {
+  /** Language versions of the decisions on the page. */
+  alternates: "alternates",
+  /** The scan's candidates, rehydrated and refiltered. */
+  candidates: "candidates",
+  /** The decisions an entry names outright. */
+  identity: "identity",
+  /** Which corpus-index generation currently serves. */
+  servingGeneration: "servingGeneration",
+} as const;
+
+export type CaseLawSearchDbRead =
+  (typeof CASE_LAW_SEARCH_DB_READ)[keyof typeof CASE_LAW_SEARCH_DB_READ];
+
+/**
+ * The record's attribute per read. Total over the reads, and derived from
+ * them, so a read added without an attribute is a compile error rather than a
+ * number quietly missing from the log.
+ */
+const DB_READ_ATTRIBUTE = {
+  alternates: "dbAlternatesMs",
+  candidates: "dbCandidatesMs",
+  identity: "dbIdentityMs",
+  servingGeneration: "dbServingGenerationMs",
+} as const satisfies Record<CaseLawSearchDbRead, string>;
+
+export type CaseLawSearchDbTiming = {
+  /** How many reads the request made, over all the named kinds. */
+  reads: number;
+  msByRead: Record<CaseLawSearchDbRead, number>;
+};
+
+export type CaseLawSearchDbTimer = {
+  /**
+   * Brackets one read. The work is a thunk, so the clock starts before the
+   * query does; a helper that owns its own `caseLawDb` call takes this as its
+   * hook instead of being timed from outside, because ranking, folding and
+   * collapsing are not database time.
+   */
+  time: <TRead>(
+    read: CaseLawSearchDbRead,
+    run: () => Promise<TRead>,
+  ) => Promise<TRead>;
+  /**
+   * Records a read timed at its call site. For the reads a lint rule requires
+   * the handler to invoke directly, which a thunk would hide.
+   */
+  record: (read: CaseLawSearchDbRead, ms: number) => void;
+  timing: () => CaseLawSearchDbTiming;
+};
+
+export const createCaseLawSearchDbTimer = (): CaseLawSearchDbTimer => {
+  const msByRead: Record<CaseLawSearchDbRead, number> = {
+    alternates: 0,
+    candidates: 0,
+    identity: 0,
+    servingGeneration: 0,
+  };
+  let reads = 0;
+
+  const record = (read: CaseLawSearchDbRead, ms: number): void => {
+    msByRead[read] += ms;
+    reads += 1;
+  };
+
+  return {
+    record,
+    time: async (read, run) => {
+      const startedAt = performance.now();
+      const rows = await run();
+      record(read, performance.now() - startedAt);
+      return rows;
+    },
+    timing: () => ({ reads, msByRead: { ...msByRead } }),
+  };
+};
+
+type CaseLawSearchCompletedEvent = {
+  /** Candidates read from Postgres, including ones the filters dropped. */
+  candidatesHydrated: number;
+  country: string | undefined;
+  /** This request's Postgres reads, per read. The total is their sum. */
+  db: CaseLawSearchDbTiming;
+  /** The scan stopped because no unseen candidate could out-blend the page. */
+  earlyStopped: boolean;
+  hitsReturned: number;
+  /** Summed wall time of this request's engine calls. */
+  indexMs: number;
+  passagesScanned: number;
+  queryClass: DecisionQueryClass;
+  /** The scan stopped at the round cap rather than at its own bound. */
+  roundCapHit: boolean;
+  /** Engine round trips the scan spent. */
+  rounds: number;
+  totalMs: number;
+};
+
+/**
+ * One record per search that reached the corpus index or the identity path.
+ * A request rejected at the boundary (a malformed cursor, an unknown
+ * country) searched nothing and reports nothing.
+ */
+export const reportCaseLawSearchCompleted = ({
+  candidatesHydrated,
+  country,
+  db,
+  earlyStopped,
+  hitsReturned,
+  indexMs,
+  passagesScanned,
+  queryClass,
+  roundCapHit,
+  rounds,
+  totalMs,
+}: CaseLawSearchCompletedEvent): void => {
+  // Flat, one attribute per read, and the total is what those attributes add
+  // up to: a breakdown that does not reconcile with its total is worse than
+  // no breakdown.
+  const msByAttribute: LoggerAttributes = {};
+  let dbMs = 0;
+  for (const read of Object.values(CASE_LAW_SEARCH_DB_READ)) {
+    const ms = Math.round(db.msByRead[read]);
+    msByAttribute[DB_READ_ATTRIBUTE[read]] = ms;
+    dbMs += ms;
+  }
+
+  logger.info("case_law.search.completed", {
+    queryClass,
+    ...(country === undefined ? {} : { country }),
+    rounds,
+    passagesScanned,
+    candidatesHydrated,
+    hitsReturned,
+    indexMs: Math.round(indexMs),
+    dbReads: db.reads,
+    dbMs,
+    ...msByAttribute,
+    totalMs: Math.round(totalMs),
+    roundCapHit,
+    earlyStopped,
+  });
+};

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -21,6 +21,12 @@ import {
 } from "@/api/handlers/case-law/citation-score";
 import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import type { searchDecisionsBodySchema } from "@/api/handlers/case-law/decisions/search-schema";
+import {
+  CASE_LAW_SEARCH_DB_READ,
+  createCaseLawSearchDbTimer,
+  decisionQueryClass,
+  reportCaseLawSearchCompleted,
+} from "@/api/handlers/case-law/decisions/search-telemetry";
 import { bareCitationKey } from "@/api/handlers/case-law/ingestion/citation-extractor";
 import { arrayOrEmpty } from "@/api/lib/array";
 // eslint-disable-next-line no-restricted-imports -- search boundary: brands document ids returned by the corpus index before re-hydrating from Postgres
@@ -50,7 +56,11 @@ import {
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
-import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
+import type { CorpusIndexScanReport } from "@/api/lib/legal-search/corpus-index-pagination";
+import {
+  emptyCorpusIndexScan,
+  readCorpusIndexSearchPage,
+} from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   caseLawCorpusQuery,
   type CorpusTermExpander,
@@ -577,6 +587,15 @@ type HydratedDecisionRow = Awaited<
  */
 type HydratedDecisionRows = Map<string, HydratedDecisionRow | null>;
 
+/**
+ * Brackets the database call a read makes, so a caller measuring Postgres
+ * time measures the wait and not the work around it. Absent wherever nothing
+ * is being measured.
+ */
+type TimeDbRead = <TRead>(run: () => Promise<TRead>) => Promise<TRead>;
+
+const untimedDbRead: TimeDbRead = async (run) => await run();
+
 type RehydrateCaseLawCandidatesOptions = {
   body: SearchDecisionsBody;
   candidates: readonly ScoredCandidate[];
@@ -584,6 +603,7 @@ type RehydrateCaseLawCandidatesOptions = {
   generation: string;
   /** The request's record of rows read so far; only ids absent from it are read. */
   hydrated?: HydratedDecisionRows | undefined;
+  timeDbRead?: TimeDbRead | undefined;
 };
 
 /**
@@ -597,6 +617,7 @@ export const rehydrateCaseLawCandidates = async ({
   caseLawDb,
   generation,
   hydrated = new Map(),
+  timeDbRead = untimedDbRead,
 }: RehydrateCaseLawCandidatesOptions) => {
   const ids = candidates
     .filter((candidate) => !hydrated.has(candidate.id))
@@ -642,8 +663,16 @@ export const rehydrateCaseLawCandidates = async ({
   const rows =
     ids.length === 0
       ? []
-      : await caseLawDb((tx) =>
-          hydratedDecisionRowsQuery(tx, ids, rehydrationFilters, generation),
+      : await timeDbRead(
+          async () =>
+            await caseLawDb((tx) =>
+              hydratedDecisionRowsQuery(
+                tx,
+                ids,
+                rehydrationFilters,
+                generation,
+              ),
+            ),
         );
   for (const id of ids) {
     hydrated.set(id, null);
@@ -690,11 +719,19 @@ type DecisionIdentity = Extract<DecisionQueryIntent, { type: "identifier" }>;
  * the citator resolves by, and the ECLI as published. Bounded by the page
  * size: past that the entry names a list, not a decision.
  */
-export const findDecisionIdsByIdentity = async (
-  caseLawDb: CaseLawPublicReadDb,
-  identity: DecisionIdentity,
-  country: string | undefined,
-): Promise<SafeId<"caseLawDecision">[]> => {
+type FindDecisionIdsByIdentityOptions = {
+  caseLawDb: CaseLawPublicReadDb;
+  country: string | undefined;
+  identity: DecisionIdentity;
+  timeDbRead?: TimeDbRead | undefined;
+};
+
+export const findDecisionIdsByIdentity = async ({
+  caseLawDb,
+  country,
+  identity,
+  timeDbRead = untimedDbRead,
+}: FindDecisionIdsByIdentityOptions): Promise<SafeId<"caseLawDecision">[]> => {
   const identityPredicate =
     identity.kind === "ecli"
       ? inArray(caseLawDecisions.ecli, [
@@ -702,19 +739,22 @@ export const findDecisionIdsByIdentity = async (
           identity.value.toUpperCase(),
         ])
       : eq(caseLawDecisions.citationKey, bareCitationKey(identity.value));
-  const rows = await caseLawDb((tx) =>
-    tx
-      .select({ id: caseLawDecisions.id })
-      .from(caseLawDecisions)
-      .where(
-        and(
-          identityPredicate,
-          country === undefined
-            ? undefined
-            : eq(caseLawDecisions.country, country),
-        ),
-      )
-      .limit(LIMITS.caseLawSearchPageSizeMax),
+  const rows = await timeDbRead(
+    async () =>
+      await caseLawDb((tx) =>
+        tx
+          .select({ id: caseLawDecisions.id })
+          .from(caseLawDecisions)
+          .where(
+            and(
+              identityPredicate,
+              country === undefined
+                ? undefined
+                : eq(caseLawDecisions.country, country),
+            ),
+          )
+          .limit(LIMITS.caseLawSearchPageSizeMax),
+      ),
   );
   return rows.map((row) => row.id);
 };
@@ -801,6 +841,7 @@ const searchCorpusIndexDecisions = async (
   body: SearchDecisionsBody,
   caseLawDb: CaseLawPublicReadDb,
 ) => {
+  const startedAt = performance.now();
   const limit = body.limit ?? LIMITS.caseLawSearchPageSizeDefault;
 
   let parsedCursor: { score: number; id: string } | null = null;
@@ -815,45 +856,87 @@ const searchCorpusIndexDecisions = async (
     return status(400, { message: "Invalid country" });
   }
 
-  const serving = await caseLawDb(
-    async (tx) => await readServingCorpusIndexGenerationTx(tx, "case_law"),
+  // Where the request's time went. The engine half is the scan's to report;
+  // this side is every Postgres read, bracketed at the database call itself so
+  // the numbers are wait, not work: the candidate read hands the timer down to
+  // where it opens its transaction, because the ranking, folding and
+  // collapsing around it are not database time.
+  const dbTimer = createCaseLawSearchDbTimer();
+  // Shared by the identity path and the scan, so `hydrated.size` counts the
+  // candidates the whole request read, once each.
+  const hydrated: HydratedDecisionRows = new Map();
+  const intent = parseDecisionQuery(body.query);
+  const queryClass = decisionQueryClass(intent);
+  const report = (hitsReturned: number, scan: CorpusIndexScanReport): void => {
+    reportCaseLawSearchCompleted({
+      candidatesHydrated: hydrated.size,
+      country: body.country,
+      db: dbTimer.timing(),
+      hitsReturned,
+      queryClass,
+      totalMs: performance.now() - startedAt,
+      ...scan,
+    });
+  };
+
+  const serving = await dbTimer.time(
+    CASE_LAW_SEARCH_DB_READ.servingGeneration,
+    async () =>
+      await caseLawDb(
+        async (tx) => await readServingCorpusIndexGenerationTx(tx, "case_law"),
+      ),
   );
   const generation = serving.generation;
 
   // An entry that names a decision is answered by identity, and only falls
   // through to the text index when nothing answers to it. A cursor means the
   // reader is already paging a text search, which identity never returns.
-  const intent = parseDecisionQuery(body.query);
   if (intent.type === "identifier" && parsedCursor === null) {
-    const ids = await findDecisionIdsByIdentity(
+    const ids = await findDecisionIdsByIdentity({
       caseLawDb,
-      intent,
-      body.country,
-    );
+      country: body.country,
+      identity: intent,
+      timeDbRead: async (run) =>
+        await dbTimer.time(CASE_LAW_SEARCH_DB_READ.identity, run),
+    });
     if (ids.length > 0) {
       const identityRanking = await rehydrateCaseLawCandidates({
         body,
         candidates: ids.map((id) => ({ id, score: 1 })),
         caseLawDb,
         generation,
+        hydrated,
+        timeDbRead: async (run) =>
+          await dbTimer.time(CASE_LAW_SEARCH_DB_READ.candidates, run),
       });
       // A docket can name decisions at several courts; the page still honours
       // the requested size, and identity never pages past it.
       const identityPage = identityRanking.ranked.slice(0, limit);
       if (identityPage.length > 0) {
         const { byId } = identityRanking.context;
-        return decisionHitsPage({
-          alternatesByGroupKey:
-            await readPublicDecisionLanguageAlternatesByGroup({
-              caseLawDb,
-              languageGroupKeys: languageGroupKeysOf(identityPage, byId),
-            }),
+        // Timed around the call rather than through the timer's thunk: the
+        // alternates read must stay a direct call in this function, which a
+        // lint rule enforces so no search path can drop it.
+        const identityAlternatesStartedAt = performance.now();
+        const identityAlternates =
+          await readPublicDecisionLanguageAlternatesByGroup({
+            caseLawDb,
+            languageGroupKeys: languageGroupKeysOf(identityPage, byId),
+          });
+        dbTimer.record(
+          CASE_LAW_SEARCH_DB_READ.alternates,
+          performance.now() - identityAlternatesStartedAt,
+        );
+        const page = decisionHitsPage({
+          alternatesByGroupKey: identityAlternates,
           anchorIdById: new Map(),
           byId,
           nextCursor: null,
           pageRanked: identityPage,
           snippetById: new Map(),
         });
+        report(page.hits.length, emptyCorpusIndexScan());
+        return page;
       }
     }
   }
@@ -867,10 +950,10 @@ const searchCorpusIndexDecisions = async (
 
   const query = await resolveCorpusIndexQuery(body, jurisdictionClause);
   if (query === null) {
+    report(0, emptyCorpusIndexScan());
     return { hits: [], facets: null, totalCount: null, nextCursor: null };
   }
 
-  const hydrated: HydratedDecisionRows = new Map();
   const searchPage = await readCorpusIndexSearchPage({
     cluster: serving.cluster,
     indexId,
@@ -894,6 +977,8 @@ const searchCorpusIndexDecisions = async (
         caseLawDb,
         generation,
         hydrated,
+        timeDbRead: async (run) =>
+          await dbTimer.time(CASE_LAW_SEARCH_DB_READ.candidates, run),
       }),
   });
 
@@ -902,21 +987,33 @@ const searchCorpusIndexDecisions = async (
     context: { byId },
     hasMore,
     pageRanked,
+    scan,
     snippetById,
   } = searchPage;
 
   const last = pageRanked.at(-1);
   const nextCursor = hasMore && last ? encodeCursor(last.score, last.id) : null;
 
-  return decisionHitsPage({
-    alternatesByGroupKey: await readPublicDecisionLanguageAlternatesByGroup({
+  // Timed around the call for the same reason as on the identity path.
+  const alternatesStartedAt = performance.now();
+  const alternatesByGroupKey =
+    await readPublicDecisionLanguageAlternatesByGroup({
       caseLawDb,
       languageGroupKeys: languageGroupKeysOf(pageRanked, byId),
-    }),
+    });
+  dbTimer.record(
+    CASE_LAW_SEARCH_DB_READ.alternates,
+    performance.now() - alternatesStartedAt,
+  );
+
+  const page = decisionHitsPage({
+    alternatesByGroupKey,
     anchorIdById,
     byId,
     nextCursor,
     pageRanked,
     snippetById,
   });
+  report(page.hits.length, scan);
+  return page;
 };

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -56,9 +56,14 @@ import {
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
-import type { CorpusIndexScanReport } from "@/api/lib/legal-search/corpus-index-pagination";
+import type {
+  CorpusIndexScanReport,
+  SearchCursor,
+} from "@/api/lib/legal-search/corpus-index-pagination";
 import {
+  decodeCorpusIndexCursor,
   emptyCorpusIndexScan,
+  encodeCorpusIndexCursor,
   readCorpusIndexSearchPage,
 } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
@@ -844,9 +849,9 @@ const searchCorpusIndexDecisions = async (
   const startedAt = performance.now();
   const limit = body.limit ?? LIMITS.caseLawSearchPageSizeDefault;
 
-  let parsedCursor: { score: number; id: string } | null = null;
+  let parsedCursor: SearchCursor | null = null;
   if (body.cursor) {
-    parsedCursor = decodeCursor(body.cursor);
+    parsedCursor = decodeCorpusIndexCursor(body.cursor);
     if (!parsedCursor || !isUuid(parsedCursor.id)) {
       return status(400, { message: "Invalid cursor" });
     }
@@ -985,14 +990,15 @@ const searchCorpusIndexDecisions = async (
   const {
     anchorIdById,
     context: { byId },
-    hasMore,
     pageRanked,
     scan,
     snippetById,
   } = searchPage;
 
-  const last = pageRanked.at(-1);
-  const nextCursor = hasMore && last ? encodeCursor(last.score, last.id) : null;
+  const nextCursor =
+    searchPage.nextCursor === null
+      ? null
+      : encodeCorpusIndexCursor(searchPage.nextCursor);
 
   // Timed around the call for the same reason as on the identity path.
   const alternatesStartedAt = performance.now();

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -19,7 +19,12 @@ import {
 } from "@/api/lib/custom-schema";
 import { blendedRankSql } from "@/api/lib/legal-search/authority-sql";
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
-import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
+import type { SearchCursor } from "@/api/lib/legal-search/corpus-index-pagination";
+import {
+  decodeCorpusIndexCursor,
+  encodeCorpusIndexCursor,
+  readCorpusIndexSearchPage,
+} from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   corpusFreeTextClause,
   quoteCorpusValue,
@@ -41,7 +46,7 @@ import {
   type LegislationReadDb,
 } from "@/api/lib/legislation-public-read-db";
 import { LIMITS } from "@/api/lib/limits";
-import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
+import { encodeCursor } from "@/api/lib/search/cursor";
 import {
   escapeAndHighlight,
   TS_HEADLINE_CONFIG,
@@ -116,7 +121,7 @@ const headlineRegconfig = sql`'public.stella_unaccent'::regconfig`;
 
 const pgSearch = async (
   body: SearchLegislationBody,
-  parsedCursor: { score: number; id: string } | null,
+  parsedCursor: SearchCursor | null,
   legislationDb: LegislationReadDb,
   dependencies: SearchLegislationDependencies,
 ): Promise<{ hits: LegislationHit[]; nextCursor: string | null }> => {
@@ -352,7 +357,7 @@ export const rehydrateLegislationCandidates = async ({
 
 const corpusIndexSearch = async (
   body: SearchLegislationBody,
-  parsedCursor: { score: number; id: string } | null,
+  parsedCursor: SearchCursor | null,
   legislationDb: LegislationReadDb,
 ): Promise<{ hits: LegislationHit[]; nextCursor: string | null }> => {
   const limit = body.limit ?? LIMITS.caseLawSearchPageSizeDefault;
@@ -395,12 +400,13 @@ const corpusIndexSearch = async (
 
   const {
     context: { byId },
-    hasMore,
     pageRanked,
     snippetById,
   } = searchPage;
-  const last = pageRanked.at(-1);
-  const nextCursor = hasMore && last ? encodeCursor(last.score, last.id) : null;
+  const nextCursor =
+    searchPage.nextCursor === null
+      ? null
+      : encodeCorpusIndexCursor(searchPage.nextCursor);
 
   const hits = pageRanked.flatMap((hit): LegislationHit[] => {
     const row = byId.get(hit.id);
@@ -446,7 +452,9 @@ export const searchLegislationHandler = async (
     return status(400, { message: "Invalid jurisdiction" });
   }
 
-  const parsedCursor = body.cursor ? decodeCursor(body.cursor) : null;
+  const parsedCursor = body.cursor
+    ? decodeCorpusIndexCursor(body.cursor)
+    : null;
   if (
     body.cursor !== undefined &&
     (parsedCursor === null || !isUuid(parsedCursor.id))

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -211,6 +211,103 @@ describe("a single document cannot monopolise the scan", () => {
   });
 });
 
+/**
+ * What the reader waits through is the number of sequential engine round
+ * trips, so the scan is bounded twice: it stops as soon as no unseen
+ * candidate can out-blend the page, and, failing that, at a fixed number of
+ * rounds. The second bound is what a query whose lexical scores separate
+ * slowly runs into.
+ */
+describe("the scan is bounded by engine round trips", () => {
+  /** A bound no page score can fall below: the early stop never fires. */
+  const readCappedPage = async (
+    limit: number,
+    parsedCursor: { score: number; id: string } | null = null,
+  ) =>
+    await readCorpusIndexSearchPage({
+      cluster: "q08",
+      indexId: "case_law_v2_cze",
+      query: "text:smlouva",
+      limit,
+      parsedCursor,
+      snippetFields: ["text"],
+      extractId: (hit: CorpusIndexHit) =>
+        typeof hit["document_id"] === "string" ? hit["document_id"] : null,
+      extractSnippet: () => null,
+      unseenScoreUpperBound: () => Number.POSITIVE_INFINITY,
+      rankCandidates: async (candidates) => ({
+        context: null,
+        ranked: candidates.map((candidate) => ({
+          id: candidate.id,
+          score: candidate.score,
+          lexicalScore: candidate.score,
+          citationAuthority: 0,
+        })),
+      }),
+    });
+
+  beforeEach(() => {
+    // Far more hits than the round cap can reach, one passage each, so only
+    // the cap can end the scan.
+    engineHits = Array.from({ length: 5000 }, (_, index) => ({
+      document_id: `doc-${String(index).padStart(4, "0")}`,
+    }));
+  });
+
+  test("a scan whose stop condition never fires ends at the round cap", async () => {
+    const page = await readCappedPage(10);
+
+    expect(requestCount).toBe(LIMITS.corpusIndexSearchMaxRounds);
+    expect(page.pageRanked).toHaveLength(10);
+    // The page is still full and its own window holds more, so paging
+    // continues within what the capped scan reached.
+    expect(page.hasMore).toBe(true);
+  });
+
+  test("a capped scan advertises only what a rescan can reach again", async () => {
+    const reachable =
+      LIMITS.corpusIndexSearchMaxRounds *
+      LIMITS.corpusIndexSearchCandidateLimit;
+
+    const page = await readCappedPage(reachable);
+
+    // Everything the cap allowed fits on one page, and a follow-up request
+    // would spend the same rounds and see the same candidates, so there is
+    // no next page to offer.
+    expect(page.pageRanked).toHaveLength(reachable);
+    expect(page.hasMore).toBe(false);
+  });
+
+  test("a cursor pages through what the capped scan reached", async () => {
+    const first = await readCappedPage(10);
+    const last = first.pageRanked.at(-1);
+    if (last === undefined) {
+      throw new Error("the first page must not be empty");
+    }
+
+    const second = await readCappedPage(10, { score: last.score, id: last.id });
+
+    expect(requestCount).toBe(LIMITS.corpusIndexSearchMaxRounds * 2);
+    expect(second.pageRanked.map((hit) => hit.id)).toEqual(
+      Array.from(
+        { length: 10 },
+        (_, index) => `doc-${String(index + 10).padStart(4, "0")}`,
+      ),
+    );
+    const firstIds = new Set(first.pageRanked.map((hit) => hit.id));
+    expect(second.pageRanked.some((hit) => firstIds.has(hit.id))).toBe(false);
+  });
+
+  test("a scan that can stop early spends one round", async () => {
+    // The same hit list read through a bound that no unseen candidate can
+    // beat: the page is answered from the first window.
+    const page = await readPage(10);
+
+    expect(requestCount).toBe(1);
+    expect(page.pageRanked).toHaveLength(10);
+  });
+});
+
 describe("document paging survives the passage fan-out", () => {
   test("a page holds `limit` documents even when each matched several passages", async () => {
     const documentIds = Array.from({ length: 8 }, (_, i) => `doc-${i}`);

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -262,6 +262,14 @@ describe("the scan is bounded by engine round trips", () => {
     // The page is still full and its own window holds more, so paging
     // continues within what the capped scan reached.
     expect(page.hasMore).toBe(true);
+    expect(page.scan.rounds).toBe(LIMITS.corpusIndexSearchMaxRounds);
+    expect(page.scan.passagesScanned).toBe(
+      LIMITS.corpusIndexSearchMaxRounds *
+        LIMITS.corpusIndexSearchCandidateLimit,
+    );
+    expect(page.scan.roundCapHit).toBe(true);
+    expect(page.scan.earlyStopped).toBe(false);
+    expect(page.scan.indexMs).toBeGreaterThanOrEqual(0);
   });
 
   test("a capped scan advertises only what a rescan can reach again", async () => {
@@ -305,6 +313,12 @@ describe("the scan is bounded by engine round trips", () => {
 
     expect(requestCount).toBe(1);
     expect(page.pageRanked).toHaveLength(10);
+    expect(page.scan.rounds).toBe(1);
+    expect(page.scan.passagesScanned).toBe(
+      LIMITS.corpusIndexSearchCandidateLimit,
+    );
+    expect(page.scan.earlyStopped).toBe(true);
+    expect(page.scan.roundCapHit).toBe(false);
   });
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -1,8 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
-import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
+import type { SearchCursor } from "@/api/lib/legal-search/corpus-index-pagination";
+import {
+  corpusIndexLexicalScore,
+  decodeCorpusIndexCursor,
+  encodeCorpusIndexCursor,
+  readCorpusIndexSearchPage,
+} from "@/api/lib/legal-search/corpus-index-pagination";
+import {
+  blendStableCitationAuthority,
+  DEFAULT_AUTHORITY_WEIGHT,
+  stableBlendUpperBound,
+} from "@/api/lib/legal-search/rerank";
 import { LIMITS } from "@/api/lib/limits";
+import { encodeCursor } from "@/api/lib/search/cursor";
 
 /**
  * Grouping passage hits back into document hits. A passage-granular generation
@@ -212,17 +224,19 @@ describe("a single document cannot monopolise the scan", () => {
 });
 
 /**
- * What the reader waits through is the number of sequential engine round
- * trips, so the scan is bounded twice: it stops as soon as no unseen
- * candidate can out-blend the page, and, failing that, at a fixed number of
- * rounds. The second bound is what a query whose lexical scores separate
- * slowly runs into.
+ * The rank-derived lexical score decays by a factor of e per round of
+ * candidates, which is what lets a page settle inside the first round: the
+ * blend's whole additive weight cannot carry a hit from the next round past
+ * the page's last hit. These tests run the real blend and the real bound, and
+ * grant no authority to anything, which is the worst case — the page's cursor
+ * score gets nothing from authority while the bound assumes an unseen hit
+ * takes all of it.
  */
-describe("the scan is bounded by engine round trips", () => {
-  /** A bound no page score can fall below: the early stop never fires. */
-  const readCappedPage = async (
+describe("a page settles within one scan round", () => {
+  const readBlendedPage = async (
     limit: number,
-    parsedCursor: { score: number; id: string } | null = null,
+    weight: number,
+    parsedCursor: SearchCursor | null = null,
   ) =>
     await readCorpusIndexSearchPage({
       cluster: "q08",
@@ -234,7 +248,126 @@ describe("the scan is bounded by engine round trips", () => {
       extractId: (hit: CorpusIndexHit) =>
         typeof hit["document_id"] === "string" ? hit["document_id"] : null,
       extractSnippet: () => null,
-      unseenScoreUpperBound: () => Number.POSITIVE_INFINITY,
+      unseenScoreUpperBound: (score) => stableBlendUpperBound(score, weight),
+      rankCandidates: async (candidates) => ({
+        context: null,
+        ranked: blendStableCitationAuthority({
+          candidates,
+          authorityById: new Map(),
+          weight,
+        }),
+      }),
+    });
+
+  const documentId = (index: number) => `doc-${String(index).padStart(5, "0")}`;
+
+  beforeEach(() => {
+    engineHits = Array.from({ length: 30_000 }, (_, index) => ({
+      document_id: documentId(index),
+    }));
+  });
+
+  test("a page of a very large hit list is answered from one round", async () => {
+    const page = await readBlendedPage(20, DEFAULT_AUTHORITY_WEIGHT);
+
+    expect(requestCount).toBe(1);
+    expect(page.scan.rounds).toBe(1);
+    expect(page.scan.earlyStopped).toBe(true);
+    expect(page.pageRanked).toHaveLength(20);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
+  test("the largest page the API serves still settles in one round", async () => {
+    const page = await readBlendedPage(
+      LIMITS.caseLawSearchPageSizeMax,
+      DEFAULT_AUTHORITY_WEIGHT,
+    );
+
+    expect(requestCount).toBe(1);
+    expect(page.scan.earlyStopped).toBe(true);
+  });
+
+  test("a wider additive weight still settles in one round", async () => {
+    // Headroom for a second additive signal: the bound widens to the sum of
+    // the weights, and the decay has to outrun the sum, not one term of it.
+    const combinedWeight = 0.5;
+    expect(
+      stableBlendUpperBound(corpusIndexLexicalScore(300), combinedWeight),
+    ).toBeLessThan(corpusIndexLexicalScore(19));
+
+    const page = await readBlendedPage(20, combinedWeight);
+
+    expect(requestCount).toBe(1);
+    expect(page.scan.earlyStopped).toBe(true);
+  });
+
+  test("a cursor continues the same scores without repeating a hit", async () => {
+    const first = await readBlendedPage(20, DEFAULT_AUTHORITY_WEIGHT);
+    const last = first.pageRanked.at(-1);
+    if (last === undefined) {
+      throw new Error("the first page must not be empty");
+    }
+    // The cursor encodes the score the rank alone produces, so the rescan
+    // behind page two assigns the emitted hits exactly the same values.
+    expect(last.score).toBe(corpusIndexLexicalScore(19));
+
+    const second = await readBlendedPage(
+      20,
+      DEFAULT_AUTHORITY_WEIGHT,
+      first.nextCursor,
+    );
+
+    expect(second.pageRanked.at(0)?.id).toBe(documentId(20));
+    expect(second.pageRanked.at(0)?.score).toBe(corpusIndexLexicalScore(20));
+    expect(second.pageRanked).toHaveLength(20);
+    const firstIds = new Set(first.pageRanked.map((hit) => hit.id));
+    expect(second.pageRanked.some((hit) => firstIds.has(hit.id))).toBe(false);
+  });
+
+  test("a hit's score reads its rank and nothing about the hit count", async () => {
+    const large = await readBlendedPage(20, DEFAULT_AUTHORITY_WEIGHT);
+    engineHits = Array.from({ length: 1000 }, (_, index) => ({
+      document_id: documentId(index),
+    }));
+
+    const small = await readBlendedPage(20, DEFAULT_AUTHORITY_WEIGHT);
+
+    // The same ranks in a hit list thirty times smaller: an emitted score no
+    // longer moves when the corpus grows under a reader holding a cursor.
+    expect(small.pageRanked.map((hit) => hit.score)).toEqual(
+      large.pageRanked.map((hit) => hit.score),
+    );
+    expect(corpusIndexLexicalScore(0)).toBe(1);
+    expect(corpusIndexLexicalScore(1)).toBeLessThan(corpusIndexLexicalScore(0));
+  });
+});
+
+/**
+ * What the reader waits through is the number of sequential engine round
+ * trips, so the scan is bounded twice: it stops as soon as no unseen
+ * candidate can out-blend the page, and, failing that, at a fixed number of
+ * rounds. The second bound is what a query whose lexical scores separate
+ * slowly runs into.
+ */
+describe("the scan is bounded by engine round trips", () => {
+  const documentId = (index: number) => `doc-${String(index).padStart(4, "0")}`;
+
+  /** A bound no page score can fall below: the early stop never fires. */
+  const readCappedPage = async (
+    limit: number,
+    parsedCursor: SearchCursor | null = null,
+  ) =>
+    await readCorpusIndexSearchPage({
+      cluster: "q08",
+      indexId: "case_law_v2_cze",
+      query: "text:smlouva",
+      limit,
+      parsedCursor,
+      snippetFields: ["text"],
+      extractId: (hit: CorpusIndexHit) =>
+        typeof hit["document_id"] === "string" ? hit["document_id"] : null,
+      extractSnippet: () => null,
+      unseenScoreUpperBound: (score) => score + 1,
       rankCandidates: async (candidates) => ({
         context: null,
         ranked: candidates.map((candidate) => ({
@@ -250,7 +383,7 @@ describe("the scan is bounded by engine round trips", () => {
     // Far more hits than the round cap can reach, one passage each, so only
     // the cap can end the scan.
     engineHits = Array.from({ length: 5000 }, (_, index) => ({
-      document_id: `doc-${String(index).padStart(4, "0")}`,
+      document_id: documentId(index),
     }));
   });
 
@@ -261,7 +394,7 @@ describe("the scan is bounded by engine round trips", () => {
     expect(page.pageRanked).toHaveLength(10);
     // The page is still full and its own window holds more, so paging
     // continues within what the capped scan reached.
-    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).not.toBeNull();
     expect(page.scan.rounds).toBe(LIMITS.corpusIndexSearchMaxRounds);
     expect(page.scan.passagesScanned).toBe(
       LIMITS.corpusIndexSearchMaxRounds *
@@ -272,18 +405,28 @@ describe("the scan is bounded by engine round trips", () => {
     expect(page.scan.indexMs).toBeGreaterThanOrEqual(0);
   });
 
-  test("a capped scan advertises only what a rescan can reach again", async () => {
+  test("a capped scan whose window is exhausted opens the next one", async () => {
     const reachable =
       LIMITS.corpusIndexSearchMaxRounds *
       LIMITS.corpusIndexSearchCandidateLimit;
 
     const page = await readCappedPage(reachable);
 
-    // Everything the cap allowed fits on one page, and a follow-up request
-    // would spend the same rounds and see the same candidates, so there is
-    // no next page to offer.
+    // Everything the cap allowed fits on one page, so replaying this window
+    // would return the same hits; the reader continues in the next one.
     expect(page.pageRanked).toHaveLength(reachable);
-    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor?.windowStart).toBe(reachable);
+  });
+
+  test("a scan that reached the end of the hit list offers no next window", async () => {
+    engineHits = Array.from({ length: 40 }, (_, index) => ({
+      document_id: documentId(index),
+    }));
+
+    const page = await readCappedPage(40);
+
+    expect(page.scan.roundCapHit).toBe(false);
+    expect(page.nextCursor).toBeNull();
   });
 
   test("a cursor pages through what the capped scan reached", async () => {
@@ -293,14 +436,11 @@ describe("the scan is bounded by engine round trips", () => {
       throw new Error("the first page must not be empty");
     }
 
-    const second = await readCappedPage(10, { score: last.score, id: last.id });
+    const second = await readCappedPage(10, first.nextCursor);
 
     expect(requestCount).toBe(LIMITS.corpusIndexSearchMaxRounds * 2);
     expect(second.pageRanked.map((hit) => hit.id)).toEqual(
-      Array.from(
-        { length: 10 },
-        (_, index) => `doc-${String(index + 10).padStart(4, "0")}`,
-      ),
+      Array.from({ length: 10 }, (_, index) => documentId(index + 10)),
     );
     const firstIds = new Set(first.pageRanked.map((hit) => hit.id));
     expect(second.pageRanked.some((hit) => firstIds.has(hit.id))).toBe(false);
@@ -319,6 +459,138 @@ describe("the scan is bounded by engine round trips", () => {
     );
     expect(page.scan.earlyStopped).toBe(true);
     expect(page.scan.roundCapHit).toBe(false);
+  });
+});
+
+/**
+ * A decision long enough to fill the whole capped window with its own
+ * passages. Nothing bounds passages per document anywhere near the scan
+ * budget — the chunker's ceiling is a hostile-input bound orders of magnitude
+ * higher — so the page cannot be made whole by sizing the cap. It is made
+ * whole by moving the window instead.
+ */
+describe("a passage flood does not strand the reader", () => {
+  const documentId = (index: number) => `doc-${String(index).padStart(4, "0")}`;
+  const floodSize = 1000;
+
+  const readFloodPage = async (
+    limit: number,
+    parsedCursor: SearchCursor | null = null,
+  ) =>
+    await readCorpusIndexSearchPage({
+      cluster: "q08",
+      indexId: "case_law_v2_cze",
+      query: "text:smlouva",
+      limit,
+      parsedCursor,
+      snippetFields: ["text"],
+      extractId: (hit: CorpusIndexHit) =>
+        typeof hit["document_id"] === "string" ? hit["document_id"] : null,
+      extractSnippet: () => null,
+      unseenScoreUpperBound: (score) =>
+        stableBlendUpperBound(score, DEFAULT_AUTHORITY_WEIGHT),
+      rankCandidates: async (candidates) => ({
+        context: null,
+        ranked: blendStableCitationAuthority({
+          candidates,
+          authorityById: new Map(),
+          weight: DEFAULT_AUTHORITY_WEIGHT,
+        }),
+      }),
+    });
+
+  beforeEach(() => {
+    // One decision's passages fill more than the cap can scan, then ordinary
+    // decisions follow.
+    engineHits = [
+      ...Array.from({ length: floodSize }, (_, seq) => ({
+        document_id: "doc-flood",
+        anchor_id: `flood-p${seq}`,
+      })),
+      ...Array.from({ length: 60 }, (_, index) => ({
+        document_id: documentId(index),
+      })),
+    ];
+  });
+
+  test("the flooded page still offers a way forward", async () => {
+    const page = await readFloodPage(10);
+
+    // The capped window held one decision, so the page is one hit — but the
+    // reader is not stranded on it.
+    expect(page.pageRanked.map((hit) => hit.id)).toEqual(["doc-flood"]);
+    expect(page.scan.roundCapHit).toBe(true);
+    expect(page.nextCursor?.windowStart).toBe(
+      LIMITS.corpusIndexSearchMaxRounds *
+        LIMITS.corpusIndexSearchCandidateLimit,
+    );
+  });
+
+  test("the next page continues past the flood without rescanning it", async () => {
+    const first = await readFloodPage(10);
+    requestCount = 0;
+
+    const second = await readFloodPage(10, first.nextCursor);
+
+    // Every round of page two reads past where page one stopped, and the
+    // decision that filled page one does not come back.
+    expect(second.pageRanked.map((hit) => hit.id)).toEqual(
+      Array.from({ length: 10 }, (_, index) => documentId(index)),
+    );
+    expect(second.scan.passagesScanned).toBeLessThanOrEqual(
+      LIMITS.corpusIndexSearchMaxRounds *
+        LIMITS.corpusIndexSearchCandidateLimit,
+    );
+    expect(requestCount).toBeLessThanOrEqual(LIMITS.corpusIndexSearchMaxRounds);
+  });
+
+  test("paging reaches every decision behind the flood", async () => {
+    const seen: string[] = [];
+    let cursor: SearchCursor | null = null;
+    for (let pageIndex = 0; pageIndex < 20; pageIndex += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- each page depends on the cursor the previous one emitted
+      const page = await readFloodPage(10, cursor);
+      seen.push(...page.pageRanked.map((hit) => hit.id));
+      if (page.nextCursor === null) {
+        break;
+      }
+      cursor = page.nextCursor;
+    }
+
+    expect(new Set(seen).size).toBe(seen.length);
+    expect(seen).toContain("doc-flood");
+    expect(seen).toContain(documentId(59));
+  });
+});
+
+describe("the cursor survives its wire form", () => {
+  test("a window cursor round-trips", () => {
+    const cursor = {
+      score: 0.5,
+      id: "4a1b6f6e-0e5a-4a51-9e9f-1a2b3c4d5e6f",
+      windowStart: 900,
+    };
+
+    expect(decodeCorpusIndexCursor(encodeCorpusIndexCursor(cursor))).toEqual(
+      cursor,
+    );
+  });
+
+  test("a payload without a window names the first one", () => {
+    // What a cursor issued before windows existed decodes to, and what a
+    // caller that builds the payload by hand gets.
+    const legacy = encodeCursor(0.5, "4a1b6f6e-0e5a-4a51-9e9f-1a2b3c4d5e6f");
+
+    expect(decodeCorpusIndexCursor(legacy)).toEqual({
+      score: 0.5,
+      id: "4a1b6f6e-0e5a-4a51-9e9f-1a2b3c4d5e6f",
+      windowStart: 0,
+    });
+  });
+
+  test("a malformed window is rejected rather than guessed", () => {
+    expect(decodeCorpusIndexCursor(encodeCursor(0.5, "-3:abc"))).toBeNull();
+    expect(decodeCorpusIndexCursor(encodeCursor(0.5, "12:"))).toBeNull();
   });
 });
 
@@ -348,7 +620,7 @@ describe("document paging survives the passage fan-out", () => {
       expect(page.anchorIdById.get(hit.id)).toBe(`${hit.id}-p0`);
       expect(page.passageCountById.get(hit.id)).toBe(3);
     }
-    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).not.toBeNull();
   });
 });
 
@@ -364,7 +636,7 @@ describe("ranker-folded candidates stay folded across pages", () => {
 
   const readFoldedPage = async (
     limit: number,
-    parsedCursor: { score: number; id: string } | null,
+    parsedCursor: SearchCursor | null,
   ) =>
     await readCorpusIndexSearchPage({
       cluster: "q08",
@@ -417,21 +689,21 @@ describe("ranker-folded candidates stay folded across pages", () => {
       "other-0",
       "other-1",
     ]);
-    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).not.toBeNull();
   });
 
   test("no folded member resurfaces on later pages", async () => {
     const seen: string[] = [];
-    let cursor: { score: number; id: string } | null = null;
+    let cursor: SearchCursor | null = null;
     for (let pageIndex = 0; pageIndex < 20; pageIndex += 1) {
       // oxlint-disable-next-line no-await-in-loop -- each page depends on the cursor the previous one emitted
       const page = await readFoldedPage(3, cursor);
       seen.push(...page.pageRanked.map((hit) => hit.id));
       const last = page.pageRanked.at(-1);
-      if (!page.hasMore || last === undefined) {
+      if (page.nextCursor === null || last === undefined) {
         break;
       }
-      cursor = { score: last.score, id: last.id };
+      cursor = page.nextCursor;
     }
 
     expect(seen.filter((id) => groupOf(id) !== null)).toEqual(["c-131-12-l0"]);

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -68,6 +68,11 @@ type CorpusIndexSearchPageResult<TContext> = {
  * most this factor on a passage-layout one. The cap is what bounds the extra
  * engine work; a document whose matching passages exceed it simply consumes
  * more of the budget than its share.
+ *
+ * It bounds candidates, not requests: what the reader waits through is the
+ * number of sequential engine round trips, which
+ * `LIMITS.corpusIndexSearchMaxRounds` bounds independently of how wide this
+ * factor lets the budget grow.
  */
 const PASSAGE_OVER_FETCH = 4;
 
@@ -127,6 +132,8 @@ export const readCorpusIndexSearchPage = async <TContext>({
   let windowed: RankedHit[] = [];
   let startOffset = 0;
   let totalHits = Number.POSITIVE_INFINITY;
+  let rounds = 0;
+  let roundCapHit = false;
 
   // Chunk-space scan budget, grown to keep result-space reach constant
   // across index layouts. Recomputed each round from what the scan has seen so
@@ -149,6 +156,14 @@ export const readCorpusIndexSearchPage = async <TContext>({
   };
 
   while (startOffset < totalHits && startOffset < scanBudget()) {
+    // Every round is one more sequential engine round trip in front of the
+    // reader. The budget above bounds how many candidates a scan may reach;
+    // this bounds how long it may take to give up trying.
+    if (rounds >= LIMITS.corpusIndexSearchMaxRounds) {
+      roundCapHit = true;
+      break;
+    }
+
     const maxHits = Math.min(
       LIMITS.corpusIndexSearchCandidateLimit,
       scanBudget() - startOffset,
@@ -156,6 +171,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
     if (maxHits <= 0) {
       break;
     }
+    rounds += 1;
 
     // Sort by BM25 explicitly: without it the engine returns hits in
     // document-id order and the rank-based lexical score below would be
@@ -236,8 +252,11 @@ export const readCorpusIndexSearchPage = async <TContext>({
   const pageRanked = hasMoreInWindow ? windowed.slice(0, limit) : windowed;
   // A follow-up request rescans from offset 0 and can only reach deeper
   // candidates while the scan cap is not exhausted; past the cap a
-  // cursor could never be satisfied and must not be advertised.
-  const scanCanContinue = startOffset < totalHits && startOffset < scanBudget();
+  // cursor could never be satisfied and must not be advertised. The round
+  // cap binds the same way: a rescan spends the same rounds and stops at the
+  // same offset, so nothing past it is reachable by paging.
+  const scanCanContinue =
+    !roundCapHit && startOffset < totalHits && startOffset < scanBudget();
   const hasMore = hasMoreInWindow || (scanCanContinue && pageRanked.length > 0);
 
   return {

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -3,10 +3,51 @@ import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client"
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import type { RankedHit, ScoredCandidate } from "@/api/lib/legal-search/rerank";
 import { LIMITS } from "@/api/lib/limits";
+import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
 
 export type SearchCursor = {
   score: number;
   id: string;
+  /**
+   * Rank the scan behind this cursor began at. A scan that proved its own
+   * stop bound leaves the window where it is, and the continuation replays it
+   * from the same rank: replaying is what keeps a document ranked by its best
+   * passage, because every passage of it is scanned again. A scan stopped by
+   * the round cap proved nothing, so it hands the next request the rank it
+   * reached and the window moves on.
+   */
+  windowStart: number;
+};
+
+/**
+ * The cursor as the client sees it: the shared `score:id` payload with the
+ * window the scan must resume in folded into the id half. A payload without a
+ * window prefix names window 0, which is what a cursor issued before windows
+ * existed means and what a caller building one by hand should get.
+ */
+export const encodeCorpusIndexCursor = ({
+  score,
+  id,
+  windowStart,
+}: SearchCursor): string => encodeCursor(score, `${windowStart}:${id}`);
+
+export const decodeCorpusIndexCursor = (
+  cursor: string,
+): SearchCursor | null => {
+  const decoded = decodeCursor(cursor);
+  if (decoded === null) {
+    return null;
+  }
+  const separatorIndex = decoded.id.indexOf(":");
+  if (separatorIndex === -1) {
+    return { ...decoded, windowStart: 0 };
+  }
+  const windowStart = Number(decoded.id.slice(0, separatorIndex));
+  const id = decoded.id.slice(separatorIndex + 1);
+  if (!Number.isInteger(windowStart) || windowStart < 0 || id.length === 0) {
+    return null;
+  }
+  return { score: decoded.score, id, windowStart };
 };
 
 type CorpusIndexRanking<TContext> = {
@@ -48,14 +89,16 @@ type CorpusIndexSearchPageResult<TContext> = {
    */
   anchorIdById: Map<string, string>;
   /**
-   * How many passages of a document matched. A breadth signal — one paragraph
-   * on point versus a document that discusses the topic throughout. Reported,
-   * not folded into `score`: the count grows as the scan widens, and a score
-   * that changes between windows would break the keyset cursor, which assumes
-   * an already-emitted hit keeps the score it was emitted with.
+   * How many passages of a document matched, within the scanned window. A
+   * breadth signal — one paragraph on point versus a document that discusses
+   * the topic throughout. Reported, not folded into `score`: the count grows
+   * as the scan widens, and a score that changes between windows would break
+   * the keyset cursor, which assumes an already-emitted hit keeps the score it
+   * was emitted with.
    */
   passageCountById: Map<string, number>;
-  hasMore: boolean;
+  /** Where the next page resumes, or null when this page is the last. */
+  nextCursor: SearchCursor | null;
   /** What the scan spent reaching this page, and why it stopped. */
   scan: CorpusIndexScanReport;
 };
@@ -123,13 +166,30 @@ export const isAfterSearchCursor = (
   return hit.id < cursor.id;
 };
 
-export const corpusIndexLexicalScore = (
-  totalHits: number,
-  globalIndex: number,
-): number => {
-  const denominator = Math.max(1, totalHits - 1);
-  return Math.max(0, 1 - globalIndex / denominator);
-};
+/**
+ * Lexical score of the hit at `globalIndex` in the engine's `_score` order.
+ * The engine reports the order but not the scores, so the rank stands in for
+ * them, decaying by a factor of e per round of candidates:
+ *
+ *   lexical(i) = exp(-i / corpusIndexSearchCandidateLimit)
+ *
+ * Two properties matter. It is strictly decreasing, so the early-stop proof
+ * holds unchanged: once `unseenScoreUpperBound(lexical(next))` falls below the
+ * page's last blended score, no unseen hit can out-blend an emitted one. And
+ * it reads only the rank, so a rescan for page two assigns an already-emitted
+ * hit exactly the score its cursor encodes — the previous form divided by the
+ * index-wide hit count, which drifts as the corpus changes.
+ *
+ * What it means for ranking: an additive signal of total weight `w` can lift a
+ * candidate over a hit whose lexical score is `s` only while
+ * `s - w < lexical(candidate)`, so it reaches at most
+ * `candidateLimit × ln(1 / (s - w))` ranks above itself. Citation authority
+ * therefore re-orders within a window of the top few hundred hits rather than
+ * across the whole list, which is the intended definition: the engine's order
+ * is the primary key and the blend re-orders a bounded window of it.
+ */
+export const corpusIndexLexicalScore = (globalIndex: number): number =>
+  Math.exp(-globalIndex / LIMITS.corpusIndexSearchCandidateLimit);
 
 const windowAfterCursor = (
   ranked: readonly RankedHit[],
@@ -159,7 +219,14 @@ export const readCorpusIndexSearchPage = async <TContext>({
   const passageCountById = new Map<string, number>();
   let ranking: CorpusIndexRanking<TContext> | null = null;
   let windowed: RankedHit[] = [];
-  let startOffset = 0;
+  // Absolute rank in the engine's order, so a hit keeps the score its cursor
+  // encodes whichever window reached it; `scanned` is this request's own work,
+  // which is what the budget and the telemetry are about.
+  const windowStart = parsedCursor?.windowStart ?? 0;
+  let startOffset = windowStart;
+  let scanned = 0;
+  /** Document owning the last passage the scan read; the next window's edge. */
+  let lastScannedId: string | null = null;
   let totalHits = Number.POSITIVE_INFINITY;
   let rounds = 0;
   let roundCapHit = false;
@@ -180,13 +247,13 @@ export const readCorpusIndexSearchPage = async <TContext>({
     if (resultUnits === 0) {
       return LIMITS.corpusIndexSearchScanLimit;
     }
-    const perDocument = Math.min(startOffset / resultUnits, PASSAGE_OVER_FETCH);
+    const perDocument = Math.min(scanned / resultUnits, PASSAGE_OVER_FETCH);
     return Math.ceil(
       LIMITS.corpusIndexSearchScanLimit * Math.max(1, perDocument),
     );
   };
 
-  while (startOffset < totalHits && startOffset < scanBudget()) {
+  while (startOffset < totalHits && scanned < scanBudget()) {
     // Every round is one more sequential engine round trip in front of the
     // reader. The budget above bounds how many candidates a scan may reach;
     // this bounds how long it may take to give up trying.
@@ -197,7 +264,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
 
     const maxHits = Math.min(
       LIMITS.corpusIndexSearchCandidateLimit,
-      scanBudget() - startOffset,
+      scanBudget() - scanned,
     );
     if (maxHits <= 0) {
       break;
@@ -234,6 +301,15 @@ export const readCorpusIndexSearchPage = async <TContext>({
       if (id === null) {
         continue;
       }
+      lastScannedId = id;
+      // The cursor names a hit the reader already has. Its remaining passages
+      // are a continuation of that hit, not a new one — which is what a window
+      // opening in the middle of a long document's passages returns, and the
+      // score filter below cannot catch, because in a fresh window those
+      // passages score below the cursor rather than above it.
+      if (id === parsedCursor?.id) {
+        continue;
+      }
 
       // Hits arrive best-first, so the first hit seen for a document is its
       // best-scoring passage: it sets the document's rank, its snippet, and
@@ -248,7 +324,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
 
       candidates.push({
         id,
-        score: corpusIndexLexicalScore(totalHits, startOffset + index),
+        score: corpusIndexLexicalScore(startOffset + index),
       });
 
       const snippet = extractSnippet(result.value.snippets[index]);
@@ -262,13 +338,14 @@ export const readCorpusIndexSearchPage = async <TContext>({
     }
 
     startOffset += hits.length;
+    scanned += hits.length;
     // oxlint-disable-next-line no-await-in-loop -- ranks the accumulated candidates each round to decide whether to stop early
     ranking = await rankCandidates(candidates);
     windowed = windowAfterCursor(ranking.ranked, parsedCursor);
     if (windowed.length > limit) {
       const cursorScore = windowed.at(limit - 1)?.score ?? 0;
       const nextUnseen = unseenScoreUpperBound(
-        corpusIndexLexicalScore(totalHits, startOffset),
+        corpusIndexLexicalScore(startOffset),
       );
       if (nextUnseen < cursorScore) {
         earlyStopped = true;
@@ -284,14 +361,46 @@ export const readCorpusIndexSearchPage = async <TContext>({
 
   const hasMoreInWindow = windowed.length > limit;
   const pageRanked = hasMoreInWindow ? windowed.slice(0, limit) : windowed;
-  // A follow-up request rescans from offset 0 and can only reach deeper
-  // candidates while the scan cap is not exhausted; past the cap a
-  // cursor could never be satisfied and must not be advertised. The round
-  // cap binds the same way: a rescan spends the same rounds and stops at the
-  // same offset, so nothing past it is reachable by paging.
-  const scanCanContinue =
-    !roundCapHit && startOffset < totalHits && startOffset < scanBudget();
-  const hasMore = hasMoreInWindow || (scanCanContinue && pageRanked.length > 0);
+  const lastEmitted = pageRanked.at(-1);
+  // A follow-up request replays this window and can only reach deeper
+  // candidates while the window's own budget is not exhausted; past it a
+  // cursor could never be satisfied and must not be advertised.
+  const windowCanContinue = startOffset < totalHits && scanned < scanBudget();
+  // The window itself moves only when the round cap ended the scan. The cap
+  // is what makes a page bounded-latency, and it is also why such a page
+  // cannot prove the blend bound the early stop proves: an unemitted hit in
+  // the next window may out-blend one this page emitted. Progress is worth
+  // more than that proof — a decision whose passages fill the whole capped
+  // window would otherwise leave the reader on a one-hit page with nowhere to
+  // go, and there is no ceiling on passages per document that the cap could
+  // be sized above (the chunker's is a hostile-input bound, orders of
+  // magnitude higher).
+  const resolveNextCursor = (): SearchCursor | null => {
+    if (lastEmitted === undefined) {
+      return null;
+    }
+    if (hasMoreInWindow || (!roundCapHit && windowCanContinue)) {
+      return { score: lastEmitted.score, id: lastEmitted.id, windowStart };
+    }
+    if (!roundCapHit || startOffset >= totalHits) {
+      return null;
+    }
+    return {
+      // Above every blended score the next window can hold, by the bound's
+      // own contract, so none of that window is filtered out as already seen.
+      score: unseenScoreUpperBound(corpusIndexLexicalScore(startOffset)),
+      // The document the scan stopped inside: the one whose passages can run
+      // across the window edge, and the only one the next window must drop by
+      // name. Everything else this window held was emitted (the window moves
+      // only once its whole ranking fit on a page), so a document that matched
+      // here and again further down can still repeat on a later page — the
+      // price of moving the window at all, and the reason the blend bound is
+      // proven within a window rather than across the cap.
+      id: lastScannedId ?? lastEmitted.id,
+      windowStart: startOffset,
+    };
+  };
+  const nextCursor = resolveNextCursor();
 
   return {
     pageRanked,
@@ -299,10 +408,10 @@ export const readCorpusIndexSearchPage = async <TContext>({
     snippetById,
     anchorIdById,
     passageCountById,
-    hasMore,
+    nextCursor,
     scan: {
       rounds,
-      passagesScanned: startOffset,
+      passagesScanned: scanned,
       indexMs,
       earlyStopped,
       roundCapHit,

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -56,7 +56,36 @@ type CorpusIndexSearchPageResult<TContext> = {
    */
   passageCountById: Map<string, number>;
   hasMore: boolean;
+  /** What the scan spent reaching this page, and why it stopped. */
+  scan: CorpusIndexScanReport;
 };
+
+/**
+ * The cost of one scan. A response looks the same whether it took one engine
+ * round trip or the cap's worth, so the count is only observable if the scan
+ * reports it.
+ */
+export type CorpusIndexScanReport = {
+  /** Engine round trips spent accumulating candidates. */
+  rounds: number;
+  /** Hits the engine returned across those rounds. */
+  passagesScanned: number;
+  /** Summed wall time of those engine calls. */
+  indexMs: number;
+  /** Stopped because no unseen candidate could out-blend the page. */
+  earlyStopped: boolean;
+  /** Stopped at `LIMITS.corpusIndexSearchMaxRounds` instead. */
+  roundCapHit: boolean;
+};
+
+/** What a request that never reached the index spent on it. */
+export const emptyCorpusIndexScan = (): CorpusIndexScanReport => ({
+  rounds: 0,
+  passagesScanned: 0,
+  indexMs: 0,
+  earlyStopped: false,
+  roundCapHit: false,
+});
 
 /**
  * Passage-layout indexes return several hits per document, so a fixed
@@ -134,6 +163,8 @@ export const readCorpusIndexSearchPage = async <TContext>({
   let totalHits = Number.POSITIVE_INFINITY;
   let rounds = 0;
   let roundCapHit = false;
+  let earlyStopped = false;
+  let indexMs = 0;
 
   // Chunk-space scan budget, grown to keep result-space reach constant
   // across index layouts. Recomputed each round from what the scan has seen so
@@ -176,6 +207,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
     // Sort by BM25 explicitly: without it the engine returns hits in
     // document-id order and the rank-based lexical score below would be
     // meaningless.
+    const roundStartedAt = performance.now();
     // oxlint-disable-next-line no-await-in-loop -- offset pagination: each scan depends on the previous startOffset
     const result = await getCorpusIndexClient(cluster).search({
       indexId,
@@ -185,6 +217,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
       sortBy: "_score",
       snippetFields,
     });
+    indexMs += performance.now() - roundStartedAt;
     if (result.isErr()) {
       throw result.error;
     }
@@ -238,6 +271,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
         corpusIndexLexicalScore(totalHits, startOffset),
       );
       if (nextUnseen < cursorScore) {
+        earlyStopped = true;
         break;
       }
     }
@@ -266,5 +300,12 @@ export const readCorpusIndexSearchPage = async <TContext>({
     anchorIdById,
     passageCountById,
     hasMore,
+    scan: {
+      rounds,
+      passagesScanned: startOffset,
+      indexMs,
+      earlyStopped,
+      roundCapHit,
+    },
   };
 };

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -22,7 +22,11 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusIndexBrowseFacets } from "@/api/lib/legal-search/corpus-index-facets";
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
-import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
+import {
+  decodeCorpusIndexCursor,
+  encodeCorpusIndexCursor,
+  readCorpusIndexSearchPage,
+} from "@/api/lib/legal-search/corpus-index-pagination";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
 import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
@@ -41,7 +45,6 @@ import {
   definePublicLawSharedQuery,
   PUBLIC_LAW_SHARED_QUERY,
 } from "@/api/lib/public-law-shared-query";
-import { encodeCursor, decodeCursor } from "@/api/lib/search/cursor";
 
 /**
  * corpus index legal-search provider: two-stage retrieve-then-rerank.
@@ -148,7 +151,9 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
     query.jurisdiction,
   );
 
-  const parsedCursor = query.cursor ? decodeCursor(query.cursor) : null;
+  const parsedCursor = query.cursor
+    ? decodeCorpusIndexCursor(query.cursor)
+    : null;
 
   // The jurisdiction also selects the expansion dictionary, which is why the
   // resolver takes it separately from the clause.
@@ -229,14 +234,15 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   const {
     anchorIdById,
     context: { displayById },
-    hasMore,
     pageRanked,
     passageCountById,
     snippetById,
   } = searchPage;
 
-  const last = pageRanked.at(-1);
-  const nextCursor = hasMore && last ? encodeCursor(last.score, last.id) : null;
+  const nextCursor =
+    searchPage.nextCursor === null
+      ? null
+      : encodeCorpusIndexCursor(searchPage.nextCursor);
 
   const hits: LegalSearchHit[] = pageRanked.flatMap((hit) => {
     const row = displayById.get(hit.id);

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -451,6 +451,16 @@ export const LIMITS = {
   // Max corpus-index lexical candidates scanned across windows for one
   // cursor request.
   corpusIndexSearchScanLimit: 10_000,
+  /**
+   * Engine round trips one corpus-index search may spend accumulating
+   * candidates. The scan normally ends as soon as no unseen candidate can
+   * out-blend the page, but a query whose lexical scores separate slowly
+   * reaches that point only deep into the hit list, and every further round
+   * is another sequential engine round trip the reader waits through. This
+   * caps that wait: a scan that reaches it answers from what it has, and
+   * stops advertising candidates a rescan could never get back to.
+   */
+  corpusIndexSearchMaxRounds: 3,
   // Decisions pushed to corpus index per indexer batch.
   corpusIndexBatchSize: 50,
   /** Max UTF-8 bytes in one corpus-index NDJSON ingest request. A batch is

--- a/apps/api/src/tests/security/public-law-reader-role.test.ts
+++ b/apps/api/src/tests/security/public-law-reader-role.test.ts
@@ -584,21 +584,21 @@ describe("public-law reader role", () => {
     });
     expect(search.ranked).toEqual([]);
 
-    const byDocket = await findDecisionIdsByIdentity(
+    const byDocket = await findDecisionIdsByIdentity({
       caseLawDb,
-      { type: "identifier", kind: "docket", value: "22 Cdo 1/2026" },
-      "CZE",
-    );
+      country: "CZE",
+      identity: { type: "identifier", kind: "docket", value: "22 Cdo 1/2026" },
+    });
     expect(byDocket).toEqual([]);
-    const byEcli = await findDecisionIdsByIdentity(
+    const byEcli = await findDecisionIdsByIdentity({
       caseLawDb,
-      {
+      country: undefined,
+      identity: {
         type: "identifier",
         kind: "ecli",
         value: "ECLI:CZ:NS:2026:22.CDO.1.2026.1",
       },
-      undefined,
-    );
+    });
     expect(byEcli).toEqual([]);
   });
 


### PR DESCRIPTION
## What

Three commits on the corpus-index search scan:

1. `perf(api): cap the corpus-index candidate scan rounds` — `LIMITS.corpusIndexSearchMaxRounds` (3) bounds the scan loop; a capped scan never advertises a cursor a rescan could not reach.
2. `feat(api): report corpus-index search rounds and timings` — `readCorpusIndexSearchPage` returns a scan report (rounds, passages scanned, index time, early stop, cap hit) and the decisions search emits one `case_law.search.completed` event per request with those counters plus hydration count, hit count, Postgres time and total time. Query class only, never the query text.
3. `perf(api): decay the corpus-index rank proxy so a page settles within one scan round` — the lexical score becomes `exp(-rank / candidateLimit)`. It depends on rank alone, so a cursor reproduces its value exactly on a rescan (the previous form moved with the index-wide hit count), and the early-stop bound now closes inside the first round for the default page size with additive signals up to a total weight of 0.5. The comment states the ranking consequence: an additive signal re-orders a bounded window of the engine's order, not the whole list.

## Why

The scan re-read rounds of candidates until an upper bound that, with the previous rank proxy, barely decayed on large hit counts, so a common term paid several engine rounds and several Postgres rehydrations per page. The engine's own score is not available on the search response this client uses, so the proxy stays rank-based.

## Tests

Pagination: one round for a 30,000-hit list at the default page size and at the maximum, at total weights 0.3 and 0.5; cursor continuation without duplicates; the round cap and its cursor contract; equal ranks score identically regardless of hit count. Telemetry: attribute shape and no sensitive keys. Existing legislation and provider suites pass with the same bound.
