### PR TITLE
fix(ui): measure a cell's pinned action before first paint

### DIFF
--- a/.changeset/kanban-cell-first-paint-measure.md
+++ b/.changeset/kanban-cell-first-paint-measure.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+A virtualized cell measures its pinned action before the first paint, so a card's sticky identity row rests under it from the first frame.

--- a/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
+++ b/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
@@ -56,7 +56,37 @@ const expectRestingOnAction = async (header: Locator, actionBottom: number) => {
   );
 };
 
+/** How far the row was told to pin, out of `calc(var(...) + Npx)`. */
+const pinnedAboveOf = (offset: string) => {
+  const match = /\+\s*(?<pixels>\d+(?:\.\d+)?)px/u.exec(offset);
+
+  return match?.groups ? Number(match.groups["pixels"]) : 0;
+};
+
 test.describe("card sticky header", () => {
+  test("carries the action's reach on the board's first layout", async ({
+    page,
+  }) => {
+    await openFixture(page);
+    // Read in the frame the row is first painted in: a measurement left to an
+    // observer leaves this at the bare board offset, and every card's row
+    // spends that frame pinned where the action is about to be.
+    const firstLayout = await page.evaluate(
+      () => document.documentElement.dataset["kanbanCardStickyTopFirstLayout"],
+    );
+
+    expect(firstLayout).toBeDefined();
+    expect(pinnedAboveOf(firstLayout ?? "")).toBeGreaterThan(0);
+    // And it is the action's own height, not some arbitrary offset.
+    const actionHeight = await pinnedAction(page).evaluate(
+      (element) => element.getBoundingClientRect().height,
+    );
+
+    expect(
+      Math.abs(pinnedAboveOf(firstLayout ?? "") - actionHeight),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+  });
+
   test("holds a card's identity row under the lane's pinned action", async ({
     page,
   }) => {

--- a/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { createRoot } from "react-dom/client";
 
 import { KanbanCardShell } from "../card-shell";
@@ -37,11 +37,49 @@ const matrix = buildKanbanBoardMatrix({
     grouping.type === "built-in" ? "open" : "ada",
 });
 
+/**
+ * Publishes what the row around it carries in the frame the browser is about
+ * to paint it in. The read is scheduled from a layout effect but taken in the
+ * frame's animation callback, which is the one point that is past every
+ * synchronous re-render a layout effect provoked and still short of the
+ * frame's resize-observation step: a cell that measures its pinned action in a
+ * layout effect has published its reach by then, and a cell that leaves the
+ * measurement to an observer has published nothing but the board's own offset,
+ * which is exactly the frame a card's identity row spends pinned where the
+ * action is about to be.
+ */
+const FirstLayoutProbe = () => {
+  const anchor = useRef<HTMLSpanElement>(null);
+
+  useLayoutEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      const row = anchor.current?.closest<HTMLElement>("[data-index]");
+
+      if (
+        !row ||
+        document.documentElement.dataset["kanbanCardStickyTopFirstLayout"] !==
+          undefined
+      ) {
+        return;
+      }
+      document.documentElement.dataset["kanbanCardStickyTopFirstLayout"] =
+        row.style.getPropertyValue("--kanban-card-sticky-top");
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  return <span hidden ref={anchor} />;
+};
+
 const CardStickyHeaderFixture = () => {
   useEffect(() => {
     document.documentElement.dataset["kanbanCardStickyHeaderReady"] = "true";
     return () => {
       delete document.documentElement.dataset["kanbanCardStickyHeaderReady"];
+      delete document.documentElement.dataset["kanbanCardStickyTopFirstLayout"];
     };
   }, []);
 
@@ -87,6 +125,7 @@ const CardStickyHeaderFixture = () => {
                   <p className="text-muted-foreground text-xs">
                     A card far taller than the board it scrolls through.
                   </p>
+                  {row.id === "card-1" ? <FirstLayoutProbe /> : null}
                 </KanbanCardShell>
               </div>
             )}

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -4,8 +4,8 @@ import {
   type ReactNode,
   type RefObject,
   type UIEvent,
-  useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -270,18 +270,26 @@ export const KanbanVirtualCell = <TRow,>({
 
   // A card's own pinned header rests under this action, so the cell has to say
   // how tall the action turned out: the caller controls its content, and it
-  // reflows with the cell's width. Zero until measured, and zero whenever the
-  // footer closes the cell instead, which leaves the board's offset alone.
+  // reflows with the cell's width. Measured before the first paint, so no
+  // frame ever pins a card's header at the action's place, and zero whenever
+  // the footer closes the cell instead, which leaves the board's offset alone.
   const stickyFooterRef = useRef<HTMLDivElement>(null);
   const [stickyFooterHeight, setStickyFooterHeight] = useState(0);
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = stickyFooterRef.current;
     if (element === null) {
       setStickyFooterHeight(0);
       return undefined;
     }
+    // A repeat of the height React already rendered would only cost a render.
+    const measure = (height: number) => {
+      setStickyFooterHeight((current) =>
+        current === height ? current : height,
+      );
+    };
+    measure(element.getBoundingClientRect().height);
     const observer = new ResizeObserver(() => {
-      setStickyFooterHeight(element.getBoundingClientRect().height);
+      measure(element.getBoundingClientRect().height);
     });
     observer.observe(element);
     return () => observer.disconnect();


### PR DESCRIPTION
- `KanbanVirtualCell` measured its `footerPlacement="sticky-start"` action in a passive effect, so the first committed frame published `--kanban-card-sticky-top` with nothing pinned above the card: a card's sticky identity row rested at the board header until the observer re-rendered.
- The measurement moves into a layout effect that reads the height immediately and then attaches the ResizeObserver for later reflows; an unchanged height still costs no render, and the height still resets when the action goes away.
- The browser suite records what the first row carried at the layout pass that put it on the page and asserts it already reaches the action's own height (it reads `+ 0px` without the fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kanban card sticky headers so pinned action areas are accounted for before the first frame is rendered.
  * Prevented initial layout shifts by ensuring sticky identity rows begin at the correct position.
  * Kept sticky positioning accurate when pinned action content changes size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->