### PR TITLE
feat(ui): keep a card's identity row visible while the card scrolls

### DIFF
--- a/.changeset/kanban-card-sticky-header.md
+++ b/.changeset/kanban-card-sticky-header.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+A card taller than the board it scrolls through keeps saying which card it is. `KanbanCardShell` takes a `stickyHeader` slot: whatever identifies the card (a code, a title) leads the card, pins under the chrome above it while the rest of the card passes behind it, and releases where the card ends, so the next card's row takes over. The slot is marked `data-kanban-card-sticky-header=""`, repaints the card's own surface over the card's own divider weight, and a card given none renders exactly as before. `KanbanVirtualCell` composes the offset the row rests at: the board's own `KANBAN_STICKY_TOP_VAR` plus the measured height of the cell's pinned action, published per row as `KANBAN_CARD_STICKY_TOP_VAR` (`--kanban-card-sticky-top`) with the virtualizer's own translation taken back out, since a transform between a sticky box and its scroll container is resolved in the translated space.

--- a/packages/ui/src/kanban/card-shell.test.tsx
+++ b/packages/ui/src/kanban/card-shell.test.tsx
@@ -1,0 +1,85 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { KanbanCardShell } from "./card-shell";
+import { KANBAN_CARD_STICKY_TOP_CLASS } from "./sticky-lane";
+
+// Static markup carries no layout; where the pinned row actually comes to rest
+// is the browser suite's job. These pin the markup that suite depends on.
+
+describe("KanbanCardShell sticky header", () => {
+  test("renders no pinned row by default", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell>
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+
+    expect(markup).not.toContain("data-kanban-card-sticky-header");
+    expect(markup).not.toContain("sticky");
+  });
+
+  test("leads the card with the identity row", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell stickyHeader={<span>ACME-1</span>}>
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+
+    expect(markup).toContain('data-kanban-card-sticky-header=""');
+    expect(markup).toContain(KANBAN_CARD_STICKY_TOP_CLASS);
+    // The card passes behind the row: its own surface, over the card's own
+    // divider weight.
+    expect(markup).toContain("bg-card sticky");
+    expect(markup).toContain("border-b");
+    expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("body"));
+  });
+
+  test("takes no stacking layer the actions overlay would have to outrank", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell
+        actions={<button type="button">More</button>}
+        stickyHeader={<span>ACME-1</span>}
+      >
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+
+    // Callers anchor `actions` to the same corner with no layer of its own, so
+    // a layer here would paint the row over the trigger and swallow its clicks.
+    // Positioned already beats the card's flow content; tree order does the
+    // rest, and the row renders first.
+    expect(markup).not.toContain("z-[");
+    expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("More"));
+  });
+
+  test("keeps the row ahead of the children a card that opens renders", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell
+        actions={<button type="button">More</button>}
+        onOpen={() => undefined}
+        stickyHeader={<span>ACME-1</span>}
+      >
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+
+    expect(markup).toContain('role="button"');
+    expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("body"));
+    expect(markup.indexOf("body")).toBeLessThan(markup.indexOf("More"));
+  });
+
+  test("never clips the card that bounds the pinned row", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell stickyHeader={<span>ACME-1</span>}>
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+
+    // Clipping anywhere between the row and the board's scroll container ends
+    // the pinning outright, so the shell's own chrome must not introduce any.
+    expect(markup).not.toContain("overflow-hidden");
+    expect(markup).not.toContain("overflow-clip");
+  });
+});

--- a/packages/ui/src/kanban/card-shell.tsx
+++ b/packages/ui/src/kanban/card-shell.tsx
@@ -2,11 +2,23 @@ import type { ReactNode, RefObject } from "react";
 
 import { containedEventHandler } from "../hooks/use-contained-handler";
 import { cn } from "../lib/utils";
+import { KANBAN_CARD_STICKY_TOP_CLASS } from "./sticky-lane";
 
 export type KanbanCardShellProps = {
   children: ReactNode;
   /** Overlay slot pinned to the top-end corner (row actions). */
   actions?: ReactNode;
+  /**
+   * The card's identity row: whatever says which card this is, held at the top
+   * of the card while the card scrolls past under it, and released where the
+   * card ends. A card taller than the viewport otherwise loses its own name
+   * halfway down. Omit it and the card renders exactly as it did before.
+   *
+   * Booleans are excluded so `condition && <Row />` cannot reach the slot: a
+   * `false` React renders as nothing would still leave the row's divider and
+   * spacing behind. Write the absent case as `condition ? <Row /> : null`.
+   */
+  stickyHeader?: Exclude<ReactNode, boolean>;
   /** Marks the card whose detail is currently open. */
   active?: boolean | undefined;
   /**
@@ -30,10 +42,14 @@ export type KanbanCardShellProps = {
  * three near-identical copies of this markup, differing only in whether the
  * card opened anything, which is why opening is a prop rather than a branch at
  * each call site.
+ *
+ * Nothing here clips its overflow: a pinned identity row stops sticking the
+ * moment anything between it and the scroll container clips.
  */
 export const KanbanCardShell = ({
   children,
   actions,
+  stickyHeader,
   active,
   onOpen,
   bodyRef,
@@ -42,6 +58,14 @@ export const KanbanCardShell = ({
 }: KanbanCardShellProps) => {
   const body = (
     <>
+      {stickyHeader === undefined || stickyHeader === null ? null : (
+        <div
+          className={cn(STICKY_HEADER_CLASS, KANBAN_CARD_STICKY_TOP_CLASS)}
+          data-kanban-card-sticky-header=""
+        >
+          {stickyHeader}
+        </div>
+      )}
       {children}
       {actions}
     </>
@@ -93,3 +117,15 @@ const CARD_CLASS =
   "bg-card relative block w-full rounded-lg border p-3 text-start shadow-xs";
 
 const ACTIVE_CLASS = "ring-primary/30 ring-2";
+
+/**
+ * The card's own surface repeated on the pinned row, so the rest of the card
+ * passes behind it instead of reading through it, ruled off with the card's own
+ * border weight.
+ *
+ * No `z-index`: being positioned is already enough to paint over the card's
+ * flow content, and taking a layer would put the row over the `actions`
+ * overlay, which callers anchor to the same corner with no layer of its own.
+ * Tree order settles the rest, and the row renders before `actions`.
+ */
+const STICKY_HEADER_CLASS = "bg-card sticky mb-2 border-b pb-2";

--- a/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
+++ b/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+const fixturePath = "/src/kanban/fixtures/card-sticky-header.fixture.html";
+
+/** Sub-pixel layout rounding, not a row that drifted off what pinned it. */
+const TOLERANCE_PX = 1;
+
+const openFixture = async (page: Page) => {
+  await page.goto(fixturePath);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () =>
+            document.documentElement.dataset["kanbanCardStickyHeaderReady"] ??
+            "",
+        ),
+    )
+    .toBe("true");
+  return page.locator(".fixture-board");
+};
+
+const topOf = async (locator: Locator) =>
+  await locator.evaluate((element) => element.getBoundingClientRect().top);
+
+const bottomOf = async (locator: Locator) =>
+  await locator.evaluate((element) => element.getBoundingClientRect().bottom);
+
+const scrollTo = async (board: Locator, top: number) => {
+  await board.evaluate((element, value) => {
+    element.scrollTop = value;
+  }, top);
+  await board.page().evaluate(async () => {
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        resolve(null);
+      });
+    });
+  });
+};
+
+const card = (page: Page, id: string) => page.locator(`[data-card="${id}"]`);
+
+const headerOf = (page: Page, id: string) =>
+  card(page, id).locator("[data-kanban-card-sticky-header]");
+
+/** The lane's own pinned action: what a card's header comes to rest under. */
+const pinnedAction = (page: Page) =>
+  page.locator('[data-kanban-cell-footer="sticky-start"]').first();
+
+/** Resting where it was pinned: the row's top edge is the action's bottom. */
+const expectRestingOnAction = async (header: Locator, actionBottom: number) => {
+  expect(Math.abs((await topOf(header)) - actionBottom)).toBeLessThanOrEqual(
+    TOLERANCE_PX,
+  );
+};
+
+test.describe("card sticky header", () => {
+  test("holds a card's identity row under the lane's pinned action", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const action = pinnedAction(page);
+    const first = headerOf(page, "card-1");
+
+    // Unscrolled, the row sits where its card starts: below the action, not
+    // on it.
+    expect(await topOf(first)).toBeGreaterThan(await bottomOf(action));
+
+    // Mid-way down a card taller than the board's viewport.
+    await scrollTo(board, 300);
+    await expectRestingOnAction(first, await bottomOf(action));
+
+    // The card passes behind the row rather than reading through it.
+    const background = await first.evaluate(
+      (element) => getComputedStyle(element).backgroundColor,
+    );
+
+    expect(background).not.toBe("rgba(0, 0, 0, 0)");
+    expect(background).not.toContain("/");
+  });
+
+  test("releases the row where its card ends and hands over to the next", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const action = pinnedAction(page);
+    const first = headerOf(page, "card-1");
+    const second = headerOf(page, "card-2");
+
+    const boardTop = await topOf(board);
+    const secondTop = await topOf(card(page, "card-2"));
+    // Well inside the second card, so the first one is behind us.
+    await scrollTo(board, secondTop - boardTop + 300);
+
+    const actionBottom = await bottomOf(action);
+
+    // The card that ended took its row with it...
+    expect(await topOf(first)).toBeLessThan(actionBottom);
+    // ...and the card now under the action holds its own.
+    await expectRestingOnAction(second, actionBottom);
+  });
+
+  test("leaves the card's actions overlay on top of the row", async ({
+    page,
+  }) => {
+    await openFixture(page);
+    const actions = page.locator('[data-card-actions="card-1"]');
+
+    // At rest the row leads the very corner the overlay is anchored to, so a
+    // stacking layer on the row would paint over the trigger and take its
+    // clicks.
+    const hit = await actions.evaluate((element) => {
+      const { left, top, width, height } = element.getBoundingClientRect();
+      return element.contains(
+        document.elementFromPoint(left + width / 2, top + height / 2),
+      );
+    });
+
+    expect(hit).toBe(true);
+  });
+
+  test("keeps the row with its card while the card is the drag source", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const first = card(page, "card-1");
+    const header = headerOf(page, "card-1");
+
+    await scrollTo(board, 300);
+    const pinnedTop = await topOf(header);
+
+    // The transform `useKanbanSortable` puts on the active drag source. The
+    // row must ride with the card instead of staying behind on the action.
+    await first.evaluate((element) => {
+      element.style.transform = "translate3d(0px, -80px, 0)";
+    });
+    await scrollTo(board, 300);
+
+    expect(
+      Math.abs((await topOf(header)) - (pinnedTop - 80)),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+  });
+});

--- a/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.css
+++ b/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.css
@@ -1,0 +1,3 @@
+@import "tailwindcss";
+@import "../../styles/theme.css";
+@source "../../";

--- a/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.html
+++ b/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Card sticky header fixture</title>
+    <link rel="stylesheet" href="./card-sticky-header.fixture.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./card-sticky-header.fixture.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.tsx
@@ -1,0 +1,115 @@
+import { useEffect } from "react";
+import { createRoot } from "react-dom/client";
+
+import { KanbanCardShell } from "../card-shell";
+import { KanbanCellAction } from "../cell-action";
+import { resolveKanbanGrouping } from "../grouping";
+import type { KanbanSchema } from "../grouping";
+import { buildKanbanBoardMatrix } from "../matrix";
+import { KanbanSubgroupBoard } from "../subgroup-board";
+import { KanbanVirtualCell } from "../virtual-cell";
+
+type Row = { id: string };
+type Property = { id: string };
+
+const schema: KanbanSchema<Row, Property> = {
+  builtInGroups: [
+    { id: "_status", options: [{ label: "Open", value: "open" }] },
+  ],
+  getPropertyId: ({ id }) => id,
+  getPropertyOptions: ({ id }) =>
+    id === "owner" ? [{ label: "Ada", value: "ada" }] : null,
+  properties: [{ id: "owner" }],
+};
+
+// Each card is taller than the board's viewport, so a scroll always rests
+// inside one of them: exactly the case a card's identity row has to survive.
+const rows: Row[] = Array.from({ length: 4 }, (_, index) => ({
+  id: `card-${String(index + 1)}`,
+}));
+
+const matrix = buildKanbanBoardMatrix({
+  group: resolveKanbanGrouping({ groupBy: "_status", schema }),
+  subgroup: resolveKanbanGrouping({ groupBy: "owner", schema }),
+  rows,
+  uncategorizedLabel: "No value",
+  resolveGroupValue: ({ grouping }) =>
+    grouping.type === "built-in" ? "open" : "ada",
+});
+
+const CardStickyHeaderFixture = () => {
+  useEffect(() => {
+    document.documentElement.dataset["kanbanCardStickyHeaderReady"] = "true";
+    return () => {
+      delete document.documentElement.dataset["kanbanCardStickyHeaderReady"];
+    };
+  }, []);
+
+  return (
+    <div className="h-[420px]">
+      <KanbanSubgroupBoard
+        className="fixture-board"
+        isBandCollapsed={() => false}
+        isLaneCollapsed={() => false}
+        matrix={matrix}
+        renderCell={({ cell }) => (
+          <KanbanVirtualCell
+            // The lane, not the cell, owns the scroll here: the board's header
+            // and the cell's pinned action both sit above the cards.
+            className="max-h-none overflow-y-visible"
+            estimateSize={600}
+            footer={<KanbanCellAction>Add card</KanbanCellAction>}
+            footerPlacement="sticky-start"
+            getRowKey={(row) => row.id}
+            pagination={{ type: "none" }}
+            renderRow={(row) => (
+              <div data-card={row.id}>
+                <KanbanCardShell
+                  // The overlay slot callers anchor to the same corner the
+                  // identity row leads: it has to stay on top of the row.
+                  actions={
+                    <div className="absolute end-1.5 top-1.5">
+                      <button data-card-actions={row.id} type="button">
+                        More
+                      </button>
+                    </div>
+                  }
+                  className="h-[600px]"
+                  stickyHeader={
+                    <div
+                      className="text-xs font-medium"
+                      data-card-title={row.id}
+                    >
+                      {row.id}
+                    </div>
+                  }
+                >
+                  <p className="text-muted-foreground text-xs">
+                    A card far taller than the board it scrolls through.
+                  </p>
+                </KanbanCardShell>
+              </div>
+            )}
+            rows={cell.rows}
+          />
+        )}
+        renderColumnHeader={({ column }) => (
+          <div className="text-sm font-medium">
+            {column.type === "group" ? column.group.label : "Other"}
+          </div>
+        )}
+        renderLaneIdentity={({ group }) => (
+          <span data-lane={group.value}>{group.label}</span>
+        )}
+        onBandCollapsedChange={() => undefined}
+        onLaneCollapsedChange={() => undefined}
+      />
+    </div>
+  );
+};
+
+const root = document.querySelector("#root");
+
+if (root) {
+  createRoot(root).render(<CardStickyHeaderFixture />);
+}

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -137,6 +137,7 @@ export {
 export { KanbanSubgroupBoard } from "./subgroup-board";
 export type { KanbanCollapsedBandCaptionProps } from "./sticky-lane";
 export {
+  KANBAN_CARD_STICKY_TOP_VAR,
   KANBAN_STICKY_TOP_VAR,
   KanbanCollapsedBandCaption,
 } from "./sticky-lane";

--- a/packages/ui/src/kanban/sticky-lane.test.tsx
+++ b/packages/ui/src/kanban/sticky-lane.test.tsx
@@ -3,9 +3,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "bun:test";
 
 import {
+  KANBAN_CARD_STICKY_TOP_CLASS,
+  KANBAN_CARD_STICKY_TOP_VAR,
   KANBAN_STICKY_TOP_CLASS,
   KANBAN_STICKY_TOP_VAR,
   KanbanCollapsedBandCaption,
+  resolveKanbanCardStickyTop,
 } from "./sticky-lane";
 
 describe("KANBAN_STICKY_TOP_VAR", () => {
@@ -15,6 +18,39 @@ describe("KANBAN_STICKY_TOP_VAR", () => {
     // renamed variable that left the utility behind would stick every lane
     // control at the fallback offset instead, silently.
     expect(KANBAN_STICKY_TOP_CLASS).toBe(`top-(${KANBAN_STICKY_TOP_VAR},0px)`);
+  });
+});
+
+describe("KANBAN_CARD_STICKY_TOP_VAR", () => {
+  test("names the property the cell publishes and the card shell reads", () => {
+    expect(KANBAN_CARD_STICKY_TOP_VAR).toBe("--kanban-card-sticky-top");
+    expect(KANBAN_CARD_STICKY_TOP_CLASS).toBe(
+      `top-(${KANBAN_CARD_STICKY_TOP_VAR},0px)`,
+    );
+  });
+});
+
+describe("resolveKanbanCardStickyTop", () => {
+  test("adds the pinned action to the board's own offset", () => {
+    expect(resolveKanbanCardStickyTop({ pinnedAbove: 52, rowOffset: 0 })).toBe(
+      "calc(var(--kanban-sticky-top, 0px) + 52px)",
+    );
+  });
+
+  test("subtracts the translation the row is already carrying", () => {
+    // A row 608px down asks for its offset in its own translated space, so the
+    // browser resolves it to the same place on screen as the first row's.
+    expect(
+      resolveKanbanCardStickyTop({ pinnedAbove: 52, rowOffset: 608 }),
+    ).toBe("calc(var(--kanban-sticky-top, 0px) - 556px)");
+  });
+
+  test("keeps the offset a single signed term", () => {
+    // `calc(var(--x) + -556px)` parses in no engine: the sign has to be the
+    // operator, not part of the value.
+    expect(
+      resolveKanbanCardStickyTop({ pinnedAbove: 0, rowOffset: 556 }),
+    ).not.toContain("+ -");
   });
 });
 

--- a/packages/ui/src/kanban/sticky-lane.tsx
+++ b/packages/ui/src/kanban/sticky-lane.tsx
@@ -24,6 +24,54 @@ export type KanbanStickyTopStyle = CSSProperties & {
   [KANBAN_STICKY_TOP_VAR]?: string;
 };
 
+/**
+ * How far everything already pinned above a card reaches: the board's header
+ * block plus a cell's own pinned action, where the cell pins one. A card taller
+ * than the viewport keeps its identity row visible by sticking at this offset,
+ * so the row comes to rest under the action rather than behind it. The cell
+ * publishes it on each row it renders, because only the cell knows how tall its
+ * own pinned action turned out and how far it translated that row.
+ */
+export const KANBAN_CARD_STICKY_TOP_VAR = "--kanban-card-sticky-top" as const;
+
+/**
+ * Sticks a card's identity row under everything pinned above it. The fallback
+ * keeps the row usable inside a card rendered outside a cell that publishes the
+ * offset, where nothing is pinned above it at all.
+ */
+export const KANBAN_CARD_STICKY_TOP_CLASS =
+  "top-(--kanban-card-sticky-top,0px)";
+
+export type KanbanCardStickyTopStyle = CSSProperties & {
+  [KANBAN_CARD_STICKY_TOP_VAR]?: string;
+};
+
+type ResolveKanbanCardStickyTopOptions = {
+  /** How far the cell's own pinned action reaches, in pixels. */
+  pinnedAbove: number;
+  /** How far the virtualizer translated the row the card sits in, in pixels. */
+  rowOffset: number;
+};
+
+/**
+ * The offset a card's identity row sticks at, in the row's own coordinates.
+ *
+ * A virtualized row is translated into place, and a transform between a sticky
+ * box and its scroll container is resolved in the translated space: asking for
+ * the board's offset there lands the row that far below its card, which parks
+ * it at the card's end instead. Subtracting the translation back out states the
+ * offset in the space the browser actually resolves it in, so every card pins
+ * where the chrome above it ends no matter how far down the lane it is.
+ */
+export const resolveKanbanCardStickyTop = ({
+  pinnedAbove,
+  rowOffset,
+}: ResolveKanbanCardStickyTopOptions) => {
+  const offset = pinnedAbove - rowOffset;
+  const sign = offset < 0 ? "-" : "+";
+  return `calc(var(${KANBAN_STICKY_TOP_VAR}, 0px) ${sign} ${String(Math.abs(offset))}px)`;
+};
+
 export type KanbanCollapsedBandCaptionProps = {
   label: string;
   /** What the folded band stands in for: its count, already formatted. */

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -4,8 +4,10 @@ import {
   type ReactNode,
   type RefObject,
   type UIEvent,
+  useEffect,
   useId,
   useRef,
+  useState,
 } from "react";
 
 import { useDndContext, type UniqueIdentifier } from "@dnd-kit/core";
@@ -28,7 +30,12 @@ import {
   type KanbanVirtualScrollRequest,
   type UseKanbanDropTargetOptions,
 } from "./sortable-interactions";
-import { KANBAN_STICKY_TOP_CLASS } from "./sticky-lane";
+import {
+  KANBAN_CARD_STICKY_TOP_VAR,
+  KANBAN_STICKY_TOP_CLASS,
+  resolveKanbanCardStickyTop,
+  type KanbanCardStickyTopStyle,
+} from "./sticky-lane";
 
 const DEFAULT_ESTIMATE_SIZE_PX = 128;
 const DEFAULT_OVERSCAN = 8;
@@ -131,6 +138,10 @@ export type KanbanVirtualCellProps<TRow> = {
    * own scroll container, and the board's header means nothing inside it:
    * reset the variable to `0px` on such a cell (`[--kanban-sticky-top:0px]`)
    * so the action rests at the cell's own top.
+   *
+   * Either way the cell publishes the total reach of what is pinned above a
+   * card as `KANBAN_CARD_STICKY_TOP_VAR` on every row it renders, so a card's
+   * own sticky header comes to rest under the action rather than behind it.
    */
   footerPlacement?: "end" | "sticky-start" | undefined;
   estimateSize?: number | undefined;
@@ -252,30 +263,52 @@ export const KanbanVirtualCell = <TRow,>({
             : { [KANBAN_CELL_ACCENT_VAR]: accentVariants.color }),
         };
 
+  const hasStickyFooter =
+    footerPlacement === "sticky-start" &&
+    footer !== null &&
+    footer !== undefined;
+
+  // A card's own pinned header rests under this action, so the cell has to say
+  // how tall the action turned out: the caller controls its content, and it
+  // reflows with the cell's width. Zero until measured, and zero whenever the
+  // footer closes the cell instead, which leaves the board's offset alone.
+  const stickyFooterRef = useRef<HTMLDivElement>(null);
+  const [stickyFooterHeight, setStickyFooterHeight] = useState(0);
+  useEffect(() => {
+    const element = stickyFooterRef.current;
+    if (element === null) {
+      setStickyFooterHeight(0);
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => {
+      setStickyFooterHeight(element.getBoundingClientRect().height);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [hasStickyFooter]);
+
   // The resting surface is translucent unless a caller sets one of their own,
   // so a pinned action repaints the cell's surface over an opaque base: cards
   // pass behind the action instead of reading through it. The row keeps the
   // cards' own bottom padding, so pinning it shifts nothing below.
-  const stickyFooter =
-    footerPlacement === "sticky-start" &&
-    footer !== null &&
-    footer !== undefined ? (
+  const stickyFooter = hasStickyFooter ? (
+    <div
+      className={cn("bg-background sticky z-10", KANBAN_STICKY_TOP_CLASS)}
+      data-kanban-cell-footer="sticky-start"
+      ref={stickyFooterRef}
+    >
       <div
-        className={cn("bg-background sticky z-10", KANBAN_STICKY_TOP_CLASS)}
-        data-kanban-cell-footer="sticky-start"
+        className={cn(
+          "pb-2",
+          surface === undefined
+            ? KANBAN_CELL_SURFACE_CLASS
+            : "bg-(--kanban-cell-surface)",
+        )}
       >
-        <div
-          className={cn(
-            "pb-2",
-            surface === undefined
-              ? KANBAN_CELL_SURFACE_CLASS
-              : "bg-(--kanban-cell-surface)",
-          )}
-        >
-          {footer}
-        </div>
+        {footer}
       </div>
-    ) : null;
+    </div>
+  ) : null;
 
   const content = (
     <div
@@ -302,13 +335,20 @@ export const KanbanVirtualCell = <TRow,>({
           if (row === undefined) {
             return null;
           }
+          const rowStyle: KanbanCardStickyTopStyle = {
+            transform: `translateY(${String(virtualRow.start)}px)`,
+            [KANBAN_CARD_STICKY_TOP_VAR]: resolveKanbanCardStickyTop({
+              pinnedAbove: stickyFooterHeight,
+              rowOffset: virtualRow.start,
+            }),
+          };
           return (
             <div
               className="absolute inset-x-0 top-0 pb-2"
               data-index={virtualRow.index}
               key={getRowKey(row)}
               ref={virtualizer.measureElement}
-              style={{ transform: `translateY(${virtualRow.start}px)` }}
+              style={rowStyle}
             >
               {renderRow(row)}
             </div>


### PR DESCRIPTION
- `KanbanCardShell` gains `stickyHeader`: the card's identity row leads the card, pins at `--kanban-card-sticky-top` under the chrome above it (`data-kanban-card-sticky-header=""`, opaque `bg-card` over the card's own divider weight), and releases where the card ends. Omit it and the markup is unchanged; the shell clips no overflow, which would end the pinning.
- `KanbanVirtualCell` publishes that offset on each row: the board's `--kanban-sticky-top` plus its pinned action, measured with a `ResizeObserver`, minus the virtualizer's translation for that row. A transform between a sticky box and its scroll container is resolved in the translated space, so without the subtraction every row past the first parks its header at the end of its card.
- Covered by a browser spec over a lane of cards taller than the viewport (pins on the action's bottom edge, hands over to the next card, rides with a card carrying the drag source's transform) and static-markup tests for the slot and the offset.
