### PR TITLE
feat(api): carry the expansion dictionary version in the search cursor and allow the live mode

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -29,8 +29,9 @@
 # [internal] Optional with a default. Morphological expansion of case-law
 # search terms: "off" builds today's query, "shadow" runs the unexpanded query
 # and records leaf counts comparing it with the expanded one (never the query
-# text). "on" runs the expanded query and is currently refused at startup,
-# pending cursors that carry the dictionary version.
+# text). "on" runs the expanded query; a search cursor names the dictionary
+# its page used, so a continuation built against another one is rejected as
+# invalid.
 # QUERY_EXPANSION_MODE="off"
 
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts

--- a/apps/api/src/env-base-schema.test.ts
+++ b/apps/api/src/env-base-schema.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
 
-import { envBaseInvariantViolation } from "@/api/env-base-schema";
+import {
+  envBaseInvariantViolation,
+  envBaseServerSchema,
+} from "@/api/env-base-schema";
+import { QUERY_EXPANSION_MODES } from "@/api/lib/legal-search/query-expansion-mode";
 
 const deployedCorpusEnvironment = {
   CORPUS_INDEX_BACKPRESSURE_HIGH_WATERMARK: 80,
@@ -12,7 +17,6 @@ const deployedCorpusEnvironment = {
   LEGAL_CORPUS_S3_BUCKET: "stella-staging-legal-corpus",
   LEGAL_SEARCH_INDEX_GENERATION: "case_law_v2",
   LEGAL_SEARCH_PROVIDER: "corpus-index",
-  QUERY_EXPANSION_MODE: "off",
   S3_CREDENTIALS_PROVIDER: "aws-runtime",
   S3_ENDPOINT: "https://s3.eu-central-1.amazonaws.com",
   isDev: false,
@@ -70,5 +74,26 @@ describe("corpus cluster endpoint transport", () => {
     ).toBe(
       "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets loopback or the private corpus-index-v09 Cloud Map service.",
     );
+  });
+});
+
+describe("query expansion mode", () => {
+  // Every mode is deployable. `on` was reserved by a boot refusal while a
+  // corpus cursor could not say which dictionary built its page; the cursor
+  // carries that now, so nothing is left to reserve.
+  test.each([...QUERY_EXPANSION_MODES])("accepts %p", (mode) => {
+    expect(v.parse(envBaseServerSchema.QUERY_EXPANSION_MODE, mode)).toBe(mode);
+  });
+
+  test("defaults to off", () => {
+    expect(v.parse(envBaseServerSchema.QUERY_EXPANSION_MODE, undefined)).toBe(
+      "off",
+    );
+  });
+
+  test("rejects a mode outside the union", () => {
+    expect(
+      v.safeParse(envBaseServerSchema.QUERY_EXPANSION_MODE, "live").success,
+    ).toBe(false);
   });
 });

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -17,10 +17,7 @@ import {
   resolveCorpusStorageMode,
 } from "@/api/lib/corpus-storage-mode";
 import { parseCorpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
-import {
-  QUERY_EXPANSION_MODES,
-  type QueryExpansionMode,
-} from "@/api/lib/legal-search/query-expansion-mode";
+import { QUERY_EXPANSION_MODES } from "@/api/lib/legal-search/query-expansion-mode";
 import { isUsableStaticCredential } from "@/api/lib/s3-credentials";
 import {
   isLoopbackHostname,
@@ -296,8 +293,9 @@ export const envBaseServerSchema = {
   // `off` is byte-identical to the pre-expansion query builder and fetches
   // no dictionary; `shadow` executes the unexpanded query and records how the
   // expanded one compares (leaf counts only, never query text). `on` executes
-  // the expanded query and is refused at boot by the invariant below until
-  // corpus cursors carry the dictionary version they were built against.
+  // the expanded query; a corpus cursor names the dictionary it was built
+  // against, so a continuation page is either ranked against that same
+  // dictionary or refused as a stale cursor.
   QUERY_EXPANSION_MODE: v.optional(v.picklist(QUERY_EXPANSION_MODES), "off"),
   isDev: v.boolean(),
 };
@@ -332,7 +330,6 @@ type EnvBaseInvariantInput = {
   LEGAL_CORPUS_S3_BUCKET?: string | undefined;
   LEGAL_SEARCH_INDEX_GENERATION: string;
   LEGAL_SEARCH_PROVIDER: "pg-fts" | "corpus-index";
-  QUERY_EXPANSION_MODE: QueryExpansionMode;
   S3_ACCESS_KEY_ID?: string | undefined;
   S3_CREDENTIALS_PROVIDER: "auto" | "env" | "aws-runtime" | "none";
   S3_ENDPOINT: string;
@@ -411,7 +408,6 @@ const corpusEndpointInvariantViolation = ({
   CORPUS_INDEX_Q09_ENDPOINT,
   CORPUS_INDEX_Q09_SEARCH_ENDPOINT,
   CORPUS_INDEX_SEARCH_ENDPOINT,
-  QUERY_EXPANSION_MODE,
   isDev,
 }: EnvBaseInvariantInput): string | null => {
   if (
@@ -443,19 +439,6 @@ const corpusEndpointInvariantViolation = ({
     !isSecureOrPrivateQ09MutationEndpoint(CORPUS_INDEX_Q09_ENDPOINT)
   ) {
     return "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets loopback or the private corpus-index-v09 Cloud Map service.";
-  }
-  // REMOVAL CONDITION: delete this invariant in the PR that makes a corpus
-  // cursor carry the dictionary version it was built against.
-  //
-  // Under `on` the engine query depends on which dictionary the serving
-  // replica loaded, so a page-2 request landing on a replica mid-refresh
-  // rebuilds a different query and ranks a different result set against page
-  // 1's cursor, skipping or repeating decisions. `shadow` cannot reach this,
-  // because it executes the unexpanded query. Refusing the mode at boot is
-  // what keeps the broken combination unreachable rather than merely
-  // documented.
-  if (QUERY_EXPANSION_MODE === "on") {
-    return 'QUERY_EXPANSION_MODE="on" requires dictionary-version-carrying cursors; not yet implemented — use "shadow".';
   }
   return null;
 };

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -54,14 +54,9 @@ import {
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
-import type {
-  CorpusIndexScanReport,
-  SearchCursor,
-} from "@/api/lib/legal-search/corpus-index-pagination";
+import type { CorpusIndexScanReport } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
-  decodeCorpusIndexCursor,
   emptyCorpusIndexScan,
-  encodeCorpusIndexCursor,
   readCorpusIndexSearchPage,
 } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
@@ -72,7 +67,16 @@ import {
   caseLawCorpusQuery,
   type CorpusTermExpander,
 } from "@/api/lib/legal-search/corpus-query";
-import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
+import {
+  type CorpusSearchCursor,
+  decodeCorpusSearchCursor,
+  encodeCorpusSearchCursor,
+  isStaleCorpusSearchCursor,
+} from "@/api/lib/legal-search/corpus-search-cursor";
+import {
+  type ExpandedCorpusQuery,
+  resolveExpandedCorpusQuery,
+} from "@/api/lib/legal-search/expansion";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
 import {
   corpusIndexRoute,
@@ -537,7 +541,7 @@ const resolveCorpusIndexQuery = async ({
   body,
   generation,
   jurisdictionClause,
-}: ResolveCorpusIndexQueryOptions): Promise<string | null> => {
+}: ResolveCorpusIndexQueryOptions): Promise<ExpandedCorpusQuery> => {
   const fields = caseLawCorpusQueryFields({
     generation,
     jurisdiction: body.country,
@@ -959,9 +963,9 @@ const searchCorpusIndexDecisions = async (
   const startedAt = performance.now();
   const limit = body.limit ?? LIMITS.caseLawSearchPageSizeDefault;
 
-  let parsedCursor: SearchCursor | null = null;
+  let parsedCursor: CorpusSearchCursor | null = null;
   if (body.cursor) {
-    parsedCursor = decodeCorpusIndexCursor(body.cursor);
+    parsedCursor = decodeCorpusSearchCursor(body.cursor);
     if (!parsedCursor || !isUuid(parsedCursor.id)) {
       return status(400, { message: "Invalid cursor" });
     }
@@ -1081,20 +1085,26 @@ const searchCorpusIndexDecisions = async (
     body.country,
   );
 
-  const query = await resolveCorpusIndexQuery({
+  const resolved = await resolveCorpusIndexQuery({
     body,
     generation,
     jurisdictionClause,
   });
-  if (query === null) {
+  if (resolved.type === "empty") {
     report(0, emptyCorpusIndexScan());
     return { hits: [], facets: null, totalCount: null, nextCursor: null };
+  }
+  // A page boundary only means something inside the ranking that produced it,
+  // and expansion makes the dictionary part of that ranking. A cursor from a
+  // different one is stale, and takes the same path a tampered one does.
+  if (isStaleCorpusSearchCursor(parsedCursor, resolved.dictionary)) {
+    return status(400, { message: "Invalid cursor" });
   }
 
   const searchPage = await readCorpusIndexSearchPage({
     cluster: serving.cluster,
     indexId,
-    query,
+    query: resolved.query,
     limit,
     parsedCursor,
     snippetFields: ["text"],
@@ -1124,7 +1134,10 @@ const searchCorpusIndexDecisions = async (
   const nextCursor =
     searchPage.nextCursor === null
       ? null
-      : encodeCorpusIndexCursor(searchPage.nextCursor);
+      : encodeCorpusSearchCursor({
+          ...searchPage.nextCursor,
+          dictionary: resolved.dictionary,
+        });
 
   // A row the candidate read saw and this one no longer answers for was
   // scrubbed mid-request; it drops out of the page rather than being served

--- a/apps/api/src/handlers/legislation/search-cursor.test.ts
+++ b/apps/api/src/handlers/legislation/search-cursor.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import nodePath from "node:path";
+
+import { searchLegislationHandler } from "@/api/handlers/legislation/search";
+import { encodeCorpusSearchCursor } from "@/api/lib/legal-search/corpus-search-cursor";
+import type { LegislationReadDb } from "@/api/lib/legislation-public-read-db";
+
+const DOCUMENT_ID = "6b1d2f34-58aa-4d1c-9d0f-2c3b4a5e6f70";
+
+/**
+ * A database that refuses to be read. Both search paths begin by reading
+ * through one, so a call here would mean the cursor got past the boundary.
+ */
+const unreachableDb = () => {
+  let reads = 0;
+  const db: LegislationReadDb = async () => {
+    reads += 1;
+    // Never resolves to a transaction, because no test below lets it be
+    // called: the assertion is that the boundary answered first.
+    throw new Error("a search path read the database");
+  };
+  return { db, reads: () => reads };
+};
+
+const CASE_LAW_CURSOR = encodeCorpusSearchCursor({
+  dictionary: { contentHash: "a".repeat(64), type: "dictionary" },
+  id: DOCUMENT_ID,
+  score: 0.5,
+  windowStart: 0,
+});
+
+// The legislation corpus is never expanded, so a cursor naming a dictionary
+// came from an expanded case-law search: its score, id and window bound a
+// ranking of other documents entirely. The database would throw if either
+// search path started, so the refusal is proven to cost nothing as well as to
+// happen.
+test("a cursor naming a dictionary is refused, and reads nothing", async () => {
+  const { db, reads } = unreachableDb();
+
+  const result = await searchLegislationHandler(
+    { cursor: CASE_LAW_CURSOR, query: "nájemné" },
+    db,
+  );
+
+  expect(result).not.toHaveProperty("hits");
+  expect(result).toMatchObject({
+    code: 400,
+    response: { message: "Invalid cursor" },
+  });
+  expect(reads()).toBe(0);
+});
+
+// What makes the test above cover the corpus-index path and the pg-fts path
+// alike: the identity is checked before the provider is consulted, so neither
+// path can be the one that accepts a case-law cursor. A guard that moved below
+// the branch would have to be proven twice, once per provider, and the
+// provider is not switchable from a test.
+test("the identity is checked before either search path is chosen", async () => {
+  const source = await Bun.file(
+    nodePath.resolve(import.meta.dir, "search.ts"),
+  ).text();
+  const guard = source.indexOf("isStaleCorpusSearchCursor(");
+  const providerBranch = source.indexOf("envBase.LEGAL_SEARCH_PROVIDER");
+
+  expect(guard).toBeGreaterThan(-1);
+  expect(providerBranch).toBeGreaterThan(-1);
+  expect(guard).toBeLessThan(providerBranch);
+});

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -20,21 +20,23 @@ import {
 import { blendedRankSql } from "@/api/lib/legal-search/authority-sql";
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
 import type { SearchCursor } from "@/api/lib/legal-search/corpus-index-pagination";
-import {
-  decodeCorpusIndexCursor,
-  encodeCorpusIndexCursor,
-  readCorpusIndexSearchPage,
-} from "@/api/lib/legal-search/corpus-index-pagination";
+import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   corpusFreeTextClause,
   quoteCorpusValue,
 } from "@/api/lib/legal-search/corpus-query";
+import {
+  decodeCorpusSearchCursor,
+  encodeCorpusSearchCursor,
+  isStaleCorpusSearchCursor,
+} from "@/api/lib/legal-search/corpus-search-cursor";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
 import {
   corpusIndexId,
   corpusIndexPattern,
   isCorpusIndexJurisdiction,
 } from "@/api/lib/legal-search/index-naming";
+import { NO_EXPANSION_DICTIONARY_IDENTITY } from "@/api/lib/legal-search/morphology/dictionary";
 import { buildPgFtsSearchSql } from "@/api/lib/legal-search/pg-fts-query";
 import {
   blendStableCitationAuthority,
@@ -403,10 +405,16 @@ const corpusIndexSearch = async (
     pageRanked,
     snippetById,
   } = searchPage;
+  // Legislation queries are never expanded, so the identity a legislation
+  // page reports is always `none` — one wire format across both corpora, and
+  // a cursor that crosses them is refused rather than misread.
   const nextCursor =
     searchPage.nextCursor === null
       ? null
-      : encodeCorpusIndexCursor(searchPage.nextCursor);
+      : encodeCorpusSearchCursor({
+          ...searchPage.nextCursor,
+          dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+        });
 
   const hits = pageRanked.flatMap((hit): LegislationHit[] => {
     const row = byId.get(hit.id);
@@ -452,12 +460,20 @@ export const searchLegislationHandler = async (
     return status(400, { message: "Invalid jurisdiction" });
   }
 
+  // One rejection for every way a cursor can fail to name a page of this
+  // corpus, checked before either search path reads anything. A cursor that
+  // names a dictionary was issued by an expanded case-law search: legislation
+  // is never expanded, so its score, id and window describe a ranking of
+  // other documents entirely, and applying them here would page a legislation
+  // result set from a case-law boundary.
   const parsedCursor = body.cursor
-    ? decodeCorpusIndexCursor(body.cursor)
+    ? decodeCorpusSearchCursor(body.cursor)
     : null;
   if (
     body.cursor !== undefined &&
-    (parsedCursor === null || !isUuid(parsedCursor.id))
+    (parsedCursor === null ||
+      !isUuid(parsedCursor.id) ||
+      isStaleCorpusSearchCursor(parsedCursor, NO_EXPANSION_DICTIONARY_IDENTITY))
   ) {
     return status(400, { message: "Invalid cursor" });
   }

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -4,8 +4,6 @@ import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client"
 import type { SearchCursor } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   corpusIndexLexicalScore,
-  decodeCorpusIndexCursor,
-  encodeCorpusIndexCursor,
   HIGHLIGHT_COPIES_PER_PASSAGE,
   readCorpusIndexSearchPage,
 } from "@/api/lib/legal-search/corpus-index-pagination";
@@ -15,7 +13,6 @@ import {
   stableBlendUpperBound,
 } from "@/api/lib/legal-search/rerank";
 import { LIMITS } from "@/api/lib/limits";
-import { encodeCursor } from "@/api/lib/search/cursor";
 
 /**
  * Grouping passage hits back into document hits. A passage-granular generation
@@ -593,37 +590,6 @@ describe("a passage flood does not strand the reader", () => {
     expect(new Set(seen).size).toBe(seen.length);
     expect(seen).toContain("doc-flood");
     expect(seen).toContain(documentId(59));
-  });
-});
-
-describe("the cursor survives its wire form", () => {
-  test("a window cursor round-trips", () => {
-    const cursor = {
-      score: 0.5,
-      id: "4a1b6f6e-0e5a-4a51-9e9f-1a2b3c4d5e6f",
-      windowStart: 900,
-    };
-
-    expect(decodeCorpusIndexCursor(encodeCorpusIndexCursor(cursor))).toEqual(
-      cursor,
-    );
-  });
-
-  test("a payload without a window names the first one", () => {
-    // What a cursor issued before windows existed decodes to, and what a
-    // caller that builds the payload by hand gets.
-    const legacy = encodeCursor(0.5, "4a1b6f6e-0e5a-4a51-9e9f-1a2b3c4d5e6f");
-
-    expect(decodeCorpusIndexCursor(legacy)).toEqual({
-      score: 0.5,
-      id: "4a1b6f6e-0e5a-4a51-9e9f-1a2b3c4d5e6f",
-      windowStart: 0,
-    });
-  });
-
-  test("a malformed window is rejected rather than guessed", () => {
-    expect(decodeCorpusIndexCursor(encodeCursor(0.5, "-3:abc"))).toBeNull();
-    expect(decodeCorpusIndexCursor(encodeCursor(0.5, "12:"))).toBeNull();
   });
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -4,8 +4,13 @@ import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client
 import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
 import type { RankedHit, ScoredCandidate } from "@/api/lib/legal-search/rerank";
 import { LIMITS } from "@/api/lib/limits";
-import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
 
+/**
+ * A page boundary as the scan means it. `corpus-search-cursor` owns how it
+ * reaches a client and back, together with the dictionary the ranked query was
+ * built against: what the scan needs and what expansion needs are one string
+ * on the wire, and one codec answers for it.
+ */
 export type SearchCursor = {
   score: number;
   id: string;
@@ -18,37 +23,6 @@ export type SearchCursor = {
    * reached and the window moves on.
    */
   windowStart: number;
-};
-
-/**
- * The cursor as the client sees it: the shared `score:id` payload with the
- * window the scan must resume in folded into the id half. A payload without a
- * window prefix names window 0, which is what a cursor issued before windows
- * existed means and what a caller building one by hand should get.
- */
-export const encodeCorpusIndexCursor = ({
-  score,
-  id,
-  windowStart,
-}: SearchCursor): string => encodeCursor(score, `${windowStart}:${id}`);
-
-export const decodeCorpusIndexCursor = (
-  cursor: string,
-): SearchCursor | null => {
-  const decoded = decodeCursor(cursor);
-  if (decoded === null) {
-    return null;
-  }
-  const separatorIndex = decoded.id.indexOf(":");
-  if (separatorIndex === -1) {
-    return { ...decoded, windowStart: 0 };
-  }
-  const windowStart = Number(decoded.id.slice(0, separatorIndex));
-  const id = decoded.id.slice(separatorIndex + 1);
-  if (!Number.isInteger(windowStart) || windowStart < 0 || id.length === 0) {
-    return null;
-  }
-  return { score: decoded.score, id, windowStart };
 };
 
 type CorpusIndexRanking<TContext> = {

--- a/apps/api/src/lib/legal-search/corpus-index-provider.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+
+import { corpusIndexProvider } from "@/api/lib/legal-search/corpus-index-provider";
+import { InvalidCorpusSearchCursorError } from "@/api/lib/legal-search/corpus-search-cursor";
+
+// This provider has no HTTP status to answer with, so an undecodable cursor
+// has to fail the read. Falling back to page one looks like a page to a client
+// that appends, which silently duplicates everything it already has.
+//
+// The refusal also lands before the serving-generation read: a cursor is
+// request input, and this assertion is only reachable at all because nothing
+// queried a database or an engine first.
+test("an undecodable cursor fails the read instead of restarting at page one", async () => {
+  const rejection = await corpusIndexProvider
+    .search({ cursor: "not a cursor", limit: 10, query: "nájemné" })
+    .catch((error: unknown) => error);
+
+  expect(rejection).toBeInstanceOf(InvalidCorpusSearchCursorError);
+  expect(
+    rejection instanceof InvalidCorpusSearchCursorError
+      ? rejection.reason
+      : null,
+  ).toBe("undecodable");
+});

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -22,13 +22,15 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusIndexBrowseFacets } from "@/api/lib/legal-search/corpus-index-facets";
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
-import {
-  decodeCorpusIndexCursor,
-  encodeCorpusIndexCursor,
-  readCorpusIndexSearchPage,
-} from "@/api/lib/legal-search/corpus-index-pagination";
+import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import { caseLawCorpusQueryFields } from "@/api/lib/legal-search/corpus-index-read-contract";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
+import {
+  decodeCorpusSearchCursor,
+  encodeCorpusSearchCursor,
+  InvalidCorpusSearchCursorError,
+  isStaleCorpusSearchCursor,
+} from "@/api/lib/legal-search/corpus-search-cursor";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
 import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
 import { corpusIndexRoute } from "@/api/lib/legal-search/index-naming";
@@ -139,6 +141,20 @@ export const rehydrateCorpusIndexProviderCandidates =
 const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   const limit = query.limit;
   const family = query.documentFamily ?? "case_law";
+
+  // Before the generation read, and before any engine work: a cursor that does
+  // not decode must fail rather than fall back to page one, which a client
+  // appending pages cannot tell from a page and reads as duplicates.
+  const parsedCursor = query.cursor
+    ? decodeCorpusSearchCursor(query.cursor)
+    : null;
+  if (query.cursor !== undefined && parsedCursor === null) {
+    throw new InvalidCorpusSearchCursorError({
+      message: "Search cursor did not decode.",
+      reason: "undecodable",
+    });
+  }
+
   const serving = await caseLawPublicReadDb(
     async (tx) => await readServingCorpusIndexGenerationTx(tx, family),
   );
@@ -152,10 +168,6 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
     query.jurisdiction,
   );
 
-  const parsedCursor = query.cursor
-    ? decodeCorpusIndexCursor(query.cursor)
-    : null;
-
   // The jurisdiction also selects the expansion dictionary, which is why the
   // resolver takes it separately from the clause.
   // The generation decides which fields exist to be named; the language
@@ -165,7 +177,7 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
     jurisdiction: query.jurisdiction,
     language: query.language,
   });
-  const engineQuery = await resolveExpandedCorpusQuery({
+  const resolved = await resolveExpandedCorpusQuery({
     build: (expand) =>
       caseLawCorpusQuery({
         text: query.query,
@@ -186,14 +198,23 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
     mode: envBase.QUERY_EXPANSION_MODE,
     text: query.query,
   });
-  if (engineQuery === null) {
+  if (resolved.type === "empty") {
     return { hits: [], facets: null, nextCursor: null, limit };
+  }
+  // This boundary has no HTTP status to answer with, so a cursor from another
+  // dictionary fails the read rather than paging a different result set.
+  if (isStaleCorpusSearchCursor(parsedCursor, resolved.dictionary)) {
+    throw new InvalidCorpusSearchCursorError({
+      message:
+        "Search cursor was built against a different expansion dictionary.",
+      reason: "dictionary_mismatch",
+    });
   }
 
   const searchPage = await readCorpusIndexSearchPage({
     cluster: serving.cluster,
     indexId,
-    query: engineQuery,
+    query: resolved.query,
     limit,
     parsedCursor,
     snippetFields: ["text"],
@@ -252,7 +273,10 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   const nextCursor =
     searchPage.nextCursor === null
       ? null
-      : encodeCorpusIndexCursor(searchPage.nextCursor);
+      : encodeCorpusSearchCursor({
+          ...searchPage.nextCursor,
+          dictionary: resolved.dictionary,
+        });
 
   const hits: LegalSearchHit[] = pageRanked.flatMap((hit) => {
     const row = displayById.get(hit.id);

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -123,6 +123,12 @@ const noTermExpansion: CorpusTermExpander = () => [];
  * asked to match adjacently; a term stands for a word and may carry that
  * word's other inflections. Total over the token union, so a new token kind
  * cannot reach the engine without a decision recorded here.
+ *
+ * This holds under every expansion mode: no dictionary form is ever
+ * substituted into a phrase, so a phrase matches the exact surface forms the
+ * reader typed and quoting stays the way to ask for those and no others. The
+ * stem leaf beside it is the generation's own and is that same phrase,
+ * stemmed word for word, not another wording of it.
  */
 const TOKEN_EXPANSION_POLICY = {
   phrase: "verbatim",

--- a/apps/api/src/lib/legal-search/corpus-search-cursor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-search-cursor.test.ts
@@ -1,0 +1,194 @@
+import { expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import {
+  decodeCorpusSearchCursor,
+  encodeCorpusSearchCursor,
+  isStaleCorpusSearchCursor,
+} from "@/api/lib/legal-search/corpus-search-cursor";
+import {
+  type ExpansionDictionaryIdentity,
+  NO_EXPANSION_DICTIONARY_IDENTITY,
+} from "@/api/lib/legal-search/morphology/dictionary";
+import { encodeCursor } from "@/api/lib/search/cursor";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+const DICTIONARY_A: ExpansionDictionaryIdentity = {
+  contentHash: HASH_A,
+  type: "dictionary",
+};
+const DICTIONARY_B: ExpansionDictionaryIdentity = {
+  contentHash: HASH_B,
+  type: "dictionary",
+};
+const DECISION_ID = "5a3e6f52-1f0b-4f7e-9a44-3f2c1d0e9b8a";
+
+test("a cursor round-trips the window and the dictionary that built its page", () => {
+  const cursor = {
+    dictionary: DICTIONARY_A,
+    id: DECISION_ID,
+    score: 0.875,
+    windowStart: 900,
+  };
+
+  expect(decodeCorpusSearchCursor(encodeCorpusSearchCursor(cursor))).toEqual(
+    cursor,
+  );
+});
+
+// A query nothing was expanded against pages against itself, whatever made it
+// unexpanded: mode `off`, mode `shadow`, a jurisdiction with no dictionary.
+test("an unexpanded page round-trips the no-dictionary identity", () => {
+  const cursor = encodeCorpusSearchCursor({
+    dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+    id: DECISION_ID,
+    score: 0.5,
+    windowStart: 0,
+  });
+
+  expect(decodeCorpusSearchCursor(cursor)?.dictionary).toEqual(
+    NO_EXPANSION_DICTIONARY_IDENTITY,
+  );
+  expect(
+    isStaleCorpusSearchCursor(
+      decodeCorpusSearchCursor(cursor),
+      NO_EXPANSION_DICTIONARY_IDENTITY,
+    ),
+  ).toBe(false);
+});
+
+test("a cursor continues only against the dictionary it names", () => {
+  const cursor = decodeCorpusSearchCursor(
+    encodeCorpusSearchCursor({
+      dictionary: DICTIONARY_A,
+      id: DECISION_ID,
+      score: 0.4,
+      windowStart: 12,
+    }),
+  );
+
+  expect(isStaleCorpusSearchCursor(cursor, DICTIONARY_A)).toBe(false);
+  expect(isStaleCorpusSearchCursor(cursor, DICTIONARY_B)).toBe(true);
+  // A rebuilt or unreachable dictionary is not the one that ranked page 1.
+  expect(
+    isStaleCorpusSearchCursor(cursor, NO_EXPANSION_DICTIONARY_IDENTITY),
+  ).toBe(true);
+});
+
+// The other direction of the same rule: a page that expanded nothing must not
+// be continued against a dictionary that would rank a different result set.
+test("an unexpanded cursor does not continue into an expanded query", () => {
+  const cursor = decodeCorpusSearchCursor(
+    encodeCorpusSearchCursor({
+      dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+      id: DECISION_ID,
+      score: 0.4,
+      windowStart: 0,
+    }),
+  );
+
+  expect(isStaleCorpusSearchCursor(cursor, DICTIONARY_A)).toBe(true);
+});
+
+test("a first page is never stale", () => {
+  expect(isStaleCorpusSearchCursor(null, DICTIONARY_A)).toBe(false);
+  expect(
+    isStaleCorpusSearchCursor(null, NO_EXPANSION_DICTIONARY_IDENTITY),
+  ).toBe(false);
+});
+
+// Both legacy forms a rolling deploy can hand back. Neither could have been
+// issued by a replica that ran the expanded query, so `none` is what their
+// page was built with; the window is what the older format says it is.
+test("reads a cursor from before the window field as the first window", () => {
+  expect(decodeCorpusSearchCursor(encodeCursor(0.25, DECISION_ID))).toEqual({
+    dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+    id: DECISION_ID,
+    score: 0.25,
+    windowStart: 0,
+  });
+});
+
+test("reads a cursor from before the dictionary field in its own window", () => {
+  expect(
+    decodeCorpusSearchCursor(encodeCursor(0.5, `900:${DECISION_ID}`)),
+  ).toEqual({
+    dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+    id: DECISION_ID,
+    score: 0.5,
+    windowStart: 900,
+  });
+});
+
+// The legacy readers admit a missing field, never a wrong one.
+test("a legacy cursor is not a way past the identity check", () => {
+  expect(
+    isStaleCorpusSearchCursor(
+      decodeCorpusSearchCursor(encodeCursor(0.25, `900:${DECISION_ID}`)),
+      DICTIONARY_A,
+    ),
+  ).toBe(true);
+});
+
+test.each([
+  // One metadata segment is a window rank and nothing else.
+  `garbage:${DECISION_ID}`,
+  `-3:${DECISION_ID}`,
+  `1.5:${DECISION_ID}`,
+  `${HASH_A}:${DECISION_ID}`,
+  `none:${DECISION_ID}`,
+  // A rank no scan could have reached is not one this service issued.
+  `${"9".repeat(11)}:${DECISION_ID}`,
+  // Well-shaped segments in the wrong order, or one too many.
+  `${HASH_A}:900:${DECISION_ID}`,
+  `900:none-ish:${DECISION_ID}`,
+  `900:${HASH_A.slice(0, 63)}:${DECISION_ID}`,
+  `900:none:extra:${DECISION_ID}`,
+  // Nothing left to page from.
+  "900:",
+  `900:${HASH_A}:`,
+])("rejects the malformed payload %p rather than guessing", (payload) => {
+  expect(decodeCorpusSearchCursor(encodeCursor(0.5, payload))).toBeNull();
+});
+
+test("decode is total — never throws on arbitrary strings", () => {
+  fc.assert(
+    fc.property(fc.string(), (input) => {
+      expect(() => decodeCorpusSearchCursor(input)).not.toThrow();
+    }),
+    propertyConfig(),
+  );
+});
+
+test("encode → decode round-trips every window and identity", () => {
+  fc.assert(
+    fc.property(
+      fc.double({ noDefaultInfinity: true, noNaN: true }).filter(
+        // -0 is excluded because String(-0) === "0" loses the sign.
+        (score) => !Object.is(score, -0),
+      ),
+      fc.nat({ max: 1_000_000 }),
+      fc.constantFrom(
+        DICTIONARY_A,
+        DICTIONARY_B,
+        NO_EXPANSION_DICTIONARY_IDENTITY,
+      ),
+      // The corpus addresses documents by uuid, which is what makes the id one
+      // segment; the property holds over any id spelled without a separator.
+      fc
+        .string({ maxLength: 64, minLength: 1 })
+        .filter((id) => !id.includes(":")),
+      (score, windowStart, dictionary, id) => {
+        expect(
+          decodeCorpusSearchCursor(
+            encodeCorpusSearchCursor({ dictionary, id, score, windowStart }),
+          ),
+        ).toEqual({ dictionary, id, score, windowStart });
+      },
+    ),
+    propertyConfig(),
+  );
+});

--- a/apps/api/src/lib/legal-search/corpus-search-cursor.ts
+++ b/apps/api/src/lib/legal-search/corpus-search-cursor.ts
@@ -1,0 +1,168 @@
+/**
+ * The wire format of a corpus-index search cursor: its one owner.
+ *
+ * A page boundary is only meaningful inside the ranking that produced it, and
+ * two things decide that ranking. The scan window fixes which slice of the
+ * engine's order was ranked, so a continuation has to resume in the same
+ * window or rank a different slice against the page's boundary. Under
+ * `QUERY_EXPANSION_MODE="on"` the engine query itself is a function of the
+ * dictionary the serving replica had loaded, so two replicas mid-rebuild build
+ * two different queries from one request. Either mismatch skips or repeats
+ * decisions behind an ordinary-looking page.
+ *
+ * Both therefore travel in the cursor, which is the only thing that survives
+ * between the two requests, and one codec owns them: a second module encoding
+ * part of this string is a second answer to what a page boundary means.
+ *
+ * Current form, inside the shared `(score, id)` framing:
+ *
+ *     base64("<score>:<windowStart>:<dictionary>:<id>")
+ *
+ * `windowStart` is a decimal rank, `dictionary` is a payload's sha256 hex or
+ * `none`, and `id` is one segment — the corpus addresses documents by uuid, so
+ * the grammar is fixed-width in its metadata and needs no escaping rule.
+ *
+ * REMOVAL CONDITION: delete `legacy` handling in `decodeCorpusSearchCursor`
+ * in the release after the next one, once no replica issuing a shorter form
+ * can still be serving.
+ *
+ * Two shorter forms were issued to clients before this one, and a rolling
+ * deploy hands them back mid-pagination, so both are read rather than
+ * rejected. Their identity is `none` soundly, not as a courtesy: neither
+ * release could run the expanded query at all, so the page each bounds came
+ * from the unexpanded one, which is exactly what `none` means.
+ *
+ *   - `<score>:<id>` predates windows and expansion, and window 0 is where a
+ *     scan with no window began.
+ *   - `<score>:<windowStart>:<id>` predates expansion only, so its window is
+ *     read as written.
+ *
+ * One metadata segment therefore means a window rank and nothing else.
+ */
+
+import { TaggedError } from "better-result";
+
+import type { SearchCursor } from "@/api/lib/legal-search/corpus-index-pagination";
+import {
+  type ExpansionDictionaryIdentity,
+  NO_EXPANSION_DICTIONARY_IDENTITY,
+  parseExpansionDictionaryIdentity,
+  sameExpansionDictionary,
+  serializeExpansionDictionaryIdentity,
+} from "@/api/lib/legal-search/morphology/dictionary";
+import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
+
+/**
+ * The scan's own boundary plus the dictionary that built the query it ranked.
+ * Derived from `SearchCursor` rather than restated, so a field the scan starts
+ * carrying cannot go missing from the format that has to survive the request.
+ */
+export type CorpusSearchCursor = SearchCursor & {
+  dictionary: ExpansionDictionaryIdentity;
+};
+
+/**
+ * Why a cursor cannot be continued: it did not decode at all, or it names a
+ * dictionary other than the one this request resolved. Named rather than
+ * flagged, because both answers are "start over" to a client and only the
+ * reason tells an operator which.
+ */
+export type InvalidCorpusSearchCursorReason =
+  | "dictionary_mismatch"
+  | "undecodable";
+
+/**
+ * A continuation page cannot be served for the cursor it was asked with. Read
+ * paths without an HTTP status of their own fail on this rather than restarting
+ * at page one, which a client that appends pages reads as duplicates.
+ */
+export class InvalidCorpusSearchCursorError extends TaggedError(
+  "InvalidCorpusSearchCursorError",
+)<{
+  message: string;
+  reason: InvalidCorpusSearchCursorReason;
+}> {}
+
+/**
+ * A window rank on the wire: decimal digits, bounded so the parse is total.
+ * Ten digits is far above any rank a scan can reach, and a longer run of them
+ * is not a rank this service issued.
+ */
+const WINDOW_RANK_PATTERN = /^\d{1,10}$/u;
+
+const parseWindowStart = (value: string): number | null =>
+  WINDOW_RANK_PATTERN.test(value) ? Number(value) : null;
+
+export const encodeCorpusSearchCursor = ({
+  dictionary,
+  id,
+  score,
+  windowStart,
+}: CorpusSearchCursor): string =>
+  encodeCursor(
+    score,
+    `${windowStart}:${serializeExpansionDictionaryIdentity(dictionary)}:${id}`,
+  );
+
+export const decodeCorpusSearchCursor = (
+  cursor: string,
+): CorpusSearchCursor | null => {
+  const decoded = decodeCursor(cursor);
+  if (decoded === null) {
+    return null;
+  }
+  const segments = decoded.id.split(":");
+  const id = segments.at(-1);
+  if (id === undefined || id.length === 0) {
+    return null;
+  }
+  const cursorOf = (
+    dictionary: ExpansionDictionaryIdentity,
+    windowStart: number,
+  ): CorpusSearchCursor => ({
+    dictionary,
+    id,
+    score: decoded.score,
+    windowStart,
+  });
+
+  switch (segments.length) {
+    // legacy: `<score>:<id>`.
+    case 1: {
+      return cursorOf(NO_EXPANSION_DICTIONARY_IDENTITY, 0);
+    }
+    // legacy: `<score>:<windowStart>:<id>`.
+    case 2: {
+      const windowStart = parseWindowStart(segments.at(0) ?? "");
+      return windowStart === null
+        ? null
+        : cursorOf(NO_EXPANSION_DICTIONARY_IDENTITY, windowStart);
+    }
+    case 3: {
+      const windowStart = parseWindowStart(segments.at(0) ?? "");
+      const dictionary = parseExpansionDictionaryIdentity(segments.at(1) ?? "");
+      if (windowStart === null || dictionary === null) {
+        return null;
+      }
+      return cursorOf(dictionary, windowStart);
+    }
+    // An id carrying a colon is not a cursor this service issued: the grammar
+    // above spends every segment it defines, so a longer payload is malformed
+    // rather than an id with a separator in it.
+    default: {
+      return null;
+    }
+  }
+};
+
+/**
+ * Whether this cursor may not be continued against `dictionary`. The one
+ * owner of the rule: both corpus read paths ask it, and each turns a true
+ * into the rejection its own boundary speaks (an HTTP 400, or the error
+ * above).
+ */
+export const isStaleCorpusSearchCursor = (
+  cursor: CorpusSearchCursor | null,
+  dictionary: ExpansionDictionaryIdentity,
+): boolean =>
+  cursor !== null && !sameExpansionDictionary(cursor.dictionary, dictionary);

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -4,15 +4,20 @@ import { extractCitations } from "@/api/handlers/case-law/ingestion/citation-ext
 import {
   CORPUS_QUERY_LEAF_BUDGET,
   corpusFreeTextClause,
+  type CorpusStemming,
+  type CorpusTermExpander,
   tokenizeCorpusFreeText,
 } from "@/api/lib/legal-search/corpus-query";
 import {
   expandTermWith,
   expansionLanguageForJurisdiction,
+  resolveExpandedCorpusQuery,
+  rewrittenCorpusQuery,
   shadowExpansionAttributes,
 } from "@/api/lib/legal-search/expansion";
 import {
   type ExpansionBucket,
+  NO_EXPANSION_DICTIONARY_IDENTITY,
   parseExpansionDictionary,
   serializeExpansionDictionary,
 } from "@/api/lib/legal-search/morphology/dictionary";
@@ -273,4 +278,84 @@ test("the shadow event carries no query text", () => {
   expect(Object.values(attributes)).toEqual(
     expect.arrayContaining([3, 9, 6, true, "cs", "expanded"]),
   );
+});
+
+// The identity travels with the query so a cursor can pin it. Every mode that
+// runs the unexpanded query reports the same `none`, which is what lets a page
+// built under one of them be continued under another, and refused against a
+// dictionary.
+test.each(["off", "on", "shadow"] as const)(
+  "%p reports no dictionary when nothing was expanded",
+  async (mode) => {
+    const resolved = await resolveExpandedCorpusQuery({
+      build: (expand) => corpusFreeTextClause("nájemné", { expand }),
+      // An unscoped search spans every index and expands against nothing, so
+      // no mode reaches object storage from here.
+      jurisdiction: undefined,
+      mode,
+      text: "nájemné",
+    });
+
+    expect(resolved).toEqual({
+      dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+      query: '("nájemné")',
+      type: "query",
+    });
+  },
+);
+
+// The `on` branch, at the point where the identity is chosen. A dictionary
+// that matched nothing the reader typed leaves the pre-expansion query, and a
+// page built from those bytes must stay continuable across the next rebuild.
+//
+// Built against a generation that declares stem fields, so both sides of the
+// comparison carry leaves expansion did not put there: what makes the two
+// queries equal has to be the dictionary adding nothing, not the builder
+// emitting less.
+test("a dictionary that changed nothing is not the dictionary a page reports", () => {
+  const entries = dictionaryOf(CS_BUCKETS);
+  const contentHash = "a".repeat(64);
+  const stemming = {
+    language: "cs",
+    fields: ["text_stem"],
+  } as const satisfies CorpusStemming;
+  const clauseOf = (text: string, expand?: CorpusTermExpander) =>
+    corpusFreeTextClause(text, { expand, stemming }) ?? "";
+  const rewriteOf = (text: string) =>
+    rewrittenCorpusQuery({
+      baseQuery: clauseOf(text),
+      contentHash,
+      expandedQuery: clauseOf(text, (term) => expandTermWith(entries, term)),
+    });
+
+  // `smlouva` has no bucket, so the rewrite is the identity on these bytes —
+  // stem leaf and all.
+  expect(clauseOf("smlouva")).toContain("text_stem:");
+  expect(rewriteOf("smlouva")).toEqual({
+    dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+    query: clauseOf("smlouva"),
+    type: "query",
+  });
+
+  // `nájemné` does, so the payload that widened the query is what the page
+  // reports and what its cursor pins.
+  const expanded = clauseOf("nájemné", (term) => expandTermWith(entries, term));
+  expect(expanded).toContain('"nájemného"');
+  expect(expanded).not.toBe(clauseOf("nájemné"));
+  expect(rewriteOf("nájemné")).toEqual({
+    dictionary: { contentHash, type: "dictionary" },
+    query: expanded,
+    type: "query",
+  });
+});
+
+test("free text with no searchable token resolves to an empty page", async () => {
+  const resolved = await resolveExpandedCorpusQuery({
+    build: (expand) => corpusFreeTextClause("§ ,,,", { expand }),
+    jurisdiction: undefined,
+    mode: "off",
+    text: "§ ,,,",
+  });
+
+  expect(resolved).toEqual({ type: "empty" });
 });

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -30,12 +30,14 @@ import {
 } from "@/api/lib/legal-search/corpus-query";
 import { corpusMorphologyLanguage } from "@/api/lib/legal-search/morphology/corpus-language";
 import {
+  type ExpansionDictionaryIdentity,
   foldExpansionKey,
   isMorphologyDictionaryContentHash,
   isSurfaceForm,
   MORPHOLOGY_DICTIONARY_MAX_BYTES,
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
+  NO_EXPANSION_DICTIONARY_IDENTITY,
   parseExpansionDictionaryOffLoop,
   unpackExpansionForms,
 } from "@/api/lib/legal-search/morphology/dictionary";
@@ -664,6 +666,63 @@ type ResolveExpandedQueryOptions = {
 };
 
 /**
+ * The engine query, and which dictionary produced it.
+ *
+ * The identity travels with the query rather than beside it: a caller that
+ * paginates must write it into the cursor, and one that resolved a query it
+ * could pair with any identity is the mismatch the cursor exists to catch.
+ * `empty` is the free text carrying no searchable term, where callers return
+ * an empty page without querying the engine.
+ */
+export type ExpandedCorpusQuery =
+  | { dictionary: ExpansionDictionaryIdentity; query: string; type: "query" }
+  | { type: "empty" };
+
+/** The pre-expansion query, which no dictionary was applied to. */
+const unexpandedCorpusQuery = (query: string): ExpandedCorpusQuery => ({
+  dictionary: NO_EXPANSION_DICTIONARY_IDENTITY,
+  query,
+  type: "query",
+});
+
+type RewrittenCorpusQueryOptions = {
+  baseQuery: string;
+  contentHash: string;
+  expandedQuery: string;
+};
+
+/**
+ * What a rewrite reports as the dictionary behind it.
+ *
+ * A payload that changed nothing did not rank this query: the bytes sent to
+ * the engine are the pre-expansion ones, so the page is continuable by any
+ * request that builds the same pre-expansion query. Naming the payload here
+ * instead would expire a live cursor on the next rebuild over a dictionary
+ * that cannot affect this query either way.
+ *
+ * Both sides are the assembled clause, so the comparison sees the generation's
+ * own leaves (a summary field, the stem fields) exactly as the engine will.
+ * Only the expansion leaves can differ between them, which is what makes
+ * equality here mean "the dictionary added nothing" rather than "the two
+ * builds happened to agree".
+ *
+ * Exported for the test that pins this rule; the request path reaches it
+ * through `resolveExpandedCorpusQuery`, which is the only caller.
+ */
+export const rewrittenCorpusQuery = ({
+  baseQuery,
+  contentHash,
+  expandedQuery,
+}: RewrittenCorpusQueryOptions): ExpandedCorpusQuery =>
+  expandedQuery === baseQuery
+    ? unexpandedCorpusQuery(baseQuery)
+    : {
+        dictionary: { contentHash, type: "dictionary" },
+        query: expandedQuery,
+        type: "query",
+      };
+
+/**
  * The query a corpus-index search sends to the engine, under the deployment's
  * expansion mode.
  *
@@ -678,35 +737,31 @@ type ResolveExpandedQueryOptions = {
  * executes the unexpanded one. `on` executes the expanded one. Every failure
  * inside resolves to the unexpanded query, so a search never depends on the
  * dictionary being reachable.
- */
-/**
- * `on` is unreachable by configuration, and this is why.
  *
- * The query a request builds depends on which dictionary its replica has
- * loaded, so a page-2 request served by a replica mid-refresh (or holding a
- * fallback payload) rebuilds a different engine query while reusing page 1's
- * cursor, which ranks a different result set against an old score/id boundary
- * and can skip or repeat decisions. Replicas converge on the pointer, so the
- * window is a rebuild or a failed refresh rather than steady state, and
- * `shadow` cannot hit it at all because it executes the unexpanded query.
+ * A query's ranking is only comparable with another built the same way, which
+ * is why every branch reports the dictionary it applied — the payload's hash
+ * under `on` when it rewrote the query, and `none` wherever the unexpanded
+ * query ran, including a mode that expands nothing, a jurisdiction with no
+ * dictionary, a payload that could not be read, and one that matched nothing
+ * the reader typed. `corpus-search-cursor` pins that answer into the page
+ * boundary so a continuation cannot be served from a different result set.
  *
- * `envBaseInvariantViolation` refuses to boot under `on` for that reason;
- * the branch below stays because the mode is part of the union, not because
- * it is reachable today. Closing this means the cursor carries the dictionary
- * version and later pages resolve that same version, which in turn means
- * retaining superseded payloads. Until then the shadow event reports which
- * payload answered (`dictionaryHash`), so replica convergence is measurable
- * from real traffic before that work is scoped.
+ * Quoted phrases are never rewritten (`corpus-query` holds the policy), so a
+ * phrase keeps matching the exact surface forms the reader typed under every
+ * mode.
  */
 export const resolveExpandedCorpusQuery = async ({
   build,
   jurisdiction,
   mode,
   text,
-}: ResolveExpandedQueryOptions): Promise<string | null> => {
+}: ResolveExpandedQueryOptions): Promise<ExpandedCorpusQuery> => {
   const baseQuery = build();
-  if (mode === "off" || baseQuery === null) {
-    return baseQuery;
+  if (baseQuery === null) {
+    return { type: "empty" };
+  }
+  if (mode === "off") {
+    return unexpandedCorpusQuery(baseQuery);
   }
 
   const countryScoped = jurisdiction !== undefined;
@@ -733,19 +788,25 @@ export const resolveExpandedCorpusQuery = async ({
         reach: expanderMissReach(language),
       });
     }
-    return baseQuery;
+    return unexpandedCorpusQuery(baseQuery);
   }
 
   // Both builds tokenize the same text, so this is null only when `baseQuery`
   // already was; returning the base query keeps the branch total anyway.
   const expandedQuery = build(expand.expand);
   if (expandedQuery === null) {
-    return baseQuery;
+    return unexpandedCorpusQuery(baseQuery);
   }
 
   switch (mode) {
     case "on": {
-      return expandedQuery;
+      // The identity names what built the query, not what happened to be
+      // loaded while it was built.
+      return rewrittenCorpusQuery({
+        baseQuery,
+        contentHash: expand.contentHash,
+        expandedQuery,
+      });
     }
     case "shadow": {
       const baseLeaves = freeTextLeaves(text);
@@ -760,7 +821,7 @@ export const resolveExpandedCorpusQuery = async ({
         // guards, or ran out of budget did not expand this query.
         reach: expandedLeaves > baseLeaves ? "expanded" : "dictionary_inert",
       });
-      return baseQuery;
+      return unexpandedCorpusQuery(baseQuery);
     }
     default: {
       return mode satisfies never;

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -2,17 +2,22 @@ import { expect, test } from "bun:test";
 
 import { FOLDED_TOKENIZER } from "@/api/lib/legal-search/corpus-index-config";
 import {
+  type ExpansionDictionaryIdentity,
   foldExpansionKey,
   isMorphologyDictionaryContentHash,
   isSurfaceForm,
   MAX_FORMS_PER_BUCKET,
+  NO_EXPANSION_DICTIONARY_IDENTITY,
   SURFACE_FORM_MAX_LENGTH,
   SURFACE_FORM_MIN_LENGTH,
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
   parseExpansionDictionary,
+  parseExpansionDictionaryIdentity,
   parseExpansionDictionaryOffLoop,
+  sameExpansionDictionary,
   serializeExpansionDictionary,
+  serializeExpansionDictionaryIdentity,
 } from "@/api/lib/legal-search/morphology/dictionary";
 
 test("serialize and parse are the same contract", () => {
@@ -236,3 +241,40 @@ test("a sha256 hex hash is accepted and addresses one key", () => {
     "legal-corpus/morphology/language=pl/current.txt",
   );
 });
+
+test("an identity round-trips through its serialized form", () => {
+  const hash = "b".repeat(64);
+  for (const identity of [
+    { contentHash: hash, type: "dictionary" },
+    NO_EXPANSION_DICTIONARY_IDENTITY,
+  ] as const satisfies readonly ExpansionDictionaryIdentity[]) {
+    expect(
+      parseExpansionDictionaryIdentity(
+        serializeExpansionDictionaryIdentity(identity),
+      ),
+    ).toEqual(identity);
+  }
+});
+
+// The sentinel and a payload's hash share one field, so they must be
+// distinguishable in it: a hash is 64 hex characters and the sentinel is not.
+test("no dictionary is never the same identity as a dictionary", () => {
+  expect(
+    sameExpansionDictionary(NO_EXPANSION_DICTIONARY_IDENTITY, {
+      contentHash: "c".repeat(64),
+      type: "dictionary",
+    }),
+  ).toBe(false);
+  expect(
+    isMorphologyDictionaryContentHash(
+      serializeExpansionDictionaryIdentity(NO_EXPANSION_DICTIONARY_IDENTITY),
+    ),
+  ).toBe(false);
+});
+
+test.each(["", "none ", "NONE", "d".repeat(63), `${"d".repeat(63)}Z`])(
+  "an identity field of %p is not one this service issued",
+  (value) => {
+    expect(parseExpansionDictionaryIdentity(value)).toBeNull();
+  },
+);

--- a/apps/api/src/lib/legal-search/morphology/dictionary.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.ts
@@ -103,6 +103,79 @@ export const isMorphologyDictionaryContentHash = (value: string): boolean =>
   CONTENT_HASH_PATTERN.test(value);
 
 /**
+ * Which dictionary a query was built against: one payload, or none at all.
+ *
+ * A search cursor carries this, so a continuation page can only be ranked
+ * against the payload its first page was built with. `none` is one answer
+ * rather than several: a mode that expands nothing, a jurisdiction with no
+ * dictionary, and a payload that could not be read all executed the same
+ * unexpanded query, so they page against each other consistently.
+ */
+export type ExpansionDictionaryIdentity =
+  | { contentHash: string; type: "dictionary" }
+  | { type: "none" };
+
+/**
+ * Serialized `none`. A sha256 hex string is 64 characters, so this can never
+ * collide with a payload's identity.
+ */
+const NO_EXPANSION_DICTIONARY = "none";
+
+export const NO_EXPANSION_DICTIONARY_IDENTITY: ExpansionDictionaryIdentity = {
+  type: "none",
+};
+
+export const serializeExpansionDictionaryIdentity = (
+  identity: ExpansionDictionaryIdentity,
+): string => {
+  switch (identity.type) {
+    case "dictionary": {
+      return identity.contentHash;
+    }
+    case "none": {
+      return NO_EXPANSION_DICTIONARY;
+    }
+    default: {
+      return identity satisfies never;
+    }
+  }
+};
+
+/**
+ * Read an identity back off the wire. The value arrives inside a cursor a
+ * client hands back, so the hash shape is enforced rather than trusted:
+ * anything that is neither the sentinel nor a sha256 hex string is not an
+ * identity this service ever issued.
+ *
+ * Enforced with this module's own hash guard rather than a schema of its own.
+ * The shape has one owner here — the same guard admits the pointer object that
+ * chooses which payload key is read — and a second spelling of what a content
+ * hash is would be a rule that can drift from the one the loader applies.
+ */
+export const parseExpansionDictionaryIdentity = (
+  value: string,
+): ExpansionDictionaryIdentity | null => {
+  if (value === NO_EXPANSION_DICTIONARY) {
+    return NO_EXPANSION_DICTIONARY_IDENTITY;
+  }
+  return isMorphologyDictionaryContentHash(value)
+    ? { contentHash: value, type: "dictionary" }
+    : null;
+};
+
+/**
+ * Whether two identities name the same payload. Compared through the
+ * serialized form, so what a cursor carries and what the comparison reads
+ * cannot drift into two answers.
+ */
+export const sameExpansionDictionary = (
+  left: ExpansionDictionaryIdentity,
+  right: ExpansionDictionaryIdentity,
+): boolean =>
+  serializeExpansionDictionaryIdentity(left) ===
+  serializeExpansionDictionaryIdentity(right);
+
+/**
  * Lookup key for a surface form: lowercased, then folded to ASCII.
  *
  * Keys are folded, values are not. The corpus is written with diacritics and

--- a/apps/api/src/lib/legal-search/query-expansion-mode.ts
+++ b/apps/api/src/lib/legal-search/query-expansion-mode.ts
@@ -8,11 +8,11 @@
  *            comparison is recorded — leaf counts and a reach disposition,
  *            never the query text. This is how the rewrite is judged against
  *            real traffic before it serves any.
- * - `on`     The expanded query is what runs. Refused at boot today: a corpus
- *            cursor does not yet carry the dictionary version it was built
- *            against, so a paginated expanded search can rank a different
- *            result set against an earlier page's cursor. See the invariant in
- *            `env-base-schema`, which is deleted when that work lands.
+ * - `on`     The expanded query is what runs. Which dictionary a replica has
+ *            loaded is part of the ranking, so a corpus cursor names the
+ *            dictionary its page was built against and a continuation
+ *            resolved against another one is refused as a stale cursor rather
+ *            than served from a different result set.
  *
  * Resolved once in `env-base`; every consumer reads that single value.
  *

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -35,8 +35,9 @@ STELLA_API_ENV_FILE="deploy/selfhost/.env"
 # [internal] Optional with a default. Morphological expansion of case-law
 # search terms: "off" builds today's query, "shadow" runs the unexpanded query
 # and records leaf counts comparing it with the expanded one (never the query
-# text). "on" runs the expanded query and is currently refused at startup,
-# pending cursors that carry the dictionary version.
+# text). "on" runs the expanded query; a search cursor names the dictionary
+# its page used, so a continuation built against another one is rejected as
+# invalid.
 # QUERY_EXPANSION_MODE="off"
 
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -355,7 +355,7 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
   PUBLIC_URL:
     "Public API origin for verification links and OAuth callbacks. Defaults to BETTER_AUTH_URL.",
   QUERY_EXPANSION_MODE:
-    'Morphological expansion of case-law search terms: "off" builds today\'s query, "shadow" runs the unexpanded query and records leaf counts comparing it with the expanded one (never the query text). "on" runs the expanded query and is currently refused at startup, pending cursors that carry the dictionary version.',
+    'Morphological expansion of case-law search terms: "off" builds today\'s query, "shadow" runs the unexpanded query and records leaf counts comparing it with the expanded one (never the query text). "on" runs the expanded query; a search cursor names the dictionary its page used, so a continuation built against another one is rejected as invalid.',
   REDIS_TLS_REJECT_UNAUTHORIZED:
     "Whether a rediss:// connection verifies the server certificate chain. " +
     "Leave on unless the endpoint presents a certificate no trust anchor can " +

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
+import { QUERY_EXPANSION_MODES } from "../apps/api/src/lib/legal-search/query-expansion-mode";
 import {
   ENV_CATALOG,
   ENV_EXPOSURE,
@@ -442,13 +443,6 @@ describe("environment doctor output", () => {
         CORPUS_INDEXING_ENABLED: "true",
       },
     },
-    // Removed together with the invariant, in the PR that makes a corpus
-    // cursor carry the dictionary version it was built against.
-    {
-      expected:
-        'QUERY_EXPANSION_MODE="on" requires dictionary-version-carrying cursors; not yet implemented — use "shadow".',
-      overrides: { QUERY_EXPANSION_MODE: "on" },
-    },
     {
       expected:
         "CONTENT_ENCRYPTION_KEY is required when NODE_ENV is 'production' or 'staging'.",
@@ -642,11 +636,11 @@ describe("environment doctor output", () => {
     }
   });
 
-  // The other half of the `on` invariant above: it must refuse exactly one
-  // mode. A guard that rejected `shadow` too would block the only way to
-  // gather the evidence for lifting it. Removed with the invariant, in the PR
-  // that makes a corpus cursor carry its dictionary version.
-  test.each(["off", "shadow"] as const)(
+  // Every mode is configurable: `on` became one once corpus cursors started
+  // naming the dictionary they were built against, and a guard left behind
+  // would keep the mode unreachable for no remaining reason. Driven by the
+  // canonical list, so a mode added later cannot skip the doctor invariant.
+  test.each([...QUERY_EXPANSION_MODES])(
     "QUERY_EXPANSION_MODE=%p passes the runtime invariants",
     (mode) => {
       expect(


### PR DESCRIPTION
## What

1. `feat(api): carry the expansion dictionary version in the corpus search cursor` — the corpus search cursor now encodes the identity of the expansion dictionary the page was built against (a content hash, or a sentinel when no expansion applied). A continuation page resolved against a different dictionary is rejected as an invalid cursor (HTTP 400, the same path as an undecodable cursor) instead of being ranked against a different result set. Previously issued cursors are treated as invalid; none are persisted.
2. `feat(api): allow the live query-expansion mode` — removes the boot refusal of `QUERY_EXPANSION_MODE=on`, which existed only because of the cursor gap above. The default stays `off`.

Quoted phrases keep matching exact surface forms under every mode; the comment in the query builder now says so.

## Tests

Cursor round trip with the hash, mismatch detection, the sentinel, rejection of pre-field cursors, encode/decode totality; every mode reports the sentinel when nothing expanded; the env schema accepts all three modes and defaults to `off`; env catalog and self-host contract suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query expansion can now run in “on” mode.
  * Search continuation cursors remain tied to the dictionary used for the original results, preventing inconsistent follow-up pages.
  * Quoted phrases preserve their exact wording across expansion modes.

* **Bug Fixes**
  * Outdated, altered or unreadable search cursors are now rejected as invalid.

* **Documentation**
  * Updated configuration guidance for query expansion modes and cursor behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->