### PR TITLE
fix(api): lengthen the constraint swap's lock waits once short ones fail

### DIFF
--- a/apps/api/drizzle/20260902100000_case_law_decision_date_ceiling/migration.sql
+++ b/apps/api/drizzle/20260902100000_case_law_decision_date_ceiling/migration.sql
@@ -23,24 +23,35 @@ SET statement_timeout = '5s';--> statement-breakpoint
 -- `decision-date-bounds-sql.db.test.ts` compares against this file.
 --
 -- Both ALTERs are metadata-only but take ACCESS EXCLUSIVE on a table the
--- ingestion and projection workers write to without pause, so a single 1s
--- lock wait rarely wins it. The block keeps each wait short (a queued ACCESS
--- EXCLUSIVE request stalls every new reader and writer behind it) and retries
--- with jitter until a gap between writer transactions lets the swap through.
--- lock_not_available is what lock_timeout raises. The statement budget is
--- lifted for the block alone: it is the sum of many short waits, not one long
--- statement.
+-- ingestion and projection workers write to without pause, in transactions
+-- that outlast a short lock wait. A queued ACCESS EXCLUSIVE request stalls
+-- every new reader and writer behind it, so the block asks for short waits
+-- first and lengthens them only once short ones have failed: a wait wins as
+-- soon as the transactions in flight when it queued have ended. Every fifth
+-- failure logs who holds the table, for the server log. lock_not_available is
+-- what lock_timeout raises. The statement budget is lifted for the block
+-- alone: it is the sum of many bounded waits, not one long statement.
 --
 -- Re-runnable as a pair: a second run drops the validated constraint, adds it
 -- NOT VALID again, and the online phase validates it again.
-SET statement_timeout = '5min';--> statement-breakpoint
-SET lock_timeout = '2s';--> statement-breakpoint
+SET statement_timeout = '10min';--> statement-breakpoint
 -- stella-migration-safety: reviewed drop-constraint - the same constraint is re-added NOT VALID in the same block with a stricter ceiling; the drop exists only so the expression can change, and no row is written between the two
 DO $$
 DECLARE
   attempts integer := 0;
+  holders text;
 BEGIN
   LOOP
+    attempts := attempts + 1;
+    PERFORM set_config(
+      'lock_timeout',
+      CASE
+        WHEN attempts <= 20 THEN '2s'
+        WHEN attempts <= 30 THEN '10s'
+        ELSE '30s'
+      END,
+      true
+    );
     BEGIN
       ALTER TABLE "case_law_decisions"
         DROP CONSTRAINT IF EXISTS "case_law_decisions_decision_date_bounds";
@@ -56,9 +67,22 @@ BEGIN
       EXIT;
     EXCEPTION
       WHEN lock_not_available THEN
-        attempts := attempts + 1;
-        IF attempts >= 60 THEN
+        IF attempts >= 36 THEN
           RAISE;
+        END IF;
+        IF attempts % 5 = 0 THEN
+          SELECT string_agg(
+                   format('%s %s %s', a.pid, coalesce(a.application_name, '?'),
+                          date_trunc('second', now() - a.xact_start)),
+                   '; ')
+            INTO holders
+            FROM pg_catalog.pg_locks l
+            JOIN pg_catalog.pg_stat_activity a ON a.pid = l.pid
+           WHERE l.relation = 'case_law_decisions'::regclass
+             AND l.granted
+             AND a.pid <> pg_backend_pid();
+          RAISE WARNING 'decision-date ceiling: attempt % could not lock case_law_decisions; holders: %',
+            attempts, coalesce(holders, 'none');
         END IF;
         PERFORM pg_sleep(1 + random() * 2);
     END;

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -85,9 +85,10 @@ const APPROVED_PROCEDURAL_STATEMENTS = new Set([
   // VALIDATE that follows it outside the migrator transaction.
   "20260818090000_case_law_decision_date_bounds/migration.sql:31f2786a7f7aed2d2e55bd3161acad6ad49e606ec1bc75e9235de07cdadd96e0",
   // Retries the decision-date constraint swap on lock_not_available with
-  // short waits: metadata-only DDL on a table the corpus workers write to
-  // without pause.
-  "20260902100000_case_law_decision_date_ceiling/migration.sql:eac25446c58abfad48e38e289fdb1ce5ac6b7a9a2eea210838f6a7f611271642",
+  // waits that lengthen in tiers: metadata-only DDL on a table the corpus
+  // workers write to without pause, in transactions that outlast a short
+  // wait.
+  "20260902100000_case_law_decision_date_ceiling/migration.sql:d799f99eb97532f1f3819aae3e325fcc65d123f2a3bc7b98d4e9f41e417f8491",
   // Fails the Better Auth cutover before any constraint or index state is
   // committed when the trusted issuer backfill is incomplete. The static body
   // performs one bounded existence read and raises; it executes no dynamic SQL.

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -311,15 +311,18 @@ const rewrittenMigrationHistories = {
   // in the file and moved the repair and the validation to the online repair
   // in src/db/decision-date-ceiling-repair.ts, but waited a single second for
   // the swap's ACCESS EXCLUSIVE lock, which the corpus workers' writes never
-  // yielded. 0.8.12 retries the swap with short waits. A database that
-  // applied either earlier file has the same constraint; the online repair
-  // finds nothing to do where the 0.8.10 file ran.
+  // yielded. 0.8.12 retried the swap with 2s waits, sixty of them, and the
+  // workers' transactions outlasted every one. 0.8.13 lengthens the waits in
+  // tiers once short ones have failed. A database that applied any earlier
+  // file has the same constraint; the online repair finds nothing to do
+  // where the 0.8.10 file ran.
   "20260902100000_case_law_decision_date_ceiling": {
     currentHash:
-      "6643de59d34aaeadb0ae79e03e4e209ac6f4a3565b735ec9af4954c1f26389b4",
+      "a8020848968a35595ee1ed952cc5002ca5c821ab567a555bc6a1b509401ee7b3",
     priorHashes: [
       "4540a61248f7d0176954c2a59afc7d697903c8b57e1cb8d60eecc870552a5cf0",
       "4197553d4a7015cd2a6c3c0d2f53399e075f7fc525e4b4a3791fba496d7b009e",
+      "6643de59d34aaeadb0ae79e03e4e209ac6f4a3565b735ec9af4954c1f26389b4",
     ],
     requiredIndexes: [],
   },

--- a/scripts/migration-rehearsal-db.ts
+++ b/scripts/migration-rehearsal-db.ts
@@ -14,15 +14,19 @@
 //
 //   bun scripts/migration-rehearsal-db.ts contend
 //     Writes to the high-volume corpus tables the way production's workers
-//     do while an upgrade runs: one row per table updated in a transaction
-//     held open for a moment, over and over, until the process is killed.
-//     A DDL statement that waits a single short lock_timeout for ACCESS
-//     EXCLUSIVE on such a table fails against this, as it does in
-//     production; one that retries wins a gap. Prints CONTENTION_HELD_LINE
-//     once the first transaction holds its locks, so a caller can wait for
-//     that before it starts the work under test, and exits non-zero if a
-//     write fails. Never run this against a database that matters.
+//     do while an upgrade runs: two sessions, each updating one row per
+//     table in a transaction held open for several seconds, over and over,
+//     staggered by half a hold, until the process is killed. With two
+//     holders out of phase there is never a moment when both end within a
+//     short wait, so DDL that only waits briefly for ACCESS EXCLUSIVE on
+//     such a table cannot win, as in production; DDL that waits longer
+//     wins once the transactions in flight when it queued have ended.
+//     Prints CONTENTION_HELD_LINE once both sessions hold their locks, so a
+//     caller can wait for that before it starts the work under test, and
+//     exits non-zero if a write fails. Never run this against a database
+//     that matters.
 
+import { panic } from "better-result";
 import { SQL } from "bun";
 
 const COMMANDS = ["assert-empty", "contend", "digest"] as const;
@@ -50,11 +54,16 @@ type DigestRow = { digest: string };
 
 /**
  * How long each contending transaction holds its row locks: longer than a
- * short DDL lock wait, the way the corpus workers' batches are, so a
- * migration that only ever waits briefly fails here as it did in production.
+ * short DDL lock wait, the way the corpus workers' batches are.
  */
 const CONTENTION_HOLD_MS = 5000;
-/** Printed once the first contending transaction holds its locks. */
+/**
+ * Two holders half a hold out of phase: whenever one is about to commit the
+ * other has half a hold left, so a wait shorter than that never finds both
+ * gone at once.
+ */
+const CONTENDERS = 2;
+/** Printed once every contending session holds its locks. */
 const CONTENTION_HELD_LINE = "contending: locks held";
 /** Tables production's workers write to continuously, with a no-op touch. */
 const CONTENDED_UPDATES = [
@@ -63,23 +72,43 @@ const CONTENDED_UPDATES = [
 ] as const;
 
 /**
- * One held transaction after another, until the process is killed.
- * Recursive rather than a loop with an awaited body: each transaction must
- * commit before the next begins, so the sequencing is structural. The
- * readiness line goes out after the first transaction's updates have
- * acquired their locks, never before.
+ * One held transaction after another on one session, until the process is
+ * killed. Recursive rather than a loop with an awaited body: each
+ * transaction must commit before the next begins, so the sequencing is
+ * structural. `onHeld` fires once, after the first transaction's updates
+ * have acquired their locks, never before.
  */
 const contendForever = async (
   connection: SQL,
-  announced = false,
+  onHeld: (() => void) | null,
 ): Promise<never> => {
   await connection.unsafe(`BEGIN; ${CONTENDED_UPDATES.join("; ")};`);
-  if (!announced) {
-    console.log(CONTENTION_HELD_LINE);
-  }
+  onHeld?.();
   await Bun.sleep(CONTENTION_HOLD_MS);
   await connection.unsafe("COMMIT");
-  return await contendForever(connection, true);
+  return await contendForever(connection, null);
+};
+
+/** Every contender, staggered, announced together once all hold. */
+const contendWithAll = async (databaseUrl: string): Promise<never> => {
+  let held = 0;
+  const onHeld = () => {
+    held += 1;
+    if (held === CONTENDERS) {
+      console.log(CONTENTION_HELD_LINE);
+    }
+  };
+  const chains = Array.from({ length: CONTENDERS }, async (_, index) => {
+    await Bun.sleep((CONTENTION_HOLD_MS * index) / CONTENDERS);
+    const connection = new SQL({
+      url: databaseUrl,
+      max: 1,
+      connectionTimeout: 30,
+    });
+    return await contendForever(connection, onHeld);
+  });
+  await Promise.all(chains);
+  return panic("contenders never return");
 };
 
 const client = new SQL({ url, max: 1, connectionTimeout: 30 });
@@ -97,7 +126,7 @@ try {
   await client.unsafe("SET statement_timeout = '10min'");
 
   if (command === "contend") {
-    await contendForever(client);
+    await contendWithAll(url);
   }
 
   if (command === "assert-empty") {

--- a/scripts/migration-rehearsal-db.ts
+++ b/scripts/migration-rehearsal-db.ts
@@ -48,8 +48,12 @@ if (!url) {
 type CountRow = { count: number };
 type DigestRow = { digest: string };
 
-/** How long each contending transaction holds its row lock. */
-const CONTENTION_HOLD_MS = 1500;
+/**
+ * How long each contending transaction holds its row locks: longer than a
+ * short DDL lock wait, the way the corpus workers' batches are, so a
+ * migration that only ever waits briefly fails here as it did in production.
+ */
+const CONTENTION_HOLD_MS = 5000;
 /** Printed once the first contending transaction holds its locks. */
 const CONTENTION_HELD_LINE = "contending: locks held";
 /** Tables production's workers write to continuously, with a no-op touch. */


### PR DESCRIPTION
## What

The v0.8.12 promotion ran the retrying constraint swap from #2886 and lost all sixty 2 s waits for `ACCESS EXCLUSIVE` on `case_law_decisions` (one migrate task, 4 min 45 s). The corpus-projection worker's transactions outlast a short wait, and a queued request only wins once the transactions in flight when it queued have ended.

- The swap now waits 2 s for twenty attempts, then 10 s for ten, then 30 s for six (bounded: a queued `ACCESS EXCLUSIVE` request stalls every new reader and writer behind it, so long waits come only after short ones have failed). The block's statement budget is 10 min.
- Every fifth failure logs the pids, application names, and transaction ages holding the table, so the server log names the holder if the swap still cannot win.
- `migration-history.ts` accepts the v0.8.12 form as a prior hash; the migration-lint fingerprint is updated.
- The rehearsal's contending writer holds its locks for 5 s, past the first tier, so a swap that only waits briefly fails in CI the way it failed in production; the escalating swap won against it in 9 s locally.

## Checks

- `decision-date-ceiling-repair.db.test.ts`, `decision-date-bounds-sql.db.test.ts`, `migration-concurrent-index.test.ts`, `migration-history.property.test.ts`; `check-migrations.sh`; oxlint.
- Local Postgres 18 with the 5 s writer: swap block completed in 9.04 s.
- This PR's CI runs the rehearsal from v0.8.8 with the 5 s writer.