### PR TITLE
perf(api): read candidates narrowly and highlight only the page

### DIFF
--- a/apps/api/src/handlers/case-law/decisions/search-hydration.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-hydration.db.test.ts
@@ -1,0 +1,245 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import {
+  readCaseLawPageDecisionRows,
+  rehydrateCaseLawCandidates,
+} from "@/api/handlers/case-law/decisions/search";
+import { createSafeId } from "@/api/lib/branded-types";
+import type {
+  CaseLawPublicReadDb,
+  CaseLawPublicReadTransaction,
+} from "@/api/lib/case-law-public-read-db";
+import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
+import {
+  createTestPglite,
+  withPublicLawReaderRole,
+} from "@/api/tests/pglite-test-db";
+
+/**
+ * Search reads Postgres twice per request. The blend read answers for every
+ * candidate the scan reaches — a few hundred per request — and carries only
+ * what ranking and the language fold consume. The page read answers for the
+ * ids the page emits and carries what a result card shows. These tests hold
+ * the split: what each read returns, that the request's filters bind on both,
+ * and that a candidate is read once however many rounds the scan spends.
+ */
+
+const GENERATION = "case_law_v3";
+const sourceId = createSafeId<"caseLawSource">();
+const closedSourceId = createSafeId<"caseLawSource">();
+const czechId = createSafeId<"caseLawDecision">();
+const slovakId = createSafeId<"caseLawDecision">();
+const closedId = createSafeId<"caseLawDecision">();
+
+/** Same budget as the schema push: an embedded Postgres is not fast. */
+const DB_TEST_TIMEOUT_MS = 120_000;
+
+let client: PGlite;
+let caseLawDb: CaseLawPublicReadDb;
+let reads: number;
+
+/** The request's record of blend rows, as the handler holds it. */
+type HydratedRows = NonNullable<
+  Parameters<typeof rehydrateCaseLawCandidates>[0]["hydrated"]
+>;
+
+const candidatesOf = (...ids: string[]) => ids.map((id) => ({ id, score: 1 }));
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    const db = drizzle({ client });
+    const readDb = async <T>(
+      fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
+    ) => {
+      reads += 1;
+      return await withPublicLawReaderRole(db, async (roleTx) => {
+        // SAFETY: the role transaction supplies the select surface the reads use.
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test handle stands in for a transaction
+        const tx = roleTx as unknown as CaseLawPublicReadTransaction;
+        return await fn(tx);
+      });
+    };
+    // SAFETY: brand-only wrapper; the reads never inspect the marker.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
+    caseLawDb = readDb as unknown as CaseLawPublicReadDb;
+
+    await db.insert(caseLawSources).values([
+      caseLawSourceRow({ adapterKey: "open", id: sourceId, name: "open" }),
+      caseLawSourceRow({
+        adapterKey: "closed",
+        descriptor: {
+          allowsDerivedAi: false,
+          allowsRedistribution: false,
+          attribution: null,
+          license: "restricted",
+        },
+        id: closedSourceId,
+        name: "closed",
+      }),
+    ]);
+    // `indexed_hash = content_hash` with no projection row is the legacy
+    // serving marker the rehydration filter accepts.
+    await db.insert(caseLawDecisions).values([
+      {
+        id: czechId,
+        sourceId,
+        caseNumber: "22 Cdo 1/2026",
+        court: "Nejvyšší soud",
+        country: "CZE",
+        language: "cs",
+        languageGroupKey: "hydration-group",
+        contentHash: "hash-cze",
+        indexedHash: "hash-cze",
+        citationAuthority: 2,
+        citationCount: 7,
+        metadata: { legalSentence: "Právní věta." },
+      },
+      {
+        id: slovakId,
+        sourceId,
+        caseNumber: "22 Cdo 1/2026",
+        court: "Najvyšší súd",
+        country: "SVK",
+        language: "sk",
+        languageGroupKey: "hydration-group",
+        contentHash: "hash-svk",
+        indexedHash: "hash-svk",
+        citationAuthority: 1,
+        citationCount: 3,
+      },
+      {
+        id: closedId,
+        sourceId: closedSourceId,
+        caseNumber: "1 Afs 2/2026",
+        court: "Nejvyšší správní soud",
+        country: "CZE",
+        language: "cs",
+        contentHash: "hash-closed",
+        indexedHash: "hash-closed",
+      },
+    ]);
+  },
+  { timeout: DB_TEST_TIMEOUT_MS },
+);
+
+beforeEach(() => {
+  reads = 0;
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("the blend read carries the authority and the group key, and nothing a card shows", async () => {
+  const hydrated: HydratedRows = new Map();
+  const ranking = await rehydrateCaseLawCandidates({
+    body: { query: "promlčení" },
+    candidates: candidatesOf(czechId, slovakId),
+    caseLawDb,
+    generation: GENERATION,
+    hydrated,
+  });
+
+  // Two language versions of one judgment fold into their best-blended member.
+  expect(ranking.ranked.map((hit) => hit.id)).toEqual([czechId]);
+  expect(ranking.ranked.at(0)?.citationAuthority).toBe(2);
+  expect([...hydrated.keys()].toSorted()).toEqual(
+    [czechId, slovakId].toSorted(),
+  );
+  for (const row of hydrated.values()) {
+    expect(Object.keys(row ?? {}).toSorted()).toEqual([
+      "citationAuthority",
+      "id",
+      "languageGroupKey",
+    ]);
+  }
+});
+
+test("a candidate is read once however many rounds ask for it", async () => {
+  const hydrated: HydratedRows = new Map();
+  await rehydrateCaseLawCandidates({
+    body: { query: "promlčení" },
+    candidates: candidatesOf(czechId),
+    caseLawDb,
+    generation: GENERATION,
+    hydrated,
+  });
+  expect(reads).toBe(1);
+
+  // The second round accumulates the first round's candidates plus one more:
+  // only the new id may reach the database.
+  await rehydrateCaseLawCandidates({
+    body: { query: "promlčení" },
+    candidates: candidatesOf(czechId, slovakId),
+    caseLawDb,
+    generation: GENERATION,
+    hydrated,
+  });
+  expect(reads).toBe(2);
+
+  // A round that adds nothing new asks the database for nothing at all.
+  await rehydrateCaseLawCandidates({
+    body: { query: "promlčení" },
+    candidates: candidatesOf(czechId, slovakId),
+    caseLawDb,
+    generation: GENERATION,
+    hydrated,
+  });
+  expect(reads).toBe(2);
+});
+
+test("the page read carries what a result card shows, for the page ids only", async () => {
+  const rows = await readCaseLawPageDecisionRows({
+    body: { query: "promlčení" },
+    caseLawDb,
+    generation: GENERATION,
+    ids: [czechId],
+  });
+
+  expect([...rows.keys()]).toEqual([czechId]);
+  const row = rows.get(czechId);
+  expect(row?.caseNumber).toBe("22 Cdo 1/2026");
+  expect(row?.court).toBe("Nejvyšší soud");
+  expect(row?.citationCount).toBe(7);
+  // The publisher summary is SQL over `metadata`, and it is the reason the
+  // wide row is worth reading only for the ids the page emits.
+  expect(row?.headnote).toBe("Právní věta.");
+});
+
+test("an empty page reads nothing", async () => {
+  const rows = await readCaseLawPageDecisionRows({
+    body: { query: "promlčení" },
+    caseLawDb,
+    generation: GENERATION,
+    ids: [],
+  });
+
+  expect(rows.size).toBe(0);
+  expect(reads).toBe(0);
+});
+
+test("both reads reapply the request filters and the redistribution boundary", async () => {
+  const scoped = {
+    body: { country: "CZE", query: "promlčení" },
+    caseLawDb,
+    generation: GENERATION,
+  };
+
+  const ranking = await rehydrateCaseLawCandidates({
+    ...scoped,
+    candidates: candidatesOf(czechId, slovakId, closedId),
+  });
+  // The Slovak version no longer matches the country filter, and the closed
+  // source is not redistributable, so neither can stand for the judgment.
+  expect(ranking.ranked.map((hit) => hit.id)).toEqual([czechId]);
+
+  const rows = await readCaseLawPageDecisionRows({
+    ...scoped,
+    ids: [czechId, slovakId, closedId],
+  });
+  expect([...rows.keys()]).toEqual([czechId]);
+});

--- a/apps/api/src/handlers/case-law/decisions/search-telemetry.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-telemetry.test.ts
@@ -60,17 +60,19 @@ describe("the completed-search record", () => {
       candidatesHydrated: 42,
       country,
       db: {
-        reads: 3,
+        reads: 4,
         msByRead: {
           alternates: 3.2,
           candidates: 8.4,
           identity: 0,
+          page: 4.6,
           servingGeneration: 0.8,
         },
       },
       earlyStopped: true,
       hitsReturned: 20,
       indexMs: 88.6,
+      pageRowsRead: 20,
       passagesScanned: 300,
       queryClass: classOf('"náhrada škody"'),
       roundCapHit: false,
@@ -95,13 +97,15 @@ describe("the completed-search record", () => {
       rounds: 1,
       passagesScanned: 300,
       candidatesHydrated: 42,
+      pageRowsRead: 20,
       hitsReturned: 20,
       indexMs: 89,
-      dbReads: 3,
-      dbMs: 12,
+      dbReads: 4,
+      dbMs: 17,
       dbAlternatesMs: 3,
       dbCandidatesMs: 8,
       dbIdentityMs: 0,
+      dbPageMs: 5,
       dbServingGenerationMs: 1,
       totalMs: 130,
       roundCapHit: false,
@@ -118,7 +122,7 @@ describe("the completed-search record", () => {
     );
     // A read that grows has to show up in one of these, and a read nobody
     // named would make the two disagree.
-    expect(parts).toHaveLength(4);
+    expect(parts).toHaveLength(5);
     const breakdown = parts.reduce((total, [, ms]) => total + Number(ms), 0);
     expect(Number(attributes["dbMs"])).toBe(breakdown);
   });

--- a/apps/api/src/handlers/case-law/decisions/search-telemetry.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-telemetry.test.ts
@@ -77,6 +77,7 @@ describe("the completed-search record", () => {
       queryClass: classOf('"náhrada škody"'),
       roundCapHit: false,
       rounds: 1,
+      highlightRounds: 1,
       totalMs: 130.2,
     });
     const record = recording.records.at(0);
@@ -95,6 +96,7 @@ describe("the completed-search record", () => {
       queryClass: "phrase",
       country: "cz",
       rounds: 1,
+      highlightRounds: 1,
       passagesScanned: 300,
       candidatesHydrated: 42,
       pageRowsRead: 20,

--- a/apps/api/src/handlers/case-law/decisions/search-telemetry.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-telemetry.ts
@@ -67,6 +67,8 @@ export const CASE_LAW_SEARCH_DB_READ = {
   candidates: "candidates",
   /** The decisions an entry names outright. */
   identity: "identity",
+  /** The display rows of the decisions the page emits. */
+  page: "page",
   /** Which corpus-index generation currently serves. */
   servingGeneration: "servingGeneration",
 } as const;
@@ -83,6 +85,7 @@ const DB_READ_ATTRIBUTE = {
   alternates: "dbAlternatesMs",
   candidates: "dbCandidatesMs",
   identity: "dbIdentityMs",
+  page: "dbPageMs",
   servingGeneration: "dbServingGenerationMs",
 } as const satisfies Record<CaseLawSearchDbRead, string>;
 
@@ -116,6 +119,7 @@ export const createCaseLawSearchDbTimer = (): CaseLawSearchDbTimer => {
     alternates: 0,
     candidates: 0,
     identity: 0,
+    page: 0,
     servingGeneration: 0,
   };
   let reads = 0;
@@ -138,7 +142,7 @@ export const createCaseLawSearchDbTimer = (): CaseLawSearchDbTimer => {
 };
 
 type CaseLawSearchCompletedEvent = {
-  /** Candidates read from Postgres, including ones the filters dropped. */
+  /** Candidate rows read for blending, including ones the filters dropped. */
   candidatesHydrated: number;
   country: string | undefined;
   /** This request's Postgres reads, per read. The total is their sum. */
@@ -148,6 +152,8 @@ type CaseLawSearchCompletedEvent = {
   hitsReturned: number;
   /** Summed wall time of this request's engine calls. */
   indexMs: number;
+  /** Wide rows read for the page, after ranking decided which ids it holds. */
+  pageRowsRead: number;
   passagesScanned: number;
   queryClass: DecisionQueryClass;
   /** The scan stopped at the round cap rather than at its own bound. */
@@ -169,6 +175,7 @@ export const reportCaseLawSearchCompleted = ({
   earlyStopped,
   hitsReturned,
   indexMs,
+  pageRowsRead,
   passagesScanned,
   queryClass,
   roundCapHit,
@@ -192,6 +199,7 @@ export const reportCaseLawSearchCompleted = ({
     rounds,
     passagesScanned,
     candidatesHydrated,
+    pageRowsRead,
     hitsReturned,
     indexMs: Math.round(indexMs),
     dbReads: db.reads,

--- a/apps/api/src/handlers/case-law/decisions/search-telemetry.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-telemetry.ts
@@ -160,6 +160,8 @@ type CaseLawSearchCompletedEvent = {
   roundCapHit: boolean;
   /** Engine round trips the scan spent. */
   rounds: number;
+  /** Engine round trips spent highlighting the page: one, or none for an empty page. */
+  highlightRounds: number;
   totalMs: number;
 };
 
@@ -180,6 +182,7 @@ export const reportCaseLawSearchCompleted = ({
   queryClass,
   roundCapHit,
   rounds,
+  highlightRounds,
   totalMs,
 }: CaseLawSearchCompletedEvent): void => {
   // Flat, one attribute per read, and the total is what those attributes add
@@ -197,6 +200,7 @@ export const reportCaseLawSearchCompleted = ({
     queryClass,
     ...(country === undefined ? {} : { country }),
     rounds,
+    highlightRounds,
     passagesScanned,
     candidatesHydrated,
     pageRowsRead,

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -563,11 +563,49 @@ const extractCorpusSnippet = (
   return raw.replaceAll("<b>", "<mark>").replaceAll("</b>", "</mark>");
 };
 
-const hydratedDecisionRowsQuery = (
+type DecisionRowsQueryOptions = {
+  filters: SQL[];
+  generation: string;
+  ids: SafeId<"caseLawDecision">[];
+};
+
+/**
+ * What blending a candidate needs, and nothing else. A request reads this for
+ * every candidate the scan reaches — a few hundred of them — so every column
+ * here is paid for a couple of hundred times to serve a page of ten. The
+ * authority drives the blend, the group key folds the language versions of one
+ * judgment, and the request's filters are applied in SQL rather than read back.
+ */
+const candidateDecisionRowsQuery = (
   tx: CaseLawPublicReadTransaction,
-  ids: SafeId<"caseLawDecision">[],
-  filters: SQL[],
-  generation: string,
+  { filters, generation, ids }: DecisionRowsQueryOptions,
+) =>
+  tx
+    .select({
+      id: caseLawDecisions.id,
+      citationAuthority: caseLawDecisions.citationAuthority,
+      languageGroupKey: caseLawDecisions.languageGroupKey,
+    })
+    .from(caseLawDecisions)
+    .leftJoin(
+      caseLawCorpusIndexProjections,
+      caseLawCorpusProjectionJoin(generation),
+    )
+    .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
+    .where(and(inArray(caseLawDecisions.id, ids), ...filters));
+
+type CandidateDecisionRow = Awaited<
+  ReturnType<typeof candidateDecisionRowsQuery>
+>[number];
+
+/**
+ * Everything a result card shows, read only for the ids the page emits. The
+ * publisher summary and the identifier aggregate are the expensive parts, and
+ * a page of ten is the only place they are wanted.
+ */
+const pageDecisionRowsQuery = (
+  tx: CaseLawPublicReadTransaction,
+  { filters, generation, ids }: DecisionRowsQueryOptions,
 ) =>
   tx
     .select({
@@ -595,7 +633,6 @@ const hydratedDecisionRowsQuery = (
       sourceUrl: caseLawDecisions.sourceUrl,
       headnote: publisherSummaryMetadataSql(caseLawDecisions.metadata),
       citationCount: caseLawDecisions.citationCount,
-      citationAuthority: caseLawDecisions.citationAuthority,
       createdAt: caseLawDecisions.createdAt,
     })
     .from(caseLawDecisions)
@@ -606,8 +643,8 @@ const hydratedDecisionRowsQuery = (
     .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
     .where(and(inArray(caseLawDecisions.id, ids), ...filters));
 
-type HydratedDecisionRow = Awaited<
-  ReturnType<typeof hydratedDecisionRowsQuery>
+type PageDecisionRow = Awaited<
+  ReturnType<typeof pageDecisionRowsQuery>
 >[number];
 
 /**
@@ -617,7 +654,50 @@ type HydratedDecisionRow = Awaited<
  * each round re-reads what the earlier rounds read, and the request's
  * database work grows with the square of the rounds.
  */
-type HydratedDecisionRows = Map<string, HydratedDecisionRow | null>;
+type HydratedDecisionRows = Map<string, CandidateDecisionRow | null>;
+
+/**
+ * Reapply the request filters against the current rows: a stale corpus hit
+ * (metadata changed, async re-index/delete pending) must not satisfy filters
+ * it no longer matches. Both reads apply them, so the page read that actually
+ * emits publisher text re-proves the row is still servable rather than
+ * inheriting the candidate read's answer.
+ */
+const caseLawSearchRowFilters = (
+  body: SearchDecisionsBody,
+  generation: string,
+): SQL[] => {
+  const filters: SQL[] = [
+    redistributableCaseLawSource,
+    // Prefer the generation-specific projection state; generations that
+    // predate durable rebuild checkpoints fall back to the serving marker.
+    // Both paths reject a scrubbed or pending row, so a stale physical
+    // copy cannot serve outdated or erased snippets.
+    currentCaseLawCorpusProjection(generation),
+  ];
+  if (body.court) {
+    filters.push(eq(caseLawDecisions.court, body.court));
+  }
+  if (body.country) {
+    filters.push(eq(caseLawDecisions.country, body.country));
+  }
+  if (body.dateFrom) {
+    filters.push(sql`${caseLawDecisions.decisionDate} >= ${body.dateFrom}`);
+  }
+  if (body.dateTo) {
+    filters.push(sql`${caseLawDecisions.decisionDate} <= ${body.dateTo}`);
+  }
+  if (body.decisionType) {
+    filters.push(eq(caseLawDecisions.decisionType, body.decisionType));
+  }
+  if (body.sourceId) {
+    filters.push(eq(caseLawDecisions.sourceId, body.sourceId));
+  }
+  if (body.language) {
+    filters.push(eq(caseLawDecisions.language, body.language));
+  }
+  return filters;
+};
 
 /**
  * Brackets the database call a read makes, so a caller measuring Postgres
@@ -627,6 +707,45 @@ type HydratedDecisionRows = Map<string, HydratedDecisionRow | null>;
 type TimeDbRead = <TRead>(run: () => Promise<TRead>) => Promise<TRead>;
 
 const untimedDbRead: TimeDbRead = async (run) => await run();
+
+type ReadCaseLawPageDecisionRowsOptions = {
+  body: SearchDecisionsBody;
+  caseLawDb: CaseLawPublicReadDb;
+  generation: string;
+  /** The ids the page emits, after ranking and the language-group fold. */
+  ids: readonly string[];
+  timeDbRead?: TimeDbRead | undefined;
+};
+
+/**
+ * The wide read, for one page. Kept independently callable for the same
+ * reason the candidate read is: the restricted-role census executes the exact
+ * production projection without a live search engine.
+ */
+export const readCaseLawPageDecisionRows = async ({
+  body,
+  caseLawDb,
+  generation,
+  ids,
+  timeDbRead = untimedDbRead,
+}: ReadCaseLawPageDecisionRowsOptions): Promise<
+  Map<string, PageDecisionRow>
+> => {
+  if (ids.length === 0) {
+    return new Map();
+  }
+  const rows = await timeDbRead(
+    async () =>
+      await caseLawDb((tx) =>
+        pageDecisionRowsQuery(tx, {
+          filters: caseLawSearchRowFilters(body, generation),
+          generation,
+          ids: ids.map((id) => toSafeId<"caseLawDecision">(id)),
+        }),
+      ),
+  );
+  return new Map(rows.map((row) => [String(row.id), row]));
+};
 
 type RehydrateCaseLawCandidatesOptions = {
   body: SearchDecisionsBody;
@@ -654,56 +773,17 @@ export const rehydrateCaseLawCandidates = async ({
   const ids = candidates
     .filter((candidate) => !hydrated.has(candidate.id))
     .map((candidate) => toSafeId<"caseLawDecision">(candidate.id));
-  // Reapply the request filters against the current rows: a stale
-  // corpus hit (metadata changed, async re-index/delete pending) must
-  // not satisfy filters it no longer matches.
-  const rehydrationFilters: SQL[] = [
-    redistributableCaseLawSource,
-    // Prefer the generation-specific projection state; generations that
-    // predate durable rebuild checkpoints fall back to the serving marker.
-    // Both paths reject a scrubbed or pending row, so a stale physical
-    // copy cannot serve outdated or erased snippets.
-    currentCaseLawCorpusProjection(generation),
-  ];
-  if (body.court) {
-    rehydrationFilters.push(eq(caseLawDecisions.court, body.court));
-  }
-  if (body.country) {
-    rehydrationFilters.push(eq(caseLawDecisions.country, body.country));
-  }
-  if (body.dateFrom) {
-    rehydrationFilters.push(
-      sql`${caseLawDecisions.decisionDate} >= ${body.dateFrom}`,
-    );
-  }
-  if (body.dateTo) {
-    rehydrationFilters.push(
-      sql`${caseLawDecisions.decisionDate} <= ${body.dateTo}`,
-    );
-  }
-  if (body.decisionType) {
-    rehydrationFilters.push(
-      eq(caseLawDecisions.decisionType, body.decisionType),
-    );
-  }
-  if (body.sourceId) {
-    rehydrationFilters.push(eq(caseLawDecisions.sourceId, body.sourceId));
-  }
-  if (body.language) {
-    rehydrationFilters.push(eq(caseLawDecisions.language, body.language));
-  }
   const rows =
     ids.length === 0
       ? []
       : await timeDbRead(
           async () =>
             await caseLawDb((tx) =>
-              hydratedDecisionRowsQuery(
-                tx,
-                ids,
-                rehydrationFilters,
+              candidateDecisionRowsQuery(tx, {
+                filters: caseLawSearchRowFilters(body, generation),
                 generation,
-              ),
+                ids,
+              }),
             ),
         );
   for (const id of ids) {
@@ -713,7 +793,7 @@ export const rehydrateCaseLawCandidates = async ({
     hydrated.set(String(row.id), row);
   }
 
-  const byId = new Map<string, HydratedDecisionRow>();
+  const byId = new Map<string, CandidateDecisionRow>();
   for (const [id, row] of hydrated) {
     if (row !== null) {
       byId.set(id, row);
@@ -738,7 +818,10 @@ export const rehydrateCaseLawCandidates = async ({
     (hitId) => byId.get(hitId)?.languageGroupKey ?? null,
   );
 
-  return { context: { byId }, ranked: representatives };
+  // No context travels with the ranking: what a page displays is read once
+  // the page is decided, for its ids only, so nothing the blend read has to
+  // be carried through the scan.
+  return { context: null, ranked: representatives };
 };
 
 type DecisionIdentity = Extract<DecisionQueryIntent, { type: "identifier" }>;
@@ -794,7 +877,7 @@ export const findDecisionIdsByIdentity = async ({
 /** The language groups a page spans, for the alternates read. */
 const languageGroupKeysOf = (
   pageRanked: readonly RankedHit[],
-  byId: ReadonlyMap<string, HydratedDecisionRow>,
+  byId: ReadonlyMap<string, { languageGroupKey: string | null }>,
 ): string[] => [
   ...new Set(
     pageRanked
@@ -808,7 +891,7 @@ type DecisionHitsPageOptions = {
     ReturnType<typeof readPublicDecisionLanguageAlternatesByGroup>
   >;
   anchorIdById: ReadonlyMap<string, string>;
-  byId: ReadonlyMap<string, HydratedDecisionRow>;
+  byId: ReadonlyMap<string, PageDecisionRow>;
   nextCursor: string | null;
   pageRanked: readonly RankedHit[];
   snippetById: ReadonlyMap<string, string>;
@@ -897,6 +980,7 @@ const searchCorpusIndexDecisions = async (
   // Shared by the identity path and the scan, so `hydrated.size` counts the
   // candidates the whole request read, once each.
   const hydrated: HydratedDecisionRows = new Map();
+  let pageRowsRead = 0;
   const intent = parseDecisionQuery(body.query);
   const queryClass = decisionQueryClass(intent);
   const report = (hitsReturned: number, scan: CorpusIndexScanReport): void => {
@@ -905,6 +989,7 @@ const searchCorpusIndexDecisions = async (
       country: body.country,
       db: dbTimer.timing(),
       hitsReturned,
+      pageRowsRead,
       queryClass,
       totalMs: performance.now() - startedAt,
       ...scan,
@@ -919,6 +1004,22 @@ const searchCorpusIndexDecisions = async (
       ),
   );
   const generation = serving.generation;
+
+  /** The wide read, for the ids a page emits and no others. */
+  const readPageRows = async (
+    pageRanked: readonly RankedHit[],
+  ): Promise<Map<string, PageDecisionRow>> => {
+    const rows = await readCaseLawPageDecisionRows({
+      body,
+      caseLawDb,
+      generation,
+      ids: pageRanked.map((hit) => hit.id),
+      timeDbRead: async (run) =>
+        await dbTimer.time(CASE_LAW_SEARCH_DB_READ.page, run),
+    });
+    pageRowsRead += rows.size;
+    return rows;
+  };
 
   // An entry that names a decision is answered by identity, and only falls
   // through to the text index when nothing answers to it. A cursor means the
@@ -945,7 +1046,7 @@ const searchCorpusIndexDecisions = async (
       // the requested size, and identity never pages past it.
       const identityPage = identityRanking.ranked.slice(0, limit);
       if (identityPage.length > 0) {
-        const { byId } = identityRanking.context;
+        const byId = await readPageRows(identityPage);
         // Timed around the call rather than through the timer's thunk: the
         // alternates read must stay a direct call in this function, which a
         // lint rule enforces so no search path can drop it.
@@ -1018,18 +1119,17 @@ const searchCorpusIndexDecisions = async (
       }),
   });
 
-  const {
-    anchorIdById,
-    context: { byId },
-    pageRanked,
-    scan,
-    snippetById,
-  } = searchPage;
+  const { anchorIdById, pageRanked, scan, snippetById } = searchPage;
 
   const nextCursor =
     searchPage.nextCursor === null
       ? null
       : encodeCorpusIndexCursor(searchPage.nextCursor);
+
+  // A row the candidate read saw and this one no longer answers for was
+  // scrubbed mid-request; it drops out of the page rather than being served
+  // from a stale copy, and the cursor keeps pointing past it.
+  const byId = await readPageRows(pageRanked);
 
   // Timed around the call for the same reason as on the identity path.
   const alternatesStartedAt = performance.now();

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -6,6 +6,7 @@ import {
   corpusIndexLexicalScore,
   decodeCorpusIndexCursor,
   encodeCorpusIndexCursor,
+  HIGHLIGHT_COPIES_PER_PASSAGE,
   readCorpusIndexSearchPage,
 } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
@@ -33,23 +34,45 @@ let responseBody: unknown;
  * way it would against the real engine; `responseBody` stays available for the
  * single-window cases.
  */
-let engineHits: { document_id: string; anchor_id?: string }[] | null;
-let requestCount: number;
+let engineHits:
+  | { document_id: string; anchor_id?: string; chunk_id?: string }[]
+  | null;
+let requestBodies: Record<string, unknown>[];
+/**
+ * Wall time the fake engine spends on every request. Zero by default, so only
+ * the test that reads `indexMs` pays for it; that test needs the number to be
+ * made of something it can predict a floor for.
+ */
+let requestDelayMs: number;
+/**
+ * What the fake engine answers the highlight round with, when that has to
+ * differ from what the scan saw — a passage the index holds more than one
+ * physical copy of, say.
+ */
+let snippetResponseBody: unknown;
 
 beforeEach(() => {
   responseBody = { num_hits: 0, hits: [], snippets: [] };
   engineHits = null;
-  requestCount = 0;
+  requestBodies = [];
+  requestDelayMs = 0;
+  snippetResponseBody = null;
   const stub = async (
     _input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ): Promise<Response> => {
-    requestCount += 1;
+    const body: Record<string, unknown> =
+      typeof init?.body === "string" ? JSON.parse(init.body) : {};
+    requestBodies.push(body);
+    if (requestDelayMs > 0) {
+      await Bun.sleep(requestDelayMs);
+    }
+    if (snippetResponseBody !== null && body["snippet_fields"] !== undefined) {
+      return new Response(JSON.stringify(snippetResponseBody), { status: 200 });
+    }
     if (engineHits === null) {
       return new Response(JSON.stringify(responseBody), { status: 200 });
     }
-    const body: Record<string, unknown> =
-      typeof init?.body === "string" ? JSON.parse(init.body) : {};
     const offset = Number(body["start_offset"] ?? 0);
     const window = engineHits.slice(offset, offset + Number(body["max_hits"]));
     return new Response(
@@ -69,6 +92,14 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
+
+/**
+ * Engine calls the scan itself made. The page's snippet round is the one
+ * request that asks for highlighting, so the scan's own rounds are everything
+ * else.
+ */
+const scanRequestCount = (): number =>
+  requestBodies.filter((body) => body["snippet_fields"] === undefined).length;
 
 const readPage = async (limit = 10) =>
   await readCorpusIndexSearchPage({
@@ -201,7 +232,7 @@ describe("a single document cannot monopolise the scan", () => {
     // Only a flood that overruns one window proves the scan kept walking to
     // reach the other decisions; a smaller one is served in a single request.
     if (floodSize > LIMITS.corpusIndexSearchCandidateLimit) {
-      expect(requestCount).toBeGreaterThan(1);
+      expect(scanRequestCount()).toBeGreaterThan(1);
     }
     expect(page.passageCountById.get("doc-flood")).toBe(floodSize);
     for (const hit of page.pageRanked.slice(1)) {
@@ -270,7 +301,7 @@ describe("a page settles within one scan round", () => {
   test("a page of a very large hit list is answered from one round", async () => {
     const page = await readBlendedPage(20, DEFAULT_AUTHORITY_WEIGHT);
 
-    expect(requestCount).toBe(1);
+    expect(scanRequestCount()).toBe(1);
     expect(page.scan.rounds).toBe(1);
     expect(page.scan.earlyStopped).toBe(true);
     expect(page.pageRanked).toHaveLength(20);
@@ -283,7 +314,7 @@ describe("a page settles within one scan round", () => {
       DEFAULT_AUTHORITY_WEIGHT,
     );
 
-    expect(requestCount).toBe(1);
+    expect(scanRequestCount()).toBe(1);
     expect(page.scan.earlyStopped).toBe(true);
   });
 
@@ -297,7 +328,7 @@ describe("a page settles within one scan round", () => {
 
     const page = await readBlendedPage(20, combinedWeight);
 
-    expect(requestCount).toBe(1);
+    expect(scanRequestCount()).toBe(1);
     expect(page.scan.earlyStopped).toBe(true);
   });
 
@@ -390,7 +421,7 @@ describe("the scan is bounded by engine round trips", () => {
   test("a scan whose stop condition never fires ends at the round cap", async () => {
     const page = await readCappedPage(10);
 
-    expect(requestCount).toBe(LIMITS.corpusIndexSearchMaxRounds);
+    expect(scanRequestCount()).toBe(LIMITS.corpusIndexSearchMaxRounds);
     expect(page.pageRanked).toHaveLength(10);
     // The page is still full and its own window holds more, so paging
     // continues within what the capped scan reached.
@@ -438,7 +469,7 @@ describe("the scan is bounded by engine round trips", () => {
 
     const second = await readCappedPage(10, first.nextCursor);
 
-    expect(requestCount).toBe(LIMITS.corpusIndexSearchMaxRounds * 2);
+    expect(scanRequestCount()).toBe(LIMITS.corpusIndexSearchMaxRounds * 2);
     expect(second.pageRanked.map((hit) => hit.id)).toEqual(
       Array.from({ length: 10 }, (_, index) => documentId(index + 10)),
     );
@@ -451,7 +482,7 @@ describe("the scan is bounded by engine round trips", () => {
     // beat: the page is answered from the first window.
     const page = await readPage(10);
 
-    expect(requestCount).toBe(1);
+    expect(scanRequestCount()).toBe(1);
     expect(page.pageRanked).toHaveLength(10);
     expect(page.scan.rounds).toBe(1);
     expect(page.scan.passagesScanned).toBe(
@@ -528,7 +559,7 @@ describe("a passage flood does not strand the reader", () => {
 
   test("the next page continues past the flood without rescanning it", async () => {
     const first = await readFloodPage(10);
-    requestCount = 0;
+    requestBodies = [];
 
     const second = await readFloodPage(10, first.nextCursor);
 
@@ -541,7 +572,9 @@ describe("a passage flood does not strand the reader", () => {
       LIMITS.corpusIndexSearchMaxRounds *
         LIMITS.corpusIndexSearchCandidateLimit,
     );
-    expect(requestCount).toBeLessThanOrEqual(LIMITS.corpusIndexSearchMaxRounds);
+    expect(scanRequestCount()).toBeLessThanOrEqual(
+      LIMITS.corpusIndexSearchMaxRounds,
+    );
   });
 
   test("paging reaches every decision behind the flood", async () => {
@@ -709,5 +742,195 @@ describe("ranker-folded candidates stay folded across pages", () => {
     expect(seen.filter((id) => groupOf(id) !== null)).toEqual(["c-131-12-l0"]);
     expect(seen.filter((id) => groupOf(id) === null)).toHaveLength(24);
     expect(new Set(seen).size).toBe(seen.length);
+  });
+});
+
+/**
+ * Highlighting is per-hit work the engine does, so a scan that asked for it
+ * highlighted every passage it walked — a few hundred of them — to serve a
+ * page of ten. The page decides which passages are worth highlighting, so the
+ * snippets are cut after it, in one request addressing exactly those passages.
+ */
+describe("only the passages a page emits are highlighted", () => {
+  const snippetRequests = (): Record<string, unknown>[] =>
+    requestBodies.filter((body) => body["snippet_fields"] !== undefined);
+
+  test("the scan asks for no highlighting and the page round asks for it once", async () => {
+    engineHits = Array.from({ length: 5000 }, (_, index) => ({
+      chunk_id: `doc-${index}:0`,
+      document_id: `doc-${index}`,
+    }));
+
+    const page = await readPage(3);
+
+    expect(scanRequestCount()).toBeGreaterThan(0);
+    expect(snippetRequests()).toHaveLength(1);
+    expect(page.scan.highlightRounds).toBe(1);
+    const snippetRequest = snippetRequests().at(0);
+    expect(snippetRequest?.["snippet_fields"]).toBe("text");
+    // One passage per emitted hit, with room for the physical copies a
+    // passage mid-refresh has: bounded by the page, not by the scan.
+    expect(snippetRequest?.["max_hits"]).toBe(3 * HIGHLIGHT_COPIES_PER_PASSAGE);
+    expect(snippetRequest?.["query"]).toBe(
+      '(text:promlčení) AND (chunk_id:"doc-0:0" OR chunk_id:"doc-1:0" OR chunk_id:"doc-2:0")',
+    );
+  });
+
+  test("a document-granular generation is addressed by document", async () => {
+    const hits = [{ document_id: "doc-a" }, { document_id: "doc-b" }];
+    responseBody = {
+      num_hits: hits.length,
+      hits,
+      snippets: hits.map((hit) => ({ text: [`whole ${hit.document_id}`] })),
+    };
+
+    const page = await readPage();
+
+    expect(snippetRequests().at(0)?.["query"]).toBe(
+      '(text:promlčení) AND (document_id:"doc-a" OR document_id:"doc-b")',
+    );
+    expect(page.snippetById.get("doc-a")).toBe("whole doc-a");
+  });
+
+  test("the highlighted passage is the one the document ranked by", async () => {
+    const hits = [
+      { document_id: "doc-b", chunk_id: "doc-b:7" },
+      { document_id: "doc-a", chunk_id: "doc-a:2" },
+      { document_id: "doc-a", chunk_id: "doc-a:9" },
+    ];
+    responseBody = {
+      num_hits: hits.length,
+      hits,
+      snippets: hits.map((hit) => ({ text: [`passage ${hit.chunk_id}`] })),
+    };
+
+    const page = await readPage();
+
+    // doc-a matched three passages; only its best is worth highlighting, and
+    // it is the same passage the anchor deep-links to.
+    expect(snippetRequests().at(0)?.["query"]).toBe(
+      '(text:promlčení) AND (chunk_id:"doc-b:7" OR chunk_id:"doc-a:2")',
+    );
+    expect(page.snippetById.get("doc-a")).toBe("passage doc-a:2");
+  });
+
+  test("an empty page asks the engine for nothing to highlight", async () => {
+    responseBody = { num_hits: 0, hits: [] };
+
+    const page = await readPage();
+
+    expect(page.pageRanked).toEqual([]);
+    expect(page.snippetById.size).toBe(0);
+    expect(snippetRequests()).toEqual([]);
+    expect(page.scan.highlightRounds).toBe(0);
+  });
+
+  test("a passage the index holds twice does not cost another hit its snippet", async () => {
+    // Mid-refresh: ingestion has appended doc-a's new copy and the engine has
+    // not applied the delete yet, so one clause matches two rows.
+    const scanned = [
+      { document_id: "doc-a", chunk_id: "doc-a:0" },
+      { document_id: "doc-b", chunk_id: "doc-b:0" },
+      { document_id: "doc-c", chunk_id: "doc-c:0" },
+    ];
+    responseBody = {
+      num_hits: scanned.length,
+      hits: scanned,
+      snippets: scanned.map(() => ({ text: ["scanned"] })),
+    };
+    const highlighted = [
+      { document_id: "doc-a", chunk_id: "doc-a:0" },
+      { document_id: "doc-a", chunk_id: "doc-a:0" },
+      { document_id: "doc-b", chunk_id: "doc-b:0" },
+      { document_id: "doc-c", chunk_id: "doc-c:0" },
+    ];
+    snippetResponseBody = {
+      num_hits: highlighted.length,
+      hits: highlighted,
+      snippets: [
+        { text: ["doc-a current"] },
+        { text: ["doc-a superseded"] },
+        { text: ["doc-b"] },
+        { text: ["doc-c"] },
+      ],
+    };
+
+    const page = await readPage();
+
+    // Room for the overlap, so the duplicate does not push doc-c out of the
+    // answer, and the copy that ranked first is the one the reader sees.
+    expect(snippetRequests().at(0)?.["max_hits"]).toBe(
+      3 * HIGHLIGHT_COPIES_PER_PASSAGE,
+    );
+    expect(page.snippetById.get("doc-a")).toBe("doc-a current");
+    expect(page.snippetById.get("doc-b")).toBe("doc-b");
+    expect(page.snippetById.get("doc-c")).toBe("doc-c");
+    for (const hit of page.pageRanked) {
+      expect(page.snippetById.get(hit.id)).toBeDefined();
+    }
+  });
+});
+
+/**
+ * `indexMs` is the engine half of a search's latency, and a page now spends it
+ * in two places: the scan's rounds and the one round that highlights the page.
+ * The two counts are what reconcile the total, so a round trip that stopped
+ * being counted — or a duration that stopped being added — has to fail here
+ * rather than surface as engine time nobody can attribute.
+ */
+describe("the reported engine time accounts for every round trip", () => {
+  /** Long enough that the floors below cannot be met by scheduling noise. */
+  const DELAY_MS = 20;
+
+  test("every engine request is one of the counted rounds", async () => {
+    engineHits = Array.from({ length: 5000 }, (_, index) => ({
+      chunk_id: `doc-${index}:0`,
+      document_id: `doc-${index}`,
+    }));
+
+    const page = await readPage(3);
+
+    expect(page.scan.rounds).toBeGreaterThan(0);
+    expect(page.scan.highlightRounds).toBe(1);
+    expect(requestBodies).toHaveLength(
+      page.scan.rounds + page.scan.highlightRounds,
+    );
+  });
+
+  test("the total covers the highlight round, not the scan alone", async () => {
+    requestDelayMs = DELAY_MS;
+    engineHits = Array.from({ length: 5000 }, (_, index) => ({
+      chunk_id: `doc-${index}:0`,
+      document_id: `doc-${index}`,
+    }));
+
+    const startedAt = performance.now();
+    const page = await readPage(3);
+    const elapsedMs = performance.now() - startedAt;
+
+    // One round of scanning plus one of highlighting, each of which the fake
+    // engine held open for a known minimum: a total that dropped either would
+    // fall under this floor. The read's own elapsed time is the ceiling —
+    // engine time is time the read spent, so a duration counted twice would
+    // cross it.
+    expect(page.scan.rounds).toBe(1);
+    expect(page.scan.highlightRounds).toBe(1);
+    expect(page.scan.indexMs).toBeGreaterThanOrEqual(2 * DELAY_MS);
+    expect(page.scan.indexMs).toBeLessThanOrEqual(elapsedMs);
+  });
+
+  test("a page that highlights nothing is charged for the scan only", async () => {
+    requestDelayMs = DELAY_MS;
+    responseBody = { num_hits: 0, hits: [] };
+
+    const startedAt = performance.now();
+    const page = await readPage();
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(page.scan.rounds).toBe(1);
+    expect(page.scan.highlightRounds).toBe(0);
+    expect(requestBodies).toHaveLength(1);
+    expect(page.scan.indexMs).toBeGreaterThanOrEqual(DELAY_MS);
+    expect(page.scan.indexMs).toBeLessThanOrEqual(elapsedMs);
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -1,6 +1,7 @@
 import type { QuickwitCluster } from "@/api/lib/legal-search/corpus-generation-contract";
 import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
 import type { RankedHit, ScoredCandidate } from "@/api/lib/legal-search/rerank";
 import { LIMITS } from "@/api/lib/limits";
 import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
@@ -61,6 +62,11 @@ type CorpusIndexSearchPageInput<TContext> = {
   query: string;
   limit: number;
   parsedCursor: SearchCursor | null;
+  /**
+   * Fields the engine highlights. Requested for the passages the page emits
+   * and never for the scan: highlighting is per-hit work, and a scan reaches
+   * a couple of hundred passages to answer with ten.
+   */
   snippetFields: string[];
   extractId: (hit: CorpusIndexHit) => string | null;
   extractSnippet: (
@@ -113,12 +119,18 @@ export type CorpusIndexScanReport = {
   rounds: number;
   /** Hits the engine returned across those rounds. */
   passagesScanned: number;
-  /** Summed wall time of those engine calls. */
+  /** Summed wall time of every engine call the read made. */
   indexMs: number;
   /** Stopped because no unseen candidate could out-blend the page. */
   earlyStopped: boolean;
   /** Stopped at `LIMITS.corpusIndexSearchMaxRounds` instead. */
   roundCapHit: boolean;
+  /**
+   * Engine round trips spent highlighting the page: one, or none when the
+   * page is empty. Separate from `rounds` because it reaches a page's worth
+   * of passages rather than the scan's, and a reader waits through both.
+   */
+  highlightRounds: number;
 };
 
 /** What a request that never reached the index spent on it. */
@@ -128,6 +140,7 @@ export const emptyCorpusIndexScan = (): CorpusIndexScanReport => ({
   indexMs: 0,
   earlyStopped: false,
   roundCapHit: false,
+  highlightRounds: 0,
 });
 
 /**
@@ -151,6 +164,107 @@ const PASSAGE_OVER_FETCH = 4;
 const readAnchorId = (hit: CorpusIndexHit): string | null => {
   const anchorId = hit["anchor_id"];
   return typeof anchorId === "string" && anchorId.length > 0 ? anchorId : null;
+};
+
+/**
+ * Physical copies of one passage the highlight round is willing to receive.
+ *
+ * A passage clause names a passage, not a row: `chunk_id` is deterministic
+ * (`<document_id>:<seq>`) rather than unique, and during a content refresh the
+ * old and new copies coexist — ingestion appends, and the engine applies the
+ * delete asynchronously. Asking for one hit per clause would let a document
+ * mid-refresh consume another document's slot and cost that document its
+ * snippet. The multiplier is the overlap allowance; a passage carrying more
+ * copies than this degrades to no snippet, never to another document's.
+ */
+export const HIGHLIGHT_COPIES_PER_PASSAGE = 4;
+
+/**
+ * The clause that addresses exactly this hit again. `chunk_id` on a
+ * passage-granular generation, `document_id` where the document is the
+ * indexed unit; both are raw-tokenised, so a quoted value is an exact term
+ * lookup rather than a text match. Read from the hit rather than from the
+ * generation's configuration, so a layout the index actually serves decides
+ * it.
+ */
+const passageClause = (hit: CorpusIndexHit): string | null => {
+  const chunkId = hit["chunk_id"];
+  if (typeof chunkId === "string" && chunkId.length > 0) {
+    return `chunk_id:${quoteCorpusValue(chunkId)}`;
+  }
+  const documentId = hit["document_id"];
+  return typeof documentId === "string" && documentId.length > 0
+    ? `document_id:${quoteCorpusValue(documentId)}`
+    : null;
+};
+
+type ReadPageSnippetsOptions = {
+  clauses: readonly string[];
+  cluster: QuickwitCluster;
+  extractId: (hit: CorpusIndexHit) => string | null;
+  extractSnippet: (
+    snippet: Record<string, unknown> | undefined,
+  ) => string | null;
+  indexId: string;
+  query: string;
+  snippetFields: string[];
+};
+
+type PageSnippets = {
+  indexMs: number;
+  rounds: number;
+  snippetById: Map<string, string>;
+};
+
+/**
+ * Highlight the passages the page emits, and only those.
+ *
+ * The scan's query is kept whole and narrowed by the page's passage clauses,
+ * so the engine highlights against exactly the terms it matched on: the
+ * snippet a hit gets here is the snippet the scan would have produced for it.
+ * Hits arrive best-first, so the first hit seen for a document supplies its
+ * snippet, matching how the scan chose the document's passage.
+ */
+const readPageSnippets = async ({
+  clauses,
+  cluster,
+  extractId,
+  extractSnippet,
+  indexId,
+  query,
+  snippetFields,
+}: ReadPageSnippetsOptions): Promise<PageSnippets> => {
+  const snippetById = new Map<string, string>();
+  if (clauses.length === 0 || snippetFields.length === 0) {
+    return { indexMs: 0, rounds: 0, snippetById };
+  }
+
+  const startedAt = performance.now();
+  const result = await getCorpusIndexClient(cluster).search({
+    indexId,
+    query: `(${query}) AND (${clauses.join(" OR ")})`,
+    maxHits: clauses.length * HIGHLIGHT_COPIES_PER_PASSAGE,
+    sortBy: "_score",
+    snippetFields,
+  });
+  const indexMs = performance.now() - startedAt;
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  // Best-first, so the first snippet a document gets is its best-scoring
+  // copy's; the later ones are the refresh overlap and are dropped.
+  for (const [index, hit] of result.value.hits.entries()) {
+    const id = extractId(hit);
+    if (id === null || snippetById.has(id)) {
+      continue;
+    }
+    const snippet = extractSnippet(result.value.snippets[index]);
+    if (snippet !== null) {
+      snippetById.set(id, snippet);
+    }
+  }
+  return { indexMs, rounds: 1, snippetById };
 };
 
 export const isAfterSearchCursor = (
@@ -214,7 +328,8 @@ export const readCorpusIndexSearchPage = async <TContext>({
   CorpusIndexSearchPageResult<TContext>
 > => {
   const candidates: ScoredCandidate[] = [];
-  const snippetById = new Map<string, string>();
+  /** Best passage per document, as the clause a snippet round addresses it by. */
+  const passageClauseById = new Map<string, string>();
   const anchorIdById = new Map<string, string>();
   const passageCountById = new Map<string, number>();
   let ranking: CorpusIndexRanking<TContext> | null = null;
@@ -282,7 +397,6 @@ export const readCorpusIndexSearchPage = async <TContext>({
       maxHits,
       startOffset,
       sortBy: "_score",
-      snippetFields,
     });
     indexMs += performance.now() - roundStartedAt;
     if (result.isErr()) {
@@ -312,9 +426,9 @@ export const readCorpusIndexSearchPage = async <TContext>({
       }
 
       // Hits arrive best-first, so the first hit seen for a document is its
-      // best-scoring passage: it sets the document's rank, its snippet, and
-      // the anchor the result deep-links to. Later passages of the same
-      // document only add to its breadth count.
+      // best-scoring passage: it sets the document's rank, the passage a
+      // snippet is later cut from, and the anchor the result deep-links to.
+      // Later passages of the same document only add to its breadth count.
       const seen = passageCountById.get(id);
       if (seen !== undefined) {
         passageCountById.set(id, seen + 1);
@@ -327,9 +441,9 @@ export const readCorpusIndexSearchPage = async <TContext>({
         score: corpusIndexLexicalScore(startOffset + index),
       });
 
-      const snippet = extractSnippet(result.value.snippets[index]);
-      if (snippet !== null) {
-        snippetById.set(id, snippet);
+      const clause = passageClause(hit);
+      if (clause !== null) {
+        passageClauseById.set(id, clause);
       }
       const anchorId = readAnchorId(hit);
       if (anchorId !== null) {
@@ -402,19 +516,30 @@ export const readCorpusIndexSearchPage = async <TContext>({
   };
   const nextCursor = resolveNextCursor();
 
+  const snippets = await readPageSnippets({
+    clauses: pageRanked.flatMap((hit) => passageClauseById.get(hit.id) ?? []),
+    cluster,
+    extractId,
+    extractSnippet,
+    indexId,
+    query,
+    snippetFields,
+  });
+
   return {
     pageRanked,
     context: ranking.context,
-    snippetById,
+    snippetById: snippets.snippetById,
     anchorIdById,
     passageCountById,
     nextCursor,
     scan: {
       rounds,
       passagesScanned: scanned,
-      indexMs,
+      indexMs: indexMs + snippets.indexMs,
       earlyStopped,
       roundCapHit,
+      highlightRounds: snippets.rounds,
     },
   };
 };

--- a/apps/api/src/tests/security/public-law-reader-role.test.ts
+++ b/apps/api/src/tests/security/public-law-reader-role.test.ts
@@ -21,6 +21,7 @@ import { listDecisionsHandler } from "@/api/handlers/case-law/decisions/list";
 import { withRedistributableSubject } from "@/api/handlers/case-law/decisions/public-subject";
 import {
   findDecisionIdsByIdentity,
+  readCaseLawPageDecisionRows,
   rehydrateCaseLawCandidates,
 } from "@/api/handlers/case-law/decisions/search";
 import {
@@ -583,6 +584,16 @@ describe("public-law reader role", () => {
       generation: "case_law_v3",
     });
     expect(search.ranked).toEqual([]);
+
+    // Search reads twice: narrow rows for every candidate it blends, wide
+    // rows for the ids the page emits. Both have to clear the reader role.
+    const pageRows = await readCaseLawPageDecisionRows({
+      body: { query: "reader role census" },
+      caseLawDb,
+      generation: "case_law_v3",
+      ids: [createSafeId<"caseLawDecision">()],
+    });
+    expect(pageRows.size).toBe(0);
 
     const byDocket = await findDecisionIdsByIdentity({
       caseLawDb,


### PR DESCRIPTION
## What

1. `perf(api): hydrate search candidates narrowly and page hits fully` — the scan's ranking callback read the wide decision row (identifiers, dates, publisher summary over `metadata`, counts) for every candidate. The blend needs three columns, so candidates are now read narrowly and the wide row is read once for the hits the page emits, on both the scan and the identity path. Both reads apply the same row filters, so the read that emits publisher text re-proves the row is servable. The reader-role census exercises both reads; no new columns.
2. `perf(api): highlight only the passages a page emits` — the scan no longer asks the engine for snippets on every scanned passage. After the page is decided, one engine call highlights the emitted passages by their chunk ids (or document ids on document-granular generations), so the snippet is the engine's own for the passage the document ranked by. The scan report counts the highlight round and its time; the search event gains `pageRowsRead` and `dbPageMs`.

## Tests

Exact column set of the blend read, read-once across rounds, wide row contents, no read for an empty page, both reads reapply filters and the redistribution boundary; the scan sends no highlighting and the page round sends it once with the right size and query; document-granular addressing; the highlighted passage is the ranking one; an empty page issues no highlight; engine time accounts for every round trip (counts reconcile exactly, and the total is bounded below by the rounds and above by the read's elapsed time).
