### PR TITLE
fix(ui): size popover and tooltip positioners to their content

### DIFF
--- a/.changeset/popover-positioner-follows-content.md
+++ b/.changeset/popover-positioner-follows-content.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+`Popover` and `Tooltip` size their positioner to the rendered popup (`w-max`, still capped by `max-w-(--available-width)`) instead of to `--positioner-width`, and pass an 8px `collisionPadding`. Base UI writes `--positioner-width` from the popup payload, so a popup whose content grew from local state (a picker view swapping to a wide editor view) left the positioner at the old width; Base UI positions and collision-tests the positioner, so `shift()` saw no overflow while the popup rendered wider and ran past the viewport edge. `max-content` also tracks `--popup-width` as it interpolates, so payload transitions keep animating their width and no longer need the variable on the positioner.

--- a/packages/ui/src/components/fixtures/popover-resize.fixture.css
+++ b/packages/ui/src/components/fixtures/popover-resize.fixture.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+@source "../";

--- a/packages/ui/src/components/fixtures/popover-resize.fixture.html
+++ b/packages/ui/src/components/fixtures/popover-resize.fixture.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Popover resize fixture</title>
+    <link rel="stylesheet" href="./popover-resize.fixture.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./popover-resize.fixture.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/src/components/fixtures/popover-resize.fixture.tsx
+++ b/packages/ui/src/components/fixtures/popover-resize.fixture.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import { panic } from "better-result";
+
+import { Popover, PopoverPanel, PopoverTrigger } from "../popover";
+
+// The editor is far wider than the picker it replaces, and the swap happens
+// from local state while the popover stays open: the popup payload never
+// changes, so nothing re-measures `--positioner-width`. Anchored `start`
+// against a trigger at the inline end, the wide view only stays on screen if
+// the positioner grows with the popup and collision handling shifts it back.
+const VIEW_WIDTH_CLASS = {
+  picker: "w-56",
+  editor: "w-[44rem]",
+} as const;
+
+type PopoverView = keyof typeof VIEW_WIDTH_CLASS;
+
+const PopoverResizeFixture = () => {
+  const [view, setView] = useState<PopoverView>("picker");
+
+  useEffect(() => {
+    document.documentElement.dataset["popoverResizeReady"] = "true";
+    return () => {
+      delete document.documentElement.dataset["popoverResizeReady"];
+    };
+  }, []);
+
+  return (
+    <main className="flex justify-end p-2">
+      <Popover
+        onOpenChange={(open) => {
+          if (!open) {
+            setView("picker");
+          }
+        }}
+      >
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverPanel align="start" className={VIEW_WIDTH_CLASS[view]}>
+          {view === "picker" ? (
+            <button onClick={() => setView("editor")} type="button">
+              Edit
+            </button>
+          ) : (
+            <p data-testid="editor">Wide editor view</p>
+          )}
+        </PopoverPanel>
+      </Popover>
+    </main>
+  );
+};
+
+const rootElement = document.querySelector("#root");
+if (!rootElement) {
+  panic("Missing fixture root");
+}
+
+createRoot(rootElement).render(<PopoverResizeFixture />);

--- a/packages/ui/src/components/popover-resize.playwright.spec.ts
+++ b/packages/ui/src/components/popover-resize.playwright.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+const fixturePath = "/src/components/fixtures/popover-resize.fixture.html";
+
+const VIEWPORT = { width: 1280, height: 800 };
+// `w-[44rem]` on the editor view.
+const EDITOR_WIDTH = 704;
+
+test.use({
+  viewport: VIEWPORT,
+  isMobile: false,
+  hasTouch: false,
+  deviceScaleFactor: 1,
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(fixturePath);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["popoverResizeReady"] ?? "",
+        ),
+    )
+    .toBe("true");
+});
+
+test("keeps a popup that widens while open inside the viewport", async ({
+  page,
+}) => {
+  await page.getByRole("button", { name: "Open" }).click();
+
+  const popup = page.locator('[data-slot="popover-popup"]');
+  await expect(popup).toBeVisible();
+
+  await page.getByRole("button", { name: "Edit" }).click();
+  await expect(page.getByTestId("editor")).toBeVisible();
+
+  // The popup animates its width, and Base UI repositions on the resize, so
+  // wait for the rendered width to settle before measuring the edges.
+  await expect
+    .poll(async () => Math.round((await popup.boundingBox())?.width ?? 0))
+    .toBe(EDITOR_WIDTH);
+
+  const box = await popup.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box?.x).toBeGreaterThanOrEqual(0);
+  expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(VIEWPORT.width);
+});

--- a/packages/ui/src/components/popover.test.tsx
+++ b/packages/ui/src/components/popover.test.tsx
@@ -1,0 +1,62 @@
+import { isValidElement, type ReactNode } from "react";
+
+import { panic } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { OVERLAY_COLLISION_PADDING } from "../lib/overlay-layer";
+import { PopoverPopup } from "./popover";
+import { TooltipPopup } from "./tooltip";
+
+type SlotProps = {
+  children?: ReactNode;
+  className?: string;
+  collisionPadding?: number;
+  "data-slot"?: string;
+};
+
+// The positioner mounts through a portal, which renders nothing on the server,
+// so `renderToStaticMarkup` cannot reach it. Walk the single-child chain the
+// popup builds instead (portal, positioner, popup, viewport): `cn` has already
+// run by then, so these are the props the browser would receive.
+const findSlot = (root: ReactNode, slot: string): SlotProps => {
+  let node = root;
+  while (isValidElement<SlotProps>(node)) {
+    if (node.props["data-slot"] === slot) {
+      return node.props;
+    }
+    node = node.props.children;
+  }
+  return panic(`No element with data-slot="${slot}" in the popup tree`);
+};
+
+describe("PopoverPopup", () => {
+  test("sizes the positioner to the rendered popup, not to the payload width", () => {
+    const positioner = findSlot(
+      PopoverPopup({ children: "content" }),
+      "popover-positioner",
+    );
+
+    // `w-(--positioner-width)` pins the positioner to the width measured when
+    // the payload last changed. Content that grows from local state then
+    // renders wider than the box Base UI collision-tests, so `shift()` sees no
+    // overflow and the popup runs off-screen.
+    expect(positioner.className).not.toContain("w-(--positioner-width)");
+    expect(positioner.className).toContain("w-max");
+    expect(positioner.className).toContain("max-w-(--available-width)");
+    expect(positioner.collisionPadding).toBe(OVERLAY_COLLISION_PADDING);
+  });
+});
+
+describe("TooltipPopup", () => {
+  test("sizes its positioner the same way the popover does", () => {
+    const positioner = findSlot(
+      TooltipPopup({ children: "content" }),
+      "tooltip-positioner",
+    );
+
+    expect(positioner.className).not.toContain("w-(--positioner-width)");
+    expect(positioner.className).toContain("w-max");
+    expect(positioner.className).toContain("max-w-(--available-width)");
+    expect(positioner.collisionPadding).toBe(OVERLAY_COLLISION_PADDING);
+  });
+});

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -6,6 +6,7 @@ import type { ComponentProps } from "react";
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 
 import {
+  OVERLAY_COLLISION_PADDING,
   OVERLAY_LAYER_CLASS_NAMES,
   type OverlayLayer,
 } from "../lib/overlay-layer";
@@ -53,10 +54,18 @@ const PopoverPopup = ({
       align={align}
       alignOffset={alignOffset}
       anchor={anchor}
+      // `--positioner-width` is written from the popup *payload*, so a popup
+      // whose content grows from local state (a picker swapping to an editor)
+      // left the positioner at the old width. Base UI collision-tests the
+      // positioner, so `shift()` saw no overflow while the popup rendered wider
+      // and ran off-screen. Sizing to content keeps the two in step; the popup
+      // still animates its own width through `--popup-width`, and `max-content`
+      // tracks that as it interpolates.
       className={cn(
-        "h-(--positioner-height) w-(--positioner-width) max-w-(--available-width)",
+        "h-(--positioner-height) w-max max-w-(--available-width)",
         OVERLAY_LAYER_CLASS_NAMES[layer],
       )}
+      collisionPadding={OVERLAY_COLLISION_PADDING}
       data-slot="popover-positioner"
       side={side}
       sideOffset={sideOffset}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -3,6 +3,7 @@
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
 import {
+  OVERLAY_COLLISION_PADDING,
   OVERLAY_LAYER_CLASS_NAMES,
   type OverlayLayer,
 } from "../lib/overlay-layer";
@@ -35,10 +36,13 @@ const TooltipPopup = ({
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Positioner
       align={align}
+      // Same payload-driven staleness as the popover positioner: size to the
+      // rendered popup instead of to `--positioner-width`.
       className={cn(
-        "h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none",
+        "h-(--positioner-height) w-max max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none",
         OVERLAY_LAYER_CLASS_NAMES[layer],
       )}
+      collisionPadding={OVERLAY_COLLISION_PADDING}
       data-slot="tooltip-positioner"
       side={side}
       sideOffset={sideOffset}

--- a/packages/ui/src/lib/overlay-layer.ts
+++ b/packages/ui/src/lib/overlay-layer.ts
@@ -29,3 +29,11 @@ export const OVERLAY_LAYER_CLASS_NAMES = {
 } as const;
 
 export type OverlayLayer = keyof typeof OVERLAY_LAYER_CLASS_NAMES;
+
+/**
+ * Gap kept between a collision-shifted floating surface and its boundary, in
+ * pixels. Base UI's 5px default puts the popup shadow flush against the
+ * viewport edge once `shift()` has to move a popup that is wider than its
+ * anchor, which reads as a clipped surface rather than a repositioned one.
+ */
+export const OVERLAY_COLLISION_PADDING = 8;


### PR DESCRIPTION
- `Popover.Positioner` and `Tooltip.Positioner` were sized `w-(--positioner-width)`, a variable Base UI writes from the popup *payload*. A popup that widens from local state (a picker view swapping to an editor view) kept the old positioner width, so the collision test found no overflow and the popup ran off-screen. Both now use `w-max`, still capped by `max-w-(--available-width)`, plus an 8px `collisionPadding` shared through `OVERLAY_COLLISION_PADDING`.
- Payload transitions still animate: the popup interpolates its own `--popup-width`, and a `max-content` positioner tracks it, so nothing on the positioner has to read the variable.
- A Playwright fixture opens a popover at the inline end, swaps a 224px view for a 704px one while open, and asserts the popup stays inside a 1280px viewport (472px outside it before this change). A unit test pins the positioner classes and the collision padding for both components.
