### PR TITLE
fix(landing): omit releases that never reached production from the changelog

### DIFF
--- a/apps/landing/src/data/changelog-release-dates.json
+++ b/apps/landing/src/data/changelog-release-dates.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Publication timestamps for stable releases, keyed by tag. Sourced from the GitHub releases API (published_at; v0.3.0 and v0.8.9 have no GitHub release, so their tag dates are used). The server-rendered changelog list reads these at build time; the client-side live feed replaces it with fresh GitHub data. A release missing here renders without a date until the entry is added.",
+  "_note": "Publication timestamps for stable releases, keyed by tag, sourced from the GitHub releases API (published_at; v0.3.0 has no GitHub release, so its tag date is used). null records a stable tag whose release was built but never promoted to production; the changelog omits it everywhere (server-rendered list, preview pages, live feed). The server-rendered changelog list reads these at build time; the client-side live feed replaces it with fresh GitHub data. A release missing here renders without a date until the entry is added.",
   "v0.1.2": "2026-05-06T10:46:08Z",
   "v0.1.3": "2026-05-06T13:39:55Z",
   "v0.1.4": "2026-05-09T11:29:13Z",
@@ -94,6 +94,6 @@
   "v0.8.6": "2026-09-01T21:39:26Z",
   "v0.8.7": "2026-09-01T23:11:53Z",
   "v0.8.8": "2026-09-02T11:19:32Z",
-  "v0.8.9": "2026-09-02T20:52:44Z",
-  "v0.8.10": "2026-09-02T22:00:33Z"
+  "v0.8.9": null,
+  "v0.8.10": null
 }

--- a/apps/landing/src/lib/changelog.test.ts
+++ b/apps/landing/src/lib/changelog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { getChangelogReleaseEntries, getChangelogReleases } from "./changelog";
+import {
+  getChangelogReleaseEntries,
+  getChangelogReleases,
+  getUnpromotedReleaseTags,
+} from "./changelog";
 
 describe("changelog release dates", () => {
   // A release page without a date entry renders dateless silently; the entry
@@ -15,6 +19,20 @@ describe("changelog release dates", () => {
       .filter((release) => release.publishedAt === null)
       .map((release) => release.tagName);
     expect(undated).toEqual([]);
+  });
+
+  // A stable tag that was built but never promoted has its notes file (the
+  // release cut requires one) and a `null` date entry; it must not surface
+  // anywhere the list feeds: the changelog, its preview pages, the homepage.
+  test("a release recorded as never promoted is omitted", () => {
+    const unpromoted = getUnpromotedReleaseTags();
+    expect(unpromoted).toContain("v0.8.10");
+    const listed = new Set(
+      getChangelogReleases().map(({ tagName }) => tagName),
+    );
+    for (const tagName of unpromoted) {
+      expect([tagName, listed.has(tagName)]).toEqual([tagName, false]);
+    }
   });
 
   test("grouped entries preserve every release exactly once", () => {

--- a/apps/landing/src/lib/changelog.ts
+++ b/apps/landing/src/lib/changelog.ts
@@ -16,7 +16,11 @@ export type ChangelogRelease = {
 
 // Widen the literal-keyed JSON import so lookups by arbitrary tag are typed as
 // possibly absent (a new release lands before its date entry is committed).
-const RELEASE_DATES: Partial<Record<string, string>> = releaseDates;
+// A `null` entry records a stable tag whose release was built but never
+// promoted to production: its notes file exists, and nothing here lists it.
+const RELEASE_DATES: Partial<Record<string, string | null>> = releaseDates;
+
+const isUnpromoted = (tagName: string) => RELEASE_DATES[tagName] === null;
 
 const CHANGELOG_DIR = resolveRepoPath("docs", "changelog");
 const STABLE_CHANGELOG_FILE_PATTERN = /^v\d+\.\d+\.\d+\.md$/u;
@@ -36,8 +40,12 @@ const listReleaseTags = (): string[] => {
 
   const tags: string[] = [];
   for (const fileName of readdirSync(CHANGELOG_DIR)) {
-    if (STABLE_CHANGELOG_FILE_PATTERN.test(fileName)) {
-      tags.push(fileName.replace(/\.md$/u, ""));
+    if (!STABLE_CHANGELOG_FILE_PATTERN.test(fileName)) {
+      continue;
+    }
+    const tagName = fileName.replace(/\.md$/u, "");
+    if (!isUnpromoted(tagName)) {
+      tags.push(tagName);
     }
   }
 
@@ -68,6 +76,16 @@ const readRelease = (tagName: string): ChangelogRelease => {
 
 export const getChangelogReleases = (): ChangelogRelease[] =>
   listReleaseTags().map(readRelease);
+
+/**
+ * Stable tags recorded as never promoted. The live GitHub feed on the
+ * changelog page drops these too: their release objects may still be
+ * published, since the draft-until-promoted publication came later.
+ */
+export const getUnpromotedReleaseTags = (): string[] =>
+  Object.entries(RELEASE_DATES)
+    .filter(([, publishedAt]) => publishedAt === null)
+    .map(([tagName]) => tagName);
 
 export const getChangelogReleaseEntries = () =>
   groupMaintenanceReleases(

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -563,6 +563,11 @@ const formatReleaseDate = (publishedAt: string) =>
     // Stable tags built but never promoted; their release objects predate the
     // draft-until-promoted publication and are still published on GitHub.
     let unpromotedReleaseTags = new Set<string>();
+    const isListedStellaRelease = (release: GitHubRelease) =>
+      !release.draft &&
+      !release.prerelease &&
+      isStellaReleaseTag(release.tag_name) &&
+      !unpromotedReleaseTags.has(release.tag_name);
     const readCurrentPage = () => {
       const page = Number(new URLSearchParams(window.location.search).get("page"));
       if (!Number.isInteger(page) || page < 1) {
@@ -1131,15 +1136,7 @@ const formatReleaseDate = (publishedAt: string) =>
 
         // eslint-disable-next-line no-await-in-loop -- body of the sequentially fetched page; see above
         const releases = parseGitHubReleases(await response.json());
-        stellaReleases.push(
-          ...releases.filter(
-            (release) =>
-              !release.draft &&
-              !release.prerelease &&
-              isStellaReleaseTag(release.tag_name) &&
-              !unpromotedReleaseTags.has(release.tag_name),
-          ),
-        );
+        stellaReleases.push(...releases.filter(isListedStellaRelease));
         releaseEntries = groupMaintenanceReleases(
           stellaReleases,
           getReleaseSummaryTitle,

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -3,6 +3,7 @@ import Base from "../layouts/Base.astro";
 import {
   getChangelogReleaseEntries,
   getChangelogReleases,
+  getUnpromotedReleaseTags,
   type ChangelogRelease,
 } from "../lib/changelog";
 import {
@@ -18,6 +19,7 @@ const releasesUrl = `${githubUrl}/releases`;
 const releases = getChangelogReleases();
 const releaseEntries = getChangelogReleaseEntries();
 const previewReleaseSlugs = releases.map((release) => release.slug);
+const unpromotedReleaseTags = getUnpromotedReleaseTags();
 
 // Server-rendered first page of the changelog: real content for crawlers and
 // the no-JS/pre-JS state. The client script below replaces it with the live
@@ -304,6 +306,12 @@ const formatReleaseDate = (publishedAt: string) =>
     type="application/json"
     set:html={JSON.stringify(previewReleaseSlugs)}
   />
+  <script
+    is:inline
+    id="changelog-unpromoted-release-tags"
+    type="application/json"
+    set:html={JSON.stringify(unpromotedReleaseTags)}
+  />
 
   <style>
     :global(.changelog-entry) {
@@ -538,12 +546,13 @@ const formatReleaseDate = (publishedAt: string) =>
     let releasesContainer: HTMLElement | null = null;
     let paginationContainer: HTMLElement | null = null;
     let previewReleaseSlugsElement: HTMLElement | null = null;
-    const readPreviewReleaseSlugs = () => {
-      if (!previewReleaseSlugsElement?.textContent) {
+    let unpromotedReleaseTagsElement: HTMLElement | null = null;
+    const readStringList = (element: HTMLElement | null) => {
+      if (!element?.textContent) {
         return [];
       }
 
-      const parsed = JSON.parse(previewReleaseSlugsElement.textContent);
+      const parsed = JSON.parse(element.textContent);
       if (!Array.isArray(parsed)) {
         return [];
       }
@@ -551,6 +560,9 @@ const formatReleaseDate = (publishedAt: string) =>
       return parsed.filter((value): value is string => typeof value === "string");
     };
     let previewReleaseSlugs = new Set<string>();
+    // Stable tags built but never promoted; their release objects predate the
+    // draft-until-promoted publication and are still published on GitHub.
+    let unpromotedReleaseTags = new Set<string>();
     const readCurrentPage = () => {
       const page = Number(new URLSearchParams(window.location.search).get("page"));
       if (!Number.isInteger(page) || page < 1) {
@@ -1124,7 +1136,8 @@ const formatReleaseDate = (publishedAt: string) =>
             (release) =>
               !release.draft &&
               !release.prerelease &&
-              isStellaReleaseTag(release.tag_name),
+              isStellaReleaseTag(release.tag_name) &&
+              !unpromotedReleaseTags.has(release.tag_name),
           ),
         );
         releaseEntries = groupMaintenanceReleases(
@@ -1323,11 +1336,17 @@ const formatReleaseDate = (publishedAt: string) =>
       previewReleaseSlugsElement = document.querySelector(
         "#changelog-preview-release-slugs",
       );
+      unpromotedReleaseTagsElement = document.querySelector(
+        "#changelog-unpromoted-release-tags",
+      );
       if (!releasesContainer) {
         return;
       }
 
-      previewReleaseSlugs = new Set(readPreviewReleaseSlugs());
+      previewReleaseSlugs = new Set(readStringList(previewReleaseSlugsElement));
+      unpromotedReleaseTags = new Set(
+        readStringList(unpromotedReleaseTagsElement),
+      );
       currentPage = readCurrentPage();
       hasNextPage = false;
       // Expand a nested anchor in the server-rendered list immediately; the

--- a/scripts/prepare-maintenance-release.ts
+++ b/scripts/prepare-maintenance-release.ts
@@ -147,21 +147,26 @@ export const parseMaintenanceReleaseOptions = (
   return { recordingReviewReason: reason };
 };
 
-const readReleaseDates = (rootDir: string): Record<string, string> => {
+// A `null` value records a stable tag that was built but never promoted; the
+// landing changelog omits it. Preserved as written: a maintenance release
+// after an unpromoted one must not turn that record into a publication date.
+const readReleaseDates = (rootDir: string): Record<string, string | null> => {
   const parsed: unknown = JSON.parse(
     readFileSync(nodePath.join(rootDir, RELEASE_DATES_PATH), "utf-8"),
   );
   if (
     !isRecord(parsed) ||
-    Object.values(parsed).some((value) => typeof value !== "string")
+    Object.values(parsed).some(
+      (value) => typeof value !== "string" && value !== null,
+    )
   ) {
     throw new MaintenanceReleaseError(
-      `${RELEASE_DATES_PATH} must be an object of string values`,
+      `${RELEASE_DATES_PATH} must be an object of string or null values`,
     );
   }
-  const releaseDates: Record<string, string> = {};
+  const releaseDates: Record<string, string | null> = {};
   for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value === "string") {
+    if (typeof value === "string" || value === null) {
       releaseDates[key] = value;
     }
   }
@@ -255,7 +260,9 @@ export const prepareMaintenanceReleaseFiles = ({
 
   const releaseDatesPath = nodePath.join(rootDir, RELEASE_DATES_PATH);
   const releaseDates = readReleaseDates(rootDir);
-  releaseDates[previousTag] = publishedAt;
+  if (releaseDates[previousTag] !== null) {
+    releaseDates[previousTag] = publishedAt;
+  }
   return withFileRollback({
     operation: () => {
       // VERSION is the commit marker: every dependent file is durable before


### PR DESCRIPTION
## What

A stable tag can be built and tagged without ever being promoted (v0.8.9 and v0.8.10). Its notes file exists because the release cut requires one, and its GitHub release object was public before #2875 made unpromoted releases drafts, so the landing changelog listed it as shipped.

- `changelog-release-dates.json` may now record a tag as `null`: built, never promoted. v0.8.9 and v0.8.10 are recorded that way.
- `getChangelogReleases()` skips null-recorded tags, so the server-rendered list, the per-release preview pages and images, and the homepage badge omit them; `getUnpromotedReleaseTags()` feeds the page's live GitHub feed, which filters them as well.
- `prepare-maintenance-release.ts` accepts and preserves null entries instead of rejecting the file or overwriting the record with a publication date.

The GitHub-side marker (a `latest.json` asset) was not used: four older shipped releases predate carry-forward and lack it, so the committed record is the honest signal. Going forward a failed promotion leaves only a draft, which the feed already ignores.

## Checks

- `changelog.test.ts`: v0.8.10 is recorded as unpromoted and absent from the list; existing date and grouping invariants hold.
- `prepare-maintenance-release.property.test.ts`, `sitemap-lastmod.test.ts`, landing typecheck, oxlint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Changelog listings now exclude stable releases that were built but never promoted to production.
  - Live changelog feeds consistently filter out drafts, prereleases, non-Stella tags and unpromoted releases.
  - Release date records now preserve unpromoted releases without assigning them a publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->