### PR TITLE
feat(api): index a decision's publisher summary and stemmed text in a new corpus generation

### DIFF
--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -551,7 +551,7 @@ const storageAndIndexInvariantViolation = ({
     CORPUS_INDEX_Q09_SEARCH_ENDPOINT === undefined &&
     CORPUS_INDEX_Q09_ENDPOINT === undefined
   ) {
-    return "Serving case_law_v5 on q09 requires CORPUS_INDEX_Q09_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_ENDPOINT.";
+    return `Serving ${LEGAL_SEARCH_INDEX_GENERATION} on q09 requires CORPUS_INDEX_Q09_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_ENDPOINT.`;
   }
   if (CORPUS_INDEXING_ENABLED && CORPUS_INDEX_ENDPOINT === undefined) {
     return "Corpus indexing requires CORPUS_INDEX_ENDPOINT for legislation_v1 on q08.";
@@ -561,7 +561,7 @@ const storageAndIndexInvariantViolation = ({
     caseLawCluster === "q09" &&
     CORPUS_INDEX_Q09_ENDPOINT === undefined
   ) {
-    return "Indexing case_law_v5 on q09 requires CORPUS_INDEX_Q09_ENDPOINT.";
+    return `Indexing ${LEGAL_SEARCH_INDEX_GENERATION} on q09 requires CORPUS_INDEX_Q09_ENDPOINT.`;
   }
   if (
     CORPUS_INDEXING_ENABLED !== (CORPUS_PROJECTION_OWNER === "embedded") &&

--- a/apps/api/src/handlers/case-law/decisions/latest.ts
+++ b/apps/api/src/handlers/case-law/decisions/latest.ts
@@ -10,15 +10,13 @@ import {
   type ShelfCourt,
 } from "@/api/handlers/case-law/decisions/shelf-courts";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
-import {
-  decisionHeadnoteSql,
-  normalizeDecisionHeadnote,
-} from "@/api/lib/case-law/decision-headnote";
+import { normalizeDecisionHeadnote } from "@/api/lib/case-law/decision-headnote";
 import {
   type PublicDecisionLanguageAlternate,
   readPublicDecisionLanguageAlternatesByGroup,
 } from "@/api/lib/case-law/language-alternates";
 import { readNonRedistributableCaseLawSourceIds } from "@/api/lib/case-law/non-redistributable-sources";
+import { publisherSummaryMetadataSql } from "@/api/lib/case-law/publisher-summary";
 import { redistributableCaseLawSourceSqlFor } from "@/api/lib/case-law/redistribution";
 import { errorTag } from "@/api/lib/errors/utils";
 import { createTtlResultCache } from "@/api/lib/legal-search/browse-facets-cache";
@@ -141,7 +139,7 @@ export const readLatestDecisionsByCourt = async ({
           d.decision_date,
           d.decision_type,
           d.citation_count,
-          ${decisionHeadnoteSql(sql.raw("d.metadata"))} AS headnote
+          ${publisherSummaryMetadataSql(sql.raw("d.metadata"))} AS headnote
         FROM jsonb_array_elements_text(${JSON.stringify(courts.map((shelf) => shelf.court))}::text::jsonb)
           WITH ORDINALITY AS shelf(court, ordinality)
         CROSS JOIN LATERAL (

--- a/apps/api/src/handlers/case-law/decisions/list.ts
+++ b/apps/api/src/handlers/case-law/decisions/list.ts
@@ -8,11 +8,9 @@ import type { Static } from "elysia";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
-import {
-  decisionHeadnoteSql,
-  normalizeDecisionHeadnote,
-} from "@/api/lib/case-law/decision-headnote";
+import { normalizeDecisionHeadnote } from "@/api/lib/case-law/decision-headnote";
 import { readPublicDecisionLanguageAlternatesByGroup } from "@/api/lib/case-law/language-alternates";
+import { publisherSummaryMetadataSql } from "@/api/lib/case-law/publisher-summary";
 import {
   redistributableCaseLawSource,
   redistributableCaseLawSourceFor,
@@ -176,7 +174,7 @@ export const listDecisionsHandler = async (
         decisionDate: caseLawDecisions.decisionDate,
         decisionType: caseLawDecisions.decisionType,
         sourceUrl: caseLawDecisions.sourceUrl,
-        headnote: decisionHeadnoteSql(caseLawDecisions.metadata),
+        headnote: publisherSummaryMetadataSql(caseLawDecisions.metadata),
         citationCount: caseLawDecisions.citationCount,
         createdAt: caseLawDecisions.createdAt,
       })

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -35,12 +35,10 @@ import type {
   CaseLawPublicReadDb,
   CaseLawPublicReadTransaction,
 } from "@/api/lib/case-law-public-read-db";
-import {
-  decisionHeadnoteSql,
-  normalizeDecisionHeadnote,
-} from "@/api/lib/case-law/decision-headnote";
+import { normalizeDecisionHeadnote } from "@/api/lib/case-law/decision-headnote";
 import { decisionIdentifierProjection } from "@/api/lib/case-law/decision-identifiers";
 import { readPublicDecisionLanguageAlternatesByGroup } from "@/api/lib/case-law/language-alternates";
+import { publisherSummaryMetadataSql } from "@/api/lib/case-law/publisher-summary";
 import {
   redistributableCaseLawSource,
   redistributableCaseLawSourceSqlFor,
@@ -282,7 +280,7 @@ const searchPostgresDecisions = async (
       d.decision_date,
       d.decision_type,
       d.source_url,
-      ${decisionHeadnoteSql(sql.raw("d.metadata"))} AS headnote,
+      ${publisherSummaryMetadataSql(sql.raw("d.metadata"))} AS headnote,
       ts_headline(
         ${headlineRegconfig},
         left(
@@ -566,7 +564,7 @@ const hydratedDecisionRowsQuery = (
       decisionDate: caseLawDecisions.decisionDate,
       decisionType: caseLawDecisions.decisionType,
       sourceUrl: caseLawDecisions.sourceUrl,
-      headnote: decisionHeadnoteSql(caseLawDecisions.metadata),
+      headnote: publisherSummaryMetadataSql(caseLawDecisions.metadata),
       citationCount: caseLawDecisions.citationCount,
       citationAuthority: caseLawDecisions.citationAuthority,
       createdAt: caseLawDecisions.createdAt,

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -65,6 +65,10 @@ import {
   readCorpusIndexSearchPage,
 } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
+  caseLawCorpusQueryFields,
+  type CaseLawCorpusQueryFields,
+} from "@/api/lib/legal-search/corpus-index-read-contract";
+import {
   caseLawCorpusQuery,
   type CorpusTermExpander,
 } from "@/api/lib/legal-search/corpus-query";
@@ -490,16 +494,25 @@ const searchPostgresDecisions = async (
 };
 
 // `country` is deliberately absent from the filters: it selects the index,
-// not a clause. It does select the expansion dictionary, which is why the
-// expander is resolved from it here rather than inside the query builder.
-const buildCorpusIndexQuery = (
-  body: SearchDecisionsBody,
-  jurisdictionClause: string | undefined,
-  expand?: CorpusTermExpander,
-): string | null =>
-  caseLawCorpusQuery(
-    body.query,
-    {
+// not a clause. It does select the expansion dictionary and the stemming
+// language, which is why both are resolved from it here rather than inside
+// the query builder.
+type CorpusIndexQueryOptions = {
+  body: SearchDecisionsBody;
+  jurisdictionClause: string | undefined;
+  fields: CaseLawCorpusQueryFields;
+  expand?: CorpusTermExpander | undefined;
+};
+
+const buildCorpusIndexQuery = ({
+  body,
+  jurisdictionClause,
+  fields,
+  expand,
+}: CorpusIndexQueryOptions): string | null =>
+  caseLawCorpusQuery({
+    text: body.query,
+    filters: {
       court: body.court,
       dateFrom: body.dateFrom,
       dateTo: body.dateTo,
@@ -509,19 +522,35 @@ const buildCorpusIndexQuery = (
       source: body.sourceId,
     },
     expand,
-  );
+    stemming: fields.stemming,
+    surfaceFields: fields.surfaceFields,
+  });
+
+type ResolveCorpusIndexQueryOptions = {
+  body: SearchDecisionsBody;
+  generation: string;
+  jurisdictionClause: string | undefined;
+};
 
 /** Mode, dictionary, and shadow accounting are the shared resolver's. */
-const resolveCorpusIndexQuery = async (
-  body: SearchDecisionsBody,
-  jurisdictionClause: string | undefined,
-): Promise<string | null> =>
-  await resolveExpandedCorpusQuery({
-    build: (expand) => buildCorpusIndexQuery(body, jurisdictionClause, expand),
+const resolveCorpusIndexQuery = async ({
+  body,
+  generation,
+  jurisdictionClause,
+}: ResolveCorpusIndexQueryOptions): Promise<string | null> => {
+  const fields = caseLawCorpusQueryFields({
+    generation,
+    jurisdiction: body.country,
+    language: body.language,
+  });
+  return await resolveExpandedCorpusQuery({
+    build: (expand) =>
+      buildCorpusIndexQuery({ body, jurisdictionClause, fields, expand }),
     jurisdiction: body.country,
     mode: envBase.QUERY_EXPANSION_MODE,
     text: body.query,
   });
+};
 
 const extractCorpusSnippet = (
   snippet: Record<string, unknown> | undefined,
@@ -951,7 +980,11 @@ const searchCorpusIndexDecisions = async (
     body.country,
   );
 
-  const query = await resolveCorpusIndexQuery(body, jurisdictionClause);
+  const query = await resolveCorpusIndexQuery({
+    body,
+    generation,
+    jurisdictionClause,
+  });
   if (query === null) {
     report(0, emptyCorpusIndexScan());
     return { hits: [], facets: null, totalCount: null, nextCursor: null };

--- a/apps/api/src/lib/case-law/decision-headnote.test.ts
+++ b/apps/api/src/lib/case-law/decision-headnote.test.ts
@@ -1,14 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { sql } from "drizzle-orm";
-import { PgDialect } from "drizzle-orm/pg-core";
 import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
-import {
-  decisionHeadnoteSql,
-  normalizeDecisionHeadnote,
-} from "@/api/lib/case-law/decision-headnote";
+import { normalizeDecisionHeadnote } from "@/api/lib/case-law/decision-headnote";
 import { LIMITS } from "@/api/lib/limits";
 
 describe("headnote text fits one row", () => {
@@ -58,26 +53,6 @@ describe("headnote text fits one row", () => {
     expect(normalizeDecisionHeadnote("   \n ")).toBeNull();
     expect(normalizeDecisionHeadnote(null)).toBeNull();
     expect(normalizeDecisionHeadnote(["legal sentence"])).toBeNull();
-  });
-});
-
-describe("headnote SQL", () => {
-  test("prefers the legal sentence, then abstract, keywords, legal area", () => {
-    const rendered = new PgDialect().sqlToQuery(
-      decisionHeadnoteSql(sql.raw("d.metadata")),
-    ).sql;
-    const order = ["legalSentence", "abstract", "keywords", "legalArea"].map(
-      (key) => rendered.indexOf(key),
-    );
-
-    for (const position of order) {
-      expect(position).toBeGreaterThanOrEqual(0);
-    }
-    expect([...order].toSorted((a, b) => a - b)).toEqual(order);
-    // Keywords are only ever read as an array; a scalar under that key must
-    // not raise in the database.
-    expect(rendered).toContain("jsonb_typeof(d.metadata -> 'keywords')");
-    expect(rendered).toContain("WITH ORDINALITY");
   });
 });
 

--- a/apps/api/src/lib/case-law/decision-headnote.ts
+++ b/apps/api/src/lib/case-law/decision-headnote.ts
@@ -1,43 +1,15 @@
-import { sql } from "drizzle-orm";
-import type { SQL, SQLWrapper } from "drizzle-orm";
-
 import { LIMITS } from "@/api/lib/limits";
 
-const KEYWORD_SEPARATOR = " · ";
 const ELLIPSIS = "…";
 /** Cut on a word boundary only when that keeps most of the budget. */
 const WORD_BOUNDARY_MIN_RATIO = 0.6;
 
 /**
- * The one line a lawyer recognises a decision by, from what publishers
- * supply: the court's own legal sentence, an abstract, the keyword chain,
- * or at least the area of law. First non-empty wins; the order is from the
- * most to the least specific, and it is the same for every source so a row's
- * second line means the same thing across courts.
- */
-export const decisionHeadnoteSql = (metadata: SQLWrapper): SQL<string | null> =>
-  sql<string | null>`coalesce(
-    nullif(btrim(${metadata} ->> 'legalSentence'), ''),
-    nullif(btrim(${metadata} ->> 'abstract'), ''),
-    nullif(
-      (
-        SELECT string_agg(keyword.value, ${KEYWORD_SEPARATOR} ORDER BY keyword.ordinality)
-        FROM jsonb_array_elements_text(
-          CASE jsonb_typeof(${metadata} -> 'keywords')
-            WHEN 'array' THEN ${metadata} -> 'keywords'
-            ELSE '[]'::jsonb
-          END
-        ) WITH ORDINALITY AS keyword(value, ordinality)
-      ),
-      ''
-    ),
-    nullif(btrim(${metadata} ->> 'legalArea'), '')
-  )`;
-
-/**
- * Publisher text as one bounded line: whitespace runs collapsed, then cut
- * to the row budget on a word boundary. Null when there is nothing to show,
- * so the row can omit the line rather than render an empty one.
+ * A decision's publisher summary as one bounded line: whitespace runs
+ * collapsed, then cut to the row budget on a word boundary. Null when there
+ * is nothing to show, so the row can omit the line rather than render an
+ * empty one. What may fill it, and in what order, is
+ * `publisher-summary.ts`; this is only how it is fitted to a row.
  */
 export const normalizeDecisionHeadnote = (raw: unknown): string | null => {
   if (typeof raw !== "string") {

--- a/apps/api/src/lib/case-law/decision-summaries.ts
+++ b/apps/api/src/lib/case-law/decision-summaries.ts
@@ -3,11 +3,9 @@ import { and, eq, inArray } from "drizzle-orm";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
-import {
-  decisionHeadnoteSql,
-  normalizeDecisionHeadnote,
-} from "@/api/lib/case-law/decision-headnote";
+import { normalizeDecisionHeadnote } from "@/api/lib/case-law/decision-headnote";
 import { readPublicDecisionLanguageAlternatesByGroup } from "@/api/lib/case-law/language-alternates";
+import { publisherSummaryMetadataSql } from "@/api/lib/case-law/publisher-summary";
 import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
 
 type ReadPublicDecisionSummariesOptions = {
@@ -41,7 +39,7 @@ export const readPublicDecisionSummaries = async ({
         decisionDate: caseLawDecisions.decisionDate,
         decisionType: caseLawDecisions.decisionType,
         sourceUrl: caseLawDecisions.sourceUrl,
-        headnote: decisionHeadnoteSql(caseLawDecisions.metadata),
+        headnote: publisherSummaryMetadataSql(caseLawDecisions.metadata),
         citationCount: caseLawDecisions.citationCount,
         createdAt: caseLawDecisions.createdAt,
       })

--- a/apps/api/src/lib/case-law/publisher-summary.db.test.ts
+++ b/apps/api/src/lib/case-law/publisher-summary.db.test.ts
@@ -1,0 +1,171 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import {
+  PUBLISHER_SUMMARY_SOURCES,
+  publisherSummaryMetadataSql,
+  publisherSummaryOf,
+} from "@/api/lib/case-law/publisher-summary";
+import { isRecord } from "@/api/lib/type-guards";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+/**
+ * One ordered source list, two implementations: `publisherSummaryOf` in
+ * TypeScript for the projection, `publisherSummaryMetadataSql` in SQL for the
+ * read path. Neither may be edited into a different answer, so the list is
+ * walked here and both readings are proved equal on a fixture per source,
+ * against a real PostgreSQL.
+ */
+
+type MetadataSource = Extract<
+  (typeof PUBLISHER_SUMMARY_SOURCES)[number],
+  { origin: "metadata" }
+>;
+
+const METADATA_SOURCES: readonly MetadataSource[] =
+  PUBLISHER_SUMMARY_SOURCES.filter(
+    (source): source is MetadataSource => source.origin === "metadata",
+  );
+
+/**
+ * A fixture per value shape, total so a new shape cannot be added without a
+ * fixture that pins how both implementations read it. Every fixture carries
+ * padding, and the list carries a blank and a non-string item, because that is
+ * where a hand-written pair of readings drifts.
+ */
+const FIXTURE_BY_SHAPE = {
+  text: { value: " \n Publisher text \t", expected: "Publisher text" },
+  list: { value: ["  alfa ", "  ", 7, "beta"], expected: "alfa · beta" },
+} as const satisfies Record<
+  MetadataSource["shape"],
+  { value: unknown; expected: string }
+>;
+
+/**
+ * Metadata carrying every source from `index` on. Walking the list this way
+ * proves both the per-source reading and the fall-through order: with the
+ * better sources removed, the answer must be exactly the next one.
+ */
+const metadataFrom = (index: number): Record<string, unknown> =>
+  Object.fromEntries(
+    METADATA_SOURCES.slice(index).map(({ key, shape }) => [
+      key,
+      FIXTURE_BY_SHAPE[shape].value,
+    ]),
+  );
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+/** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
+const executedRows = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
+};
+
+const readSummary = (row: unknown): string | null => {
+  const value = isRecord(row) ? row["summary"] : undefined;
+  if (value === null || typeof value === "string") {
+    return value ?? null;
+  }
+  throw new TypeError("summary did not render as text");
+};
+
+const readMetadataSummary = async (
+  metadata: Record<string, unknown>,
+): Promise<string | null> => {
+  const rows = executedRows(
+    await db.execute(sql`
+      SELECT ${publisherSummaryMetadataSql(sql.raw("f.metadata"))} AS "summary"
+        FROM (VALUES (${JSON.stringify(metadata)}::text::jsonb)) AS f(metadata)
+    `),
+  );
+  return readSummary(rows.at(0));
+};
+
+test("both readings of the source list agree, source by source", async () => {
+  const fixtures = METADATA_SOURCES.map((_, index) => metadataFrom(index));
+  const values = sql.join(
+    fixtures.map(
+      (metadata, index) =>
+        sql`(${index}::int, ${JSON.stringify(metadata)}::text::jsonb)`,
+    ),
+    sql`, `,
+  );
+  const rows = executedRows(
+    await db.execute(sql`
+      SELECT f.ordinal AS "ordinal",
+             ${publisherSummaryMetadataSql(sql.raw("f.metadata"))} AS "summary"
+        FROM (VALUES ${values}) AS f(ordinal, metadata)
+       ORDER BY f.ordinal
+    `),
+  );
+
+  expect(rows.length).toBe(METADATA_SOURCES.length);
+  for (const [index, source] of METADATA_SOURCES.entries()) {
+    const expected = FIXTURE_BY_SHAPE[source.shape].expected;
+    expect([
+      source.key,
+      publisherSummaryOf({
+        documentAst: null,
+        metadata: fixtures[index] ?? null,
+      }),
+    ]).toEqual([source.key, expected]);
+    expect([source.key, readSummary(rows[index])]).toEqual([
+      source.key,
+      expected,
+    ]);
+  }
+});
+
+test("both readings answer nothing for metadata with no publisher summary", async () => {
+  const empty = {
+    legalSentence: "   ",
+    keywords: [],
+    legalAreas: ["  ", 3],
+    unrelated: "not a summary source",
+  };
+  expect(publisherSummaryOf({ documentAst: null, metadata: empty })).toBeNull();
+  expect(await readMetadataSummary(empty)).toBeNull();
+});
+
+test("both readings keep a leading word the trim set must not eat", async () => {
+  // "v" is a preposition every Czech and Slovak summary tends to open with,
+  // and a one-character word is exactly what a trim set built on an escape the
+  // manual does not document would start eating. Pinned here so the set can
+  // never quietly acquire a letter.
+  const metadata = { legalSentence: "v řízení o dovolání" };
+  const expected = "v řízení o dovolání";
+
+  expect(publisherSummaryOf({ documentAst: null, metadata })).toBe(expected);
+  expect(await readMetadataSummary(metadata)).toBe(expected);
+});
+
+test("both readings still strip the whitespace the set does cover", async () => {
+  const metadata = {
+    legalSentence: " \u000b\tPrávní věta\u000b ",
+  };
+
+  expect(publisherSummaryOf({ documentAst: null, metadata })).toBe(
+    "Právní věta",
+  );
+  expect(await readMetadataSummary(metadata)).toBe("Právní věta");
+});

--- a/apps/api/src/lib/case-law/publisher-summary.test.ts
+++ b/apps/api/src/lib/case-law/publisher-summary.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test";
+
+import type {
+  Block,
+  DocumentAst,
+  ParagraphRole,
+} from "@stll/legal-ast/document-ast";
+
+import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
+
+const documentAst = (blocks: Block[]): DocumentAst => ({
+  version: 1,
+  source: {
+    system: "test",
+    documentId: "1",
+    webUrl: "https://example.test/1",
+    printUrl: "https://example.test/1.pdf",
+  },
+  metadata: {
+    caseNumber: null,
+    ecli: null,
+    court: null,
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks,
+});
+
+const paragraph = (
+  id: string,
+  plainText: string,
+  role?: ParagraphRole,
+): Block => ({
+  id,
+  anchorId: id,
+  type: "paragraph",
+  ...(role === undefined ? {} : { role }),
+  inlines: [{ type: "text", text: plainText }],
+  plainText,
+});
+
+test("marked apparatus paragraphs win over every metadata key, in document order", () => {
+  const summary = publisherSummaryOf({
+    documentAst: documentAst([
+      paragraph("b1", "Nadpis"),
+      paragraph("b2", "Věta druhá", "summary"),
+      paragraph("b3", "Odůvodnění", "argumentation"),
+      paragraph("b4", "Věta první", "headnotes"),
+    ]),
+    metadata: { legalSentence: "z metadat" },
+  });
+
+  // Document order, not the order the roles are declared in: the publisher
+  // decided which paragraph comes first.
+  expect(summary).toBe("Věta druhá\n\nVěta první");
+});
+
+test("an AST without apparatus paragraphs falls through to metadata", () => {
+  expect(
+    publisherSummaryOf({
+      documentAst: documentAst([
+        paragraph("b1", "Odůvodnění", "argumentation"),
+      ]),
+      metadata: { legalSentence: "z metadat" },
+    }),
+  ).toBe("z metadat");
+});
+
+test("a source that publishes only an abstract under `summary` is read", () => {
+  // The PL adapter records the publisher's `summary`; before the sources were
+  // declared in one list the display chain never looked at that key.
+  expect(
+    publisherSummaryOf({
+      documentAst: null,
+      metadata: { summary: "Teza orzeczenia" },
+    }),
+  ).toBe("Teza orzeczenia");
+});
+
+test("a source that publishes plural `legalAreas` is read", () => {
+  // The AT adapter records `legalAreas`; the display chain read the singular
+  // `legalArea` only, so those decisions showed nothing.
+  expect(
+    publisherSummaryOf({
+      documentAst: null,
+      metadata: { legalAreas: ["Zivilrecht", "Mietrecht"] },
+    }),
+  ).toBe("Zivilrecht · Mietrecht");
+});
+
+test("nothing publisher-authored is no summary", () => {
+  expect(publisherSummaryOf({ documentAst: null, metadata: null })).toBeNull();
+  expect(
+    publisherSummaryOf({
+      documentAst: documentAst([]),
+      metadata: { legalSentence: "   ", keywords: [], legalAreas: ["  "] },
+    }),
+  ).toBeNull();
+});
+
+test("a value of the wrong JSON shape is skipped, not coerced", () => {
+  expect(
+    publisherSummaryOf({
+      documentAst: null,
+      metadata: {
+        legalSentence: 42,
+        keywords: "not a list",
+        legalArea: "Daně",
+      },
+    }),
+  ).toBe("Daně");
+});
+
+test("a summary opening with a one-letter word keeps it", () => {
+  // "v" is a preposition in the corpus languages and opens summaries often,
+  // which makes it the first casualty of a trim set that acquires a letter.
+  // Pinned on both readings; the SQL side is in the database binding test.
+  expect(
+    publisherSummaryOf({
+      documentAst: null,
+      metadata: { legalSentence: "v řízení o dovolání" },
+    }),
+  ).toBe("v řízení o dovolání");
+  expect(
+    publisherSummaryOf({
+      documentAst: null,
+      metadata: { legalArea: "  v likvidaci  " },
+    }),
+  ).toBe("v likvidaci");
+});

--- a/apps/api/src/lib/case-law/publisher-summary.ts
+++ b/apps/api/src/lib/case-law/publisher-summary.ts
@@ -1,0 +1,237 @@
+import { sql } from "drizzle-orm";
+import type { SQL, SQLWrapper } from "drizzle-orm";
+
+import type { ApparatusRole, DocumentAst } from "@stll/legal-ast/document-ast";
+
+/**
+ * The publisher's own summary of a decision: the sentence a reader
+ * recognises the case by, written by whoever published it rather than by the
+ * court. Every jurisdiction the corpus covers has one under a different name
+ * and in a different place, so the sources are declared once, in order, and
+ * every consumer walks that one list.
+ *
+ * Order is from the most to the least specific, and it is the same for every
+ * court, so a decision's summary means the same thing across jurisdictions.
+ * Adding a jurisdiction means adding a source here, never a branch anywhere
+ * else.
+ */
+
+/**
+ * Publisher-authored paragraphs a parser can already recognise structurally.
+ * A parser that marks these roles beats any metadata key: the text is the
+ * publisher's own, in document order, with no key naming convention in
+ * between.
+ *
+ * `apparatus` and `counsel` are apparatus too but are not summaries: the
+ * first is unnamed publisher matter, the second is who appeared.
+ */
+const PUBLISHER_SUMMARY_AST_ROLES = [
+  "headnotes",
+  "syllabus",
+  "summary",
+] as const satisfies readonly ApparatusRole[];
+
+/** How one metadata value is read into summary text. */
+type PublisherSummaryValueShape = "text" | "list";
+
+type PublisherSummarySource =
+  | { origin: "ast"; roles: readonly ApparatusRole[] }
+  | { origin: "metadata"; key: string; shape: PublisherSummaryValueShape };
+
+/**
+ * Every place a publisher summary can live, best first. Each metadata key is
+ * one an adapter records verbatim from its source; a key arrives here with the
+ * adapter that writes it, never before one.
+ */
+export const PUBLISHER_SUMMARY_SOURCES = [
+  { origin: "ast", roles: PUBLISHER_SUMMARY_AST_ROLES },
+  { origin: "metadata", key: "legalSentence", shape: "text" },
+  { origin: "metadata", key: "abstract", shape: "text" },
+  { origin: "metadata", key: "summary", shape: "text" },
+  { origin: "metadata", key: "keywords", shape: "list" },
+  { origin: "metadata", key: "legalAreas", shape: "list" },
+  { origin: "metadata", key: "legalArea", shape: "text" },
+] as const satisfies readonly PublisherSummarySource[];
+
+/** Items of a list-shaped source, as one line. */
+const LIST_SEPARATOR = " · ";
+
+/** Publisher paragraphs, kept as paragraphs. */
+const PARAGRAPH_SEPARATOR = "\n\n";
+
+/**
+ * The whitespace both implementations strip, spelled out rather than left to
+ * each engine's default: PostgreSQL's one-argument `btrim` removes spaces
+ * only, where JavaScript's `trim` removes every whitespace character. The set
+ * below is what a publisher payload carries, and the binding test holds the
+ * two readings to the same answer over it.
+ *
+ * Vertical tab is written `\x0B` on the SQL side rather than `\v`, and the
+ * reason is the manual, not the behaviour: Table 4.1 lists `\b \f \n \r \t`,
+ * the numeric escapes, and nothing else, while "any other character following
+ * a backslash is taken literally". The lexer does accept `\v` — this was
+ * checked against the engine — but a set built on an escape the documentation
+ * does not promise would put a literal `v` in it the day that stops being
+ * true, and `btrim` would then eat the leading preposition of every summary
+ * opening with one ("v řízení"). `\x0B` is documented and identical, so the
+ * hazard is spelled away rather than relied against. The binding test pins
+ * both the trimming and that no leading word is lost.
+ */
+const TRIMMED_WHITESPACE = " \t\n\r\f\v";
+const TRIMMED_WHITESPACE_SQL = "E' \\t\\n\\r\\f\\x0B'";
+const TRIM_PATTERN = new RegExp(
+  `^[${TRIMMED_WHITESPACE}]+|[${TRIMMED_WHITESPACE}]+$`,
+  "gu",
+);
+
+const trimmed = (value: string): string | null => {
+  const text = value.replaceAll(TRIM_PATTERN, "");
+  return text.length === 0 ? null : text;
+};
+
+const READ_METADATA_VALUE = {
+  text: (value) => (typeof value === "string" ? trimmed(value) : null),
+  list: (value) => {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+    const items: string[] = [];
+    for (const item of value) {
+      const text = typeof item === "string" ? trimmed(item) : null;
+      if (text !== null) {
+        items.push(text);
+      }
+    }
+    return items.length === 0 ? null : items.join(LIST_SEPARATOR);
+  },
+} as const satisfies Record<
+  PublisherSummaryValueShape,
+  (value: unknown) => string | null
+>;
+
+/**
+ * A metadata key as a SQL literal rather than a bound parameter. The keys are
+ * this module's own constants, and `->>` is overloaded on its right operand,
+ * so an untyped parameter there is ambiguous to the planner.
+ */
+const jsonKey = (key: string): SQL => sql.raw(`'${key.replaceAll("'", "''")}'`);
+
+const trimSql = (value: SQL): SQL =>
+  sql`nullif(btrim(${value}, ${sql.raw(TRIMMED_WHITESPACE_SQL)}), '')`;
+
+/**
+ * Each shape as SQL, reading exactly what its TypeScript reading reads: a
+ * JSON string for `text`, the string items of a JSON array for `list`. The
+ * type guards are not defensive — an untyped `->>` would render a number as
+ * text where TypeScript skips it, and the two would disagree.
+ */
+const METADATA_VALUE_SQL = {
+  text: (metadata, key) =>
+    sql`CASE jsonb_typeof(${metadata} -> ${jsonKey(key)})
+          WHEN 'string' THEN ${trimSql(sql`${metadata} ->> ${jsonKey(key)}`)}
+        END`,
+  list: (metadata, key) =>
+    sql`nullif(
+      (
+        SELECT string_agg(
+                 btrim(item.value #>> '{}', ${sql.raw(TRIMMED_WHITESPACE_SQL)}),
+                 ${LIST_SEPARATOR}
+                 ORDER BY item.ordinality
+               )
+        FROM jsonb_array_elements(
+          CASE jsonb_typeof(${metadata} -> ${jsonKey(key)})
+            WHEN 'array' THEN ${metadata} -> ${jsonKey(key)}
+            ELSE '[]'::jsonb
+          END
+        ) WITH ORDINALITY AS item(value, ordinality)
+        WHERE jsonb_typeof(item.value) = 'string'
+          AND btrim(item.value #>> '{}', ${sql.raw(TRIMMED_WHITESPACE_SQL)}) <> ''
+      ),
+      ''
+    )`,
+} as const satisfies Record<
+  PublisherSummaryValueShape,
+  (metadata: SQLWrapper, key: string) => SQL
+>;
+
+const astSummary = (
+  documentAst: DocumentAst | null,
+  roles: readonly ApparatusRole[],
+): string | null => {
+  if (documentAst === null) {
+    return null;
+  }
+  const paragraphs: string[] = [];
+  for (const block of documentAst.blocks) {
+    if (
+      block.type !== "paragraph" ||
+      !roles.some((role) => role === block.role)
+    ) {
+      continue;
+    }
+    const text = trimmed(block.plainText);
+    if (text !== null) {
+      paragraphs.push(text);
+    }
+  }
+  return paragraphs.length === 0 ? null : paragraphs.join(PARAGRAPH_SEPARATOR);
+};
+
+type PublisherSummaryInput = {
+  documentAst: DocumentAst | null;
+  metadata: Record<string, unknown> | null;
+};
+
+/**
+ * The first source that has something, over the full list. Null when the
+ * publisher supplied nothing, so a consumer omits the line rather than
+ * rendering an empty one.
+ */
+export const publisherSummaryOf = ({
+  documentAst,
+  metadata,
+}: PublisherSummaryInput): string | null => {
+  for (const source of PUBLISHER_SUMMARY_SOURCES) {
+    switch (source.origin) {
+      case "ast": {
+        const text = astSummary(documentAst, source.roles);
+        if (text !== null) {
+          return text;
+        }
+        break;
+      }
+      case "metadata": {
+        const text = READ_METADATA_VALUE[source.shape](metadata?.[source.key]);
+        if (text !== null) {
+          return text;
+        }
+        break;
+      }
+      default: {
+        return source satisfies never;
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * The same list, as one SQL expression over a decision's `metadata`, and the
+ * reason it is a strict subset: the AST sources live in an object the read
+ * path does not load, and joining a multi-megabyte document per row to reach
+ * three paragraphs would cost far more than the line is worth. The projection
+ * path already holds the AST and therefore evaluates the whole list, so an
+ * indexed summary is a superset of a displayed one: never a different answer,
+ * only a better one where a parser marked the roles.
+ */
+export const publisherSummaryMetadataSql = (
+  metadata: SQLWrapper,
+): SQL<string | null> => {
+  const arms: SQL[] = [];
+  for (const source of PUBLISHER_SUMMARY_SOURCES) {
+    if (source.origin === "metadata") {
+      arms.push(METADATA_VALUE_SQL[source.shape](metadata, source.key));
+    }
+  }
+  return sql<string | null>`coalesce(${sql.join(arms, sql`, `)})`;
+};

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
@@ -62,8 +62,11 @@ test("every deployable generation selects one explicit Quickwit cluster", () => 
   expect(corpusIndexClusterForGeneration("legislation", "legislation_v2")).toBe(
     "q09",
   );
+  expect(corpusIndexClusterForGeneration("case_law", "case_law_v6")).toBe(
+    "q09",
+  );
   expect(() =>
-    corpusIndexClusterForGeneration("case_law", "case_law_v6"),
+    corpusIndexClusterForGeneration("case_law", "case_law_v7"),
   ).toThrow("Unknown case_law corpus index generation");
 });
 

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -45,7 +45,7 @@ type FinalManifestGenerationByFamily = {
 };
 
 const FINAL_Q09_GENERATIONS = {
-  case_law: ["case_law_v5"],
+  case_law: ["case_law_v5", "case_law_v6"],
   legislation: ["legislation_v2"],
 } as const satisfies {
   [Family in CorpusFamily]: readonly FinalManifestGenerationByFamily[Family][];

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -348,6 +348,24 @@ export const DECISION_TIMESTAMP_FIELD = "decision_date_ts";
  */
 export const UNDATED_DECISION_TIMESTAMP = "1800-01-01";
 
+/**
+ * The index field carrying a decision's publisher summary: the publisher's
+ * own sentence about the case, from `publisher-summary.ts`. Its own field
+ * rather than a prefix of `text`, so a term matching the summary is a
+ * document-level hit that ranks and reads as one, and so `heading_path`'s
+ * problem cannot recur: it is written to the opening passage only, exactly
+ * like `title`, and therefore answers once per document.
+ *
+ * Not stored: the line a reader sees is read from Postgres, so a copy in the
+ * docstore would pay object-storage bytes for nothing.
+ *
+ * A generation carries it only if its manifest declares it. Adding the field
+ * to a mapping an index was already created with does nothing, and writing it
+ * into a `strict` index that never mapped it drops the whole document, so it
+ * arrives with a generation and never before one.
+ */
+export const PUBLISHER_SUMMARY_FIELD = "headnote";
+
 const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
   case_law: [
     // The docket, exactly as the court wrote it. Raw-tokenized, so it answers

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -366,6 +366,26 @@ export const UNDATED_DECISION_TIMESTAMP = "1800-01-01";
  */
 export const PUBLISHER_SUMMARY_FIELD = "headnote";
 
+/**
+ * The stem companions of the two full-text fields a reader's words reach.
+ *
+ * The corpus languages inflect heavily, and the `folded` tokenizer only
+ * lowercases and folds diacritics: a query written in the nominative does not
+ * reach a judgment that carries the genitive, and a phrase can match only the
+ * exact surface forms it was typed in. These fields carry the same text
+ * reduced to stems, so a query stemmed the same way matches across the
+ * inflection.
+ *
+ * Companions rather than a replacement: the surface fields keep answering
+ * exactly what they answer today, and a stem clause is an alternative beside
+ * the surface clause, never instead of it. Not stored, because nothing reads
+ * them back; they exist to be matched.
+ */
+export const STEM_FIELD_OF = {
+  text: "text_stem",
+  [PUBLISHER_SUMMARY_FIELD]: "headnote_stem",
+} as const;
+
 const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
   case_law: [
     // The docket, exactly as the court wrote it. Raw-tokenized, so it answers

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -6,13 +6,21 @@ import {
   corpusIndexConfigFromManifest,
   corpusIndexIdFromManifest,
   corpusIndexManifestDigest,
+  corpusIndexPublisherSummaryField,
   requireCorpusIndexIdForManifest,
   requireCorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 
+/**
+ * A published generation's digest is the identity every projection fingerprint
+ * is derived from, so it may never move: a changed digest re-projects the whole
+ * corpus. Extend this map with a new generation; never edit an entry.
+ */
 const EXPECTED_DIGESTS = {
   case_law_v5:
     "7ee1e1bdbc0a1c746407333cac6eba21446d32b0eca461235569eac4197ed0ce",
+  case_law_v6:
+    "81a11a8216b59eaf076253b016c1dac8901d890e3ab183a6ac3f34fd051b0aea",
   legislation_v2:
     "dc252d8635081d8037e7f9b1aca6713181a27390e8eb6dda54139ae6a1e68583",
 } as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
@@ -20,10 +28,14 @@ const EXPECTED_DIGESTS = {
 test("the final-generation registry is exact and fails closed", () => {
   expect(Object.keys(CORPUS_INDEX_MANIFESTS).sort()).toEqual([
     "case_law_v5",
+    "case_law_v6",
     "legislation_v2",
   ]);
   expect(requireCorpusIndexManifest("case_law", "case_law_v5")).toBe(
     CORPUS_INDEX_MANIFESTS.case_law_v5,
+  );
+  expect(requireCorpusIndexManifest("case_law", "case_law_v6")).toBe(
+    CORPUS_INDEX_MANIFESTS.case_law_v6,
   );
   expect(requireCorpusIndexManifest("legislation", "legislation_v2")).toBe(
     CORPUS_INDEX_MANIFESTS.legislation_v2,
@@ -39,6 +51,9 @@ test("the final-generation registry is exact and fails closed", () => {
 test("manifest digests pin every semantic array and ignore object key order", () => {
   expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.case_law_v5)).toBe(
     EXPECTED_DIGESTS.case_law_v5,
+  );
+  expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.case_law_v6)).toBe(
+    EXPECTED_DIGESTS.case_law_v6,
   );
   expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.legislation_v2)).toBe(
     EXPECTED_DIGESTS.legislation_v2,
@@ -307,9 +322,12 @@ test("final manifests make every storage and index cost explicit", () => {
       min_shards: 1,
     });
     expect(manifest.engine.indexConfig.retention).toBeNull();
-    expect(manifest.engine.indexConfig.search_settings).toEqual({
-      default_search_fields: ["title", "text"],
-    });
+    expect(
+      manifest.engine.indexConfig.search_settings.default_search_fields.slice(
+        0,
+        2,
+      ),
+    ).toEqual(["title", "text"]);
   }
 });
 
@@ -371,4 +389,62 @@ test("route topology and tag pruning are part of the manifest", () => {
     "status",
     "language",
   ]);
+});
+
+test("v6 adds the publisher summary and nothing else", () => {
+  const v5 = CORPUS_INDEX_MANIFESTS.case_law_v5.engine.indexConfig.doc_mapping;
+  const v6 = CORPUS_INDEX_MANIFESTS.case_law_v6.engine.indexConfig.doc_mapping;
+
+  expect(v6.field_mappings.map(({ name }) => name)).toEqual([
+    ...v5.field_mappings.map(({ name }) => name),
+    "headnote",
+  ]);
+  expect(v6.field_mappings.at(-1)).toEqual({
+    name: "headnote",
+    type: "text",
+    tokenizer: "folded",
+    record: "position",
+    fieldnorms: true,
+    indexed: true,
+    stored: false,
+    fast: false,
+  });
+  expect(v6.mode).toBe("strict");
+  expect(v6.tag_fields).toEqual(v5.tag_fields);
+  expect(v6.timestamp_field).toBe(v5.timestamp_field);
+  expect(
+    CORPUS_INDEX_MANIFESTS.case_law_v6.engine.indexConfig.search_settings,
+  ).toEqual({ default_search_fields: ["title", "text", "headnote"] });
+  // The reason the field can be a default search field at all: it is written
+  // once per document, so a free-text term reaching it cannot fan out over a
+  // decision's passages.
+  expect(
+    CORPUS_INDEX_MANIFESTS.case_law_v5.engine.indexConfig.search_settings,
+  ).toEqual({ default_search_fields: ["title", "text"] });
+  expect(CORPUS_INDEX_MANIFESTS.case_law_v6.projection.builderVersion).toBe(
+    "case-law-passages-v2",
+  );
+});
+
+test("only a generation that maps the field reports one", () => {
+  expect(
+    corpusIndexPublisherSummaryField(CORPUS_INDEX_MANIFESTS.case_law_v5),
+  ).toBeNull();
+  expect(
+    corpusIndexPublisherSummaryField(CORPUS_INDEX_MANIFESTS.case_law_v6),
+  ).toBe("headnote");
+  expect(
+    corpusIndexPublisherSummaryField(CORPUS_INDEX_MANIFESTS.legislation_v2),
+  ).toBeNull();
+  for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
+    const field = corpusIndexPublisherSummaryField(manifest);
+    if (field === null) {
+      continue;
+    }
+    expect(
+      manifest.engine.indexConfig.doc_mapping.field_mappings.some(
+        ({ name }) => name === field,
+      ),
+    ).toBe(true);
+  }
 });

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -7,6 +7,7 @@ import {
   corpusIndexIdFromManifest,
   corpusIndexManifestDigest,
   corpusIndexPublisherSummaryField,
+  corpusIndexStemFields,
   requireCorpusIndexIdForManifest,
   requireCorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
@@ -20,7 +21,7 @@ const EXPECTED_DIGESTS = {
   case_law_v5:
     "7ee1e1bdbc0a1c746407333cac6eba21446d32b0eca461235569eac4197ed0ce",
   case_law_v6:
-    "81a11a8216b59eaf076253b016c1dac8901d890e3ab183a6ac3f34fd051b0aea",
+    "1fc5f09b5471e49a4e5588c9f59c3ce78c08a9aa54b55e5edef168bc315accc8",
   legislation_v2:
     "dc252d8635081d8037e7f9b1aca6713181a27390e8eb6dda54139ae6a1e68583",
 } as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
@@ -322,12 +323,12 @@ test("final manifests make every storage and index cost explicit", () => {
       min_shards: 1,
     });
     expect(manifest.engine.indexConfig.retention).toBeNull();
-    expect(
-      manifest.engine.indexConfig.search_settings.default_search_fields.slice(
-        0,
-        2,
-      ),
-    ).toEqual(["title", "text"]);
+    // Exact, over every generation: a hit is a passage and its stored `text`
+    // is the excerpt that stands for the match, so a field written to one
+    // passage of a document may never be reachable by a bare term.
+    expect(manifest.engine.indexConfig.search_settings).toEqual({
+      default_search_fields: ["title", "text"],
+    });
   }
 });
 
@@ -398,8 +399,10 @@ test("v6 adds the publisher summary and nothing else", () => {
   expect(v6.field_mappings.map(({ name }) => name)).toEqual([
     ...v5.field_mappings.map(({ name }) => name),
     "headnote",
+    "text_stem",
+    "headnote_stem",
   ]);
-  expect(v6.field_mappings.at(-1)).toEqual({
+  expect(v6.field_mappings.at(-3)).toEqual({
     name: "headnote",
     type: "text",
     tokenizer: "folded",
@@ -412,15 +415,6 @@ test("v6 adds the publisher summary and nothing else", () => {
   expect(v6.mode).toBe("strict");
   expect(v6.tag_fields).toEqual(v5.tag_fields);
   expect(v6.timestamp_field).toBe(v5.timestamp_field);
-  expect(
-    CORPUS_INDEX_MANIFESTS.case_law_v6.engine.indexConfig.search_settings,
-  ).toEqual({ default_search_fields: ["title", "text", "headnote"] });
-  // The reason the field can be a default search field at all: it is written
-  // once per document, so a free-text term reaching it cannot fan out over a
-  // decision's passages.
-  expect(
-    CORPUS_INDEX_MANIFESTS.case_law_v5.engine.indexConfig.search_settings,
-  ).toEqual({ default_search_fields: ["title", "text"] });
   expect(CORPUS_INDEX_MANIFESTS.case_law_v6.projection.builderVersion).toBe(
     "case-law-passages-v2",
   );
@@ -446,5 +440,49 @@ test("only a generation that maps the field reports one", () => {
         ({ name }) => name === field,
       ),
     ).toBe(true);
+  }
+});
+
+test("v6 keeps the default search fields v5 has", () => {
+  // The load-bearing property behind the whole design: a hit is a passage, and
+  // its stored `text` is what a reader and the research answer runner are
+  // handed as the excerpt that matched. A field written to the opening passage
+  // only — the summary, or either stem — must never be reachable by a bare
+  // term, or a summary-only match would answer with a passage whose text does
+  // not carry the terms. The query builder names those fields explicitly.
+  const defaultsOf = (generation: "case_law_v5" | "case_law_v6") =>
+    CORPUS_INDEX_MANIFESTS[generation].engine.indexConfig.search_settings
+      .default_search_fields;
+
+  expect(defaultsOf("case_law_v6")).toEqual(["title", "text"]);
+  expect(defaultsOf("case_law_v6")).toEqual(defaultsOf("case_law_v5"));
+  for (const absent of ["headnote", "text_stem", "headnote_stem"]) {
+    expect(defaultsOf("case_law_v6")).not.toContain(absent);
+  }
+});
+
+test("only a generation that maps the stem fields reports them", () => {
+  expect(corpusIndexStemFields(CORPUS_INDEX_MANIFESTS.case_law_v5)).toBeNull();
+  expect(corpusIndexStemFields(CORPUS_INDEX_MANIFESTS.case_law_v6)).toEqual({
+    text: "text_stem",
+    publisherSummary: "headnote_stem",
+  });
+  expect(
+    corpusIndexStemFields(CORPUS_INDEX_MANIFESTS.legislation_v2),
+  ).toBeNull();
+  for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
+    const fields = corpusIndexStemFields(manifest);
+    if (fields === null) {
+      continue;
+    }
+    const declared = new Set(
+      manifest.engine.indexConfig.doc_mapping.field_mappings.map(
+        ({ name }) => name,
+      ),
+    );
+    expect([
+      declared.has(fields.text),
+      declared.has(fields.publisherSummary),
+    ]).toEqual([true, true]);
   }
 });

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -15,6 +15,7 @@ import {
   CORPUS_INDEX_DATE_INPUT_FORMATS,
   DECISION_TIMESTAMP_FIELD,
   FOLDED_TOKENIZER,
+  PUBLISHER_SUMMARY_FIELD,
   canonicalCorpusIndexMaturationPeriod,
   type CorpusIndexConfig,
 } from "@/api/lib/legal-search/corpus-index-config";
@@ -41,17 +42,39 @@ type CorpusIndexManifestBase = {
   };
 };
 
-type CaseLawV5Manifest = CorpusIndexManifestBase & {
+type CaseLawManifestBase = CorpusIndexManifestBase & {
   family: "case_law";
+  route: {
+    type: "case_law_group";
+    byJurisdiction: typeof CASE_LAW_INDEX_GROUP_OF;
+  };
+};
+
+type CaseLawV5Manifest = CaseLawManifestBase & {
   generation: "case_law_v5";
   projection: CorpusIndexProjectionContract & {
     layout: "passage";
     builderVersion: "case-law-passages-v1";
     yearFacetField: "decision_year";
   };
-  route: {
-    type: "case_law_group";
-    byJurisdiction: typeof CASE_LAW_INDEX_GROUP_OF;
+};
+
+/**
+ * v5 plus the publisher summary, as its own searchable field on the opening
+ * passage. A new generation rather than a field added to v5: the case-law doc
+ * mapping is `strict`, so an index created without the field drops every
+ * document that carries it, and the engine never diffs the mapping of an
+ * index that already exists. v5 therefore keeps its exact bytes, and with them
+ * its manifest digest and every projection fingerprint derived from it, while
+ * v6 builds beside it.
+ */
+type CaseLawV6Manifest = CaseLawManifestBase & {
+  generation: "case_law_v6";
+  projection: CorpusIndexProjectionContract & {
+    layout: "passage";
+    builderVersion: "case-law-passages-v2";
+    yearFacetField: "decision_year";
+    publisherSummaryField: typeof PUBLISHER_SUMMARY_FIELD;
   };
 };
 
@@ -68,7 +91,10 @@ type LegislationV2Manifest = CorpusIndexManifestBase & {
   route: { type: "jurisdiction" };
 };
 
-export type CorpusIndexManifest = CaseLawV5Manifest | LegislationV2Manifest;
+export type CorpusIndexManifest =
+  | CaseLawV5Manifest
+  | CaseLawV6Manifest
+  | LegislationV2Manifest;
 export type CorpusIndexManifestGeneration = CorpusIndexManifest["generation"];
 
 type CorpusIndexFieldMapping =
@@ -147,11 +173,25 @@ const commonFields = (): CorpusIndexFieldMapping[] => [
   },
 ];
 
-const indexConfig = (
-  fieldMappings: CorpusIndexFieldMapping[],
-  tagFields: string[],
-  timestampField?: string,
-): Omit<CorpusIndexConfig, "index_id"> => ({
+type IndexConfigOptions = {
+  fieldMappings: CorpusIndexFieldMapping[];
+  tagFields: string[];
+  timestampField?: string;
+  /**
+   * What a bare free-text term reaches. Only a field written once per document
+   * belongs here: under a passage layout a field repeated across a document's
+   * passages lets one document answer a broad query with as many hits as it
+   * has passages.
+   */
+  defaultSearchFields: string[];
+};
+
+const indexConfig = ({
+  fieldMappings,
+  tagFields,
+  timestampField,
+  defaultSearchFields,
+}: IndexConfigOptions): Omit<CorpusIndexConfig, "index_id"> => ({
   version: CORPUS_FINAL_INDEX_CONFIG_VERSION,
   doc_mapping: {
     mode: "strict",
@@ -173,7 +213,7 @@ const indexConfig = (
     resources: { heap_size: CORPUS_FINAL_INDEX_HEAP_SIZE_BYTES },
   },
   ingest_settings: { min_shards: CORPUS_FINAL_INDEX_MIN_SHARDS },
-  search_settings: { default_search_fields: ["title", "text"] },
+  search_settings: { default_search_fields: defaultSearchFields },
   retention: null,
 });
 
@@ -188,43 +228,86 @@ const deepFreeze = <T>(value: T): T => {
   return value;
 };
 
+const caseLawFields = (): CorpusIndexFieldMapping[] => [
+  ...commonFields(),
+  {
+    name: "anchor_id",
+    type: "text",
+    indexed: false,
+    stored: true,
+    fast: false,
+    fieldnorms: false,
+  },
+  rawField("case_number", { stored: false, fast: false }),
+  rawField("court", { stored: false, fast: true }),
+  dateField("decision_date"),
+  // Quickwit 0.9 supports only fixed, not calendar, date-histogram
+  // intervals. The projection emits this exact civil year on the one
+  // opening passage only, avoiding both leap-year drift and per-passage
+  // fast-field duplication for browse facets.
+  unsignedIntegerField("decision_year"),
+  {
+    ...dateField(DECISION_TIMESTAMP_FIELD),
+    fast_precision: "seconds",
+  },
+  rawField("ecli", { stored: false, fast: false }),
+];
+
+const CASE_LAW_TAG_FIELDS = [
+  "jurisdiction",
+  "document_type",
+  "source",
+  "court",
+  "language",
+];
+
 const CASE_LAW_V5_INDEX_CONFIG = deepFreeze(
   structuredClone(
-    indexConfig(
-      [
-        ...commonFields(),
+    indexConfig({
+      fieldMappings: caseLawFields(),
+      tagFields: [...CASE_LAW_TAG_FIELDS],
+      timestampField: DECISION_TIMESTAMP_FIELD,
+      defaultSearchFields: ["title", "text"],
+    }),
+  ),
+);
+
+const CASE_LAW_V6_INDEX_CONFIG = deepFreeze(
+  structuredClone(
+    indexConfig({
+      fieldMappings: [
+        ...caseLawFields(),
+        // Positions and fieldnorms because the summary is prose a reader
+        // quotes from: a phrase has to match adjacently, and BM25 has to see
+        // how long the line is. Not stored, because the line a reader sees
+        // comes from Postgres; not fast, because nothing filters, sorts or
+        // aggregates on it.
         {
-          name: "anchor_id",
+          name: PUBLISHER_SUMMARY_FIELD,
           type: "text",
-          indexed: false,
-          stored: true,
+          tokenizer: FOLDED_TOKENIZER.name,
+          record: "position",
+          fieldnorms: true,
+          indexed: true,
+          stored: false,
           fast: false,
-          fieldnorms: false,
         },
-        rawField("case_number", { stored: false, fast: false }),
-        rawField("court", { stored: false, fast: true }),
-        dateField("decision_date"),
-        // Quickwit 0.9 supports only fixed, not calendar, date-histogram
-        // intervals. The projection emits this exact civil year on the one
-        // opening passage only, avoiding both leap-year drift and per-passage
-        // fast-field duplication for browse facets.
-        unsignedIntegerField("decision_year"),
-        {
-          ...dateField(DECISION_TIMESTAMP_FIELD),
-          fast_precision: "seconds",
-        },
-        rawField("ecli", { stored: false, fast: false }),
       ],
-      ["jurisdiction", "document_type", "source", "court", "language"],
-      DECISION_TIMESTAMP_FIELD,
-    ),
+      tagFields: [...CASE_LAW_TAG_FIELDS],
+      timestampField: DECISION_TIMESTAMP_FIELD,
+      // Safe to widen here and nowhere else: the summary is written to the
+      // opening passage only, so a free-text term reaching it answers once per
+      // document, exactly as `title` does. A generation's search settings are
+      // fixed when its indexes are created, so v5 keeps searching two fields.
+      defaultSearchFields: ["title", "text", PUBLISHER_SUMMARY_FIELD],
+    }),
   ),
 );
 
 const LEGISLATION_V2_INDEX_CONFIG = deepFreeze(
   structuredClone(
-    indexConfig(
-      [
+    indexConfig({
+      fieldMappings: [
         ...commonFields(),
         rawField("status", { stored: false, fast: true }),
         dateField("effective_date"),
@@ -232,8 +315,15 @@ const LEGISLATION_V2_INDEX_CONFIG = deepFreeze(
         dateField("version_valid_to"),
         rawField("eli", { stored: false, fast: false }),
       ],
-      ["jurisdiction", "document_type", "source", "status", "language"],
-    ),
+      tagFields: [
+        "jurisdiction",
+        "document_type",
+        "source",
+        "status",
+        "language",
+      ],
+      defaultSearchFields: ["title", "text"],
+    }),
   ),
 );
 
@@ -254,6 +344,29 @@ export const CORPUS_INDEX_MANIFESTS = deepFreeze({
       projectionRevisionField: "projection_revision",
       openingField: "is_opening",
       yearFacetField: "decision_year",
+    },
+    route: {
+      type: "case_law_group",
+      byJurisdiction: { ...CASE_LAW_INDEX_GROUP_OF },
+    },
+  },
+  case_law_v6: {
+    schemaVersion: CORPUS_INDEX_MANIFEST_SCHEMA_VERSION,
+    family: "case_law",
+    generation: "case_law_v6",
+    cluster: "q09",
+    engine: {
+      binaryVersion: QUICKWIT_V09_BINARY_VERSION,
+      indexConfig: CASE_LAW_V6_INDEX_CONFIG,
+    },
+    projection: {
+      layout: "passage",
+      builderVersion: "case-law-passages-v2",
+      documentIdField: "document_id",
+      projectionRevisionField: "projection_revision",
+      openingField: "is_opening",
+      yearFacetField: "decision_year",
+      publisherSummaryField: PUBLISHER_SUMMARY_FIELD,
     },
     route: {
       type: "case_law_group",
@@ -289,15 +402,42 @@ export const requireCorpusIndexManifest = (
 ): CorpusIndexManifest => {
   switch (family) {
     case "case_law":
-      return generation === "case_law_v5"
-        ? CORPUS_INDEX_MANIFESTS.case_law_v5
-        : panic(`Unknown case-law index manifest: ${generation}`);
+      switch (generation) {
+        case "case_law_v5":
+          return CORPUS_INDEX_MANIFESTS.case_law_v5;
+        case "case_law_v6":
+          return CORPUS_INDEX_MANIFESTS.case_law_v6;
+        default:
+          return panic(`Unknown case-law index manifest: ${generation}`);
+      }
     case "legislation":
       return generation === "legislation_v2"
         ? CORPUS_INDEX_MANIFESTS.legislation_v2
         : panic(`Unknown legislation index manifest: ${generation}`);
     default:
       return panic("Unknown corpus index manifest family");
+  }
+};
+
+/**
+ * The index field a generation carries the publisher summary in, or null for
+ * a generation whose indexes never mapped one. Total over every generation, so
+ * a new one has to answer rather than inherit: writing the field into a
+ * `strict` index that does not map it drops the whole document, and the engine
+ * reports that as a successful ingest.
+ */
+export const corpusIndexPublisherSummaryField = (
+  manifest: CorpusIndexManifest,
+): typeof PUBLISHER_SUMMARY_FIELD | null => {
+  switch (manifest.generation) {
+    case "case_law_v5":
+      return null;
+    case "case_law_v6":
+      return manifest.projection.publisherSummaryField;
+    case "legislation_v2":
+      return null;
+    default:
+      return manifest satisfies never;
   }
 };
 

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -16,6 +16,7 @@ import {
   DECISION_TIMESTAMP_FIELD,
   FOLDED_TOKENIZER,
   PUBLISHER_SUMMARY_FIELD,
+  STEM_FIELD_OF,
   canonicalCorpusIndexMaturationPeriod,
   type CorpusIndexConfig,
 } from "@/api/lib/legal-search/corpus-index-config";
@@ -60,10 +61,10 @@ type CaseLawV5Manifest = CaseLawManifestBase & {
 };
 
 /**
- * v5 plus the publisher summary, as its own searchable field on the opening
- * passage. A new generation rather than a field added to v5: the case-law doc
- * mapping is `strict`, so an index created without the field drops every
- * document that carries it, and the engine never diffs the mapping of an
+ * v5 plus the publisher summary and the stem companions of the two fields a
+ * reader's words reach. A new generation rather than fields added to v5: the
+ * case-law doc mapping is `strict`, so an index created without a field drops
+ * every document that carries it, and the engine never diffs the mapping of an
  * index that already exists. v5 therefore keeps its exact bytes, and with them
  * its manifest digest and every projection fingerprint derived from it, while
  * v6 builds beside it.
@@ -75,6 +76,10 @@ type CaseLawV6Manifest = CaseLawManifestBase & {
     builderVersion: "case-law-passages-v2";
     yearFacetField: "decision_year";
     publisherSummaryField: typeof PUBLISHER_SUMMARY_FIELD;
+    stemFields: {
+      text: (typeof STEM_FIELD_OF)["text"];
+      publisherSummary: (typeof STEM_FIELD_OF)[typeof PUBLISHER_SUMMARY_FIELD];
+    };
   };
 };
 
@@ -124,6 +129,19 @@ const dateField = (name: string): CorpusIndexFieldMapping => ({
   fast_precision: "seconds",
   output_format: "rfc3339",
 });
+
+/**
+ * The stem companion of a full-text field, derived from that field rather than
+ * restated beside it: same tokenizer, positions and fieldnorms, or a stem hit
+ * would phrase-match and score on different terms than the field it stands in
+ * for. Only the name and the docstore differ, because nothing reads a stem
+ * back. Deriving it is what makes the two impossible to drift apart; a copied
+ * literal would need a test to notice.
+ */
+const stemCompanionField = (
+  surface: CorpusIndexFieldMapping,
+  name: string,
+): CorpusIndexFieldMapping => ({ ...surface, name, stored: false });
 
 const unsignedIntegerField = (name: string): CorpusIndexFieldMapping => ({
   name,
@@ -272,34 +290,47 @@ const CASE_LAW_V5_INDEX_CONFIG = deepFreeze(
   ),
 );
 
+const caseLawV6Fields = (): CorpusIndexFieldMapping[] => {
+  const base = caseLawFields();
+  const text =
+    base.find((field) => field.name === "text") ??
+    panic("Case-law fields no longer map `text`");
+  // The summary is prose a reader quotes from, so it is mapped exactly like
+  // the body text: positions for adjacency, fieldnorms for BM25. Not stored,
+  // because the line a reader sees comes from Postgres; not fast, because
+  // nothing filters, sorts or aggregates on it.
+  const publisherSummary: CorpusIndexFieldMapping = {
+    ...text,
+    name: PUBLISHER_SUMMARY_FIELD,
+    stored: false,
+  };
+  return [
+    ...base,
+    publisherSummary,
+    stemCompanionField(text, STEM_FIELD_OF.text),
+    stemCompanionField(
+      publisherSummary,
+      STEM_FIELD_OF[PUBLISHER_SUMMARY_FIELD],
+    ),
+  ];
+};
+
 const CASE_LAW_V6_INDEX_CONFIG = deepFreeze(
   structuredClone(
     indexConfig({
-      fieldMappings: [
-        ...caseLawFields(),
-        // Positions and fieldnorms because the summary is prose a reader
-        // quotes from: a phrase has to match adjacently, and BM25 has to see
-        // how long the line is. Not stored, because the line a reader sees
-        // comes from Postgres; not fast, because nothing filters, sorts or
-        // aggregates on it.
-        {
-          name: PUBLISHER_SUMMARY_FIELD,
-          type: "text",
-          tokenizer: FOLDED_TOKENIZER.name,
-          record: "position",
-          fieldnorms: true,
-          indexed: true,
-          stored: false,
-          fast: false,
-        },
-      ],
+      fieldMappings: caseLawV6Fields(),
       tagFields: [...CASE_LAW_TAG_FIELDS],
       timestampField: DECISION_TIMESTAMP_FIELD,
-      // Safe to widen here and nowhere else: the summary is written to the
-      // opening passage only, so a free-text term reaching it answers once per
-      // document, exactly as `title` does. A generation's search settings are
-      // fixed when its indexes are created, so v5 keeps searching two fields.
-      defaultSearchFields: ["title", "text", PUBLISHER_SUMMARY_FIELD],
+      // Unchanged from v5, and the summary is deliberately not added.
+      //
+      // A default search field decides what a *bare* term matches, and a hit
+      // is a passage whose stored `text` is what a reader — or the research
+      // answer runner — is handed as the excerpt that matched. A summary-only
+      // match would return the opening passage with text that does not carry
+      // the terms at all. The summary and the stem fields are therefore named
+      // explicitly by the query builder, which knows it is asking for them,
+      // and never reached by a term that did not ask.
+      defaultSearchFields: ["title", "text"],
     }),
   ),
 );
@@ -367,6 +398,10 @@ export const CORPUS_INDEX_MANIFESTS = deepFreeze({
       openingField: "is_opening",
       yearFacetField: "decision_year",
       publisherSummaryField: PUBLISHER_SUMMARY_FIELD,
+      stemFields: {
+        text: STEM_FIELD_OF.text,
+        publisherSummary: STEM_FIELD_OF[PUBLISHER_SUMMARY_FIELD],
+      },
     },
     route: {
       type: "case_law_group",
@@ -434,6 +469,32 @@ export const corpusIndexPublisherSummaryField = (
       return null;
     case "case_law_v6":
       return manifest.projection.publisherSummaryField;
+    case "legislation_v2":
+      return null;
+    default:
+      return manifest satisfies never;
+  }
+};
+
+export type CorpusIndexStemFields = {
+  text: (typeof STEM_FIELD_OF)["text"];
+  publisherSummary: (typeof STEM_FIELD_OF)[typeof PUBLISHER_SUMMARY_FIELD];
+};
+
+/**
+ * The stem companions a generation maps, or null. Total for the same reason:
+ * the writer must not emit a field the generation's mapping lacks, and the
+ * query builder must not name one, since a `strict` index rejects a clause
+ * over a field it never declared.
+ */
+export const corpusIndexStemFields = (
+  manifest: CorpusIndexManifest,
+): CorpusIndexStemFields | null => {
+  switch (manifest.generation) {
+    case "case_law_v5":
+      return null;
+    case "case_law_v6":
+      return manifest.projection.stemFields;
     case "legislation_v2":
       return null;
     default:

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -107,6 +107,7 @@ type BootstrapCaseLawRow = {
   court: string;
   decisionDate: string | null;
   ecli: string | null;
+  metadata: Record<string, unknown> | null;
   projectionEpoch: bigint;
 };
 
@@ -262,6 +263,7 @@ const bootstrapCaseLaw = async (
       court: caseLawDecisions.court,
       decisionDate: caseLawDecisions.decisionDate,
       ecli: caseLawDecisions.ecli,
+      metadata: caseLawDecisions.metadata,
       projectionEpoch: caseLawDecisions.projectionEpoch,
     })
     .from(caseLawDecisions)
@@ -371,6 +373,7 @@ const bootstrapCaseLaw = async (
         court: row.court,
         decisionDate: row.decisionDate,
         ecli: row.ecli,
+        metadata: row.metadata,
       }),
     }),
   );

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
@@ -14,6 +14,7 @@ import type {
   CaseLawProjectionInput,
   LegislationV2ProjectionInput,
 } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
 
 const REVISION = toSafeId<"corpusIndexProjectionIntent">(
   "0198e331-e578-7000-8000-000000000001",
@@ -250,6 +251,105 @@ test("v5 never emits a field its strict mapping does not declare", () => {
 
   for (const document of documents) {
     expect("headnote" in document).toBe(false);
+    expect(
+      Object.keys(document).every((key) =>
+        manifestFields("case_law_v5").has(key),
+      ),
+    ).toBe(true);
+  }
+});
+
+test("v6 writes a stem beside each field a reader's words reach", () => {
+  const [document] = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
+    input: {
+      ...CASE_LAW_INPUT,
+      language: "cs",
+      metadata: { legalSentence: "Nájemního bytu se to netýká." },
+    },
+    payload: { text: "Nájemního bytu se to netýká.", ast: null },
+    revision: REVISION,
+  });
+
+  expect(document).toMatchObject({
+    text: "Nájemního bytu se to netýká.",
+    headnote: "Nájemního bytu se to netýká.",
+  });
+  // One stem per token, so the stem stream lines up with the surface stream
+  // and a stemmed phrase matches adjacently. Counted rather than compared to a
+  // pinned string: the assertion is the alignment, not this stemmer's output.
+  const tokenCount = (value: string | undefined): number =>
+    corpusTokens(value ?? "").length;
+
+  expect(tokenCount(document?.text_stem)).toBeGreaterThan(0);
+  expect(tokenCount(document?.text_stem)).toBe(tokenCount(document?.text));
+  expect(tokenCount(document?.headnote_stem)).toBe(
+    tokenCount(document?.headnote),
+  );
+  expect(
+    Object.keys(document ?? {}).every((key) =>
+      manifestFields("case_law_v6").has(key),
+    ),
+  ).toBe(true);
+});
+
+test("a language with no stemmer writes no stem field at all", () => {
+  const documents = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
+    input: {
+      ...CASE_LAW_INPUT,
+      language: "de",
+      metadata: { legalSentence: "Der Mietvertrag." },
+    },
+    payload: { text: "Der Mietvertrag wurde gekündigt.", ast: null },
+    revision: REVISION,
+  });
+
+  for (const document of documents) {
+    // Not an empty string under a stem name: a field the writer cannot fill
+    // is a field it does not emit.
+    expect("text_stem" in document).toBe(false);
+    expect("headnote_stem" in document).toBe(false);
+    expect("headnote" in document).toBe(true);
+  }
+});
+
+test("the summary stem is written to the opening passage only", () => {
+  const documents = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
+    input: {
+      ...CASE_LAW_INPUT,
+      language: "cs",
+      metadata: { legalSentence: "Právní věta." },
+    },
+    payload: {
+      text: `${"první ".repeat(400)}\n\n${"druhý ".repeat(400)}`,
+      ast: null,
+    },
+    revision: REVISION,
+  });
+
+  expect(documents.length).toBeGreaterThan(1);
+  for (const [index, document] of documents.entries()) {
+    expect("headnote_stem" in document).toBe(index === 0);
+    // The passage stem is per passage, beside that passage's own text.
+    expect("text_stem" in document).toBe(true);
+  }
+});
+
+test("v5 emits neither stem field", () => {
+  const documents = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v5,
+    input: {
+      ...CASE_LAW_INPUT,
+      language: "cs",
+      metadata: { legalSentence: "Právní věta." },
+    },
+    payload: { text: "Nájemního bytu se to netýká.", ast: null },
+    revision: REVISION,
+  });
+
+  for (const document of documents) {
     expect(
       Object.keys(document).every((key) =>
         manifestFields("case_law_v5").has(key),

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
@@ -1,15 +1,17 @@
 import { expect, test } from "bun:test";
 
+import type { DocumentAst } from "@stll/legal-ast/document-ast";
+
 import { toSafeId } from "@/api/lib/branded-types";
 import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
 import { CORPUS_INDEX_MANIFESTS } from "@/api/lib/legal-search/corpus-index-manifest";
 import {
-  buildCaseLawV5ProjectionDocuments,
+  buildCaseLawProjectionDocuments,
   buildCorpusProjectionDocuments,
   buildLegislationV2ProjectionDocuments,
 } from "@/api/lib/legal-search/corpus-index-projection-builder";
 import type {
-  CaseLawV5ProjectionInput,
+  CaseLawProjectionInput,
   LegislationV2ProjectionInput,
 } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
 
@@ -34,7 +36,8 @@ const CASE_LAW_INPUT = {
   court: "Nejvyšší správní soud",
   decisionDate: null,
   ecli: null,
-} as const satisfies CaseLawV5ProjectionInput;
+  metadata: null,
+} as const satisfies CaseLawProjectionInput;
 const LEGISLATION_INPUT = {
   family: "legislation",
   documentId: "0198e331-e578-7000-8000-000000000004",
@@ -54,17 +57,20 @@ const LEGISLATION_INPUT = {
 const DATED_CASE_LAW_INPUT = {
   ...CASE_LAW_INPUT,
   decisionDate: "2008-01-30",
-} as const satisfies CaseLawV5ProjectionInput;
+} as const satisfies CaseLawProjectionInput;
 
-const manifestFields = (family: "case_law" | "legislation"): Set<string> =>
+const manifestFields = (
+  generation: keyof typeof CORPUS_INDEX_MANIFESTS,
+): Set<string> =>
   new Set(
     CORPUS_INDEX_MANIFESTS[
-      family === "case_law" ? "case_law_v5" : "legislation_v2"
+      generation
     ].engine.indexConfig.doc_mapping.field_mappings.map(({ name }) => name),
   );
 
 test("case-law v5 emits exact attempt identity and one opening passage", () => {
-  const documents = buildCaseLawV5ProjectionDocuments({
+  const documents = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v5,
     input: DATED_CASE_LAW_INPUT,
     payload: {
       text: `${"první ".repeat(400)}\n\n${"druhý ".repeat(400)}`,
@@ -89,13 +95,16 @@ test("case-law v5 emits exact attempt identity and one opening passage", () => {
     expect("title" in document).toBe(index === 0);
     expect("decision_year" in document).toBe(index === 0);
     expect(
-      Object.keys(document).every((key) => manifestFields("case_law").has(key)),
+      Object.keys(document).every((key) =>
+        manifestFields("case_law_v5").has(key),
+      ),
     ).toBe(true);
   }
 });
 
 test("case-law v5 omits a year for an undated decision", () => {
-  const [document] = buildCaseLawV5ProjectionDocuments({
+  const [document] = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v5,
     input: CASE_LAW_INPUT,
     payload: { text: "Usnesení", ast: null },
     revision: REVISION,
@@ -133,7 +142,7 @@ test("legislation v2 emits one strict pointer-free document", () => {
   ]);
   expect(
     Object.keys(documents[0]).every((key) =>
-      manifestFields("legislation").has(key),
+      manifestFields("legislation_v2").has(key),
     ),
   ).toBe(true);
 });
@@ -141,6 +150,7 @@ test("legislation v2 emits one strict pointer-free document", () => {
 test("builder dispatch is exhaustive over manifest-owned versions", () => {
   expect(
     buildCorpusProjectionDocuments({
+      family: "case_law",
       manifest: CORPUS_INDEX_MANIFESTS.case_law_v5,
       input: CASE_LAW_INPUT,
       payload: { text: "Rozsudek", ast: null },
@@ -149,10 +159,101 @@ test("builder dispatch is exhaustive over manifest-owned versions", () => {
   ).toHaveLength(1);
   expect(
     buildCorpusProjectionDocuments({
+      family: "legislation",
       manifest: CORPUS_INDEX_MANIFESTS.legislation_v2,
       input: LEGISLATION_INPUT,
       payload: { text: "Zákon", ast: null },
       revision: REVISION,
     }),
   ).toHaveLength(1);
+});
+
+const SUMMARY_AST = {
+  version: 1,
+  source: {
+    system: "test",
+    documentId: "1",
+    webUrl: "https://example.test/1",
+    printUrl: "https://example.test/1.pdf",
+  },
+  metadata: {
+    caseNumber: null,
+    ecli: null,
+    court: null,
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks: [
+    {
+      id: "b1",
+      anchorId: "b1",
+      type: "paragraph",
+      role: "headnotes",
+      inlines: [{ type: "text", text: "Právní věta" }],
+      plainText: "Právní věta",
+    },
+    {
+      id: "b2",
+      anchorId: "b2",
+      type: "paragraph",
+      role: "argumentation",
+      inlines: [{ type: "text", text: "Odůvodnění" }],
+      plainText: "Odůvodnění",
+    },
+  ],
+} as const satisfies DocumentAst;
+
+test("v6 writes the publisher summary on the opening passage only", () => {
+  const documents = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
+    input: { ...CASE_LAW_INPUT, metadata: { legalArea: "Daně" } },
+    payload: {
+      text: `${"první ".repeat(400)}\n\n${"druhý ".repeat(400)}`,
+      ast: null,
+    },
+    revision: REVISION,
+  });
+
+  expect(documents.length).toBeGreaterThan(1);
+  // Metadata only, because this payload carries no AST.
+  expect(documents.at(0)).toMatchObject({ headnote: "Daně" });
+  for (const [index, document] of documents.entries()) {
+    expect("headnote" in document).toBe(index === 0);
+    expect(
+      Object.keys(document).every((key) =>
+        manifestFields("case_law_v6").has(key),
+      ),
+    ).toBe(true);
+  }
+});
+
+test("v6 prefers a marked apparatus paragraph to a metadata key", () => {
+  const [document] = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
+    input: { ...CASE_LAW_INPUT, metadata: { legalArea: "Daně" } },
+    payload: { text: "Právní věta\n\nOdůvodnění", ast: SUMMARY_AST },
+    revision: REVISION,
+  });
+
+  expect(document).toMatchObject({ headnote: "Právní věta" });
+});
+
+test("v5 never emits a field its strict mapping does not declare", () => {
+  const documents = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v5,
+    input: { ...CASE_LAW_INPUT, metadata: { legalArea: "Daně" } },
+    payload: { text: "Právní věta", ast: SUMMARY_AST },
+    revision: REVISION,
+  });
+
+  for (const document of documents) {
+    expect("headnote" in document).toBe(false);
+    expect(
+      Object.keys(document).every((key) =>
+        manifestFields("case_law_v5").has(key),
+      ),
+    ).toBe(true);
+  }
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
@@ -8,6 +8,7 @@ import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
 import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
 import {
   corpusIndexPublisherSummaryField,
+  corpusIndexStemFields,
   type CorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import {
@@ -15,6 +16,8 @@ import {
   type CaseLawProjectionInput,
   type LegislationV2ProjectionInput,
 } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+import { documentMorphologyLanguage } from "@/api/lib/legal-search/morphology/corpus-language";
+import { stemCorpusText } from "@/api/lib/legal-search/morphology/stem-text";
 
 type ProjectionRevision = SafeId<"corpusIndexProjectionIntent">;
 
@@ -39,6 +42,8 @@ type CaseLawProjectionDocument = SharedProjectionDocument & {
   decision_year?: number;
   ecli?: string;
   headnote?: string;
+  text_stem?: string;
+  headnote_stem?: string;
 };
 
 type LegislationV2ProjectionDocument = SharedProjectionDocument & {
@@ -126,9 +131,25 @@ export const buildCaseLawProjectionDocuments = ({
     summaryField === null
       ? null
       : publisherSummaryOf({ documentAst: ast, metadata: input.metadata });
+  // Stems come from the decision's own language, not its jurisdiction: an
+  // index group spans several countries and a court may publish in more than
+  // one language. A language with no stemmer writes no stem fields at all,
+  // rather than a copy of the surface text under a stem name.
+  const stemFields = corpusIndexStemFields(manifest);
+  const stemLanguage = documentMorphologyLanguage(input.language);
+  const stemmed =
+    stemFields === null || stemLanguage === null
+      ? null
+      : { fields: stemFields, language: stemLanguage };
+  const summaryStem =
+    stemmed === null || summary === null
+      ? null
+      : stemCorpusText(summary, stemmed.language);
   const chunks = chunkDocument({ ast, fallbackText: payload.text });
   const documents: CaseLawProjectionDocument[] = [];
   for (const chunk of chunks) {
+    const textStem =
+      stemmed === null ? null : stemCorpusText(chunk.text, stemmed.language);
     documents.push({
       ...shared,
       text: chunk.text,
@@ -139,9 +160,18 @@ export const buildCaseLawProjectionDocuments = ({
         : {}),
       // Opening passage only, like `title`: a document-level line repeated on
       // every passage would let one decision answer a broad query as many
-      // times as it has passages.
+      // times as it has passages. The summary's stem follows it, so the two
+      // are always written together or not at all.
       ...(chunk.seq === 0 && summaryField !== null && summary !== null
         ? { [summaryField]: summary }
+        : {}),
+      ...(chunk.seq === 0 && stemmed !== null && summaryStem !== null
+        ? { [stemmed.fields.publisherSummary]: summaryStem }
+        : {}),
+      // Per passage, beside that passage's own text, so a stemmed phrase
+      // matches inside one passage exactly as a surface phrase does.
+      ...(stemmed !== null && textStem !== null && textStem !== ""
+        ? { [stemmed.fields.text]: textStem }
         : {}),
       ...(chunk.anchorId === null ? {} : { anchor_id: chunk.anchorId }),
     });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
@@ -2,13 +2,17 @@ import { panic } from "better-result";
 
 import type { SafeId } from "@/api/lib/branded-types";
 import { hasUsableAst } from "@/api/lib/case-law/document-ast";
+import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
 import { chunkDocument } from "@/api/lib/corpus-index/chunking";
 import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
 import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
-import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
 import {
-  caseLawV5Title,
-  type CaseLawV5ProjectionInput,
+  corpusIndexPublisherSummaryField,
+  type CorpusIndexManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  caseLawProjectionTitle,
+  type CaseLawProjectionInput,
   type LegislationV2ProjectionInput,
 } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
 
@@ -26,7 +30,7 @@ type SharedProjectionDocument = {
   is_opening: boolean;
 };
 
-type CaseLawV5ProjectionDocument = SharedProjectionDocument & {
+type CaseLawProjectionDocument = SharedProjectionDocument & {
   anchor_id?: string;
   case_number: string;
   court: string;
@@ -34,6 +38,7 @@ type CaseLawV5ProjectionDocument = SharedProjectionDocument & {
   decision_date_ts: string;
   decision_year?: number;
   ecli?: string;
+  headnote?: string;
 };
 
 type LegislationV2ProjectionDocument = SharedProjectionDocument & {
@@ -49,18 +54,26 @@ type ProjectionBuildBase = {
   revision: ProjectionRevision;
 };
 
+/**
+ * The family is carried at the top level so the manifest and the input are
+ * paired by the type rather than by a runtime check: a case-law manifest can
+ * only arrive with a case-law input, and the dispatch below narrows both at
+ * once.
+ */
 type BuildCorpusProjectionDocumentsOptions =
   | (ProjectionBuildBase & {
+      family: "case_law";
       manifest: Extract<CorpusIndexManifest, { family: "case_law" }>;
-      input: CaseLawV5ProjectionInput;
+      input: CaseLawProjectionInput;
     })
   | (ProjectionBuildBase & {
+      family: "legislation";
       manifest: Extract<CorpusIndexManifest, { family: "legislation" }>;
       input: LegislationV2ProjectionInput;
     });
 
 const sharedFields = (
-  input: CaseLawV5ProjectionInput | LegislationV2ProjectionInput,
+  input: CaseLawProjectionInput | LegislationV2ProjectionInput,
   revision: ProjectionRevision,
 ): Omit<SharedProjectionDocument, "title" | "text" | "is_opening"> => ({
   document_id: input.documentId,
@@ -71,17 +84,19 @@ const sharedFields = (
   ...(input.documentType === null ? {} : { document_type: input.documentType }),
 });
 
-type BuildCaseLawV5Options = ProjectionBuildBase & {
-  input: CaseLawV5ProjectionInput;
+type BuildCaseLawOptions = ProjectionBuildBase & {
+  manifest: Extract<CorpusIndexManifest, { family: "case_law" }>;
+  input: CaseLawProjectionInput;
 };
 
 const CASE_LAW_DECISION_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 
-export const buildCaseLawV5ProjectionDocuments = ({
+export const buildCaseLawProjectionDocuments = ({
+  manifest,
   input,
   payload,
   revision,
-}: BuildCaseLawV5Options): CaseLawV5ProjectionDocument[] => {
+}: BuildCaseLawOptions): CaseLawProjectionDocument[] => {
   if (
     input.decisionDate !== null &&
     !CASE_LAW_DECISION_DATE_PATTERN.test(input.decisionDate)
@@ -98,14 +113,21 @@ export const buildCaseLawV5ProjectionDocuments = ({
       : { decision_date: input.decisionDate }),
     ...(input.ecli === null ? {} : { ecli: input.ecli }),
   };
-  const title = caseLawV5Title(input);
+  const title = caseLawProjectionTitle(input);
   const decisionYear =
     input.decisionDate === null ? null : Number(input.decisionDate.slice(0, 4));
-  const chunks = chunkDocument({
-    ast: hasUsableAst(payload.ast) ? payload.ast : null,
-    fallbackText: payload.text,
-  });
-  const documents: CaseLawV5ProjectionDocument[] = [];
+  const ast = hasUsableAst(payload.ast) ? payload.ast : null;
+  // The full source list, AST roles included: this is the one place holding
+  // both a parsed document and its publisher metadata. The read path sees the
+  // metadata prefix of the same list, so the indexed line is never a different
+  // answer, only a better one.
+  const summaryField = corpusIndexPublisherSummaryField(manifest);
+  const summary =
+    summaryField === null
+      ? null
+      : publisherSummaryOf({ documentAst: ast, metadata: input.metadata });
+  const chunks = chunkDocument({ ast, fallbackText: payload.text });
+  const documents: CaseLawProjectionDocument[] = [];
   for (const chunk of chunks) {
     documents.push({
       ...shared,
@@ -114,6 +136,12 @@ export const buildCaseLawV5ProjectionDocuments = ({
       ...(chunk.seq === 0 ? { title } : {}),
       ...(chunk.seq === 0 && decisionYear !== null
         ? { decision_year: decisionYear }
+        : {}),
+      // Opening passage only, like `title`: a document-level line repeated on
+      // every passage would let one decision answer a broad query as many
+      // times as it has passages.
+      ...(chunk.seq === 0 && summaryField !== null && summary !== null
+        ? { [summaryField]: summary }
         : {}),
       ...(chunk.anchorId === null ? {} : { anchor_id: chunk.anchorId }),
     });
@@ -152,24 +180,21 @@ export const buildLegislationV2ProjectionDocuments = ({
 export const buildCorpusProjectionDocuments = (
   options: BuildCorpusProjectionDocumentsOptions,
 ): Record<string, unknown>[] => {
-  if (options.input.family === "case_law") {
-    if (options.manifest.projection.builderVersion !== "case-law-passages-v1") {
-      return panic("Case-law projection input has a non-case-law manifest");
-    }
-    return buildCaseLawV5ProjectionDocuments({
-      input: options.input,
-      payload: options.payload,
-      revision: options.revision,
-    });
+  switch (options.family) {
+    case "case_law":
+      return buildCaseLawProjectionDocuments({
+        manifest: options.manifest,
+        input: options.input,
+        payload: options.payload,
+        revision: options.revision,
+      });
+    case "legislation":
+      return buildLegislationV2ProjectionDocuments({
+        input: options.input,
+        payload: options.payload,
+        revision: options.revision,
+      });
+    default:
+      return options satisfies never;
   }
-  if (
-    options.manifest.projection.builderVersion !== "legislation-document-v1"
-  ) {
-    return panic("Legislation projection input has a non-legislation manifest");
-  }
-  return buildLegislationV2ProjectionDocuments({
-    input: options.input,
-    payload: options.payload,
-    revision: options.revision,
-  });
 };

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
@@ -2,9 +2,9 @@ import { expect, test } from "bun:test";
 
 import { CORPUS_INDEX_MANIFESTS } from "@/api/lib/legal-search/corpus-index-manifest";
 import {
-  caseLawV5Title,
+  caseLawProjectionTitle,
   deriveCorpusIndexProjectionDescriptor,
-  type CaseLawV5ProjectionInput,
+  type CaseLawProjectionInput,
   type LegislationV2ProjectionInput,
 } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
@@ -27,7 +27,8 @@ const CASE_LAW_INPUT = {
   court: "Nejvyšší správní soud",
   decisionDate: "2008-02-27",
   ecli: null,
-} as const satisfies CaseLawV5ProjectionInput;
+  metadata: null,
+} as const satisfies CaseLawProjectionInput;
 
 const LEGISLATION_INPUT = {
   family: "legislation",
@@ -47,7 +48,7 @@ const LEGISLATION_INPUT = {
 } as const satisfies LegislationV2ProjectionInput;
 
 test("case-law title and fingerprint canonicalize identifier order", () => {
-  expect(caseLawV5Title(CASE_LAW_INPUT)).toBe(
+  expect(caseLawProjectionTitle(CASE_LAW_INPUT)).toBe(
     "4 As 3/2008 · NSS-4-AS-3-2008 — Nejvyšší správní soud",
   );
   const first = deriveCorpusIndexProjectionDescriptor(
@@ -127,4 +128,48 @@ test("manifest and projection families cannot be crossed", () => {
       CASE_LAW_INPUT,
     ),
   ).toThrow("Corpus projection family mismatch");
+});
+
+test("only a generation that indexes the summary fingerprints it", () => {
+  const withSummary = {
+    ...CASE_LAW_INPUT,
+    metadata: { legalSentence: "Právní věta" },
+  };
+
+  // v5 never writes the field, so a publisher editing the summary must not
+  // re-project the generation currently serving.
+  expect(
+    deriveCorpusIndexProjectionDescriptor(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+      withSummary,
+    ),
+  ).toEqual(
+    deriveCorpusIndexProjectionDescriptor(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+      CASE_LAW_INPUT,
+    ),
+  );
+  expect(
+    deriveCorpusIndexProjectionDescriptor(
+      CORPUS_INDEX_MANIFESTS.case_law_v6,
+      withSummary,
+    ),
+  ).not.toEqual(
+    deriveCorpusIndexProjectionDescriptor(
+      CORPUS_INDEX_MANIFESTS.case_law_v6,
+      CASE_LAW_INPUT,
+    ),
+  );
+  // A metadata key no source of the summary names changes nothing anywhere.
+  expect(
+    deriveCorpusIndexProjectionDescriptor(CORPUS_INDEX_MANIFESTS.case_law_v6, {
+      ...CASE_LAW_INPUT,
+      metadata: { unrelated: "bookkeeping" },
+    }),
+  ).toEqual(
+    deriveCorpusIndexProjectionDescriptor(
+      CORPUS_INDEX_MANIFESTS.case_law_v6,
+      CASE_LAW_INPUT,
+    ),
+  );
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
@@ -1,10 +1,12 @@
 import { panic } from "better-result";
 
+import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
 import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
 import {
   corpusIndexContractDigest,
   corpusIndexIdFromManifest,
   corpusIndexManifestDigest,
+  corpusIndexPublisherSummaryField,
   type CorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
@@ -19,7 +21,7 @@ type ProjectionInputBase = {
   redistributionEligible: boolean;
 };
 
-export type CaseLawV5ProjectionInput = ProjectionInputBase & {
+export type CaseLawProjectionInput = ProjectionInputBase & {
   family: "case_law";
   redacted: boolean;
   caseNumber: string;
@@ -27,6 +29,13 @@ export type CaseLawV5ProjectionInput = ProjectionInputBase & {
   court: string;
   decisionDate: string | null;
   ecli: string | null;
+  /**
+   * Publisher metadata as the adapter recorded it, read only through
+   * `publisherSummaryOf`. The document AST is that summary's other source and
+   * is deliberately absent here: it lives in object storage, while this input
+   * is assembled per row inside the canonical transaction.
+   */
+  metadata: Record<string, unknown> | null;
 };
 
 export type LegislationV2ProjectionInput = ProjectionInputBase & {
@@ -40,7 +49,7 @@ export type LegislationV2ProjectionInput = ProjectionInputBase & {
 };
 
 export type CorpusIndexProjectionInput =
-  | CaseLawV5ProjectionInput
+  | CaseLawProjectionInput
   | LegislationV2ProjectionInput;
 
 export type CorpusIndexProjectionDescriptor =
@@ -48,8 +57,8 @@ export type CorpusIndexProjectionDescriptor =
   | { action: "upsert"; fingerprint: string; indexId: string };
 
 const compareIdentifiers = (
-  left: CaseLawV5ProjectionInput["identifiers"][number],
-  right: CaseLawV5ProjectionInput["identifiers"][number],
+  left: CaseLawProjectionInput["identifiers"][number],
+  right: CaseLawProjectionInput["identifiers"][number],
 ): number => {
   if (left.type < right.type) {
     return -1;
@@ -63,12 +72,12 @@ const compareIdentifiers = (
   return left.value > right.value ? 1 : 0;
 };
 
-export const caseLawV5Title = ({
+export const caseLawProjectionTitle = ({
   identifiers,
   caseNumber,
   court,
 }: Pick<
-  CaseLawV5ProjectionInput,
+  CaseLawProjectionInput,
   "identifiers" | "caseNumber" | "court"
 >): string => {
   const canonicalIdentifiers = identifiers.toSorted(compareIdentifiers);
@@ -112,21 +121,37 @@ export const deriveCorpusIndexProjectionDescriptor = (
   } as const;
 
   switch (input.family) {
-    case "case_law":
+    case "case_law": {
+      // A fingerprint has to cover everything the generation writes. The
+      // summary's AST source is already covered through `contentHash`; its
+      // metadata source is not, so a generation carrying the field folds the
+      // metadata reading in and re-projects when a publisher edits it. A
+      // generation without the field keeps the fingerprints it already has.
+      const publisherSummary =
+        corpusIndexPublisherSummaryField(manifest) === null
+          ? {}
+          : {
+              publisherSummary: publisherSummaryOf({
+                documentAst: null,
+                metadata: input.metadata,
+              }),
+            };
       return {
         action: "upsert",
         indexId,
         fingerprint: corpusIndexContractDigest({
           ...common,
-          title: caseLawV5Title(input),
+          title: caseLawProjectionTitle(input),
           caseNumber: input.caseNumber,
           court: input.court,
           decisionDate: input.decisionDate,
           decisionDateTimestamp:
             input.decisionDate ?? UNDATED_DECISION_TIMESTAMP,
           ecli: input.ecli,
+          ...publisherSummary,
         }),
       };
+    }
     case "legislation":
       return {
         action: "upsert",

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -21,7 +21,7 @@ import {
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import {
   deriveCorpusIndexProjectionDescriptor,
-  type CaseLawV5ProjectionInput,
+  type CaseLawProjectionInput,
   type CorpusIndexProjectionDescriptor,
   type CorpusIndexProjectionInput,
   type LegislationV2ProjectionInput,
@@ -101,6 +101,7 @@ export type CaseLawProjectionCanonicalInput = {
   court: string;
   decisionDate: string | null;
   ecli: string | null;
+  metadata: Record<string, unknown> | null;
   sourceDescriptor: Parameters<typeof isRedistributable>[0];
 };
 
@@ -117,8 +118,9 @@ export const caseLawProjectionInputFromCanonical = ({
   court,
   decisionDate,
   ecli,
+  metadata,
   sourceDescriptor,
-}: CaseLawProjectionCanonicalInput): CaseLawV5ProjectionInput => ({
+}: CaseLawProjectionCanonicalInput): CaseLawProjectionInput => ({
   family: "case_law",
   documentId,
   sourceId,
@@ -133,6 +135,7 @@ export const caseLawProjectionInputFromCanonical = ({
   court,
   decisionDate,
   ecli,
+  metadata,
 });
 
 export type LegislationProjectionCanonicalInput = {
@@ -369,6 +372,7 @@ const lockCaseLawProjectionInput = async (
       court: caseLawDecisions.court,
       decisionDate: caseLawDecisions.decisionDate,
       ecli: caseLawDecisions.ecli,
+      metadata: caseLawDecisions.metadata,
       projectionEpoch: caseLawDecisions.projectionEpoch,
     })
     .from(caseLawDecisions)

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -398,6 +398,7 @@ const buildPreparedEntry = async (
     switch (material.family) {
       case "case_law":
         return buildCorpusProjectionDocuments({
+          family: material.family,
           manifest: material.manifest,
           input: material.input,
           payload: payload.value,
@@ -405,6 +406,7 @@ const buildPreparedEntry = async (
         });
       case "legislation":
         return buildCorpusProjectionDocuments({
+          family: material.family,
           manifest: material.manifest,
           input: material.input,
           payload: payload.value,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-materials.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-materials.ts
@@ -172,6 +172,10 @@ const readCaseLawMaterials = async (
       court: caseLawDecisions.court,
       decisionDate: caseLawDecisions.decisionDate,
       ecli: caseLawDecisions.ecli,
+      // Read for `publisherSummaryOf` only. The decision's AST is not read
+      // here: the builder already holds it, from the payload object this
+      // transaction hands on a pointer to.
+      metadata: caseLawDecisions.metadata,
       projectionEpoch: caseLawDecisions.projectionEpoch,
       textS3Key: caseLawDecisions.textS3Key,
       astS3Key: caseLawDecisions.astS3Key,

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -27,6 +27,7 @@ import {
   encodeCorpusIndexCursor,
   readCorpusIndexSearchPage,
 } from "@/api/lib/legal-search/corpus-index-pagination";
+import { caseLawCorpusQueryFields } from "@/api/lib/legal-search/corpus-index-read-contract";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
 import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
@@ -157,11 +158,18 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
 
   // The jurisdiction also selects the expansion dictionary, which is why the
   // resolver takes it separately from the clause.
+  // The generation decides which fields exist to be named; the language
+  // filter, then the jurisdiction, decides how the reader's words are stemmed.
+  const { surfaceFields, stemming } = caseLawCorpusQueryFields({
+    generation,
+    jurisdiction: query.jurisdiction,
+    language: query.language,
+  });
   const engineQuery = await resolveExpandedCorpusQuery({
     build: (expand) =>
-      caseLawCorpusQuery(
-        query.query,
-        {
+      caseLawCorpusQuery({
+        text: query.query,
+        filters: {
           court: query.court,
           dateFrom: query.dateFrom,
           dateTo: query.dateTo,
@@ -171,7 +179,9 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
           source: query.source,
         },
         expand,
-      ),
+        stemming,
+        surfaceFields,
+      }),
     jurisdiction: query.jurisdiction,
     mode: envBase.QUERY_EXPANSION_MODE,
     text: query.query,

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
@@ -13,6 +13,13 @@ test("legacy and final case-law reads use their declared schema", () => {
     openingPassageQuery: "is_opening:true",
     yearFacetField: "decision_year",
   });
+  // v6 changes what a bare term reaches, which the index decides, not the
+  // reader: the read contract is unchanged.
+  expect(corpusIndexReadContract("case_law", "case_law_v6")).toEqual({
+    family: "case_law",
+    openingPassageQuery: "is_opening:true",
+    yearFacetField: "decision_year",
+  });
 });
 
 test("legislation reads derive the final opening marker", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
@@ -1,24 +1,34 @@
 import { expect, test } from "bun:test";
 
-import { corpusIndexReadContract } from "@/api/lib/legal-search/corpus-index-read-contract";
+import {
+  caseLawCorpusQueryFields,
+  corpusIndexReadContract,
+} from "@/api/lib/legal-search/corpus-index-read-contract";
 
 test("legacy and final case-law reads use their declared schema", () => {
   expect(corpusIndexReadContract("case_law", "case_law_v4")).toEqual({
     family: "case_law",
     openingPassageQuery: "seq:0",
     yearFacetField: "year",
+    stemFields: null,
+    searchableFields: [],
   });
   expect(corpusIndexReadContract("case_law", "case_law_v5")).toEqual({
     family: "case_law",
     openingPassageQuery: "is_opening:true",
     yearFacetField: "decision_year",
+    stemFields: null,
+    searchableFields: [],
   });
-  // v6 changes what a bare term reaches, which the index decides, not the
-  // reader: the read contract is unchanged.
+  // What a *bare* term reaches is the index's decision, not the reader's, so
+  // the summary changed nothing here; the stem fields did, because only a
+  // query naming them explicitly can reach them.
   expect(corpusIndexReadContract("case_law", "case_law_v6")).toEqual({
     family: "case_law",
     openingPassageQuery: "is_opening:true",
     yearFacetField: "decision_year",
+    stemFields: { text: "text_stem", publisherSummary: "headnote_stem" },
+    searchableFields: ["headnote"],
   });
 });
 
@@ -31,4 +41,82 @@ test("legislation reads derive the final opening marker", () => {
     family: "legislation",
     openingPassageQuery: "is_opening:true",
   });
+});
+
+test("extra fields and stemming both need a generation that maps them", () => {
+  expect(
+    caseLawCorpusQueryFields({
+      generation: "case_law_v6",
+      jurisdiction: "CZE",
+      language: undefined,
+    }),
+  ).toEqual({
+    surfaceFields: ["headnote"],
+    stemming: { language: "cs", fields: ["text_stem", "headnote_stem"] },
+  });
+  // Slovak has a stemmer but no published expansion dictionary; the two are
+  // separate questions and only the dictionary one is answered elsewhere.
+  expect(
+    caseLawCorpusQueryFields({
+      generation: "case_law_v6",
+      jurisdiction: "SVK",
+      language: undefined,
+    }).stemming,
+  ).toEqual({ language: "sk", fields: ["text_stem", "headnote_stem"] });
+  // A generation whose indexes never mapped the fields: naming one would be
+  // an invalid query against a strict mapping, not a narrower one.
+  expect(
+    caseLawCorpusQueryFields({
+      generation: "case_law_v5",
+      jurisdiction: "CZE",
+      language: undefined,
+    }),
+  ).toEqual({ surfaceFields: [], stemming: null });
+  expect(
+    caseLawCorpusQueryFields({
+      generation: "case_law_v6",
+      jurisdiction: "AUT",
+      language: undefined,
+    }).stemming,
+  ).toBeNull();
+  // Unscoped and unfiltered: the index pattern spans every jurisdiction of
+  // the generation, so no one language describes the text being matched.
+  expect(
+    caseLawCorpusQueryFields({
+      generation: "case_law_v6",
+      jurisdiction: undefined,
+      language: undefined,
+    }).stemming,
+  ).toBeNull();
+});
+
+test("the language filter, not the jurisdiction, decides how words stem", () => {
+  const stemmingOf = (
+    jurisdiction: string | undefined,
+    language: string | undefined,
+  ) =>
+    caseLawCorpusQueryFields({
+      generation: "case_law_v6",
+      jurisdiction,
+      language,
+    }).stemming;
+
+  // A filter with no country at all has no jurisdiction to fall back on, and
+  // still names the language of the documents it selects.
+  expect(stemmingOf(undefined, "cs")).toEqual({
+    language: "cs",
+    fields: ["text_stem", "headnote_stem"],
+  });
+  // Agreeing: the same answer either way.
+  expect(stemmingOf("CZE", "cs")).toEqual(stemmingOf("CZE", undefined));
+  // Disagreeing: the European index carries 24 languages and the jurisdiction
+  // names none of them, so only the filter can say what these stems are.
+  expect(stemmingOf("EU", "cs")).toEqual({
+    language: "cs",
+    fields: ["text_stem", "headnote_stem"],
+  });
+  expect(stemmingOf("CZE", "pl")?.language).toBe("pl");
+  // A language no stemmer covers yields none, rather than falling back to the
+  // jurisdiction's and stemming against a language the documents are not in.
+  expect(stemmingOf("CZE", "de")).toBeNull();
 });

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
@@ -1,11 +1,33 @@
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
-import { requireCorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  corpusIndexPublisherSummaryField,
+  corpusIndexStemFields,
+  requireCorpusIndexManifest,
+  type CorpusIndexStemFields,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import type { CorpusStemming } from "@/api/lib/legal-search/corpus-query";
+import {
+  corpusMorphologyLanguage,
+  documentMorphologyLanguage,
+} from "@/api/lib/legal-search/morphology/corpus-language";
 
 export type CaseLawIndexReadContract = {
   family: "case_law";
   openingPassageQuery: string;
   yearFacetField: string;
+  /**
+   * The stem companions this generation maps, or null. The query builder may
+   * name a field only when it appears here: the case-law doc mapping is
+   * `strict`, so a clause over a field the index never declared is not a
+   * narrower query but an invalid one.
+   */
+  stemFields: CorpusIndexStemFields | null;
+  /**
+   * Full-text fields this generation maps beside the ones a bare term already
+   * reaches. Named explicitly by a query or not matched at all.
+   */
+  searchableFields: readonly string[];
 };
 
 export type LegislationIndexReadContract = {
@@ -46,18 +68,24 @@ export function corpusIndexReadContract(
           family,
           openingPassageQuery: "seq:0",
           yearFacetField: "year",
+          stemFields: null,
+          searchableFields: [],
         }
       : { family, openingPassageQuery: "seq:0" };
   }
 
   const manifest = requireCorpusIndexManifest(family, generation);
   switch (manifest.family) {
-    case "case_law":
+    case "case_law": {
+      const publisherSummary = corpusIndexPublisherSummaryField(manifest);
       return {
         family: manifest.family,
         openingPassageQuery: `${manifest.projection.openingField}:true`,
         yearFacetField: manifest.projection.yearFacetField,
+        stemFields: corpusIndexStemFields(manifest),
+        searchableFields: publisherSummary === null ? [] : [publisherSummary],
       };
+    }
     case "legislation":
       return {
         family: manifest.family,
@@ -67,3 +95,61 @@ export function corpusIndexReadContract(
       return manifest satisfies never;
   }
 }
+
+type CaseLawCorpusQueryFieldsOptions = {
+  generation: string;
+  /** The query's jurisdiction, or undefined for an unscoped search. */
+  jurisdiction: string | undefined;
+  /** The request's language filter, when it carries one. */
+  language: string | undefined;
+};
+
+export type CaseLawCorpusQueryFields = {
+  surfaceFields: readonly string[];
+  stemming: CorpusStemming | null;
+};
+
+/**
+ * Which fields beyond the default ones a case-law query may name, and under
+ * which language its words are stemmed.
+ *
+ * Both read paths resolve it here rather than each assembling its own answer,
+ * for the same reason both assemble their query through one builder: two
+ * answers to what the engine sees is the failure this indirection exists to
+ * prevent. A generation that maps nothing extra yields the query it yields
+ * today.
+ *
+ * The stemming language comes from the request's `language` filter first,
+ * because that filter names the documents whose stems are being matched: a
+ * search scoped to `EU` but filtered to Czech text has to stem Czech, and a
+ * filter with no country at all has no jurisdiction to fall back on. Only when
+ * the request names no language does the jurisdiction answer, and an unscoped
+ * search — spanning every jurisdiction of a generation — answers with none.
+ * A language filter naming text no stemmer covers yields no stemming rather
+ * than the jurisdiction's, which would stem the reader's words against a
+ * language the documents are not written in.
+ */
+export const caseLawCorpusQueryFields = ({
+  generation,
+  jurisdiction,
+  language,
+}: CaseLawCorpusQueryFieldsOptions): CaseLawCorpusQueryFields => {
+  const { stemFields, searchableFields } = corpusIndexReadContract(
+    "case_law",
+    generation,
+  );
+  const stemLanguage =
+    language === undefined
+      ? corpusMorphologyLanguage(jurisdiction)
+      : documentMorphologyLanguage(language);
+  return {
+    surfaceFields: searchableFields,
+    stemming:
+      stemFields === null || stemLanguage === null
+        ? null
+        : {
+            language: stemLanguage,
+            fields: [stemFields.text, stemFields.publisherSummary],
+          },
+  };
+};

--- a/apps/api/src/lib/legal-search/corpus-query.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
 
 import {
+  CORPUS_QUERY_LEAF_BUDGET,
   caseLawCorpusQuery,
+  type CorpusStemming,
   corpusFreeTextClause,
   quoteCorpusValue,
   tokenizeCorpusFreeText,
@@ -200,14 +202,17 @@ test("the clause is exactly the tokenization, quoted and ANDed", () => {
 
 test("the assembler ANDs filter clauses onto the free-text clause", () => {
   expect(
-    caseLawCorpusQuery('"náhrada škody"', {
-      court: "Nejvyšší soud",
-      dateFrom: "2020-01-01",
-      dateTo: "2024-12-31",
-      documentType: "rozsudek",
-      jurisdiction: "CZE",
-      language: "cs",
-      source: "7449df27-2067-4827-b22f-3091f564ae50",
+    caseLawCorpusQuery({
+      text: '"náhrada škody"',
+      filters: {
+        court: "Nejvyšší soud",
+        dateFrom: "2020-01-01",
+        dateTo: "2024-12-31",
+        documentType: "rozsudek",
+        jurisdiction: "CZE",
+        language: "cs",
+        source: "7449df27-2067-4827-b22f-3091f564ae50",
+      },
     }),
   ).toBe(
     '("náhrada škody")' +
@@ -221,31 +226,162 @@ test("the assembler ANDs filter clauses onto the free-text clause", () => {
 });
 
 test("an open-ended date range keeps the wildcard bound", () => {
-  expect(caseLawCorpusQuery("smlouva", { dateFrom: "2020-01-01" })).toBe(
-    '("smlouva") AND decision_date:[2020-01-01 TO *]',
-  );
-  expect(caseLawCorpusQuery("smlouva", { dateTo: "2020-01-01" })).toBe(
-    '("smlouva") AND decision_date:[* TO 2020-01-01]',
-  );
+  expect(
+    caseLawCorpusQuery({
+      text: "smlouva",
+      filters: { dateFrom: "2020-01-01" },
+    }),
+  ).toBe('("smlouva") AND decision_date:[2020-01-01 TO *]');
+  expect(
+    caseLawCorpusQuery({
+      text: "smlouva",
+      filters: { dateTo: "2020-01-01" },
+    }),
+  ).toBe('("smlouva") AND decision_date:[* TO 2020-01-01]');
 });
 
 test("no filters leaves the free-text clause alone", () => {
-  expect(caseLawCorpusQuery("smlouva", {})).toBe('("smlouva")');
+  expect(caseLawCorpusQuery({ text: "smlouva", filters: {} })).toBe(
+    '("smlouva")',
+  );
 });
 
 test("text without a searchable term yields no query", () => {
-  expect(caseLawCorpusQuery("?!()", { court: "Nejvyšší soud" })).toBeNull();
-  expect(caseLawCorpusQuery('""', {})).toBeNull();
+  expect(
+    caseLawCorpusQuery({
+      text: "?!()",
+      filters: { court: "Nejvyšší soud" },
+    }),
+  ).toBeNull();
+  expect(caseLawCorpusQuery({ text: '""', filters: {} })).toBeNull();
 });
 
 // A filter value reaching the engine unescaped would let a caller that does
 // not validate its inputs (the provider takes them straight from its caller)
 // close the clause and append DSL of its own.
 test("filter values cannot close their clause", () => {
-  expect(caseLawCorpusQuery("smlouva", { court: 'X" OR text:*' })).toBe(
-    '("smlouva") AND court:"X\\" OR text:*"',
+  expect(
+    caseLawCorpusQuery({
+      text: "smlouva",
+      filters: { court: 'X" OR text:*' },
+    }),
+  ).toBe('("smlouva") AND court:"X\\" OR text:*"');
+  expect(
+    caseLawCorpusQuery({
+      text: "smlouva",
+      filters: { language: "cs\\" },
+    }),
+  ).toBe('("smlouva") AND language:"cs\\\\"');
+});
+
+const CS_STEMMING = {
+  language: "cs",
+  fields: ["text_stem", "headnote_stem"],
+} as const satisfies CorpusStemming;
+
+test("a term carries a stem alternative beside the word as typed", () => {
+  // The surface leaf is unscoped and still reaches every default field; the
+  // stem leaves name their fields, because a bare term must never be matched
+  // against a spelling the reader did not write.
+  expect(corpusFreeTextClause("nájemního", { stemming: CS_STEMMING })).toBe(
+    '(("nájemního" OR text_stem:"nájemn" OR headnote_stem:"nájemn"))',
   );
-  expect(caseLawCorpusQuery("smlouva", { language: "cs\\" })).toBe(
-    '("smlouva") AND language:"cs\\\\"',
+});
+
+test("an extra surface field is named, never reached by a bare term", () => {
+  expect(
+    corpusFreeTextClause("nájemního", { surfaceFields: ["headnote"] }),
+  ).toBe('(("nájemního" OR headnote:"nájemního"))');
+  expect(
+    corpusFreeTextClause('"nájemního bytu"', { surfaceFields: ["headnote"] }),
+  ).toBe('(("nájemního bytu" OR headnote:"nájemního bytu"))');
+});
+
+/**
+ * The research answer runner hands every hit's stored `text` to the answer
+ * model as the excerpt that matched, so its retrieval must never match a field
+ * written to one passage of a document: a summary-only hit would return the
+ * opening passage with text that does not carry the terms. It builds its
+ * clause with no extra fields, and the index's default fields no longer carry
+ * the summary, so neither half can reach one.
+ */
+test("a clause built with no extra fields names no field at all", () => {
+  const clause = corpusFreeTextClause("nájemního bytu");
+
+  expect(clause).toBe('("nájemního" AND "bytu")');
+  expect(clause).not.toContain("headnote");
+  expect(clause).not.toContain("_stem");
+});
+
+test("the decisions query names the summary where its generation maps one", () => {
+  const decisions = caseLawCorpusQuery({
+    text: "nájemního",
+    filters: { jurisdiction: "CZE" },
+    surfaceFields: ["headnote"],
+    stemming: CS_STEMMING,
+  });
+
+  expect(decisions).toContain('headnote:"nájemního"');
+  expect(decisions).toContain('headnote_stem:"nájemn"');
+  // The same query for a generation that maps neither is what it is today.
+  expect(
+    caseLawCorpusQuery({ text: "nájemního", filters: { jurisdiction: "CZE" } }),
+  ).toBe('("nájemního") AND jurisdiction:"CZE"');
+});
+
+test("a phrase carries a stemmed phrase, word for word", () => {
+  // Stems joined by single spaces, so the stemmed phrase is as adjacent as
+  // the surface phrase: two words in, two stems out.
+  expect(
+    corpusFreeTextClause('"nájemního bytu"', { stemming: CS_STEMMING }),
+  ).toBe(
+    '(("nájemního bytu" OR text_stem:"nájemn byt" OR headnote_stem:"nájemn byt"))',
   );
+});
+
+test("stem clauses compose with expansion rather than replacing it", () => {
+  const clause = corpusFreeTextClause("nájemné", {
+    expand: () => ["nájemného"],
+    stemming: CS_STEMMING,
+  });
+
+  expect(clause).toBe(
+    '(("nájemné" OR "nájemného" OR text_stem:"nájemn" OR headnote_stem:"nájemn"))',
+  );
+});
+
+test("a generation without extra fields gets the query it gets today", () => {
+  for (const text of [
+    "náhrada škody",
+    '"dobrá víra" a "náhrada škody"',
+    "§ 2235 odst. 1",
+  ]) {
+    expect(
+      corpusFreeTextClause(text, { stemming: null, surfaceFields: [] }),
+    ).toBe(corpusFreeTextClause(text));
+    expect(caseLawCorpusQuery({ text, filters: { jurisdiction: "CZE" } })).toBe(
+      caseLawCorpusQuery({
+        text,
+        filters: { jurisdiction: "CZE" },
+        stemming: null,
+      }),
+    );
+  }
+});
+
+test("text that stems to nothing carries no stem leaf", () => {
+  // Digits tokenize but stem to themselves, so the leaf is still worth
+  // emitting; text with no token at all yields no clause in the first place.
+  expect(corpusFreeTextClause("§ ()", { stemming: CS_STEMMING })).toBeNull();
+});
+
+test("the leaf budget counts stem leaves too", () => {
+  const clause = corpusFreeTextClause(
+    "nájemního nájemního nájemního nájemního nájemního nájemního nájemního nájemního",
+    { stemming: CS_STEMMING },
+  );
+
+  expect(clause).not.toBeNull();
+  const leaves = [...(clause ?? "").matchAll(/"/gu)].length / 2;
+  expect(leaves).toBeLessThanOrEqual(CORPUS_QUERY_LEAF_BUDGET);
 });

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -1,3 +1,7 @@
+import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
+import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
+import { stemCorpusText } from "@/api/lib/legal-search/morphology/stem-text";
+
 /**
  * Quote a trusted-shape filter value for a corpus-index field clause.
  * Backslashes are escaped before quotes so a trailing backslash cannot
@@ -24,14 +28,6 @@ const PHRASE_QUOTE_CLOSERS = new Map<string, string>([
   ["«", "»"],
   ["»", "«"],
 ]);
-
-/**
- * Unicode word characters only, or null when the text holds none. Everything
- * the engine could parse as DSL is dropped here rather than escaped, inside a
- * phrase exactly as outside one.
- */
-const corpusTerms = (text: string): RegExpMatchArray | null =>
-  text.match(/[\p{L}\p{N}]+/gu);
 
 /**
  * Index of the first character in `closers`, or -1. Every quote character is
@@ -75,11 +71,8 @@ export const tokenizeCorpusFreeText = (text: string): CorpusQueryToken[] => {
   let plain = "";
 
   const flushPlain = () => {
-    const terms = corpusTerms(plain);
+    const terms = corpusTokens(plain);
     plain = "";
-    if (terms === null) {
-      return;
-    }
     for (const term of terms) {
       tokens.push({ type: "term", value: term });
     }
@@ -102,8 +95,8 @@ export const tokenizeCorpusFreeText = (text: string): CorpusQueryToken[] => {
     }
 
     flushPlain();
-    const words = corpusTerms(text.slice(index + 1, end));
-    if (words !== null) {
+    const words = corpusTokens(text.slice(index + 1, end));
+    if (words.length > 0) {
       tokens.push({ type: "phrase", value: words.join(" ") });
     }
     index = end + 1;
@@ -148,12 +141,89 @@ const TOKEN_EXPANSION_POLICY = {
 export const CORPUS_QUERY_LEAF_BUDGET = 24;
 
 /**
- * `("typed" OR "other" ...)` — a bare grouped OR, never a field-scoped one:
- * the engine parses `(a OR b)` inside the default fields, and a field-scoped
- * group in this position does not parse at all.
+ * The stem fields a query may name, and the language the reader's words are
+ * stemmed against.
+ *
+ * Both halves are required and neither is guessed: the fields come from the
+ * generation's manifest, because a `strict` index rejects a clause over a
+ * field it never declared, and the language comes from the query's
+ * jurisdiction, because the corpus was stemmed under that language when it was
+ * projected. Null wherever either is missing, which is what keeps a query
+ * against an older generation byte-identical to what it is today.
  */
-const orGroup = (typed: string, extras: readonly string[]): string =>
-  `(${[typed, ...extras].map(quoteCorpusValue).join(" OR ")})`;
+export type CorpusStemming = {
+  language: MorphologyLanguage;
+  fields: readonly string[];
+};
+
+/**
+ * `field:"stem"` for each stem field, or nothing when the text stems to
+ * nothing. The stem is computed from the words as typed, so it is right
+ * exactly when the reader wrote the diacritics; a reader who did not still
+ * matches the surface fields, and the dictionary expander is what supplies
+ * the accented forms in that case.
+ */
+const stemLeaves = (
+  value: string,
+  stemming: CorpusStemming | null,
+): string[] => {
+  if (stemming === null) {
+    return [];
+  }
+  const stem = stemCorpusText(value, stemming.language);
+  if (stem === "") {
+    return [];
+  }
+  return stemming.fields.map((field) => `${field}:${quoteCorpusValue(stem)}`);
+};
+
+/**
+ * `field:"word"` for each extra surface field: the reader's words as typed,
+ * against a field the index does not search by default.
+ *
+ * Naming the field is the whole point. A default search field decides what a
+ * bare term matches, and every hit is a passage whose stored `text` is handed
+ * on as the excerpt that matched; a field written to the opening passage only
+ * would answer with a passage whose text does not carry the terms. A caller
+ * that wants those matches asks for them here, and one that needs every hit to
+ * be a matching passage simply does not.
+ */
+const surfaceFieldLeaves = (
+  value: string,
+  fields: readonly string[],
+): string[] => fields.map((field) => `${field}:${quoteCorpusValue(value)}`);
+
+/**
+ * Surface forms to accept beside the one the reader typed. A phrase gets
+ * none: rewriting its words would silently change what it asked to match
+ * adjacently. Total over the token union through `TOKEN_EXPANSION_POLICY`, so
+ * a new token kind cannot reach the engine without that decision recorded.
+ */
+const expansionLeaves = (
+  token: CorpusQueryToken,
+  expand: CorpusTermExpander,
+): string[] => {
+  const policy = TOKEN_EXPANSION_POLICY[token.type];
+  switch (policy) {
+    case "verbatim":
+      return [];
+    case "expandable":
+      return [...expand(token.value)].map(quoteCorpusValue);
+    default:
+      return policy satisfies never;
+  }
+};
+
+export type CorpusFreeTextOptions = {
+  expand?: CorpusTermExpander | undefined;
+  stemming?: CorpusStemming | null | undefined;
+  /**
+   * Fields matched with the reader's words as typed, beside the default search
+   * fields. Empty for a caller whose every hit has to be a passage that
+   * carries the terms.
+   */
+  surfaceFields?: readonly string[] | undefined;
+};
 
 /**
  * Convert free user text into a safe corpus-index query clause. The engine's
@@ -163,18 +233,29 @@ const orGroup = (typed: string, extras: readonly string[]): string =>
  * token, AND them. Returns null when no searchable token remains; callers
  * return an empty page without querying the engine.
  *
- * `title` and `text` — the default search fields — record positions, so a bare
- * quoted clause is a positional phrase match over both. A phrase and a term are
- * quoted identically because a phrase is no more expressive than a term here:
- * only the grouping differs.
+ * The default search fields record positions, so a bare quoted clause is a
+ * positional phrase match over all of them. A phrase and a term are quoted
+ * identically because a phrase is no more expressive than a term here: only
+ * the grouping differs.
  *
- * With no expander this emits exactly what it emitted before expansion
- * existed, byte for byte; the expanded form differs only by OR groups in the
- * positions expansion chose.
+ * A group mixes an unscoped leaf with field-scoped ones — `("slovo" OR
+ * headnote:"slovo" OR text_stem:"slov")` — which the engine reads leaf by
+ * leaf: the first is matched against the default fields and the rest against
+ * the field each names. Every extra leaf is an alternative beside the surface
+ * leaf, never instead of it, so a generation with more fields answers
+ * everything the same query answered without them, plus the wider matches.
+ *
+ * With no expander, no extra fields and no stemming this emits exactly what it
+ * emitted before any of them existed, byte for byte; the wider forms differ
+ * only by OR groups in the positions those features chose.
  */
 export const corpusFreeTextClause = (
   text: string,
-  expand: CorpusTermExpander = noTermExpansion,
+  {
+    expand = noTermExpansion,
+    stemming = null,
+    surfaceFields = [],
+  }: CorpusFreeTextOptions = {},
 ): string | null => {
   const tokens = tokenizeCorpusFreeText(text);
   if (tokens.length === 0) {
@@ -183,26 +264,23 @@ export const corpusFreeTextClause = (
 
   let leaves = tokens.length;
   const clauses = tokens.map((token) => {
-    const policy = TOKEN_EXPANSION_POLICY[token.type];
-    switch (policy) {
-      case "verbatim": {
-        return quoteCorpusValue(token.value);
-      }
-      case "expandable": {
-        const extras = expand(token.value);
-        if (
-          extras.length === 0 ||
-          leaves + extras.length > CORPUS_QUERY_LEAF_BUDGET
-        ) {
-          return quoteCorpusValue(token.value);
-        }
-        leaves += extras.length;
-        return orGroup(token.value, extras);
-      }
-      default: {
-        return policy satisfies never;
-      }
+    const typed = quoteCorpusValue(token.value);
+    const extras = [
+      ...expansionLeaves(token, expand),
+      ...surfaceFieldLeaves(token.value, surfaceFields),
+      ...stemLeaves(token.value, stemming),
+    ];
+    // The budget is spent left to right: a token whose group would cross it
+    // stays a single leaf rather than truncating a group into a clause that
+    // asks for something narrower than either alternative.
+    if (
+      extras.length === 0 ||
+      leaves + extras.length > CORPUS_QUERY_LEAF_BUDGET
+    ) {
+      return typed;
     }
+    leaves += extras.length;
+    return `(${[typed, ...extras].join(" OR ")})`;
   });
 
   return `(${clauses.join(" AND ")})`;
@@ -226,6 +304,14 @@ export type CaseLawCorpusFilters = {
   source?: string | undefined;
 };
 
+export type CaseLawCorpusQueryOptions = {
+  text: string;
+  filters: CaseLawCorpusFilters;
+  expand?: CorpusTermExpander | undefined;
+  stemming?: CorpusStemming | null | undefined;
+  surfaceFields?: readonly string[] | undefined;
+};
+
 /**
  * The one assembler for a case-law corpus-index query. Both read paths (the
  * public search handler and the shared search provider) go through it, so
@@ -233,12 +319,18 @@ export type CaseLawCorpusFilters = {
  * to audit. Null when the free text carries no searchable term: callers return
  * an empty page rather than querying the engine.
  */
-export const caseLawCorpusQuery = (
-  text: string,
-  filters: CaseLawCorpusFilters,
-  expand?: CorpusTermExpander,
-): string | null => {
-  const freeText = corpusFreeTextClause(text, expand);
+export const caseLawCorpusQuery = ({
+  text,
+  filters,
+  expand,
+  stemming,
+  surfaceFields,
+}: CaseLawCorpusQueryOptions): string | null => {
+  const freeText = corpusFreeTextClause(text, {
+    expand,
+    stemming,
+    surfaceFields,
+  });
   if (freeText === null) {
     return null;
   }

--- a/apps/api/src/lib/legal-search/corpus-tokens.ts
+++ b/apps/api/src/lib/legal-search/corpus-tokens.ts
@@ -1,0 +1,35 @@
+/**
+ * How corpus text is cut into terms, mirroring the engine's `simple`
+ * tokenizer, which the `folded` tokenizer is built on: a run of letters or
+ * digits is a token and everything else is a separator.
+ *
+ * One owner, because two sides depend on the answer being the same one. The
+ * query builder splits the reader's text this way before quoting it, and the
+ * projection splits a passage this way before stemming it; a stem stream cut
+ * on a different rule would line up with a different set of positions than
+ * the surface stream it stands in for, and a phrase would match the wrong
+ * words or none.
+ *
+ * Text is normalised to NFC first, and that is not cosmetic: a combining mark
+ * is `\p{M}`, not `\p{L}`, so decomposed text breaks a word apart at every
+ * accent — "nájemního" in NFD becomes three tokens, each of which stems to
+ * itself and matches nothing. Extracted text arrives in whatever form its
+ * producer used, and NFD is common from PDFs and from macOS, so both the
+ * corpus and a pasted query can carry it.
+ *
+ * Everything the engine could read as query syntax is dropped rather than
+ * escaped, which is the property the query builder relies on for safety.
+ */
+const CORPUS_TOKEN_PATTERN = /[\p{L}\p{N}]+/gu;
+
+export const corpusTokens = (text: string): string[] => {
+  const tokens: string[] = [];
+  // `matchAll` over `match`: text with no token is an empty iteration rather
+  // than a null needing a fallback, so there is one code path and no second
+  // spelling of "no tokens". It also iterates its own regex clone, which is
+  // what makes a shared pattern object safe to reuse here.
+  for (const [token] of text.normalize("NFC").matchAll(CORPUS_TOKEN_PATTERN)) {
+    tokens.push(token);
+  }
+  return tokens;
+};

--- a/apps/api/src/lib/legal-search/expansion.property.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.property.test.ts
@@ -123,9 +123,9 @@ test("no dictionary can produce a clause that escapes its own quoting", () => {
   fc.assert(
     fc.property(dictionaryText, queryText, (text, query) => {
       const { entries } = parseExpansionDictionary(text);
-      const clause = corpusFreeTextClause(query, (term) =>
-        expandTermWith(entries, term),
-      );
+      const clause = corpusFreeTextClause(query, {
+        expand: (term) => expandTermWith(entries, term),
+      });
       if (clause === null) {
         return;
       }
@@ -144,9 +144,9 @@ test("expansion never pushes a clause past the leaf budget it started under", ()
     fc.property(dictionaryText, queryText, (text, query) => {
       const { entries } = parseExpansionDictionary(text);
       const base = corpusFreeTextClause(query);
-      const expanded = corpusFreeTextClause(query, (term) =>
-        expandTermWith(entries, term),
-      );
+      const expanded = corpusFreeTextClause(query, {
+        expand: (term) => expandTermWith(entries, term),
+      });
       if (base === null || expanded === null) {
         return;
       }
@@ -168,9 +168,9 @@ test("expansion only ever adds leaves to the unexpanded clause", () => {
     fc.property(dictionaryText, queryText, (text, query) => {
       const { entries } = parseExpansionDictionary(text);
       const base = corpusFreeTextClause(query);
-      const expanded = corpusFreeTextClause(query, (term) =>
-        expandTermWith(entries, term),
-      );
+      const expanded = corpusFreeTextClause(query, {
+        expand: (term) => expandTermWith(entries, term),
+      });
       expect(expanded === null).toBe(base === null);
       if (base === null || expanded === null) {
         return;

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -126,18 +126,18 @@ test("a decomposed query term reaches the same bucket as its precomposed spellin
 });
 
 test("the typed term is never repeated inside its own group", () => {
-  const clause = corpusFreeTextClause("nájemné", (term) =>
-    expandTermWith(dictionaryOf(CS_BUCKETS), term),
-  );
+  const clause = corpusFreeTextClause("nájemné", {
+    expand: (term) => expandTermWith(dictionaryOf(CS_BUCKETS), term),
+  });
   expect(clause).toBe(
     '(("nájemné" OR "nájemného" OR "nájemném" OR "nájemnému"))',
   );
 });
 
 test("phrases are never expanded", () => {
-  const clause = corpusFreeTextClause('"nájemné smlouvy" nájemné', (term) =>
-    expandTermWith(dictionaryOf(CS_BUCKETS), term),
-  );
+  const clause = corpusFreeTextClause('"nájemné smlouvy" nájemné', {
+    expand: (term) => expandTermWith(dictionaryOf(CS_BUCKETS), term),
+  });
   expect(clause).toBe(
     '("nájemné smlouvy" AND ("nájemné" OR "nájemného" OR "nájemném" OR "nájemnému"))',
   );
@@ -151,10 +151,9 @@ test("expansion stops at the leaf budget, leftmost terms first", () => {
       stem: "aaa",
     },
   ]);
-  const clause = corpusFreeTextClause(
-    "aaa aaa aaa aaa aaa aaa aaa aaa",
-    (term) => expandTermWith(entries, term),
-  );
+  const clause = corpusFreeTextClause("aaa aaa aaa aaa aaa aaa aaa aaa", {
+    expand: (term) => expandTermWith(entries, term),
+  });
   expect(clause).not.toBeNull();
   // Eight tokens, each expandable by three: the budget admits five groups
   // (8 + 5*3 = 23) and the sixth would cross it.
@@ -174,7 +173,9 @@ test.each([
   'smlouva) OR (court:"X" AND text:*',
   "  spaced   out  ",
 ])("an expander with nothing to add leaves %p byte-identical", (text) => {
-  expect(corpusFreeTextClause(text, () => [])).toBe(corpusFreeTextClause(text));
+  expect(corpusFreeTextClause(text, { expand: () => [] })).toBe(
+    corpusFreeTextClause(text),
+  );
 });
 
 // Citation identifiers reach the builder as whatever the tokenizer makes of

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -28,6 +28,7 @@ import {
   corpusFreeTextClause,
   type CorpusTermExpander,
 } from "@/api/lib/legal-search/corpus-query";
+import { corpusMorphologyLanguage } from "@/api/lib/legal-search/morphology/corpus-language";
 import {
   foldExpansionKey,
   isMorphologyDictionaryContentHash,
@@ -45,49 +46,42 @@ import { logger } from "@/api/lib/observability/logger";
 import { readCorpusS3BytesBounded } from "@/api/lib/s3";
 
 /**
- * Jurisdictions the corpus index serves, and the language whose dictionary
- * their text is expanded against. `null` means the jurisdiction is served
- * without expansion.
+ * Whether a language's dictionary payload exists to be read.
  *
- * Slovak resolves to `null` in phase 1: the stemmer exists, but no Slovak
- * dictionary is published yet, and pointing SVK at a language with no payload
- * would make every Slovak search pay a pointer read that can only miss.
- * Publishing the dictionary and flipping this one entry enables it.
+ * Expansion needs one and stemming does not, which is the whole difference
+ * between this and `corpusMorphologyLanguage`: Slovak has a stemmer but no
+ * published dictionary, so pointing a Slovak search at it would pay a pointer
+ * read that can only miss. Publishing the payload and flipping this one entry
+ * enables expansion for it.
  *
- * The EU index carries 24 languages under one jurisdiction, so a single
- * dictionary could not be chosen for it at all.
+ * Total, so a language added to the stemmer has to answer this too rather
+ * than silently inheriting a dictionary it has none of.
  */
-const EXPANSION_LANGUAGE_BY_JURISDICTION = {
-  CZE: "cs",
-  EU: null,
-  POL: "pl",
-  SVK: null,
-} as const satisfies Record<string, MorphologyLanguage | null>;
-
-type ExpansionJurisdiction = keyof typeof EXPANSION_LANGUAGE_BY_JURISDICTION;
-
-const isExpansionJurisdiction = (
-  value: string,
-): value is ExpansionJurisdiction =>
-  Object.hasOwn(EXPANSION_LANGUAGE_BY_JURISDICTION, value);
+const EXPANSION_DICTIONARY = {
+  cs: "published",
+  pl: "published",
+  sk: "unpublished",
+} as const satisfies Record<MorphologyLanguage, "published" | "unpublished">;
 
 /**
  * Which language a request's jurisdiction expands against, or null for no
- * expansion. An unscoped search (no country: the index pattern spans every
- * jurisdiction) resolves to null, because no one language describes its text.
- * An unrecognised jurisdiction resolves to null for the same reason; this
- * lookup's miss is the documented phase-1 scope, not a defect to report.
+ * expansion.
+ *
+ * The jurisdiction's language is `corpusMorphologyLanguage`, the one map the
+ * projection stems against as well, so the two sides cannot disagree about
+ * what a jurisdiction is written in. Only the dictionary question is answered
+ * here. An unscoped search (no country: the index pattern spans every
+ * jurisdiction) resolves to null there, because no one language describes its
+ * text, and so does a jurisdiction with no single language of its own.
  */
 export const expansionLanguageForJurisdiction = (
   country: string | undefined,
 ): MorphologyLanguage | null => {
-  if (country === undefined) {
+  const language = corpusMorphologyLanguage(country);
+  if (language === null) {
     return null;
   }
-  const jurisdiction = country.toUpperCase();
-  return isExpansionJurisdiction(jurisdiction)
-    ? EXPANSION_LANGUAGE_BY_JURISDICTION[jurisdiction]
-    : null;
+  return EXPANSION_DICTIONARY[language] === "published" ? language : null;
 };
 
 /**
@@ -639,7 +633,7 @@ const countLeaves = (clause: string): number => {
  * filter clauses never enter the count.
  */
 const freeTextLeaves = (text: string, expand?: CorpusTermExpander): number => {
-  const clause = corpusFreeTextClause(text, expand);
+  const clause = corpusFreeTextClause(text, { expand });
   return clause === null ? 0 : countLeaves(clause);
 };
 

--- a/apps/api/src/lib/legal-search/morphology/corpus-language.ts
+++ b/apps/api/src/lib/legal-search/morphology/corpus-language.ts
@@ -1,0 +1,60 @@
+import {
+  isCaseLawJurisdiction,
+  type CaseLawJurisdiction,
+} from "@/api/lib/legal-search/ingestion-constants";
+import {
+  MORPHOLOGY_LANGUAGES,
+  type MorphologyLanguage,
+} from "@/api/lib/legal-search/morphology/stem";
+
+/**
+ * The language a jurisdiction's case-law text is written in, when a stemmer
+ * for it exists, or null.
+ *
+ * One map, because the write side and the read side must agree: the
+ * projection stems a decision under this language and the query builder stems
+ * the reader's terms under it, so a jurisdiction the two answered differently
+ * would index stems nothing ever queries.
+ *
+ * Total over the declared jurisdictions, so a new corpus has to answer rather
+ * than inherit a null. Austria is German and the European index carries 24
+ * languages under one jurisdiction, so neither has one language to stem
+ * against.
+ */
+const CORPUS_MORPHOLOGY_LANGUAGE_BY_JURISDICTION = {
+  AUT: null,
+  CZE: "cs",
+  EU: null,
+  POL: "pl",
+  SVK: "sk",
+} as const satisfies Record<CaseLawJurisdiction, MorphologyLanguage | null>;
+
+/**
+ * Which language a jurisdiction's text stems against, or null. An unscoped
+ * search spans every jurisdiction of a generation, so no one language
+ * describes its text and it stems against none.
+ */
+export const corpusMorphologyLanguage = (
+  jurisdiction: string | undefined,
+): MorphologyLanguage | null => {
+  if (jurisdiction === undefined) {
+    return null;
+  }
+  const canonical = jurisdiction.toUpperCase();
+  return isCaseLawJurisdiction(canonical)
+    ? CORPUS_MORPHOLOGY_LANGUAGE_BY_JURISDICTION[canonical]
+    : null;
+};
+
+/**
+ * A document's own ISO 639-1 language as a language this module can stem, or
+ * null. The projection reads the decision's language rather than its
+ * jurisdiction: an index group spans several countries, and a court may
+ * publish in more than one language.
+ */
+export const documentMorphologyLanguage = (
+  language: string,
+): MorphologyLanguage | null =>
+  MORPHOLOGY_LANGUAGES.find(
+    (candidate) => candidate === language.toLowerCase(),
+  ) ?? null;

--- a/apps/api/src/lib/legal-search/morphology/stem-text.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem-text.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test";
+
+import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
+import {
+  corpusMorphologyLanguage,
+  documentMorphologyLanguage,
+} from "@/api/lib/legal-search/morphology/corpus-language";
+import { MORPHOLOGY_LANGUAGES } from "@/api/lib/legal-search/morphology/stem";
+import { stemCorpusText } from "@/api/lib/legal-search/morphology/stem-text";
+
+const SAMPLES = [
+  "Nájemní smlouva byla uzavřena na dobu určitou.",
+  "§ 2235 odst. 1 občanského zákoníku",
+  "  Přezkoumání   rozhodnutí\tsprávního\norgánu  ",
+  "Odstąpienie od umowy najmu lokalu mieszkalnego.",
+  "Rozhodnutie odvolacieho súdu o náhrade škody.",
+];
+
+/**
+ * A stem stream stands in for the surface stream position by position, so a
+ * reader's phrase stemmed the same way matches adjacently. One stem per token,
+ * in order, is the whole contract; a dropped or split token would shift every
+ * position after it.
+ */
+test.each([...MORPHOLOGY_LANGUAGES])(
+  "%s stems one token to one stem, in order",
+  (language) => {
+    for (const sample of SAMPLES) {
+      const tokens = corpusTokens(sample);
+      const stems = corpusTokens(stemCorpusText(sample, language));
+      expect([sample, stems.length]).toEqual([sample, tokens.length]);
+    }
+  },
+);
+
+test("stemming strips an inflection the folded tokenizer keeps", () => {
+  // The point of the field: three surface forms, one stem, so a query in any
+  // of them reaches a judgment written in another.
+  const stems = ["nájemní", "nájemního", "nájemnímu"].map((form) =>
+    stemCorpusText(form, "cs"),
+  );
+
+  expect(new Set(stems).size).toBe(1);
+  expect(stems.at(0)).not.toBe("nájemní");
+});
+
+test("text with no tokens stems to nothing", () => {
+  expect(stemCorpusText("", "cs")).toBe("");
+  expect(stemCorpusText("§ — ()", "cs")).toBe("");
+});
+
+test("a jurisdiction and a document resolve their own language", () => {
+  expect(corpusMorphologyLanguage("CZE")).toBe("cs");
+  expect(corpusMorphologyLanguage("svk")).toBe("sk");
+  expect(corpusMorphologyLanguage("POL")).toBe("pl");
+  // German, and 24 languages under one jurisdiction: neither has one language
+  // to stem against.
+  expect(corpusMorphologyLanguage("AUT")).toBeNull();
+  expect(corpusMorphologyLanguage("EU")).toBeNull();
+  expect(corpusMorphologyLanguage("XXX")).toBeNull();
+  // An unscoped search spans every jurisdiction of a generation.
+  expect(corpusMorphologyLanguage(undefined)).toBeNull();
+
+  expect(documentMorphologyLanguage("cs")).toBe("cs");
+  expect(documentMorphologyLanguage("SK")).toBe("sk");
+  expect(documentMorphologyLanguage("de")).toBeNull();
+  expect(documentMorphologyLanguage("")).toBeNull();
+});
+
+test("decomposed text stems exactly like its precomposed spelling", () => {
+  // A combining mark is not a letter, so decomposed text would otherwise break
+  // apart at every accent: "nájemního" in NFD tokenises to three fragments,
+  // each stemming to itself and matching nothing. Extracted text arrives in
+  // whatever form its producer used, and NFD is common from PDFs and macOS.
+  const precomposed = "Nájemního bytu se to netýká.";
+  const decomposed = precomposed.normalize("NFD");
+
+  expect(decomposed).not.toBe(precomposed);
+  expect(stemCorpusText(decomposed, "cs")).toBe(
+    stemCorpusText(precomposed, "cs"),
+  );
+  expect(corpusTokens(stemCorpusText(decomposed, "cs")).length).toBe(
+    corpusTokens(precomposed).length,
+  );
+});

--- a/apps/api/src/lib/legal-search/morphology/stem-text.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem-text.ts
@@ -1,0 +1,33 @@
+import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
+import {
+  stemLegalTerm,
+  type MorphologyLanguage,
+} from "@/api/lib/legal-search/morphology/stem";
+
+/**
+ * A run of text as the stems of its tokens, in order, separated by single
+ * spaces.
+ *
+ * The separator is not cosmetic. The field this feeds is tokenised by the
+ * engine exactly like the surface field, so one stem per token joined by one
+ * space gives a stem stream whose positions correspond one to one with the
+ * surface stream's: the reader's phrase, stemmed the same way, matches
+ * adjacently or not at all. Dropping a token, or emitting two words for one,
+ * would shift every position after it and turn a phrase into a near-miss.
+ *
+ * The input must be the accented corpus text, never a folded copy: the suffix
+ * tables are written over accented characters, so a folded token keeps the
+ * ending the stemmer exists to strip. Folding happens afterwards, inside the
+ * engine, because the field's tokenizer applies `ascii_folding` to what is
+ * written here and to the query alike.
+ */
+export const stemCorpusText = (
+  text: string,
+  language: MorphologyLanguage,
+): string => {
+  const stems: string[] = [];
+  for (const token of corpusTokens(text)) {
+    stems.push(stemLegalTerm(token, language));
+  }
+  return stems.join(" ");
+};

--- a/apps/api/src/scripts/corpus-index-query-diff-report.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff-report.ts
@@ -2,6 +2,7 @@ import { Result, TaggedError } from "better-result";
 import * as v from "valibot";
 
 import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
+import { caseLawCorpusQueryFields } from "@/api/lib/legal-search/corpus-index-read-contract";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import {
   corpusIndexRoute,
@@ -112,9 +113,19 @@ export const goldenQueryRequest = (
     generation,
     query.jurisdiction,
   );
-  const engineQuery = caseLawCorpusQuery(query.text, {
-    ...query.filters,
-    jurisdiction: jurisdictionClause,
+  // The diff compares generations, so the query each one gets is the query
+  // that generation's schema supports: a clause over a field an index never
+  // mapped would compare an invalid query with a valid one.
+  const { surfaceFields, stemming } = caseLawCorpusQueryFields({
+    generation,
+    jurisdiction: query.jurisdiction,
+    language: query.filters?.language,
+  });
+  const engineQuery = caseLawCorpusQuery({
+    text: query.text,
+    filters: { ...query.filters, jurisdiction: jurisdictionClause },
+    stemming,
+    surfaceFields,
   });
   return engineQuery === null ? null : { indexId, engineQuery };
 };


### PR DESCRIPTION
## What

1. `refactor(api): derive a decision's publisher summary from one source list` — the headnote shown with a decision was a hand-written SQL coalesce over a few metadata keys. It is now derived from one ordered source list (AST apparatus roles first, then metadata keys) with a TypeScript reading and a SQL reading bound by a test that walks the list against Postgres. Two publishers whose keys the old chain never read are covered as a consequence.
2. `feat(api): index a decision's publisher summary as its own field` — a new `case_law_v6` manifest carries `headnote` on the opening passage and lists it among the default search fields. `case_law_v5`'s manifest digest is byte-identical; the digest census is extended, not edited. No generation row is created and nothing flips traffic.
3. `feat(api): index stemmed passage and summary text for inflected matching` — the corpus languages inflect heavily and the folded tokenizer only lowercases and folds diacritics, so a query in one grammatical case misses judgments that carry another, and a phrase can only match its exact surface form. `case_law_v6` also carries `text_stem` and `headnote_stem`, written at projection time as stems aligned 1:1 with the source tokens through the repository's own stemmers; the query builder adds field-scoped stem leaves beside every term and phrase leaf for generations that declare the fields. One total map now owns the jurisdiction-to-language rule for both the write and the read side.

## Why

The ranked and displayed unit for a decision is its summary, and matching should not depend on the grammatical case the reader typed. Both need index fields, and index fields need a generation, so this ships the code for one generation and leaves building and flipping it to operations.

## Tests

Source-list binding against Postgres, per-publisher regressions, manifest digests (v5 unchanged, v6 pinned), projection writes the summary and aligned stems and skips languages without a stemmer, query builder emits stem leaves for v6 only and phrase leaves for both fields, leaf budget accounting, read contract unchanged, reader-role census and public route invariants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new case-law search generation with publisher summaries and improved language-aware stemming.
  - Search now supports matching across original and stemmed text, including publisher summaries.
  - Publisher-authored summaries are displayed consistently across decision lists, latest decisions and search results.
  - Added support for the latest case-law generation on the q09 search cluster.

- **Bug Fixes**
  - Updated configuration error messages to show the active search generation instead of a fixed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->