### PR TITLE
fix(api): apply test timeout to child processes

### DIFF
--- a/apps/api/scripts/api-test-command.ts
+++ b/apps/api/scripts/api-test-command.ts
@@ -1,0 +1,22 @@
+import { API_TEST_TIMEOUT_MS } from "../src/tests/test-timeouts";
+
+type BuildApiTestCommandOptions = {
+  bunExecutable: string;
+  bunRuntimeArguments: readonly string[];
+  testArguments: readonly string[];
+  testFiles: readonly string[];
+};
+
+export const buildApiTestCommand = ({
+  bunExecutable,
+  bunRuntimeArguments,
+  testArguments,
+  testFiles,
+}: BuildApiTestCommandOptions) => [
+  bunExecutable,
+  ...bunRuntimeArguments,
+  "test",
+  `--timeout=${API_TEST_TIMEOUT_MS}`,
+  ...testArguments,
+  ...testFiles,
+];

--- a/apps/api/scripts/run-postgres-tests.ts
+++ b/apps/api/scripts/run-postgres-tests.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import packageJson from "../package.json" with { type: "json" };
+import { buildApiTestCommand } from "./api-test-command";
 
 const POSTGRES_TEST_RUNNER = packageJson.ciGateTestRunners["test:postgres"];
 const POSTGRES_TEST_MARKER = POSTGRES_TEST_RUNNER.gate;
@@ -41,16 +42,18 @@ if (testFiles.length === 0) {
 
 console.log(`Running ${String(testFiles.length)} Postgres-gated test files.`);
 const testProcess = Bun.spawn({
-  cmd: [
-    process.execPath,
-    "test",
-    // Keep suites isolated from one another's connection pools. Tests that
-    // exercise concurrency still do so internally, without runner-load races.
-    "--max-concurrency=1",
-    "--preload",
-    "./src/tests/setup-env.ts",
-    ...testFiles,
-  ],
+  cmd: buildApiTestCommand({
+    bunExecutable: process.execPath,
+    bunRuntimeArguments: [],
+    testArguments: [
+      // Keep suites isolated from one another's connection pools. Tests that
+      // exercise concurrency still do so internally, without runner-load races.
+      "--max-concurrency=1",
+      "--preload",
+      "./src/tests/setup-env.ts",
+    ],
+    testFiles,
+  }),
   cwd: apiRoot,
   env: {
     ...process.env,

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -10,6 +10,7 @@ import {
   type ModuleMockTest,
 } from "../src/tests/module-mock-batching";
 import { API_TEST_TIMEOUT_MS } from "../src/tests/test-timeouts";
+import { buildApiTestCommand } from "./api-test-command";
 import { maxRssBytesToMb } from "./resource-usage";
 import {
   classifyTestBatch,
@@ -290,17 +291,17 @@ const runTests = async ({
 
   // Each batch loads many graph-heavy API modules. Prefer more frequent garbage
   // collection so it stays within the hosted runner's memory budget.
-  const command = [
-    process.execPath,
-    "--smol",
-    "test",
-    "--preload",
-    preloadPath,
-  ];
+  const testArguments = ["--preload", preloadPath];
   if (isolate) {
-    command.push("--isolate");
+    testArguments.push("--isolate");
   }
-  command.push(...bunArguments, ...testFiles);
+  testArguments.push(...bunArguments);
+  const command = buildApiTestCommand({
+    bunExecutable: process.execPath,
+    bunRuntimeArguments: ["--smol"],
+    testArguments,
+    testFiles,
+  });
 
   const child = Bun.spawn({
     cmd: command,

--- a/apps/api/src/tests/api-test-command.test.ts
+++ b/apps/api/src/tests/api-test-command.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildApiTestCommand } from "../../scripts/api-test-command";
+import { API_TEST_TIMEOUT_MS } from "./test-timeouts";
+
+const TIMEOUT_ARGUMENT = `--timeout=${API_TEST_TIMEOUT_MS}`;
+
+describe("API test child commands", () => {
+  for (const { name, runtimeArguments, testArguments } of [
+    {
+      name: "shared-process batches",
+      runtimeArguments: ["--smol"],
+      testArguments: ["--preload", "/api/setup-env.ts", "--bail"],
+    },
+    {
+      name: "isolated batches",
+      runtimeArguments: ["--smol"],
+      testArguments: ["--preload", "/api/setup-env.ts", "--isolate"],
+    },
+    {
+      name: "Postgres-gated tests",
+      runtimeArguments: [],
+      testArguments: [
+        "--max-concurrency=1",
+        "--preload",
+        "./src/tests/setup-env.ts",
+      ],
+    },
+  ]) {
+    test(`${name} receive the shared timeout`, () => {
+      const command = buildApiTestCommand({
+        bunExecutable: "/usr/bin/bun",
+        bunRuntimeArguments: runtimeArguments,
+        testArguments,
+        testFiles: ["src/example.test.ts"],
+      });
+
+      expect(command).toContain(TIMEOUT_ARGUMENT);
+      expect(command.indexOf(TIMEOUT_ARGUMENT)).toBeLessThan(
+        command.indexOf("src/example.test.ts"),
+      );
+    });
+  }
+});

--- a/apps/api/src/tests/setup-env.ts
+++ b/apps/api/src/tests/setup-env.ts
@@ -1,16 +1,4 @@
-import { setDefaultTimeout } from "bun:test";
-
 import { configureTestDatabaseEnvironment } from "./test-database-environment";
-import { API_TEST_TIMEOUT_MS } from "./test-timeouts";
-
-// DB-backed suites rebuild the shared PGlite schema in their `beforeAll`
-// (getTestDb / getRlsFixture): a full drizzle push of the whole schema plus
-// the RLS grants/policies. On a loaded CI runner that push takes several
-// seconds — past Bun's 5s default hook timeout — so the setup was reported as
-// a flaky "(unnamed) hook timed out" failure rather than a real assertion.
-// Give every hook and test enough headroom for the legitimate schema build
-// (a genuinely hung hook still fails within this window).
-setDefaultTimeout(API_TEST_TIMEOUT_MS);
 
 configureTestDatabaseEnvironment();
 process.env["S3_ENDPOINT"] ??= "http://localhost:9000";

--- a/apps/api/src/tests/test-timeouts.ts
+++ b/apps/api/src/tests/test-timeouts.ts
@@ -1,2 +1,2 @@
-/** Baseline shared by the API test setup and property-test preload. */
+/** Baseline passed to API test children and property-test timeout scaling. */
 export const API_TEST_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## Summary

- inject the shared 30-second timeout into every spawned API Bun test command, including Postgres-gated tests
- keep the preload focused on environment configuration
- cover shared-process, isolated, and Postgres command shapes with one invariant

## Verification

- focused command invariant: passed
- mutation check: removing timeout injection fails on missing `--timeout=30000`
- projection repair queue regression target: passed
- API lint and typecheck: passed
- pre-push affected lint, typecheck, format, and i18n: passed
- `bun run verify`: all pre-test gates and completed test batches passed; the process was externally terminated by SIGTERM during API tests, so hosted CI will establish the complete suite

CC on behalf of jan-kubica