### PR TITLE
feat(ui): keep a lane's controls under the board header while it scrolls

### DIFF
--- a/.changeset/kanban-sticky-lane-controls.md
+++ b/.changeset/kanban-sticky-lane-controls.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+A lane's controls stay reachable while its cells scroll. `KanbanSubgroupBoard` measures its sticky header block and publishes the reach on its scroll container as `KANBAN_STICKY_TOP_VAR` (`--kanban-sticky-top`), so anything that must stay readable rests just under the header and releases where its lane ends. `KanbanVirtualCell` takes `footerPlacement="sticky-start"`, which leads the rows with the `footer` and pins it there instead of closing the cell with it (marked `data-kanban-cell-footer="sticky-start"`, repainting the cell's own surface, accent wash included, over an opaque base so cards pass behind it), and the new `KanbanCollapsedBandCaption` keeps a folded band's name and count in view down a lane hundreds of cards tall. A cell that keeps its own bounded scroll surface is its own scroll container, where the board's header offset means nothing: reset the variable on such a cell so its action rests at the cell's own top.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
@@ -215,6 +215,10 @@ const WorkspaceKanbanSubgroupCell = ({
           : undefined
       }
       active={isDragOver}
+      // The cell keeps its own bounded scroll surface, so it is the scroll
+      // container its pinned action sticks in: the board's header offset
+      // would push the action down past the first cards.
+      className="[--kanban-sticky-top:0px]"
       containerRef={cellRef}
       footer={
         columnValue !== null && canCreateTask ? (
@@ -226,6 +230,7 @@ const WorkspaceKanbanSubgroupCell = ({
           />
         ) : null
       }
+      footerPlacement="sticky-start"
       getRowKey={(entity) => entity.entityId}
       pagination={
         hasMore

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -236,6 +236,41 @@ reachable, and the slot peeks open while a pointer rests on it. Pass
 />
 ```
 
+### Lane controls that survive a scroll
+
+The board measures its sticky header block and publishes its height on the
+scroll container as `KANBAN_STICKY_TOP_VAR` (`--kanban-sticky-top`), so a
+lane's controls can rest just under the header and release where the lane
+ends. `KanbanVirtualCell` takes `footerPlacement="sticky-start"` to pin its
+`footer` above the rows instead of closing the cell with it, and
+`KanbanCollapsedBandCaption` keeps a folded band's name and count in view down
+a tall lane. A cell that keeps its own bounded scroll surface is its own
+scroll container, where the board's header offset means nothing; reset the
+variable on it so the action rests at the cell's own top.
+
+```tsx
+<KanbanVirtualCell
+  className="[--kanban-sticky-top:0px]"
+  footer={<KanbanCellAction onClick={addCard}>New card</KanbanCellAction>}
+  footerPlacement="sticky-start"
+  getRowKey={(row) => row.id}
+  pagination={{ type: "none" }}
+  renderRow={(row) => <Card row={row} />}
+  rows={cell.rows}
+/>
+```
+
+A host rendering its own collapsed band cell fills the slot and composes the
+caption inside it:
+
+```tsx
+renderCollapsedBandCell={({ band, cells, count }) => (
+  <FoldedDropTarget bandId={band.id} cells={cells}>
+    <KanbanCollapsedBandCaption label={band.label} meta={count} />
+  </FoldedDropTarget>
+)}
+```
+
 ## Styles
 
 No compiled CSS ships. The components carry Tailwind class names, so the

--- a/packages/ui/src/kanban/fixtures/sticky-lane-controls.fixture.css
+++ b/packages/ui/src/kanban/fixtures/sticky-lane-controls.fixture.css
@@ -1,0 +1,3 @@
+@import "tailwindcss";
+@import "../../styles/theme.css";
+@source "../../";

--- a/packages/ui/src/kanban/fixtures/sticky-lane-controls.fixture.html
+++ b/packages/ui/src/kanban/fixtures/sticky-lane-controls.fixture.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sticky lane controls fixture</title>
+    <link rel="stylesheet" href="./sticky-lane-controls.fixture.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./sticky-lane-controls.fixture.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/src/kanban/fixtures/sticky-lane-controls.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sticky-lane-controls.fixture.tsx
@@ -1,0 +1,128 @@
+import { useEffect } from "react";
+import { createRoot } from "react-dom/client";
+
+import { KanbanCellAction } from "../cell-action";
+import { resolveKanbanGrouping } from "../grouping";
+import type { KanbanSchema } from "../grouping";
+import { buildKanbanBoardMatrix } from "../matrix";
+import { KanbanSubgroupBoard } from "../subgroup-board";
+import { KanbanVirtualCell } from "../virtual-cell";
+
+type Row = { id: string; owner: string; status: string };
+type Property = { id: string };
+
+const band = { id: "todo", label: "To do" };
+
+const schema: KanbanSchema<Row, Property> = {
+  builtInGroups: [
+    {
+      id: "_status",
+      options: [
+        { band, label: "Open", value: "open" },
+        { band, label: "Blocked", value: "blocked" },
+        { label: "Done", value: "done" },
+      ],
+    },
+  ],
+  getPropertyId: ({ id }) => id,
+  getPropertyOptions: ({ id }) =>
+    id === "owner"
+      ? [
+          { label: "Ada", value: "ada" },
+          { label: "Lin", value: "lin" },
+        ]
+      : null,
+  properties: [{ id: "owner" }],
+};
+
+const laneRows = (owner: string, status: string, count: number): Row[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `${owner}-${status}-${String(index + 1)}`,
+    owner,
+    status,
+  }));
+
+// Both lanes are far taller than the board's viewport, so a scroll can rest
+// inside either one; the banded columns hold enough rows for the folded slot
+// to carry a count. The "none" rows fill the uncategorized column, whose
+// cells take no accent: a pinned action there stands on the neutral surface.
+const rows: Row[] = [
+  ...laneRows("ada", "done", 40),
+  ...laneRows("ada", "none", 40),
+  ...laneRows("lin", "done", 40),
+  ...laneRows("lin", "none", 40),
+  { id: "ada-open", owner: "ada", status: "open" },
+  { id: "ada-blocked", owner: "ada", status: "blocked" },
+  { id: "lin-open", owner: "lin", status: "open" },
+];
+
+const matrix = buildKanbanBoardMatrix({
+  group: resolveKanbanGrouping({ groupBy: "_status", schema }),
+  subgroup: resolveKanbanGrouping({ groupBy: "owner", schema }),
+  rows,
+  uncategorizedLabel: "No value",
+  resolveGroupValue: ({ grouping, row }) =>
+    grouping.type === "built-in" ? row.status : row.owner,
+});
+
+const StickyLaneControlsFixture = () => {
+  useEffect(() => {
+    document.documentElement.dataset["kanbanStickyLaneReady"] = "true";
+    return () => {
+      delete document.documentElement.dataset["kanbanStickyLaneReady"];
+    };
+  }, []);
+
+  return (
+    <div className="h-[420px]">
+      <KanbanSubgroupBoard
+        className="fixture-board"
+        isBandCollapsed={() => true}
+        isLaneCollapsed={() => false}
+        matrix={matrix}
+        renderCell={({ cell }) => (
+          <KanbanVirtualCell
+            accent={
+              cell.coordinate.column.type === "group" &&
+              cell.coordinate.column.group.value !== null
+                ? "blue"
+                : undefined
+            }
+            // The lane, not the cell, owns the scroll here: this is the tall
+            // cell the pinned action has to survive.
+            className="max-h-none overflow-y-visible"
+            footer={<KanbanCellAction>Add card</KanbanCellAction>}
+            footerPlacement="sticky-start"
+            getRowKey={(row) => row.id}
+            pagination={{ type: "none" }}
+            renderRow={(row) => (
+              <div
+                className="bg-card h-24 rounded-lg border p-2 text-xs"
+                data-card={row.id}
+              >
+                {row.id}
+              </div>
+            )}
+            rows={cell.rows}
+          />
+        )}
+        renderColumnHeader={({ column }) => (
+          <div className="text-sm font-medium">
+            {column.type === "group" ? column.group.label : "Other"}
+          </div>
+        )}
+        renderLaneIdentity={({ group }) => (
+          <span data-lane={group.value}>{group.label}</span>
+        )}
+        onBandCollapsedChange={() => undefined}
+        onLaneCollapsedChange={() => undefined}
+      />
+    </div>
+  );
+};
+
+const root = document.querySelector("#root");
+
+if (root) {
+  createRoot(root).render(<StickyLaneControlsFixture />);
+}

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -135,6 +135,11 @@ export {
   KANBAN_BAND_PEEK_LINGER_MS,
 } from "./band-peek";
 export { KanbanSubgroupBoard } from "./subgroup-board";
+export type { KanbanCollapsedBandCaptionProps } from "./sticky-lane";
+export {
+  KANBAN_STICKY_TOP_VAR,
+  KanbanCollapsedBandCaption,
+} from "./sticky-lane";
 export type {
   KanbanVirtualCellPagination,
   KanbanVirtualCellProps,

--- a/packages/ui/src/kanban/sticky-lane-controls.playwright.spec.ts
+++ b/packages/ui/src/kanban/sticky-lane-controls.playwright.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+const fixturePath = "/src/kanban/fixtures/sticky-lane-controls.fixture.html";
+
+/** Sub-pixel layout rounding, not a control that drifted off the header. */
+const TOLERANCE_PX = 1;
+
+const openFixture = async (page: Page) => {
+  await page.goto(fixturePath);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["kanbanStickyLaneReady"] ?? "",
+        ),
+    )
+    .toBe("true");
+  return page.locator(".fixture-board");
+};
+
+const topOf = async (locator: Locator) =>
+  await locator.evaluate((element) => element.getBoundingClientRect().top);
+
+const bottomOf = async (locator: Locator) =>
+  await locator.evaluate((element) => element.getBoundingClientRect().bottom);
+
+const scrollTo = async (board: Locator, top: number) => {
+  await board.evaluate((element, value) => {
+    element.scrollTop = value;
+  }, top);
+  await board.page().evaluate(async () => {
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        resolve(null);
+      });
+    });
+  });
+};
+
+/**
+ * One lane's own pinned controls. The board renders a lane per section, and a
+ * lane carries a pinned action per open column and a caption per folded band,
+ * so each control is read inside the lane it belongs to.
+ */
+const laneControls = (page: Page, lane: number) => {
+  const section = page.locator("section").nth(lane);
+  const actions = section.locator('[data-kanban-cell-footer="sticky-start"]');
+  return {
+    // The lane's first open column carries an accent wash; the uncategorized
+    // one behind it rests on the neutral surface.
+    action: actions.first(),
+    caption: section.locator("[data-kanban-collapsed-band-caption]").first(),
+    plainAction: actions.nth(1),
+  };
+};
+
+/** Cards must pass behind a pinned control, never read through it. */
+const expectOpaque = async (control: Locator) => {
+  const background = await control.evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  );
+
+  expect(background).not.toBe("rgba(0, 0, 0, 0)");
+  // A serialized alpha channel would let the cards read through the control.
+  expect(background).not.toContain("/");
+};
+
+/** Resting on the header: the control's top edge is the header's bottom. */
+const expectRestingOnHeader = async (
+  control: Locator,
+  headerBottom: number,
+) => {
+  expect(Math.abs((await topOf(control)) - headerBottom)).toBeLessThanOrEqual(
+    TOLERANCE_PX,
+  );
+};
+
+test.describe("sticky lane controls", () => {
+  test("holds a lane's action and folded caption under the board header", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const header = page.locator("[data-kanban-board-header]");
+    const { action, caption, plainAction } = laneControls(page, 0);
+
+    // Unscrolled, both sit where the lane starts: below the header, not on it.
+    expect(await topOf(action)).toBeGreaterThan(await bottomOf(header));
+    expect(await topOf(caption)).toBeGreaterThan(await bottomOf(header));
+
+    await scrollTo(board, 600);
+
+    const headerBottom = await bottomOf(header);
+    await expectRestingOnHeader(action, headerBottom);
+    await expectRestingOnHeader(caption, headerBottom);
+    await expectRestingOnHeader(plainAction, headerBottom);
+    // Both the accented cell and the one on the neutral resting surface.
+    await expectOpaque(action);
+    await expectOpaque(plainAction);
+    // Over that base, the row repaints the cell's own accent wash.
+    expect(
+      await action
+        .locator("> div")
+        .evaluate((element) => getComputedStyle(element).backgroundColor),
+    ).not.toBe("rgba(0, 0, 0, 0)");
+  });
+
+  test("releases them where the lane ends and hands over to the next", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const header = page.locator("[data-kanban-board-header]");
+    const scrolled = laneControls(page, 0);
+    const next = laneControls(page, 1);
+
+    const boardTop = await topOf(board);
+    const nextLaneTop = await topOf(page.locator("section").nth(1));
+    // Well inside the second lane, so the first lane's controls are behind us.
+    await scrollTo(board, nextLaneTop - boardTop + 400);
+
+    const headerBottom = await bottomOf(header);
+
+    // The lane that ended took its controls with it...
+    expect(await topOf(scrolled.action)).toBeLessThan(headerBottom);
+    expect(await topOf(scrolled.caption)).toBeLessThan(headerBottom);
+    // ...and the lane now under the header holds its own.
+    await expectRestingOnHeader(next.action, headerBottom);
+    await expectRestingOnHeader(next.caption, headerBottom);
+  });
+});

--- a/packages/ui/src/kanban/sticky-lane.test.tsx
+++ b/packages/ui/src/kanban/sticky-lane.test.tsx
@@ -1,0 +1,39 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  KANBAN_STICKY_TOP_CLASS,
+  KANBAN_STICKY_TOP_VAR,
+  KanbanCollapsedBandCaption,
+} from "./sticky-lane";
+
+describe("KANBAN_STICKY_TOP_VAR", () => {
+  test("names the property the board publishes and the utility reads", () => {
+    expect(KANBAN_STICKY_TOP_VAR).toBe("--kanban-sticky-top");
+    // The exported name and the class that consumes it cannot drift: a
+    // renamed variable that left the utility behind would stick every lane
+    // control at the fallback offset instead, silently.
+    expect(KANBAN_STICKY_TOP_CLASS).toBe(`top-(${KANBAN_STICKY_TOP_VAR},0px)`);
+  });
+});
+
+describe("KanbanCollapsedBandCaption", () => {
+  const markup = renderToStaticMarkup(
+    <KanbanCollapsedBandCaption label="To do" meta="7" />,
+  );
+
+  test("sets the band's name vertically over its count", () => {
+    expect(markup).toContain(">To do<");
+    expect(markup).toContain(">7<");
+    expect(markup).toContain("[writing-mode:vertical-rl]");
+    expect(markup).toContain('data-kanban-collapsed-band-caption=""');
+  });
+
+  test("sticks under the board's header without stretching in its slot", () => {
+    expect(markup).toContain("sticky");
+    expect(markup).toContain(KANBAN_STICKY_TOP_CLASS);
+    // A stretched caption fills its slot and can never travel through it.
+    expect(markup).toContain("self-start");
+  });
+});

--- a/packages/ui/src/kanban/sticky-lane.tsx
+++ b/packages/ui/src/kanban/sticky-lane.tsx
@@ -1,0 +1,61 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import { cn } from "../lib/utils";
+
+/**
+ * A lane's controls while its cells scroll.
+ *
+ * A board's header block is sticky at the top of the board's scroll
+ * container, so anything else that must stay readable has to come to rest
+ * under it rather than behind it. The board publishes how far its header
+ * reaches in this custom property; a control sticks at that offset and
+ * releases where its lane ends, because the lane's own box is what bounds it.
+ */
+export const KANBAN_STICKY_TOP_VAR = "--kanban-sticky-top" as const;
+
+/**
+ * Sticks a lane control just under the board's header. The fallback keeps a
+ * control usable outside a board that publishes the offset, and inside a cell
+ * that keeps its own scroll surface, where the board's header is irrelevant.
+ */
+export const KANBAN_STICKY_TOP_CLASS = "top-(--kanban-sticky-top,0px)";
+
+export type KanbanStickyTopStyle = CSSProperties & {
+  [KANBAN_STICKY_TOP_VAR]?: string;
+};
+
+export type KanbanCollapsedBandCaptionProps = {
+  label: string;
+  /** What the folded band stands in for: its count, already formatted. */
+  meta: ReactNode;
+  className?: string | undefined;
+};
+
+/**
+ * The name and count of a folded band, set vertically in its narrow slot.
+ *
+ * It stays under the board's header for as long as the lane lasts, so a
+ * folded band still says which band it is halfway down a tall lane. The slot
+ * has to give it room to travel: the element around it fills the slot's
+ * height (`h-full`), or a caption as tall as its own text can never move.
+ * A host rendering its own collapsed cell composes this inside that cell.
+ */
+export const KanbanCollapsedBandCaption = ({
+  className,
+  label,
+  meta,
+}: KanbanCollapsedBandCaptionProps) => (
+  <div
+    className={cn(
+      "text-muted-foreground sticky flex w-full flex-col items-center gap-2 self-start py-2 text-xs",
+      KANBAN_STICKY_TOP_CLASS,
+      className,
+    )}
+    data-kanban-collapsed-band-caption=""
+  >
+    <span className="max-h-40 truncate font-medium [writing-mode:vertical-rl]">
+      {label}
+    </span>
+    <span className="tabular-nums">{meta}</span>
+  </div>
+);

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -6,6 +6,7 @@ import { KanbanColumnBandHeader } from "./column-band-header";
 import type { KanbanSchema } from "./grouping";
 import { resolveKanbanGrouping } from "./grouping";
 import { buildKanbanBoardMatrix } from "./matrix";
+import { KANBAN_STICKY_TOP_VAR } from "./sticky-lane";
 import { KanbanSubgroupBoard } from "./subgroup-board";
 
 type Row = { id: string; owner: string | null; status: string | null };
@@ -131,6 +132,12 @@ describe("KanbanSubgroupBoard", () => {
 
   test("renders no band chrome when no column carries a band", () => {
     expect(renderBoard()).not.toContain("data-kanban-band");
+  });
+
+  test("publishes the sticky header's reach on its scroll container", () => {
+    // Nothing is measured before the board is in a document, so the offset
+    // starts at zero rather than leaving the property undeclared.
+    expect(renderBoard()).toContain(`${KANBAN_STICKY_TOP_VAR}:0px`);
   });
 });
 
@@ -296,6 +303,32 @@ describe("KanbanSubgroupBoard with column bands", () => {
     expect(foldedHeader).not.toContain(">To do<");
     expect(folded).toContain("[writing-mode:vertical-rl]");
     expect(folded).toContain('data-kanban-collapsed-band-count="2"');
+  });
+
+  test("keeps a folded band's caption under the header down its lane", () => {
+    const folded = renderToStaticMarkup(
+      <KanbanSubgroupBoard
+        isBandCollapsed={(band) => band.id === "todo"}
+        isLaneCollapsed={() => false}
+        matrix={bandedMatrix}
+        renderCell={() => <span>cell</span>}
+        renderColumnHeader={() => <span>column</span>}
+        renderLaneIdentity={() => <span>lane</span>}
+        onBandCollapsedChange={() => undefined}
+        onLaneCollapsedChange={() => undefined}
+      />,
+    );
+    const slot =
+      /<div[^>]*data-kanban-collapsed-band-count="2"[^>]*>/u.exec(
+        folded,
+      )?.[0] ?? "";
+
+    // The slot fills the lane, which is the height the caption travels
+    // through; the caption itself sticks under the board's header.
+    expect(slot).toContain("h-full");
+    expect(slot).toContain("flex-col");
+    expect(folded).toContain('data-kanban-collapsed-band-caption=""');
+    expect(folded).toContain(`top-(${KANBAN_STICKY_TOP_VAR},0px)`);
   });
 
   test("folds a collapsed band into one slot per row and keeps its cells reachable", () => {

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -24,6 +24,11 @@ import type {
   KanbanBoardColumn,
   KanbanBoardMatrix,
 } from "./matrix";
+import {
+  KANBAN_STICKY_TOP_VAR,
+  KanbanCollapsedBandCaption,
+} from "./sticky-lane";
+import type { KanbanStickyTopStyle } from "./sticky-lane";
 
 const groupValueKey = (value: string | null): string =>
   value === null ? "null" : `value:${value.length}:${value}`;
@@ -124,7 +129,9 @@ export type KanbanSubgroupBoardProps<TRow> = {
   /**
    * A lane's slot while its band is collapsed. Defaults to the band's name
    * set vertically over the count; a host that accepts drops into a collapsed
-   * band renders its target here.
+   * band renders its target here. Fill the slot's height (`h-full`) and
+   * compose `KanbanCollapsedBandCaption` inside, so the name still stays
+   * under the header halfway down a tall lane.
    */
   renderCollapsedBandCell?:
     | ((context: KanbanSubgroupCollapsedBandCellContext<TRow>) => ReactNode)
@@ -207,6 +214,22 @@ export const KanbanSubgroupBoard = <TRow,>({
     () => new Set<string>(),
   );
   const [peekingBandId, setPeekingBandId] = useState<string | null>(null);
+  // How far the sticky header block reaches into this scroll container. Lane
+  // controls stick under it (see `sticky-lane.tsx`); zero until measured, so
+  // server-rendered markup carries a usable offset.
+  const headerRef = useRef<HTMLDivElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  useEffect(() => {
+    const header = headerRef.current;
+    if (header === null) {
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => {
+      setHeaderHeight(header.getBoundingClientRect().height);
+    });
+    observer.observe(header);
+    return () => observer.disconnect();
+  }, []);
   // The peek's timing rules live in one controller (see `band-peek.ts`); the
   // board only mirrors which band it reports open.
   const [peek] = useState(() =>
@@ -519,14 +542,17 @@ export const KanbanSubgroupBoard = <TRow,>({
       );
     }
     return (
+      // The caption travels through the slot's full height, so it stays
+      // under the header until the lane ends rather than scrolling away
+      // with the first cards.
       <div
-        className="text-muted-foreground flex flex-col items-center gap-2 py-2 text-xs"
+        className="flex h-full flex-col items-center"
         data-kanban-collapsed-band-count={count}
       >
-        <span className="max-h-40 truncate font-medium [writing-mode:vertical-rl]">
-          {band.label}
-        </span>
-        <span className="tabular-nums">{formatCount(count)}</span>
+        <KanbanCollapsedBandCaption
+          label={band.label}
+          meta={formatCount(count)}
+        />
       </div>
     );
   };
@@ -548,10 +574,21 @@ export const KanbanSubgroupBoard = <TRow,>({
     );
   };
 
+  const stickyTopStyle: KanbanStickyTopStyle = {
+    [KANBAN_STICKY_TOP_VAR]: `${String(headerHeight)}px`,
+  };
+
   return (
-    <div className={cn("h-full overflow-auto px-4 pb-4", className)}>
+    <div
+      className={cn("h-full overflow-auto px-4 pb-4", className)}
+      style={stickyTopStyle}
+    >
       <div className="min-w-max">
-        <div className="bg-background sticky top-0 z-20 pt-2 pb-2">
+        <div
+          className="bg-background sticky top-0 z-20 pt-2 pb-2"
+          data-kanban-board-header=""
+          ref={headerRef}
+        >
           {hasBands ? (
             <div className="flex items-end gap-3 pb-1" data-kanban-band-row="">
               {spans.map((span) => {

--- a/packages/ui/src/kanban/virtual-cell.test.tsx
+++ b/packages/ui/src/kanban/virtual-cell.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
 
+import { KANBAN_STICKY_TOP_CLASS } from "./sticky-lane";
 import { KanbanVirtualCell } from "./virtual-cell";
 import type { KanbanVirtualCellProps } from "./virtual-cell";
 
@@ -18,18 +19,21 @@ const readCell = (markup: string) => {
   return match[0];
 };
 
-const renderCell = (overrides: Partial<KanbanVirtualCellProps<string>> = {}) =>
-  readCell(
-    renderToStaticMarkup(
-      <KanbanVirtualCell
-        getRowKey={(row) => row}
-        pagination={{ type: "none" }}
-        renderRow={(row) => <span>{row}</span>}
-        rows={["one"]}
-        {...overrides}
-      />,
-    ),
+const renderMarkup = (
+  overrides: Partial<KanbanVirtualCellProps<string>> = {},
+) =>
+  renderToStaticMarkup(
+    <KanbanVirtualCell
+      getRowKey={(row) => row}
+      pagination={{ type: "none" }}
+      renderRow={(row) => <span>{row}</span>}
+      rows={["one"]}
+      {...overrides}
+    />,
   );
+
+const renderCell = (overrides: Partial<KanbanVirtualCellProps<string>> = {}) =>
+  readCell(renderMarkup(overrides));
 
 describe("KanbanVirtualCell", () => {
   test("renders the plain neutral surface with no accent", () => {
@@ -73,5 +77,73 @@ describe("KanbanVirtualCell", () => {
     // The active accent frame replaces the generic primary-coloured one.
     expect(cell).not.toContain("bg-primary/5");
     expect(cell).not.toContain("ring-primary/50");
+  });
+});
+
+describe("KanbanVirtualCell footer placement", () => {
+  const action = <button type="button">Add card</button>;
+  // The virtualizer measures nothing without a live scroll element, so the
+  // rows' own container stands in for where the rows begin.
+  const rowsAt = (markup: string) => markup.indexOf('<div class="relative"');
+  /** The pinned row itself, and the surface it repaints inside it. */
+  const readPinned = (markup: string) => {
+    const match =
+      /<div class="(?<sticky>[^"]*)" data-kanban-cell-footer="sticky-start"><div class="(?<surface>[^"]*)"/u.exec(
+        markup,
+      );
+
+    if (!match?.groups) {
+      throw new Error("no pinned footer in the rendered markup");
+    }
+
+    return match.groups;
+  };
+
+  test("closes the cell with the action by default", () => {
+    const markup = renderMarkup({ footer: action });
+
+    expect(markup).not.toContain("data-kanban-cell-footer");
+    expect(markup.indexOf("Add card")).toBeGreaterThan(rowsAt(markup));
+  });
+
+  test("pins the action above the rows under the board's header offset", () => {
+    const markup = renderMarkup({
+      footer: action,
+      footerPlacement: "sticky-start",
+    });
+    const { sticky, surface } = readPinned(markup);
+
+    expect(sticky).toContain("sticky");
+    expect(sticky).toContain(KANBAN_STICKY_TOP_CLASS);
+    // Cards pass behind the action: the cell's surface over an opaque base.
+    expect(sticky).toContain("bg-background");
+    expect(surface).toContain("bg-muted/20");
+    // The action leads the rows, and keeps their bottom padding so nothing
+    // below it shifts.
+    expect(surface).toContain("pb-2");
+    expect(markup.indexOf("Add card")).toBeLessThan(rowsAt(markup));
+  });
+
+  test("repaints an accented cell's own surface behind the pinned action", () => {
+    const markup = renderMarkup({
+      accent: "blue",
+      footer: action,
+      footerPlacement: "sticky-start",
+    });
+
+    expect(readCell(markup)).toContain(
+      "--kanban-cell-surface:color-mix(in srgb, var(--kanban-cell-accent) 12%, var(--background))",
+    );
+    // The accent wash replaces the neutral surface over the opaque base.
+    const { surface } = readPinned(markup);
+
+    expect(surface).toContain("bg-(--kanban-cell-surface)");
+    expect(surface).not.toContain("bg-muted/20");
+  });
+
+  test("pins no empty row when the cell has no action", () => {
+    expect(renderMarkup({ footerPlacement: "sticky-start" })).not.toContain(
+      "data-kanban-cell-footer",
+    );
   });
 });

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -28,6 +28,7 @@ import {
   type KanbanVirtualScrollRequest,
   type UseKanbanDropTargetOptions,
 } from "./sortable-interactions";
+import { KANBAN_STICKY_TOP_CLASS } from "./sticky-lane";
 
 const DEFAULT_ESTIMATE_SIZE_PX = 128;
 const DEFAULT_OVERSCAN = 8;
@@ -47,8 +48,16 @@ const KANBAN_CELL_ACCENT_ACTIVE_ALPHA = 22;
  *  still reads as the drag-over affordance rather than more background tint. */
 const KANBAN_CELL_ACCENT_ACTIVE_RING_ALPHA = 55;
 
+/** The neutral resting surface, in one place: a pinned action repaints it
+ *  over an opaque base, and the two must read as one surface. */
+const KANBAN_CELL_SURFACE_CLASS = "bg-muted/20";
+/** A caller's own surface (an explicit colour, or the accent wash), published
+ *  so a pinned action can repaint that one instead. */
+const KANBAN_CELL_SURFACE_VAR = "--kanban-cell-surface" as const;
+
 type KanbanCellStyle = CSSProperties & {
   [KANBAN_CELL_ACCENT_VAR]?: string;
+  [KANBAN_CELL_SURFACE_VAR]?: string;
 };
 
 const retainActiveSortableIndex = (
@@ -111,6 +120,19 @@ export type KanbanVirtualCellProps<TRow> = {
    */
   accent?: OptionColor | undefined;
   footer?: ReactNode;
+  /**
+   * Where the `footer` sits. `"end"` closes the cell after its rows.
+   * `"sticky-start"` puts it first and pins it to the top of the scroll
+   * container the cell lives in, so the action stays reachable through a
+   * lane hundreds of cards tall and releases where the lane ends.
+   *
+   * The offset comes from `KANBAN_STICKY_TOP_VAR`, which the board publishes
+   * for its own sticky header. A cell that keeps its bounded surface is its
+   * own scroll container, and the board's header means nothing inside it:
+   * reset the variable to `0px` on such a cell (`[--kanban-sticky-top:0px]`)
+   * so the action rests at the cell's own top.
+   */
+  footerPlacement?: "end" | "sticky-start" | undefined;
   estimateSize?: number | undefined;
   overscan?: number | undefined;
   loadMoreThreshold?: number | undefined;
@@ -129,6 +151,7 @@ export const KanbanVirtualCell = <TRow,>({
   backgroundColor,
   accent,
   footer,
+  footerPlacement = "end",
   estimateSize = DEFAULT_ESTIMATE_SIZE_PX,
   overscan = DEFAULT_OVERSCAN,
   loadMoreThreshold = DEFAULT_LOAD_MORE_THRESHOLD_PX,
@@ -214,11 +237,13 @@ export const KanbanVirtualCell = <TRow,>({
     active && accentVariants !== undefined
       ? `0 0 0 2px color-mix(in srgb, var(${KANBAN_CELL_ACCENT_VAR}) ${KANBAN_CELL_ACCENT_ACTIVE_RING_ALPHA}%, transparent)`
       : undefined;
+  const surface = backgroundColor ?? accentBackground;
   const style: KanbanCellStyle | undefined =
-    backgroundColor === undefined && accentVariants === undefined
+    surface === undefined
       ? undefined
       : {
-          backgroundColor: backgroundColor ?? accentBackground,
+          backgroundColor: surface,
+          [KANBAN_CELL_SURFACE_VAR]: surface,
           ...(activeAccentRing === undefined
             ? undefined
             : { boxShadow: activeAccentRing }),
@@ -227,10 +252,36 @@ export const KanbanVirtualCell = <TRow,>({
             : { [KANBAN_CELL_ACCENT_VAR]: accentVariants.color }),
         };
 
+  // The resting surface is translucent unless a caller sets one of their own,
+  // so a pinned action repaints the cell's surface over an opaque base: cards
+  // pass behind the action instead of reading through it. The row keeps the
+  // cards' own bottom padding, so pinning it shifts nothing below.
+  const stickyFooter =
+    footerPlacement === "sticky-start" &&
+    footer !== null &&
+    footer !== undefined ? (
+      <div
+        className={cn("bg-background sticky z-10", KANBAN_STICKY_TOP_CLASS)}
+        data-kanban-cell-footer="sticky-start"
+      >
+        <div
+          className={cn(
+            "pb-2",
+            surface === undefined
+              ? KANBAN_CELL_SURFACE_CLASS
+              : "bg-(--kanban-cell-surface)",
+          )}
+        >
+          {footer}
+        </div>
+      </div>
+    ) : null;
+
   const content = (
     <div
       className={cn(
-        "bg-muted/20 max-h-[min(60vh,40rem)] min-h-20 overflow-y-auto overscroll-y-contain rounded-xl p-2 transition-[background-color,outline-color]",
+        KANBAN_CELL_SURFACE_CLASS,
+        "max-h-[min(60vh,40rem)] min-h-20 overflow-y-auto overscroll-y-contain rounded-xl p-2 transition-[background-color,outline-color]",
         active &&
           accentVariants === undefined &&
           "bg-primary/5 ring-primary/50 ring-2",
@@ -244,6 +295,7 @@ export const KanbanVirtualCell = <TRow,>({
       ref={setScrollElement}
       style={style}
     >
+      {stickyFooter}
       <div className="relative" style={{ height: virtualizer.getTotalSize() }}>
         {virtualizer.getVirtualItems().map((virtualRow) => {
           const row = rows.at(virtualRow.index);
@@ -263,7 +315,7 @@ export const KanbanVirtualCell = <TRow,>({
           );
         })}
       </div>
-      {footer}
+      {footerPlacement === "end" ? footer : null}
     </div>
   );
 


### PR DESCRIPTION
- `KanbanSubgroupBoard` measures its sticky header block (ResizeObserver, zero until measured) and publishes the reach on its scroll container as `KANBAN_STICKY_TOP_VAR` (`--kanban-sticky-top`); the lane `<section>` bounds the controls, so they release where the lane ends.
- New API: `KanbanVirtualCell`'s `footerPlacement?: "end" | "sticky-start"` (default unchanged; pinned rows carry `data-kanban-cell-footer="sticky-start"` on the cell's own surface via `bg-inherit`) and the exported `KanbanCollapsedBandCaption`, which the default collapsed band cell now renders. A cell that keeps its own bounded scroll surface is its own scroll container and resets the offset to `0px`.
- Covered by static-markup tests for the prop, the caption, the data attributes and the variable name, plus a browser spec that scrolls a tall lane and pins the action and caption to the header's bottom until the next lane takes over.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kanban lane actions can remain pinned beneath the board header while scrolling.
  * Collapsed lane captions keep their label and item count visible in tall lanes.
  * Added support for sticky-start footer placement in virtualised Kanban cells.
  * Custom scrollable cells correctly manage their own sticky positioning.

* **Documentation**
  * Added guidance and examples for implementing sticky lane controls.

* **Bug Fixes**
  * Lane controls now transition correctly as users scroll between lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->