### PR TITLE
feat(db): a corpus schema lane that upgrades take exclusive and batches share

### DIFF
--- a/.oxlint-plugins/no-facade-imports.ts
+++ b/.oxlint-plugins/no-facade-imports.ts
@@ -11,6 +11,7 @@ const ALLOWED_LEAF_IMPORTS = new Set([
   "@/api/db/auth-schema",
   "@/api/db/billing-validators",
   "@/api/db/columns",
+  "@/api/db/corpus-schema-lane",
   "@/api/db/database-relations",
   "@/api/db/json-utils",
   "@/api/db/rls",

--- a/apps/api/src/db/corpus-schema-lane.test.ts
+++ b/apps/api/src/db/corpus-schema-lane.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+
+import { CASE_LAW_MAINTENANCE_LANE } from "@/api/lib/case-law/maintenance-lane";
+
+import {
+  CORPUS_SCHEMA_LANE,
+  CORPUS_SCHEMA_LANE_LOCK_SQL,
+  CORPUS_SCHEMA_LANE_SHARED_XACT_SQL,
+  CORPUS_SCHEMA_LANE_UNLOCK_SQL,
+} from "./corpus-schema-lane";
+
+test("the schema lane is its own key, apart from the operator lane", () => {
+  expect(CORPUS_SCHEMA_LANE.domain).toBe(CASE_LAW_MAINTENANCE_LANE.domain);
+  expect(CORPUS_SCHEMA_LANE.lane).not.toBe(CASE_LAW_MAINTENANCE_LANE.lane);
+});
+
+test("the shared side is transaction-scoped and the exclusive side is a session pair", () => {
+  const key = `hashtext('${CORPUS_SCHEMA_LANE.domain}'), hashtext('${CORPUS_SCHEMA_LANE.lane}')`;
+  expect(CORPUS_SCHEMA_LANE_SHARED_XACT_SQL).toBe(
+    `SELECT pg_advisory_xact_lock_shared(${key})`,
+  );
+  expect(CORPUS_SCHEMA_LANE_LOCK_SQL).toBe(`SELECT pg_advisory_lock(${key})`);
+  expect(CORPUS_SCHEMA_LANE_UNLOCK_SQL).toBe(
+    `SELECT pg_advisory_unlock(${key})`,
+  );
+});

--- a/apps/api/src/db/corpus-schema-lane.test.ts
+++ b/apps/api/src/db/corpus-schema-lane.test.ts
@@ -117,3 +117,33 @@ test("a batch that outlives its budget fails instead of entering the lane late",
   });
   expect(ran).toBe(false);
 });
+
+test("a budget that is not a multiple of the retry pause is honoured exactly", async () => {
+  const granted = scriptedDatabase([false, false, true]);
+  const sleeps: number[] = [];
+  const value = await runUnderCorpusSchemaLane({
+    database: granted.database,
+    work: async () => "done",
+    laneWaitMs: 300,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  expect(value).toBe("done");
+  // The second pause is cut to the 50 ms left, so the last try lands on the
+  // budget, never past it.
+  expect(sleeps).toEqual([CORPUS_SCHEMA_LANE_RETRY_MS, 50]);
+
+  const refused = scriptedDatabase([false, false, false]);
+  const rejection: unknown = await runUnderCorpusSchemaLane({
+    database: refused.database,
+    work: async () => "done",
+    laneWaitMs: 300,
+    sleep: async () => {},
+  }).then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(rejection).toMatchObject({ waitedMs: 300 });
+  expect(refused.attempts.filter((step) => step === "begin")).toHaveLength(3);
+});

--- a/apps/api/src/db/corpus-schema-lane.test.ts
+++ b/apps/api/src/db/corpus-schema-lane.test.ts
@@ -5,8 +5,9 @@ import { CASE_LAW_MAINTENANCE_LANE } from "@/api/lib/case-law/maintenance-lane";
 import {
   CORPUS_SCHEMA_LANE,
   CORPUS_SCHEMA_LANE_LOCK_SQL,
-  CORPUS_SCHEMA_LANE_SHARED_XACT_SQL,
+  CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
   CORPUS_SCHEMA_LANE_UNLOCK_SQL,
+  isCorpusSchemaLaneGranted,
 } from "./corpus-schema-lane";
 
 test("the schema lane is its own key, apart from the operator lane", () => {
@@ -14,13 +15,24 @@ test("the schema lane is its own key, apart from the operator lane", () => {
   expect(CORPUS_SCHEMA_LANE.lane).not.toBe(CASE_LAW_MAINTENANCE_LANE.lane);
 });
 
-test("the shared side is transaction-scoped and the exclusive side is a session pair", () => {
+test("the shared side is a transaction-scoped try and the exclusive side is a session pair", () => {
   const key = `hashtext('${CORPUS_SCHEMA_LANE.domain}'), hashtext('${CORPUS_SCHEMA_LANE.lane}')`;
-  expect(CORPUS_SCHEMA_LANE_SHARED_XACT_SQL).toBe(
-    `SELECT pg_advisory_xact_lock_shared(${key})`,
+  // A try, never a wait: a transaction blocked on the lane would hold a
+  // snapshot that a concurrent index build in the upgrade waits on.
+  expect(CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL).toBe(
+    `SELECT pg_try_advisory_xact_lock_shared(${key}) AS "granted"`,
   );
   expect(CORPUS_SCHEMA_LANE_LOCK_SQL).toBe(`SELECT pg_advisory_lock(${key})`);
   expect(CORPUS_SCHEMA_LANE_UNLOCK_SQL).toBe(
     `SELECT pg_advisory_unlock(${key})`,
   );
+});
+
+test("a try result is granted only when its row says so, under either driver shape", () => {
+  expect(isCorpusSchemaLaneGranted([{ granted: true }])).toBe(true);
+  expect(isCorpusSchemaLaneGranted({ rows: [{ granted: true }] })).toBe(true);
+  expect(isCorpusSchemaLaneGranted([{ granted: false }])).toBe(false);
+  expect(isCorpusSchemaLaneGranted([{ granted: "t" }])).toBe(false);
+  expect(isCorpusSchemaLaneGranted([])).toBe(false);
+  expect(isCorpusSchemaLaneGranted(undefined)).toBe(false);
 });

--- a/apps/api/src/db/corpus-schema-lane.test.ts
+++ b/apps/api/src/db/corpus-schema-lane.test.ts
@@ -5,9 +5,12 @@ import { CASE_LAW_MAINTENANCE_LANE } from "@/api/lib/case-law/maintenance-lane";
 import {
   CORPUS_SCHEMA_LANE,
   CORPUS_SCHEMA_LANE_LOCK_SQL,
+  CORPUS_SCHEMA_LANE_RETRY_MS,
   CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
   CORPUS_SCHEMA_LANE_UNLOCK_SQL,
+  CorpusSchemaLaneUnavailableError,
   isCorpusSchemaLaneGranted,
+  runUnderCorpusSchemaLane,
 } from "./corpus-schema-lane";
 
 test("the schema lane is its own key, apart from the operator lane", () => {
@@ -35,4 +38,82 @@ test("a try result is granted only when its row says so, under either driver sha
   expect(isCorpusSchemaLaneGranted([{ granted: "t" }])).toBe(false);
   expect(isCorpusSchemaLaneGranted([])).toBe(false);
   expect(isCorpusSchemaLaneGranted(undefined)).toBe(false);
+});
+
+type FakeTransaction = { execute: (query: string) => Promise<unknown> };
+
+/** A database whose lane answers come from a script. */
+const scriptedDatabase = (grants: readonly boolean[]) => {
+  const remaining = [...grants];
+  const attempts: string[] = [];
+  const database = {
+    transaction: async <TResult>(
+      fn: (tx: FakeTransaction) => Promise<TResult>,
+    ): Promise<TResult> => {
+      attempts.push("begin");
+      const result = await fn({
+        execute: async (query: string) => {
+          attempts.push(query);
+          return [{ granted: remaining.shift() ?? true }];
+        },
+      });
+      attempts.push("commit");
+      return result;
+    },
+  };
+  return { attempts, database };
+};
+
+test("a refused try ends its transaction and sleeps before the next one", async () => {
+  const { attempts, database } = scriptedDatabase([false, false, true]);
+  const sleeps: number[] = [];
+  const value = await runUnderCorpusSchemaLane({
+    database,
+    work: async (tx) => {
+      await tx.execute("UPDATE case_law_decisions SET x = 1");
+      return "done";
+    },
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  expect(value).toBe("done");
+  expect(sleeps).toEqual([
+    CORPUS_SCHEMA_LANE_RETRY_MS,
+    CORPUS_SCHEMA_LANE_RETRY_MS,
+  ]);
+  // Two empty transactions, then the one that holds the lane and does work.
+  expect(attempts).toEqual([
+    "begin",
+    CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
+    "commit",
+    "begin",
+    CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
+    "commit",
+    "begin",
+    CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
+    "UPDATE case_law_decisions SET x = 1",
+    "commit",
+  ]);
+});
+
+test("a batch that outlives its budget fails instead of entering the lane late", async () => {
+  const { database } = scriptedDatabase([false, false, false, false]);
+  let ran = false;
+  const rejection: unknown = await runUnderCorpusSchemaLane({
+    database,
+    work: async () => {
+      ran = true;
+    },
+    laneWaitMs: CORPUS_SCHEMA_LANE_RETRY_MS * 2,
+    sleep: async () => {},
+  }).then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(rejection).toBeInstanceOf(CorpusSchemaLaneUnavailableError);
+  expect(rejection).toMatchObject({
+    waitedMs: CORPUS_SCHEMA_LANE_RETRY_MS * 2,
+  });
+  expect(ran).toBe(false);
 });

--- a/apps/api/src/db/corpus-schema-lane.ts
+++ b/apps/api/src/db/corpus-schema-lane.ts
@@ -9,15 +9,23 @@
  * long wait stalls every reader queued behind it. Retrying with longer waits
  * shifts the odds; it does not remove the race.
  *
- * The lane removes it. Every corpus batch transaction takes the lane SHARED
- * for its duration (`takeCorpusSchemaLaneSharedSql`, applied by
- * `createIngestionDb`, the write boundary every corpus writer goes through).
- * The migrate entrypoint takes the lane EXCLUSIVE for the whole upgrade
- * (`CORPUS_SCHEMA_LANE_LOCK_SQL`). PostgreSQL grants lock requests in
- * queue order: the exclusive request waits for the batches in flight when it
- * queued, new batches wait behind it at their own boundary, and once it is
- * granted no corpus transaction is open, so DDL wins its table lock at once
- * with a short wait. Batches resume when the upgrade releases the lane.
+ * The lane removes it. Every corpus batch transaction holds the lane SHARED
+ * for its duration (applied by `createIngestionDb`, the write boundary every
+ * corpus writer goes through). The migrate entrypoint takes the lane
+ * EXCLUSIVE for the whole upgrade (`CORPUS_SCHEMA_LANE_LOCK_SQL`), which
+ * waits for the batches in flight; once it is granted no corpus transaction
+ * is open, so DDL wins its table lock at once with a short wait. Batches
+ * resume when the upgrade releases the lane.
+ *
+ * A batch never *waits* for the lane inside a transaction. A transaction
+ * blocked on a lock still holds its snapshot, and a concurrent index build
+ * in the upgrade waits for every older snapshot to end: the build would wait
+ * for the batch, and the batch for the build's lane, a deadlock PostgreSQL
+ * resolves by aborting one side. So a batch *tries* the lane
+ * (`CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL`), and when refused it ends its
+ * empty transaction, sleeps, and tries again; nothing of it outlives the
+ * attempt. PostgreSQL queues lock requests, so a try is refused as soon as
+ * an exclusive request is waiting, which is what lets the upgrade drain.
  *
  * Distinct from the operator scripts' maintenance lane
  * (`lib/case-law/maintenance-lane.ts`), which serializes whole operator runs
@@ -37,16 +45,42 @@ export const CORPUS_SCHEMA_LANE = {
 const KEY_SQL = `hashtext('${CORPUS_SCHEMA_LANE.domain}'), hashtext('${CORPUS_SCHEMA_LANE.lane}')`;
 
 /**
- * Take the lane shared for the current transaction. Released at commit or
- * rollback; there is nothing to unlock by hand.
+ * Try the lane shared for the current transaction; one row, `granted`
+ * boolean. Held until commit or rollback when granted.
  */
-export const CORPUS_SCHEMA_LANE_SHARED_XACT_SQL = `SELECT pg_advisory_xact_lock_shared(${KEY_SQL})`;
+export const CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL = `SELECT pg_try_advisory_xact_lock_shared(${KEY_SQL}) AS "granted"`;
+
+/** How long a refused batch sleeps, outside any transaction, before trying again. */
+export const CORPUS_SCHEMA_LANE_RETRY_MS = 250;
 
 /**
  * Take the lane exclusive for the session. Blocks until every shared holder
  * has committed; pair with `CORPUS_SCHEMA_LANE_UNLOCK_SQL` on the same
- * connection, and let the session end release it on any other exit.
+ * connection, and let the session end release it on any other exit. The
+ * holder waits with nothing else held, so it cannot deadlock.
  */
 export const CORPUS_SCHEMA_LANE_LOCK_SQL = `SELECT pg_advisory_lock(${KEY_SQL})`;
 
 export const CORPUS_SCHEMA_LANE_UNLOCK_SQL = `SELECT pg_advisory_unlock(${KEY_SQL})`;
+
+/** Whether a try-lock result (either driver shape) reports the lane granted. */
+export const isCorpusSchemaLaneGranted = (result: unknown): boolean => {
+  let rows: unknown[] = [];
+  if (Array.isArray(result)) {
+    rows = result;
+  } else if (
+    typeof result === "object" &&
+    result !== null &&
+    "rows" in result &&
+    Array.isArray(result.rows)
+  ) {
+    rows = result.rows;
+  }
+  const row: unknown = rows.at(0);
+  return (
+    typeof row === "object" &&
+    row !== null &&
+    "granted" in row &&
+    row.granted === true
+  );
+};

--- a/apps/api/src/db/corpus-schema-lane.ts
+++ b/apps/api/src/db/corpus-schema-lane.ts
@@ -172,15 +172,19 @@ export const runUnderCorpusSchemaLane = async <
   if (outcome !== LANE_BUSY) {
     return outcome.value;
   }
-  if (waitedMs >= laneWaitMs) {
+  // The budget is the caller's, so the last pause ends exactly on it: a try
+  // never starts past the budget, and the failure names the budget spent.
+  const remainingMs = laneWaitMs - waitedMs;
+  if (remainingMs <= 0) {
     throw new CorpusSchemaLaneUnavailableError({
       message: `The corpus schema lane stayed unavailable for ${String(waitedMs)}ms; an upgrade is holding it`,
       waitedMs,
     });
   }
-  await sleep(CORPUS_SCHEMA_LANE_RETRY_MS);
+  const sleepMs = Math.min(CORPUS_SCHEMA_LANE_RETRY_MS, remainingMs);
+  await sleep(sleepMs);
   return await runUnderCorpusSchemaLane(
     { database, work, laneWaitMs, sleep },
-    waitedMs + CORPUS_SCHEMA_LANE_RETRY_MS,
+    waitedMs + sleepMs,
   );
 };

--- a/apps/api/src/db/corpus-schema-lane.ts
+++ b/apps/api/src/db/corpus-schema-lane.ts
@@ -10,31 +10,38 @@
  * shifts the odds; it does not remove the race.
  *
  * The lane removes it. Every corpus batch transaction holds the lane SHARED
- * for its duration (applied by `createIngestionDb`, the write boundary every
- * corpus writer goes through). The migrate entrypoint takes the lane
- * EXCLUSIVE for the whole upgrade (`CORPUS_SCHEMA_LANE_LOCK_SQL`), which
- * waits for the batches in flight; once it is granted no corpus transaction
- * is open, so DDL wins its table lock at once with a short wait. Batches
- * resume when the upgrade releases the lane.
+ * for its duration: `createIngestionDb` (the write boundary every worker
+ * goes through) and the operator scripts' write door both run their
+ * transactions through `runUnderCorpusSchemaLane`. The migrate entrypoint
+ * takes the lane EXCLUSIVE for the whole upgrade
+ * (`CORPUS_SCHEMA_LANE_LOCK_SQL`), which waits for the batches in flight;
+ * once it is granted no corpus transaction is open, so DDL wins its table
+ * lock at once with a short wait. Batches resume when the upgrade releases
+ * the lane.
  *
  * A batch never *waits* for the lane inside a transaction. A transaction
  * blocked on a lock still holds its snapshot, and a concurrent index build
  * in the upgrade waits for every older snapshot to end: the build would wait
  * for the batch, and the batch for the build's lane, a deadlock PostgreSQL
- * resolves by aborting one side. So a batch *tries* the lane
- * (`CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL`), and when refused it ends its
- * empty transaction, sleeps, and tries again; nothing of it outlives the
- * attempt. PostgreSQL queues lock requests, so a try is refused as soon as
- * an exclusive request is waiting, which is what lets the upgrade drain.
+ * resolves by aborting one side. So a batch *tries* the lane, and when
+ * refused ends its empty transaction, sleeps, and tries again; nothing of it
+ * outlives the attempt. PostgreSQL queues lock requests, so a try is refused
+ * as soon as an exclusive request is waiting, which is what lets the upgrade
+ * drain. The tries are bounded by the caller's budget: a batch that cannot
+ * enter within it fails with `CorpusSchemaLaneUnavailableError` instead of
+ * polling on after its caller has given up on it.
  *
  * Distinct from the operator scripts' maintenance lane
  * (`lib/case-law/maintenance-lane.ts`), which serializes whole operator runs
  * against each other for hours; a batch must not wait on that.
  *
  * Advisory locks need no grant, so the `stella_ingestion` role can take the
- * shared side. No imports: `migrate.ts` ships as a loose file with no path
- * aliases, and `scoped.ts` must not pull the schema in.
+ * shared side. Only `better-result` is imported: `migrate.ts` ships as a
+ * loose file with no path aliases, and `scoped.ts` must not pull the schema
+ * in.
  */
+
+import { TaggedError } from "better-result";
 
 /** The `(int, int)` key of the lane, as `hashtext` renders the two halves. */
 export const CORPUS_SCHEMA_LANE = {
@@ -52,6 +59,13 @@ export const CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL = `SELECT pg_try_advisory_xa
 
 /** How long a refused batch sleeps, outside any transaction, before trying again. */
 export const CORPUS_SCHEMA_LANE_RETRY_MS = 250;
+
+/**
+ * How long a batch keeps trying when no budget is given: longer than an
+ * upgrade of the corpus tables takes, shorter than a stuck upgrade would
+ * hold the lane before somebody notices.
+ */
+export const CORPUS_SCHEMA_LANE_DEFAULT_WAIT_MS = 20 * 60 * 1000;
 
 /**
  * Take the lane exclusive for the session. Blocks until every shared holder
@@ -82,5 +96,91 @@ export const isCorpusSchemaLaneGranted = (result: unknown): boolean => {
     row !== null &&
     "granted" in row &&
     row.granted === true
+  );
+};
+
+/** A batch that could not enter the lane within its budget. */
+export class CorpusSchemaLaneUnavailableError extends TaggedError(
+  "CorpusSchemaLaneUnavailableError",
+)<{
+  message: string;
+  waitedMs: number;
+}> {}
+
+/** The one thing a lane transaction needs from its transaction handle. */
+export type CorpusSchemaLaneTransaction = {
+  execute: (query: string) => PromiseLike<unknown>;
+};
+
+/** Anything that runs a transaction: a drizzle database, or a stand-in. */
+export type CorpusSchemaLaneDatabase<
+  TTransaction extends CorpusSchemaLaneTransaction,
+> = {
+  transaction: <TResult>(
+    fn: (tx: TTransaction) => Promise<TResult>,
+  ) => Promise<TResult>;
+};
+
+export type RunUnderCorpusSchemaLaneOptions<
+  TTransaction extends CorpusSchemaLaneTransaction,
+  TResult,
+> = {
+  /** Runs the transaction to try the lane in and, when granted, the work in. */
+  database: CorpusSchemaLaneDatabase<TTransaction>;
+  /** The work, run inside the transaction that holds the lane. */
+  work: (tx: TTransaction) => Promise<TResult>;
+  /** How long to keep trying; the caller's own budget for this transaction. */
+  laneWaitMs?: number;
+  /** Test seam; `Bun.sleep` otherwise. */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/** A transaction that ended without running its work: the lane was refused. */
+const LANE_BUSY: unique symbol = Symbol("stella.corpusSchemaLaneBusy");
+
+/**
+ * One transaction under the shared lane: try the lane, and only when granted
+ * run the work. A refused attempt commits an empty transaction and the
+ * caller sleeps outside any transaction before the next one, so no snapshot
+ * outlives a refusal. Recursive rather than a loop with an awaited body:
+ * each attempt must end before the next begins, so the sequencing is
+ * structural.
+ */
+export const runUnderCorpusSchemaLane = async <
+  TTransaction extends CorpusSchemaLaneTransaction,
+  TResult,
+>(
+  {
+    database,
+    work,
+    laneWaitMs = CORPUS_SCHEMA_LANE_DEFAULT_WAIT_MS,
+    sleep = Bun.sleep,
+  }: RunUnderCorpusSchemaLaneOptions<TTransaction, TResult>,
+  waitedMs = 0,
+): Promise<TResult> => {
+  const outcome = await database.transaction(
+    async (tx): Promise<typeof LANE_BUSY | { value: TResult }> => {
+      const granted = isCorpusSchemaLaneGranted(
+        await tx.execute(CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL),
+      );
+      if (!granted) {
+        return LANE_BUSY;
+      }
+      return { value: await work(tx) };
+    },
+  );
+  if (outcome !== LANE_BUSY) {
+    return outcome.value;
+  }
+  if (waitedMs >= laneWaitMs) {
+    throw new CorpusSchemaLaneUnavailableError({
+      message: `The corpus schema lane stayed unavailable for ${String(waitedMs)}ms; an upgrade is holding it`,
+      waitedMs,
+    });
+  }
+  await sleep(CORPUS_SCHEMA_LANE_RETRY_MS);
+  return await runUnderCorpusSchemaLane(
+    { database, work, laneWaitMs, sleep },
+    waitedMs + CORPUS_SCHEMA_LANE_RETRY_MS,
   );
 };

--- a/apps/api/src/db/corpus-schema-lane.ts
+++ b/apps/api/src/db/corpus-schema-lane.ts
@@ -1,0 +1,52 @@
+/**
+ * The corpus schema lane: how schema changes and corpus writers share the
+ * high-volume tables without racing for table locks.
+ *
+ * The corpus workers (ingestion, projection, packing, polarity, authority)
+ * write to `case_law_*` and `corpus_index_*` in batch transactions that
+ * follow one another without pause. DDL on those tables needs ACCESS
+ * EXCLUSIVE, which a short lock wait never wins against such a stream, and a
+ * long wait stalls every reader queued behind it. Retrying with longer waits
+ * shifts the odds; it does not remove the race.
+ *
+ * The lane removes it. Every corpus batch transaction takes the lane SHARED
+ * for its duration (`takeCorpusSchemaLaneSharedSql`, applied by
+ * `createIngestionDb`, the write boundary every corpus writer goes through).
+ * The migrate entrypoint takes the lane EXCLUSIVE for the whole upgrade
+ * (`CORPUS_SCHEMA_LANE_LOCK_SQL`). PostgreSQL grants lock requests in
+ * queue order: the exclusive request waits for the batches in flight when it
+ * queued, new batches wait behind it at their own boundary, and once it is
+ * granted no corpus transaction is open, so DDL wins its table lock at once
+ * with a short wait. Batches resume when the upgrade releases the lane.
+ *
+ * Distinct from the operator scripts' maintenance lane
+ * (`lib/case-law/maintenance-lane.ts`), which serializes whole operator runs
+ * against each other for hours; a batch must not wait on that.
+ *
+ * Advisory locks need no grant, so the `stella_ingestion` role can take the
+ * shared side. No imports: `migrate.ts` ships as a loose file with no path
+ * aliases, and `scoped.ts` must not pull the schema in.
+ */
+
+/** The `(int, int)` key of the lane, as `hashtext` renders the two halves. */
+export const CORPUS_SCHEMA_LANE = {
+  domain: "case_law",
+  lane: "schema",
+} as const;
+
+const KEY_SQL = `hashtext('${CORPUS_SCHEMA_LANE.domain}'), hashtext('${CORPUS_SCHEMA_LANE.lane}')`;
+
+/**
+ * Take the lane shared for the current transaction. Released at commit or
+ * rollback; there is nothing to unlock by hand.
+ */
+export const CORPUS_SCHEMA_LANE_SHARED_XACT_SQL = `SELECT pg_advisory_xact_lock_shared(${KEY_SQL})`;
+
+/**
+ * Take the lane exclusive for the session. Blocks until every shared holder
+ * has committed; pair with `CORPUS_SCHEMA_LANE_UNLOCK_SQL` on the same
+ * connection, and let the session end release it on any other exit.
+ */
+export const CORPUS_SCHEMA_LANE_LOCK_SQL = `SELECT pg_advisory_lock(${KEY_SQL})`;
+
+export const CORPUS_SCHEMA_LANE_UNLOCK_SQL = `SELECT pg_advisory_unlock(${KEY_SQL})`;

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -9,6 +9,10 @@ import nodePath from "node:path";
 // file in the runtime image, which has no tsconfig to resolve paths.
 import { resolveDatabaseUrl } from "../db-url";
 import { assertMigrationHistory } from "../lib/db/migration-history";
+import {
+  CORPUS_SCHEMA_LANE_LOCK_SQL,
+  CORPUS_SCHEMA_LANE_UNLOCK_SQL,
+} from "./corpus-schema-lane";
 import { runOnlineMigrations } from "./online-migrations";
 import { APPLICATION_RLS_ROLE_NAME } from "./role-names";
 
@@ -90,8 +94,17 @@ $$;
 const migrationsFolder = nodePath.resolve(import.meta.dir, "../../drizzle");
 type AppliedMigrationRow = { hash: string };
 
+// The corpus schema lane, exclusive, for the whole upgrade: the schema
+// migrations and the online phase both run DDL on the corpus tables. Taking
+// it here waits for the corpus batches in flight and holds every new one at
+// its boundary until the upgrade releases the lane (see
+// corpus-schema-lane.ts). One connection (`max: 1`), so the session lock,
+// the migrator, and the online phase share the session that holds it.
+let laneHeld = false;
 try {
   await client.unsafe(bootstrapRoleSql);
+  await client.unsafe(CORPUS_SCHEMA_LANE_LOCK_SQL);
+  laneHeld = true;
   const database = drizzle({ client });
   await migrate(database, { migrationsFolder });
   await assertMigrationHistory({
@@ -125,5 +138,8 @@ try {
   console.error("[migrate] failed:", error);
   process.exitCode = 1;
 } finally {
+  if (laneHeld) {
+    await client.unsafe(CORPUS_SCHEMA_LANE_UNLOCK_SQL);
+  }
   await client.end();
 }

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -13,6 +13,7 @@ import {
   CORPUS_SCHEMA_LANE_LOCK_SQL,
   CORPUS_SCHEMA_LANE_UNLOCK_SQL,
 } from "./corpus-schema-lane";
+import type { OnlineMigrationConnection } from "./online-migration-connection";
 import { runOnlineMigrations } from "./online-migrations";
 import { APPLICATION_RLS_ROLE_NAME } from "./role-names";
 
@@ -98,14 +99,16 @@ type AppliedMigrationRow = { hash: string };
 // migrations and the online phase both run DDL on the corpus tables. Taking
 // it here waits for the corpus batches in flight and holds every new one at
 // its boundary until the upgrade releases the lane (see
-// corpus-schema-lane.ts). One connection (`max: 1`), so the session lock,
-// the migrator, and the online phase share the session that holds it.
+// corpus-schema-lane.ts). The lock is session-scoped, so everything runs on
+// one reserved connection: a pool would hand later statements a replacement
+// connection, and the lock with it, if the first one closed.
 let laneHeld = false;
+const connection = await client.reserve();
 try {
-  await client.unsafe(bootstrapRoleSql);
-  await client.unsafe(CORPUS_SCHEMA_LANE_LOCK_SQL);
+  await connection.unsafe(bootstrapRoleSql);
+  await connection.unsafe(CORPUS_SCHEMA_LANE_LOCK_SQL);
   laneHeld = true;
-  const database = drizzle({ client });
+  const database = drizzle({ client: connection });
   await migrate(database, { migrationsFolder });
   await assertMigrationHistory({
     context: "migrate",
@@ -118,18 +121,18 @@ try {
     },
     remedy: "Migration completion requires every bundled migration hash.",
   });
-  await runOnlineMigrations({
-    reserve: async () => {
-      const connection = await client.reserve();
-      return {
-        execute: async (query, params = []) => {
-          await connection.unsafe(query, [...params]);
-        },
-        query: async (query, params = []) =>
-          await connection.unsafe(query, [...params]),
-        release: () => connection.release(),
-      };
+  // The same reserved connection, released once below with the lane; the
+  // phase's own release is therefore nothing.
+  const onlineConnection: OnlineMigrationConnection = {
+    execute: async (query, params = []) => {
+      await connection.unsafe(query, [...params]);
     },
+    query: async (query, params = []) =>
+      await connection.unsafe(query, [...params]),
+    release: (): void => undefined,
+  };
+  await runOnlineMigrations({
+    reserve: async () => await Promise.resolve(onlineConnection),
   });
   // eslint-disable-next-line no-console -- migrate CLI entrypoint; stdout is its interface (no app logger in this minimal-env task)
   console.info("[migrate] migrations applied");
@@ -139,7 +142,8 @@ try {
   process.exitCode = 1;
 } finally {
   if (laneHeld) {
-    await client.unsafe(CORPUS_SCHEMA_LANE_UNLOCK_SQL);
+    await connection.unsafe(CORPUS_SCHEMA_LANE_UNLOCK_SQL);
   }
+  connection.release();
   await client.end();
 }

--- a/apps/api/src/db/scoped.ts
+++ b/apps/api/src/db/scoped.ts
@@ -24,6 +24,8 @@ import {
 } from "@/api/lib/errors/tagged-errors";
 import { getPgErrorCode, PG_ERROR } from "@/api/lib/pg-error";
 
+import { CORPUS_SCHEMA_LANE_SHARED_XACT_SQL } from "./corpus-schema-lane";
+
 // Generic constraint accepts any drizzle instance (prod or
 // test PGlite) without importing test-only types.
 type ScopedTransactionBase = {
@@ -183,6 +185,12 @@ export const createMembershipScopedDb =
 // case-law ingestion daemon — narrowed to writes on case_law_*
 // (see 20260516000000_case_law_ingestion_role). No app.* settings
 // because the corpus is global; there is no tenant to scope.
+//
+// Every transaction also holds the corpus schema lane shared for its
+// duration: this is the write boundary every corpus batch goes through, so
+// an upgrade that takes the lane exclusive knows no batch is in flight
+// (see corpus-schema-lane.ts). A batch queued behind an upgrade waits here,
+// at its own boundary, rather than mid-write.
 export const createIngestionDb =
   <TTransaction extends ScopedTransactionBase>(
     database: RlsDatabase<TTransaction>,
@@ -192,6 +200,7 @@ export const createIngestionDb =
       await tx.execute(
         sql`SELECT set_config('role', '${sql.raw(stellaIngestion.name)}', true)`,
       );
+      await tx.execute(sql.raw(CORPUS_SCHEMA_LANE_SHARED_XACT_SQL));
       return await fn(tx);
     });
 

--- a/apps/api/src/db/scoped.ts
+++ b/apps/api/src/db/scoped.ts
@@ -24,11 +24,7 @@ import {
 } from "@/api/lib/errors/tagged-errors";
 import { getPgErrorCode, PG_ERROR } from "@/api/lib/pg-error";
 
-import {
-  CORPUS_SCHEMA_LANE_RETRY_MS,
-  CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
-  isCorpusSchemaLaneGranted,
-} from "./corpus-schema-lane";
+import { runUnderCorpusSchemaLane } from "./corpus-schema-lane";
 
 // Generic constraint accepts any drizzle instance (prod or
 // test PGlite) without importing test-only types.
@@ -185,47 +181,14 @@ export const createMembershipScopedDb =
       fn,
     });
 
-/** A transaction that ended without running its work: the lane was refused. */
-const CORPUS_SCHEMA_LANE_BUSY: unique symbol = Symbol(
-  "stella.corpusSchemaLaneBusy",
-);
-
-/**
- * One attempt at a corpus batch: try the lane, and only when granted assume
- * the ingestion role and run the work. A refused attempt commits an empty
- * transaction and the caller sleeps outside any transaction before the next
- * one, so no snapshot outlives a refusal (see corpus-schema-lane.ts).
- * Recursive rather than a loop with an awaited body: each attempt must end
- * before the next begins, so the sequencing is structural.
- */
-const runIngestionTransaction = async <
-  TTransaction extends ScopedTransactionBase,
-  T,
->(
-  database: RlsDatabase<TTransaction>,
-  fn: (tx: TTransaction) => Promise<T>,
-): Promise<T> => {
-  const outcome = await database.transaction(
-    async (
-      tx: TTransaction,
-    ): Promise<typeof CORPUS_SCHEMA_LANE_BUSY | { value: T }> => {
-      const granted = isCorpusSchemaLaneGranted(
-        await tx.execute(sql.raw(CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL)),
-      );
-      if (!granted) {
-        return CORPUS_SCHEMA_LANE_BUSY;
-      }
-      await tx.execute(
-        sql`SELECT set_config('role', '${sql.raw(stellaIngestion.name)}', true)`,
-      );
-      return { value: await fn(tx) };
-    },
-  );
-  if (outcome === CORPUS_SCHEMA_LANE_BUSY) {
-    await Bun.sleep(CORPUS_SCHEMA_LANE_RETRY_MS);
-    return await runIngestionTransaction(database, fn);
-  }
-  return outcome.value;
+export type CreateIngestionDbOptions = {
+  /**
+   * How long a batch keeps trying to enter the corpus schema lane. Pass the
+   * caller's own transaction budget: a batch that has outlived it must fail
+   * here rather than enter the lane late and run its work after the caller
+   * gave up on it.
+   */
+  laneWaitMs?: number;
 };
 
 // SET LOCAL ROLE stella_ingestion per transaction. Used by the
@@ -237,13 +200,24 @@ const runIngestionTransaction = async <
 // this is the write boundary every corpus batch goes through, so an upgrade
 // that takes the lane exclusive knows no batch is in flight (see
 // corpus-schema-lane.ts). A batch that meets an upgrade backs off at its own
-// boundary, rather than mid-write, until the lane is free again.
+// boundary, rather than mid-write, until the lane is free again or its
+// budget is spent.
 export const createIngestionDb =
   <TTransaction extends ScopedTransactionBase>(
     database: RlsDatabase<TTransaction>,
+    { laneWaitMs }: CreateIngestionDbOptions = {},
   ) =>
   async <T>(fn: (tx: TTransaction) => Promise<T>): Promise<T> =>
-    await runIngestionTransaction(database, fn);
+    await runUnderCorpusSchemaLane({
+      database,
+      work: async (tx) => {
+        await tx.execute(
+          sql`SELECT set_config('role', '${sql.raw(stellaIngestion.name)}', true)`,
+        );
+        return await fn(tx);
+      },
+      ...(laneWaitMs === undefined ? {} : { laneWaitMs }),
+    });
 
 const toSafeDbError = (cause: unknown): SafeDbError => {
   const code = getPgErrorCode(cause);

--- a/apps/api/src/db/scoped.ts
+++ b/apps/api/src/db/scoped.ts
@@ -24,7 +24,11 @@ import {
 } from "@/api/lib/errors/tagged-errors";
 import { getPgErrorCode, PG_ERROR } from "@/api/lib/pg-error";
 
-import { CORPUS_SCHEMA_LANE_SHARED_XACT_SQL } from "./corpus-schema-lane";
+import {
+  CORPUS_SCHEMA_LANE_RETRY_MS,
+  CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
+  isCorpusSchemaLaneGranted,
+} from "./corpus-schema-lane";
 
 // Generic constraint accepts any drizzle instance (prod or
 // test PGlite) without importing test-only types.
@@ -181,28 +185,65 @@ export const createMembershipScopedDb =
       fn,
     });
 
+/** A transaction that ended without running its work: the lane was refused. */
+const CORPUS_SCHEMA_LANE_BUSY: unique symbol = Symbol(
+  "stella.corpusSchemaLaneBusy",
+);
+
+/**
+ * One attempt at a corpus batch: try the lane, and only when granted assume
+ * the ingestion role and run the work. A refused attempt commits an empty
+ * transaction and the caller sleeps outside any transaction before the next
+ * one, so no snapshot outlives a refusal (see corpus-schema-lane.ts).
+ * Recursive rather than a loop with an awaited body: each attempt must end
+ * before the next begins, so the sequencing is structural.
+ */
+const runIngestionTransaction = async <
+  TTransaction extends ScopedTransactionBase,
+  T,
+>(
+  database: RlsDatabase<TTransaction>,
+  fn: (tx: TTransaction) => Promise<T>,
+): Promise<T> => {
+  const outcome = await database.transaction(
+    async (
+      tx: TTransaction,
+    ): Promise<typeof CORPUS_SCHEMA_LANE_BUSY | { value: T }> => {
+      const granted = isCorpusSchemaLaneGranted(
+        await tx.execute(sql.raw(CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL)),
+      );
+      if (!granted) {
+        return CORPUS_SCHEMA_LANE_BUSY;
+      }
+      await tx.execute(
+        sql`SELECT set_config('role', '${sql.raw(stellaIngestion.name)}', true)`,
+      );
+      return { value: await fn(tx) };
+    },
+  );
+  if (outcome === CORPUS_SCHEMA_LANE_BUSY) {
+    await Bun.sleep(CORPUS_SCHEMA_LANE_RETRY_MS);
+    return await runIngestionTransaction(database, fn);
+  }
+  return outcome.value;
+};
+
 // SET LOCAL ROLE stella_ingestion per transaction. Used by the
 // case-law ingestion daemon — narrowed to writes on case_law_*
 // (see 20260516000000_case_law_ingestion_role). No app.* settings
 // because the corpus is global; there is no tenant to scope.
 //
-// Every transaction also holds the corpus schema lane shared for its
-// duration: this is the write boundary every corpus batch goes through, so
-// an upgrade that takes the lane exclusive knows no batch is in flight
-// (see corpus-schema-lane.ts). A batch queued behind an upgrade waits here,
-// at its own boundary, rather than mid-write.
+// Every transaction holds the corpus schema lane shared for its duration:
+// this is the write boundary every corpus batch goes through, so an upgrade
+// that takes the lane exclusive knows no batch is in flight (see
+// corpus-schema-lane.ts). A batch that meets an upgrade backs off at its own
+// boundary, rather than mid-write, until the lane is free again.
 export const createIngestionDb =
   <TTransaction extends ScopedTransactionBase>(
     database: RlsDatabase<TTransaction>,
   ) =>
   async <T>(fn: (tx: TTransaction) => Promise<T>): Promise<T> =>
-    await database.transaction(async (tx: TTransaction) => {
-      await tx.execute(
-        sql`SELECT set_config('role', '${sql.raw(stellaIngestion.name)}', true)`,
-      );
-      await tx.execute(sql.raw(CORPUS_SCHEMA_LANE_SHARED_XACT_SQL));
-      return await fn(tx);
-    });
+    await runIngestionTransaction(database, fn);
 
 const toSafeDbError = (cause: unknown): SafeDbError => {
   const code = getPgErrorCode(cause);

--- a/apps/api/src/lib/case-law/maintenance-lane.ts
+++ b/apps/api/src/lib/case-law/maintenance-lane.ts
@@ -40,6 +40,7 @@ import { SQL } from "bun";
 import { sql } from "drizzle-orm";
 import type { SQLWrapper } from "drizzle-orm";
 
+import { runUnderCorpusSchemaLane } from "@/api/db/corpus-schema-lane";
 import type { rootDb as rootDatabase, Transaction } from "@/api/db/root";
 import { logger } from "@/api/lib/observability/logger";
 
@@ -85,8 +86,14 @@ export type CaseLawScriptHandles = {
   ingestionDb: CaseLawIngestionHandle;
 };
 
+/**
+ * The write door's handles. Its `rootDb` is the narrow handle, every
+ * transaction of which holds the corpus schema lane shared (see
+ * `db/corpus-schema-lane.ts`): a root writer would otherwise slip past the
+ * lane an upgrade drains, and race its DDL the way the workers used to.
+ */
 export type CaseLawWriteHandles = {
-  rootDb: typeof rootDatabase;
+  rootDb: CaseLawRootHandle;
   ingestionDb: CaseLawIngestionHandle;
 };
 
@@ -127,10 +134,31 @@ const openLaneConnection = async (): Promise<MaintenanceLaneSql> => {
   return new SQL({ url: envBase.DATABASE_URL, max: 1 });
 };
 
+/**
+ * The root handle with every transaction under the shared corpus schema
+ * lane. `execute` outside a transaction runs inside one, so there is no path
+ * around the lane.
+ */
+const laneRootHandle = (rootDb: typeof rootDatabase): CaseLawRootHandle => {
+  const transaction = async <T>(
+    fn: (tx: Transaction) => Promise<T>,
+  ): Promise<T> =>
+    await runUnderCorpusSchemaLane({ database: rootDb, work: fn });
+  return {
+    transaction,
+    execute: async <TRow extends Record<string, unknown>>(
+      query: SQLWrapper | string,
+    ) => await transaction(async (tx) => await tx.execute<TRow>(query)),
+  };
+};
+
 const loadWriteHandles = async (): Promise<CaseLawWriteHandles> => {
   const { rlsDb, rootDb } = await import("@/api/db/root");
   const { createIngestionDb } = await import("@/api/db/scoped");
-  return { rootDb, ingestionDb: createIngestionDb(rlsDb) };
+  return {
+    rootDb: laneRootHandle(rootDb),
+    ingestionDb: createIngestionDb(rlsDb),
+  };
 };
 
 /**

--- a/apps/api/src/scripts/backfill-fulltext.ts
+++ b/apps/api/src/scripts/backfill-fulltext.ts
@@ -140,11 +140,14 @@ const CONFIGS: BackfillConfig[] = [
 
 const backfillAdapter = async (config: BackfillConfig) => {
   // Get source ID
-  const [source] = await rootDb
-    .select({ id: caseLawSources.id })
-    .from(caseLawSources)
-    .where(eq(caseLawSources.adapterKey, config.adapterKey))
-    .limit(1);
+  const [source] = await rootDb.transaction(
+    async (tx) =>
+      await tx
+        .select({ id: caseLawSources.id })
+        .from(caseLawSources)
+        .where(eq(caseLawSources.adapterKey, config.adapterKey))
+        .limit(1),
+  );
 
   if (!source) {
     console.log(`[${config.adapterKey}] No source found, skipping`);
@@ -152,13 +155,16 @@ const backfillAdapter = async (config: BackfillConfig) => {
   }
 
   // Count missing
-  const result = await rootDb
-    .select({ count: sql<number>`count(*)` })
-    .from(caseLawDecisions)
-    .where(
-      sql`${caseLawDecisions.sourceId} = ${source.id}
-          AND ${caseLawDecisions.fulltext} IS NULL`,
-    );
+  const result = await rootDb.transaction(
+    async (tx) =>
+      await tx
+        .select({ count: sql<number>`count(*)` })
+        .from(caseLawDecisions)
+        .where(
+          sql`${caseLawDecisions.sourceId} = ${source.id}
+              AND ${caseLawDecisions.fulltext} IS NULL`,
+        ),
+  );
 
   const count = result.at(0)?.count ?? 0;
   console.log(`[${config.adapterKey}] ${count} decisions missing fulltext`);
@@ -172,19 +178,22 @@ const backfillAdapter = async (config: BackfillConfig) => {
 
   while (true) {
     // oxlint-disable-next-line no-await-in-loop -- bounded memory: fetch one batch of missing-fulltext rows at a time
-    const batch = await rootDb
-      .select({
-        id: caseLawDecisions.id,
-        sourceUrl: caseLawDecisions.sourceUrl,
-        documentUrl: caseLawDecisions.documentUrl,
-        caseNumber: caseLawDecisions.caseNumber,
-      })
-      .from(caseLawDecisions)
-      .where(
-        sql`${caseLawDecisions.sourceId} = ${source.id}
-            AND ${caseLawDecisions.fulltext} IS NULL`,
-      )
-      .limit(BATCH_SIZE);
+    const batch = await rootDb.transaction(
+      async (tx) =>
+        await tx
+          .select({
+            id: caseLawDecisions.id,
+            sourceUrl: caseLawDecisions.sourceUrl,
+            documentUrl: caseLawDecisions.documentUrl,
+            caseNumber: caseLawDecisions.caseNumber,
+          })
+          .from(caseLawDecisions)
+          .where(
+            sql`${caseLawDecisions.sourceId} = ${source.id}
+                AND ${caseLawDecisions.fulltext} IS NULL`,
+          )
+          .limit(BATCH_SIZE),
+    );
 
     if (batch.length === 0) {
       break;
@@ -197,10 +206,12 @@ const backfillAdapter = async (config: BackfillConfig) => {
       if (!url) {
         // No URL available — mark as empty to prevent re-query
         // oxlint-disable-next-line no-await-in-loop -- mark this row empty before continuing; keeps progress per row
-        await rootDb
-          .update(caseLawDecisions)
-          .set({ fulltext: "" })
-          .where(eq(caseLawDecisions.id, row.id));
+        await rootDb.transaction(async (tx) => {
+          await tx
+            .update(caseLawDecisions)
+            .set({ fulltext: "" })
+            .where(eq(caseLawDecisions.id, row.id));
+        });
         failed++;
         processed++;
         continue;
@@ -213,10 +224,12 @@ const backfillAdapter = async (config: BackfillConfig) => {
       // the NULL check no longer matches and we don't re-query
       // this row forever.
       // oxlint-disable-next-line no-await-in-loop -- update this row's fulltext after its sequential, rate-limited fetch
-      await rootDb
-        .update(caseLawDecisions)
-        .set({ fulltext: fulltext ?? "" })
-        .where(eq(caseLawDecisions.id, row.id));
+      await rootDb.transaction(async (tx) => {
+        await tx
+          .update(caseLawDecisions)
+          .set({ fulltext: fulltext ?? "" })
+          .where(eq(caseLawDecisions.id, row.id));
+      });
 
       if (fulltext) {
         filled++;

--- a/apps/api/src/scripts/seed-polarity-rules.ts
+++ b/apps/api/src/scripts/seed-polarity-rules.ts
@@ -31,25 +31,27 @@ console.log(`Seeding ${SEED_RULES.length} polarity rules...`);
 
 for (const rule of SEED_RULES) {
   // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves upsert order across rules
-  await rootDb
-    .insert(caseLawPolarityRules)
-    .values({
-      pattern: rule.pattern,
-      polarity: rule.polarity,
-      language: rule.language,
-      source: "manual",
-      confidence: 1,
-    })
-    .onConflictDoUpdate({
-      target: [caseLawPolarityRules.pattern, caseLawPolarityRules.language],
-      // `source` is part of the state being seeded, not incidental metadata:
-      // the rule loader reads `manual` and `llm-promoted` only, so a seed that
-      // collided with an `llm-proposed` rule of the same pattern and language
-      // used to leave it excluded — a successful run that changed nothing a
-      // classifier would ever see. The insert and the update have to establish
-      // the same row.
-      set: { polarity: rule.polarity, confidence: 1, source: "manual" },
-    });
+  await rootDb.transaction(async (tx) => {
+    await tx
+      .insert(caseLawPolarityRules)
+      .values({
+        pattern: rule.pattern,
+        polarity: rule.polarity,
+        language: rule.language,
+        source: "manual",
+        confidence: 1,
+      })
+      .onConflictDoUpdate({
+        target: [caseLawPolarityRules.pattern, caseLawPolarityRules.language],
+        // `source` is part of the state being seeded, not incidental
+        // metadata: the rule loader reads `manual` and `llm-promoted` only,
+        // so a seed that collided with an `llm-proposed` rule of the same
+        // pattern and language used to leave it excluded — a successful run
+        // that changed nothing a classifier would ever see. The insert and
+        // the update have to establish the same row.
+        set: { polarity: rule.polarity, confidence: 1, source: "manual" },
+      });
+  });
 }
 
 /** Rows reset per statement; bounded so the lock never spans the table. */
@@ -57,20 +59,23 @@ const RESET_BATCH = 5000;
 
 let resetIds: string[] = [];
 if (RETIRED_SEED_RULES.length > 0) {
-  const retired = await rootDb
-    .update(caseLawPolarityRules)
-    .set({ source: RULE_SOURCE.RETIRED })
-    .where(
-      or(
-        ...RETIRED_SEED_RULES.map((rule) =>
-          and(
-            eq(caseLawPolarityRules.pattern, rule.pattern),
-            eq(caseLawPolarityRules.language, rule.language),
+  const retired = await rootDb.transaction(
+    async (tx) =>
+      await tx
+        .update(caseLawPolarityRules)
+        .set({ source: RULE_SOURCE.RETIRED })
+        .where(
+          or(
+            ...RETIRED_SEED_RULES.map((rule) =>
+              and(
+                eq(caseLawPolarityRules.pattern, rule.pattern),
+                eq(caseLawPolarityRules.language, rule.language),
+              ),
+            ),
           ),
-        ),
-      ),
-    )
-    .returning({ id: caseLawPolarityRules.id });
+        )
+        .returning({ id: caseLawPolarityRules.id }),
+  );
 
   // A retired rule's verdicts go with it: the citations it labelled return
   // to the unclassified pool, and `scripts/classify-citations.ts` reads them
@@ -78,17 +83,20 @@ if (RETIRED_SEED_RULES.length > 0) {
   // keep speaking through every row it ever touched.
   const retiredIds = retired.map((rule) => rule.id);
   const resetBatch = async (): Promise<string[]> => {
-    const reset = await rootDb
-      .update(caseLawCitations)
-      .set({ polarity: null, polarityRuleId: null })
-      .where(
-        sql`${caseLawCitations.id} IN (
-          SELECT ${caseLawCitations.id} FROM ${caseLawCitations}
-          WHERE ${inArray(caseLawCitations.polarityRuleId, retiredIds)}
-          LIMIT ${RESET_BATCH}
-        )`,
-      )
-      .returning({ id: caseLawCitations.id });
+    const reset = await rootDb.transaction(
+      async (tx) =>
+        await tx
+          .update(caseLawCitations)
+          .set({ polarity: null, polarityRuleId: null })
+          .where(
+            sql`${caseLawCitations.id} IN (
+              SELECT ${caseLawCitations.id} FROM ${caseLawCitations}
+              WHERE ${inArray(caseLawCitations.polarityRuleId, retiredIds)}
+              LIMIT ${RESET_BATCH}
+            )`,
+          )
+          .returning({ id: caseLawCitations.id }),
+    );
     const ids = reset.map((row) => row.id);
     return reset.length < RESET_BATCH ? ids : [...ids, ...(await resetBatch())];
   };

--- a/apps/legal-atlas-runner/src/db.ts
+++ b/apps/legal-atlas-runner/src/db.ts
@@ -22,7 +22,6 @@ import { withTimeout } from "@/api/lib/with-timeout";
 
 import { LEGAL_ATLAS_RUNNER_ENV } from "./env";
 
-const rawIngestionDb = createIngestionDb(rlsDb);
 const transactionTimeoutMs = LEGAL_ATLAS_RUNNER_ENV.dbTransactionTimeoutMs;
 const backfillTransactionTimeoutMs =
   LEGAL_ATLAS_RUNNER_ENV.dbBackfillTransactionTimeoutMs;
@@ -38,9 +37,19 @@ const rootQueryTimeoutMs = LEGAL_ATLAS_RUNNER_ENV.dbRootQueryTimeoutMs;
  * which otherwise leaves the transaction idle and the awaiting caller
  * suspended forever.
  */
-const createBoundedIngestionDb =
-  (label: string, timeoutMs: number): ScopedDb =>
-  async (fn) => {
+const createBoundedIngestionDb = (
+  label: string,
+  timeoutMs: number,
+): ScopedDb => {
+  // The lane wait shares the transaction budget: a batch that cannot enter
+  // the corpus schema lane within it fails here, at the same moment the
+  // wall-clock guard below gives up, instead of entering late and running
+  // its work after this caller has moved on.
+  const rawIngestionDb = createIngestionDb(
+    rlsDb,
+    timeoutMs === 0 ? {} : { laneWaitMs: timeoutMs },
+  );
+  return async (fn) => {
     const operation = async () =>
       await rawIngestionDb(async (tx) => {
         if (timeoutMs > 0) {
@@ -57,6 +66,7 @@ const createBoundedIngestionDb =
       timeoutMs: timeoutMs === 0 ? 0 : timeoutMs + TRANSACTION_TIMEOUT_GRACE_MS,
     });
   };
+};
 
 /** Transaction runner for adapter ingest cycles (long pipeline writes). */
 export const ingestionDb: ScopedDb = createBoundedIngestionDb(

--- a/scripts/migration-rehearsal-db.ts
+++ b/scripts/migration-rehearsal-db.ts
@@ -31,11 +31,7 @@
 import { panic } from "better-result";
 import { SQL } from "bun";
 
-import {
-  CORPUS_SCHEMA_LANE_RETRY_MS,
-  CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
-  isCorpusSchemaLaneGranted,
-} from "../apps/api/src/db/corpus-schema-lane";
+import { runUnderCorpusSchemaLane } from "../apps/api/src/db/corpus-schema-lane";
 
 const COMMANDS = ["assert-empty", "contend", "digest"] as const;
 type Command = (typeof COMMANDS)[number];
@@ -79,6 +75,27 @@ const CONTENDED_UPDATES = [
   "UPDATE case_law_citations SET resolution_rule_id = resolution_rule_id WHERE id = (SELECT id FROM case_law_citations ORDER BY id LIMIT 1)",
 ] as const;
 
+type RawTransaction = { execute: (query: string) => Promise<unknown> };
+
+/** One session's `BEGIN`/`COMMIT` pair as the lane helper's database. */
+const rawTransactions = (connection: SQL) => ({
+  transaction: async <TResult>(
+    fn: (tx: RawTransaction) => Promise<TResult>,
+  ): Promise<TResult> => {
+    await connection.unsafe("BEGIN");
+    try {
+      const result = await fn({
+        execute: async (query) => await connection.unsafe(query),
+      });
+      await connection.unsafe("COMMIT");
+      return result;
+    } catch (error: unknown) {
+      await connection.unsafe("ROLLBACK");
+      throw error;
+    }
+  },
+});
+
 /**
  * One held transaction after another on one session, until the process is
  * killed. Recursive rather than a loop with an awaited body: each
@@ -90,19 +107,14 @@ const contendForever = async (
   connection: SQL,
   onHeld: (() => void) | null,
 ): Promise<never> => {
-  await connection.unsafe("BEGIN");
-  const granted = isCorpusSchemaLaneGranted(
-    await connection.unsafe(CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL),
-  );
-  if (!granted) {
-    await connection.unsafe("ROLLBACK");
-    await Bun.sleep(CORPUS_SCHEMA_LANE_RETRY_MS);
-    return await contendForever(connection, onHeld);
-  }
-  await connection.unsafe(CONTENDED_UPDATES.join("; "));
-  onHeld?.();
-  await Bun.sleep(CONTENTION_HOLD_MS);
-  await connection.unsafe("COMMIT");
+  await runUnderCorpusSchemaLane({
+    database: rawTransactions(connection),
+    work: async () => {
+      await connection.unsafe(CONTENDED_UPDATES.join("; "));
+      onHeld?.();
+      await Bun.sleep(CONTENTION_HOLD_MS);
+    },
+  });
   return await contendForever(connection, null);
 };
 

--- a/scripts/migration-rehearsal-db.ts
+++ b/scripts/migration-rehearsal-db.ts
@@ -17,8 +17,8 @@
 //     do while an upgrade runs: two sessions, each updating one row per
 //     table in a transaction held open for several seconds, over and over,
 //     staggered by half a hold, until the process is killed. Each
-//     transaction holds the corpus schema lane shared, as every corpus
-//     batch does through createIngestionDb, so an upgrade that takes the
+//     transaction holds the corpus schema lane shared, tried and backed
+//     off exactly as createIngestionDb does, so an upgrade that takes the
 //     lane exclusive drains them and runs its DDL against an idle table.
 //     With two holders out of phase there is never a moment when both end
 //     within a short wait, so an upgrade that skipped the lane and only
@@ -31,7 +31,11 @@
 import { panic } from "better-result";
 import { SQL } from "bun";
 
-import { CORPUS_SCHEMA_LANE_SHARED_XACT_SQL } from "../apps/api/src/db/corpus-schema-lane";
+import {
+  CORPUS_SCHEMA_LANE_RETRY_MS,
+  CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL,
+  isCorpusSchemaLaneGranted,
+} from "../apps/api/src/db/corpus-schema-lane";
 
 const COMMANDS = ["assert-empty", "contend", "digest"] as const;
 type Command = (typeof COMMANDS)[number];
@@ -86,9 +90,16 @@ const contendForever = async (
   connection: SQL,
   onHeld: (() => void) | null,
 ): Promise<never> => {
-  await connection.unsafe(
-    `BEGIN; ${CORPUS_SCHEMA_LANE_SHARED_XACT_SQL}; ${CONTENDED_UPDATES.join("; ")};`,
+  await connection.unsafe("BEGIN");
+  const granted = isCorpusSchemaLaneGranted(
+    await connection.unsafe(CORPUS_SCHEMA_LANE_TRY_SHARED_XACT_SQL),
   );
+  if (!granted) {
+    await connection.unsafe("ROLLBACK");
+    await Bun.sleep(CORPUS_SCHEMA_LANE_RETRY_MS);
+    return await contendForever(connection, onHeld);
+  }
+  await connection.unsafe(CONTENDED_UPDATES.join("; "));
   onHeld?.();
   await Bun.sleep(CONTENTION_HOLD_MS);
   await connection.unsafe("COMMIT");

--- a/scripts/migration-rehearsal-db.ts
+++ b/scripts/migration-rehearsal-db.ts
@@ -16,11 +16,13 @@
 //     Writes to the high-volume corpus tables the way production's workers
 //     do while an upgrade runs: two sessions, each updating one row per
 //     table in a transaction held open for several seconds, over and over,
-//     staggered by half a hold, until the process is killed. With two
-//     holders out of phase there is never a moment when both end within a
-//     short wait, so DDL that only waits briefly for ACCESS EXCLUSIVE on
-//     such a table cannot win, as in production; DDL that waits longer
-//     wins once the transactions in flight when it queued have ended.
+//     staggered by half a hold, until the process is killed. Each
+//     transaction holds the corpus schema lane shared, as every corpus
+//     batch does through createIngestionDb, so an upgrade that takes the
+//     lane exclusive drains them and runs its DDL against an idle table.
+//     With two holders out of phase there is never a moment when both end
+//     within a short wait, so an upgrade that skipped the lane and only
+//     waited briefly for ACCESS EXCLUSIVE could not win, as in production.
 //     Prints CONTENTION_HELD_LINE once both sessions hold their locks, so a
 //     caller can wait for that before it starts the work under test, and
 //     exits non-zero if a write fails. Never run this against a database
@@ -28,6 +30,8 @@
 
 import { panic } from "better-result";
 import { SQL } from "bun";
+
+import { CORPUS_SCHEMA_LANE_SHARED_XACT_SQL } from "../apps/api/src/db/corpus-schema-lane";
 
 const COMMANDS = ["assert-empty", "contend", "digest"] as const;
 type Command = (typeof COMMANDS)[number];
@@ -82,7 +86,9 @@ const contendForever = async (
   connection: SQL,
   onHeld: (() => void) | null,
 ): Promise<never> => {
-  await connection.unsafe(`BEGIN; ${CONTENDED_UPDATES.join("; ")};`);
+  await connection.unsafe(
+    `BEGIN; ${CORPUS_SCHEMA_LANE_SHARED_XACT_SQL}; ${CONTENDED_UPDATES.join("; ")};`,
+  );
   onHeld?.();
   await Bun.sleep(CONTENTION_HOLD_MS);
   await connection.unsafe("COMMIT");


### PR DESCRIPTION
## What

The v0.8.11 and v0.8.12 promotions lost the race for `ACCESS EXCLUSIVE` on `case_law_decisions` against the corpus workers' back-to-back batch transactions; #2891 made the swap retry with longer waits, which shifts the odds and costs reader stalls. This replaces luck with a protocol.

- `corpus-schema-lane.ts`: one advisory-lock key (`case_law`/`schema`), distinct from the operator scripts' maintenance lane. No imports, so the migrate bundle and `scoped.ts` can both use it.
- `createIngestionDb` holds the lane **shared** for every transaction. It is the write boundary every corpus writer goes through: the plane's ingest, backfill, projection, packing, and polarity loops (via `@stll/legal-atlas-runner/db`) and the API's on-demand corpus writes.
- `migrate.ts` takes the lane **exclusive** on its single connection before the schema migrations and releases it after the online phase. The exclusive request waits for the batches in flight; DDL then wins its table lock immediately.
- A batch never *waits* for the lane inside a transaction: it *tries* it, and when refused ends its empty transaction, sleeps 250 ms, and tries again. The first form of this PR waited, and CI deadlocked it: a transaction blocked on a lock still holds its snapshot, and the online phase's concurrent index build waits for every older snapshot. PostgreSQL refuses a try as soon as an exclusive request is queued, which is what lets the upgrade drain.
- The rehearsal's contending writers follow the same try-and-back-off protocol, so CI exercises it rather than the timing.

The `20260902100000` migration keeps its escalating retry: it stays correct for a database whose writers predate the lane (a plane still pinned to an older stella), and with the lane it succeeds on the first attempt.

## Checks

- Local Postgres 18: a v0.8.8 schema seeded with 5k decisions, two writers holding 5 s transactions under the lane; the full upgrade (six migrations and the online phase, including its concurrent index builds) took 10 s, the writers survived it, and the rerun changed nothing.
- `corpus-schema-lane.test.ts`, `scoped.test.ts`, `online-migrations.test.ts`, `maintenance-lane.test.ts`; migrate bundle builds; typecheck; oxlint.
- This PR's CI runs the upgrade rehearsal with the lane-holding writers.

## Follow-ups

- Cut a release once merged and let the plane's pin bump carry the lane to the projection worker.
- Name connections (`application_name` per service) so the lock-holder warning names its holder; and render its age with `clock_timestamp()`, which needs a migration hash change and is cosmetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated schema-change locking to protect corpus data operations during upgrades.
  * Database migrations now reserve a single connection and acquire exclusive access before applying schema changes.
  * Corpus ingestion and maintenance operations now wait safely for schema changes to complete, with configurable wait limits.
  * Added transaction boundaries to full-text backfills and polarity-rule seeding operations.

* **Bug Fixes**
  * Prevented concurrent corpus writes from racing with database schema migrations.
  * Improved migration rehearsal behaviour by coordinating simulated workload transactions with upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->