### PR TITLE
chore(api): treat provisioning placeholders as unset configuration

### DIFF
--- a/apps/api/src/db-url.ts
+++ b/apps/api/src/db-url.ts
@@ -16,7 +16,11 @@ import {
  * the rest of the connection metadata.
  */
 
-const COMPONENT_KEYS = [
+/**
+ * The components this helper requires when it assembles a URL. DB_SSLMODE is
+ * absent on purpose: it defaults to `require` when unset.
+ */
+export const DATABASE_COMPONENT_KEYS = [
   "DB_HOST",
   "DB_PORT",
   "DB_USER",
@@ -109,7 +113,7 @@ export const resolveDatabaseUrl = (
     DB_PASSWORD === undefined ||
     !DB_NAME
   ) {
-    const missing = COMPONENT_KEYS.filter((k) =>
+    const missing = DATABASE_COMPONENT_KEYS.filter((k) =>
       k === "DB_PASSWORD" ? env[k] === undefined : !env[k],
     );
     panic(

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -9,7 +9,11 @@
  */
 import * as v from "valibot";
 
-import { hasSecureDatabaseTransport } from "@/api/db-url";
+import {
+  DATABASE_COMPONENT_KEYS,
+  hasSecureDatabaseTransport,
+} from "@/api/db-url";
+import { resolveConfigurationPlaceholders } from "@/api/lib/configuration-placeholders";
 import {
   CORPUS_STORAGE_MODES,
   type CorpusStorageMode,
@@ -308,6 +312,46 @@ export const databaseComponentEnvSchema = {
   DB_PASSWORD: v.optional(v.string()),
   DB_NAME: v.optional(v.string()),
   DB_SSLMODE: v.optional(v.picklist(["require", "verify-ca", "verify-full"])),
+};
+
+// Derived from the keys resolveDatabaseUrl() insists on, so renaming a
+// component cannot leave this behind.
+const requiredDatabaseComponentSchema = Object.fromEntries(
+  DATABASE_COMPONENT_KEYS.map((name) => [
+    name,
+    databaseComponentEnvSchema[name],
+  ]),
+);
+
+type ResolveApiEnvironmentPlaceholdersOptions = {
+  schema: Record<string, { readonly type: string }>;
+  values: Record<string, string | undefined>;
+};
+
+/**
+ * Placeholder resolution for the API environment, shared by the runtime and
+ * the environment doctor so the two cannot report a configuration
+ * differently.
+ *
+ * The database components are scanned only when they are the selected source
+ * for DATABASE_URL. A supplied URL wins over them, and a placeholder among
+ * inputs nothing reads is not an error; on the derived path the components
+ * the URL cannot be assembled without are named, while DB_SSLMODE reads as
+ * unset and takes its default.
+ */
+export const resolveApiEnvironmentPlaceholders = ({
+  schema,
+  values,
+}: ResolveApiEnvironmentPlaceholdersOptions) => {
+  const resolved = resolveConfigurationPlaceholders({ schema, values });
+  if (resolved.violation !== null || resolved.runtimeEnv["DATABASE_URL"]) {
+    return resolved;
+  }
+  return resolveConfigurationPlaceholders({
+    schema: databaseComponentEnvSchema,
+    values: resolved.runtimeEnv,
+    derivationInputs: requiredDatabaseComponentSchema,
+  });
 };
 
 type EnvBaseInvariantInput = {

--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -17,6 +17,7 @@ import {
   envBaseServerSchema,
   KNOWN_NODE_ENVS,
   NODE_ENV_KIND,
+  resolveApiEnvironmentPlaceholders,
 } from "@/api/env-base-schema";
 import { resolveCorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 
@@ -29,12 +30,20 @@ if (nodeEnvKind === NODE_ENV_KIND.unknown) {
   );
 }
 
+const baseRuntimeEnv = resolveApiEnvironmentPlaceholders({
+  schema: envBaseServerSchema,
+  values: process.env,
+});
+if (baseRuntimeEnv.violation !== null) {
+  panic(baseRuntimeEnv.violation);
+}
+
 export const envBase = createEnv({
   server: envBaseServerSchema,
   emptyStringAsUndefined: true,
   runtimeEnv: {
-    ...process.env,
-    DATABASE_URL: resolveDatabaseUrl(),
+    ...baseRuntimeEnv.runtimeEnv,
+    DATABASE_URL: resolveDatabaseUrl(baseRuntimeEnv.runtimeEnv),
     isDev: nodeEnvKind === NODE_ENV_KIND.local,
   },
 });

--- a/apps/api/src/env-document-processing-worker.ts
+++ b/apps/api/src/env-document-processing-worker.ts
@@ -6,11 +6,20 @@ import {
   documentProcessingEnvInvariantViolation,
   envDocumentProcessingWorkerServerSchema,
 } from "@/api/env-document-processing-worker-schema";
+import { resolveConfigurationPlaceholders } from "@/api/lib/configuration-placeholders";
+
+const workerRuntimeEnv = resolveConfigurationPlaceholders({
+  schema: envDocumentProcessingWorkerServerSchema,
+  values: process.env,
+});
+if (workerRuntimeEnv.violation !== null) {
+  panic(workerRuntimeEnv.violation);
+}
 
 const envDocumentProcessingWorkerSpecific = createEnv({
   server: envDocumentProcessingWorkerServerSchema,
   emptyStringAsUndefined: true,
-  runtimeEnv: process.env,
+  runtimeEnv: workerRuntimeEnv.runtimeEnv,
 });
 
 const invariantViolation = documentProcessingEnvInvariantViolation({

--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -53,18 +53,42 @@ const readSelfhostLocalPasswordAuth = (
   return result.stdout.toString().trim();
 };
 
-const bootApiEnvironment = (env: Record<string, string | undefined>) =>
+const spawnApiEnvironment = (
+  env: Record<string, string | undefined>,
+  script: string,
+  // The repository .env would otherwise supply a DATABASE_URL, hiding the
+  // database-component path these cases exist to exercise.
+  ignoreEnvFile = false,
+) =>
   Bun.spawnSync({
     cmd: [
       process.execPath,
+      ...(ignoreEnvFile ? ["--no-env-file"] : []),
       "-e",
-      `const { env } = await import(${JSON.stringify(envModuleUrl)}); console.log(String(Object.isFrozen(env)));`,
+      script,
     ],
     cwd: repoRoot,
     env,
     stderr: "pipe",
     stdout: "pipe",
   });
+
+const FREEZE_SCRIPT = `const { env } = await import(${JSON.stringify(envModuleUrl)}); console.log(String(Object.isFrozen(env)));`;
+const DATABASE_URL_SCRIPT = `import { env } from ${JSON.stringify(envModuleUrl)}; console.log(env.DATABASE_URL);`;
+
+const bootApiEnvironment = (env: Record<string, string | undefined>) =>
+  spawnApiEnvironment(env, FREEZE_SCRIPT);
+
+const bootDerivedDatabaseEnvironment = (
+  env: Record<string, string | undefined>,
+) => spawnApiEnvironment(env, FREEZE_SCRIPT, true);
+
+const readDerivedDatabaseUrl = (env: Record<string, string | undefined>) => {
+  const result = spawnApiEnvironment(env, DATABASE_URL_SCRIPT, true);
+
+  expect(result.exitCode).toBe(0);
+  return result.stdout.toString().trim();
+};
 
 describe("API environment", () => {
   test("infers SMTP provider from complete SMTP settings", () => {
@@ -159,6 +183,91 @@ describe("API environment", () => {
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr.toString()).toContain(
       'S3_CREDENTIALS_PROVIDER="env" requires static S3 credentials.',
+    );
+  });
+
+  test("reads a provisioning placeholder in an optional credential as absent", () => {
+    const result = bootApiEnvironment({
+      ...baseEnv,
+      S3_ACCESS_KEY_ID: "PLACEHOLDER_SET_ME",
+      S3_CREDENTIALS_PROVIDER: "env",
+      S3_SECRET_ACCESS_KEY: "UNCONFIGURED",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain(
+      'S3_CREDENTIALS_PROVIDER="env" requires static S3 credentials.',
+    );
+  });
+
+  test("refuses to boot when a required value holds a placeholder", () => {
+    const result = bootApiEnvironment({
+      ...baseEnv,
+      S3_BUCKET: "PLACEHOLDER_SET_ME",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain(
+      "S3_BUCKET must be set to a real value",
+    );
+  });
+
+  const databaseComponents = {
+    DB_HOST: "localhost",
+    DB_NAME: "stella",
+    DB_PASSWORD: "postgres",
+    DB_PORT: "5432",
+    DB_SSLMODE: "require",
+    DB_USER: "postgres",
+  } as const;
+  const { DATABASE_URL: _databaseUrl, ...envWithoutDatabaseUrl } = baseEnv;
+
+  test("refuses to assemble a database URL from a placeholder component", () => {
+    const result = bootDerivedDatabaseEnvironment({
+      ...envWithoutDatabaseUrl,
+      ...databaseComponents,
+      DB_PASSWORD: "PLACEHOLDER_SET_ME",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain(
+      "DB_PASSWORD must be set to a real value",
+    );
+  });
+
+  test("ignores placeholder components when DATABASE_URL is supplied", () => {
+    const result = bootApiEnvironment({
+      ...baseEnv,
+      ...databaseComponents,
+      DB_PASSWORD: "PLACEHOLDER_SET_ME",
+      DB_USER: "UNCONFIGURED",
+    });
+
+    expect(result.stderr.toString()).not.toContain("placeholder");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("defaults the SSL mode when the component is empty", () => {
+    expect(
+      readDerivedDatabaseUrl({
+        ...envWithoutDatabaseUrl,
+        ...databaseComponents,
+        DB_SSLMODE: "",
+      }),
+    ).toBe(
+      "postgres://postgres:postgres@localhost:5432/stella?sslmode=require",
+    );
+  });
+
+  test("defaults the SSL mode when the component holds a placeholder", () => {
+    expect(
+      readDerivedDatabaseUrl({
+        ...envWithoutDatabaseUrl,
+        ...databaseComponents,
+        DB_SSLMODE: "UNCONFIGURED",
+      }),
+    ).toBe(
+      "postgres://postgres:postgres@localhost:5432/stella?sslmode=require",
     );
   });
 

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -8,6 +8,15 @@ import {
   envApiServerSchema,
   resolveEmailProvider,
 } from "@/api/env-schema";
+import { resolveConfigurationPlaceholders } from "@/api/lib/configuration-placeholders";
+
+const apiRuntimeEnv = resolveConfigurationPlaceholders({
+  schema: envApiServerSchema,
+  values: process.env,
+});
+if (apiRuntimeEnv.violation !== null) {
+  panic(apiRuntimeEnv.violation);
+}
 
 /**
  * API-specific environment variables. These are only required when the full
@@ -17,7 +26,7 @@ import {
 const envApi = createEnv({
   server: envApiServerSchema,
   emptyStringAsUndefined: true,
-  runtimeEnv: process.env,
+  runtimeEnv: apiRuntimeEnv.runtimeEnv,
 });
 
 const emailProvider = resolveEmailProvider(envApi);

--- a/apps/api/src/lib/configuration-placeholders.test.ts
+++ b/apps/api/src/lib/configuration-placeholders.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import * as v from "valibot";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import {
+  CONFIGURATION_PLACEHOLDERS,
+  isConfigurationPlaceholder,
+  resolveConfigurationPlaceholders,
+} from "@/api/lib/configuration-placeholders";
+import { credentialsFromEnvValues } from "@/api/lib/s3-credentials";
+
+const schema = {
+  REQUIRED_VALUE: v.string(),
+  OPTIONAL_VALUE: v.optional(v.string()),
+};
+
+describe("configuration placeholders", () => {
+  test("an optional credential holding a placeholder reads as absent", () => {
+    expect(
+      credentialsFromEnvValues("PLACEHOLDER_SET_ME", "PLACEHOLDER_SET_ME"),
+    ).toBeNull();
+    expect(
+      credentialsFromEnvValues("UNCONFIGURED", "a-real-secret"),
+    ).toBeNull();
+
+    const { runtimeEnv, violation } = resolveConfigurationPlaceholders({
+      schema,
+      values: {
+        OPTIONAL_VALUE: "UNCONFIGURED",
+        REQUIRED_VALUE: "a-real-value",
+      },
+    });
+    expect(runtimeEnv["OPTIONAL_VALUE"]).toBeUndefined();
+    expect(violation).toBeNull();
+  });
+
+  test("a required value holding a placeholder fails validation by name", () => {
+    const { runtimeEnv, violation } = resolveConfigurationPlaceholders({
+      schema,
+      values: {
+        OPTIONAL_VALUE: "a-real-value",
+        REQUIRED_VALUE: "PLACEHOLDER_SET_ME",
+      },
+    });
+
+    expect(runtimeEnv["REQUIRED_VALUE"]).toBeUndefined();
+    expect(violation).toContain("REQUIRED_VALUE");
+    expect(violation).not.toContain("OPTIONAL_VALUE");
+  });
+
+  test("a real value survives untouched", () => {
+    const { runtimeEnv, violation } = resolveConfigurationPlaceholders({
+      schema,
+      values: {
+        OPTIONAL_VALUE: "use-iam-roles-elsewhere",
+        REQUIRED_VALUE: "unconfigured-region",
+      },
+    });
+
+    expect(runtimeEnv["OPTIONAL_VALUE"]).toBe("use-iam-roles-elsewhere");
+    expect(runtimeEnv["REQUIRED_VALUE"]).toBe("unconfigured-region");
+    expect(violation).toBeNull();
+  });
+
+  test("no casing or padding of a sentinel ever reaches a consumer", () => {
+    const padding = fc.stringMatching(/^[ \t\r\n]{0,4}$/u);
+    const recased = (sentinel: string) =>
+      fc
+        .array(fc.boolean(), {
+          minLength: sentinel.length,
+          maxLength: sentinel.length,
+        })
+        .map((upper) =>
+          upper
+            .map((isUpper, index) =>
+              isUpper
+                ? sentinel.charAt(index).toUpperCase()
+                : sentinel.charAt(index),
+            )
+            .join(""),
+        );
+    // The empty sentinel carries no padding: padding it produces a
+    // whitespace-only value, which is malformed rather than unset.
+    const sentinelValue = fc
+      .constantFrom(...CONFIGURATION_PLACEHOLDERS)
+      .chain((sentinel) =>
+        sentinel === ""
+          ? fc.constant("")
+          : fc
+              .tuple(padding, recased(sentinel), padding)
+              .map(([before, cased, after]) => `${before}${cased}${after}`),
+      );
+
+    fc.assert(
+      fc.property(sentinelValue, (value) => {
+        expect(isConfigurationPlaceholder(value)).toBe(true);
+        expect(credentialsFromEnvValues(value, value)).toBeNull();
+
+        const { runtimeEnv, violation } = resolveConfigurationPlaceholders({
+          schema,
+          values: { OPTIONAL_VALUE: value, REQUIRED_VALUE: value },
+        });
+        expect(runtimeEnv["OPTIONAL_VALUE"]).toBeUndefined();
+        expect(runtimeEnv["REQUIRED_VALUE"]).toBeUndefined();
+        // Every sentinel reads as unset; only a seeded literal is named,
+        // because an empty value is what "unset" already looks like.
+        expect(violation === null).toBe(value === "");
+        if (violation !== null) {
+          expect(violation).toContain("REQUIRED_VALUE");
+        }
+      }),
+      propertyConfig({ numRuns: 200 }),
+    );
+  });
+
+  test("a placeholder in a derivation input is reported by name", () => {
+    const { runtimeEnv, violation } = resolveConfigurationPlaceholders({
+      schema,
+      values: { REQUIRED_VALUE: "a-real-value", DERIVED_PART: "UNCONFIGURED" },
+      derivationInputs: { DERIVED_PART: v.optional(v.string()) },
+    });
+
+    expect(runtimeEnv["DERIVED_PART"]).toBeUndefined();
+    expect(violation).toContain("DERIVED_PART");
+  });
+
+  test("an empty database password stays a password, not an unset one", () => {
+    const { runtimeEnv, violation } = resolveConfigurationPlaceholders({
+      schema,
+      values: { REQUIRED_VALUE: "a-real-value", DB_PASSWORD: "" },
+      derivationInputs: { DB_PASSWORD: v.optional(v.string()) },
+    });
+
+    expect(runtimeEnv["DB_PASSWORD"]).toBe("");
+    expect(violation).toBeNull();
+  });
+
+  test("a whitespace-only value stays a value, not an unset one", () => {
+    expect(isConfigurationPlaceholder("   ")).toBe(false);
+    expect(
+      resolveConfigurationPlaceholders({
+        schema,
+        values: { REQUIRED_VALUE: "   " },
+      }).runtimeEnv["REQUIRED_VALUE"],
+    ).toBe("   ");
+  });
+});

--- a/apps/api/src/lib/configuration-placeholders.ts
+++ b/apps/api/src/lib/configuration-placeholders.ts
@@ -1,0 +1,121 @@
+/**
+ * Values that mean "nothing has been supplied for this variable yet".
+ *
+ * The empty string is the shape a cleared variable takes; the remaining
+ * literals are seeded by provisioning tooling so a parameter exists before a
+ * human fills it in. Without this set a seeded literal validates as a real
+ * value and reaches a client, so every sentinel check routes through here:
+ * an optional variable reads as absent, a required one fails validation.
+ *
+ * Casing and stray whitespace around a literal cannot turn a placeholder back
+ * into a value.
+ */
+export const CONFIGURATION_PLACEHOLDERS = [
+  "",
+  "use-iam-role",
+  "placeholder_set_me",
+  "unconfigured",
+] as const;
+
+const PLACEHOLDER_LITERALS: ReadonlySet<string> = new Set(
+  CONFIGURATION_PLACEHOLDERS.filter((placeholder) => placeholder !== ""),
+);
+
+/**
+ * Variables where the empty string is a value rather than an absence. Only a
+ * database password qualifies: an empty one is valid, so it must survive
+ * normalisation. Every other variable treats empty as unset and takes its
+ * default. The seeded literals still read as unset here.
+ */
+export const EMPTY_VALUE_VARIABLES: ReadonlySet<string> = new Set([
+  "DB_PASSWORD",
+]);
+
+/**
+ * The empty string matches exactly, while the seeded literals match after
+ * trim + lowercase: a whitespace-only value is a malformed value rather than
+ * an unset one, and must keep failing its own variable's schema.
+ */
+export const isConfigurationPlaceholder = (value: string): boolean =>
+  value === "" || PLACEHOLDER_LITERALS.has(value.trim().toLowerCase());
+
+const isPlaceholderForVariable = (name: string, value: string): boolean =>
+  value === ""
+    ? !EMPTY_VALUE_VARIABLES.has(name)
+    : PLACEHOLDER_LITERALS.has(value.trim().toLowerCase());
+
+/** The `type` valibot gives a schema that accepts an absent value. */
+const OPTIONAL_SCHEMA_TYPE = "optional";
+
+/** The only part of an env schema entry this module reads. */
+type EnvSchemaEntry = { readonly type: string };
+
+type RuntimeEnvValues = Record<string, string | undefined>;
+
+type ConfigurationPlaceholderResolution = {
+  /** `values` with every declared placeholder replaced by undefined. */
+  runtimeEnv: RuntimeEnvValues;
+  /** Set when a variable that needs a real value held a placeholder. */
+  violation: string | null;
+};
+
+type ResolveConfigurationPlaceholdersOptions = {
+  /** Schema read for the variable names and their optionality. */
+  schema: Record<string, EnvSchemaEntry>;
+  /** Raw values, typically `process.env`. */
+  values: RuntimeEnvValues;
+  /**
+   * Variables that assemble a derived value instead of being read directly.
+   * Each is individually optional, but a placeholder in one is never an
+   * intentional "unset": it would vanish from what gets assembled and leave a
+   * usable-looking result behind, so it is always reported by name.
+   */
+  derivationInputs?: Record<string, EnvSchemaEntry>;
+};
+
+/**
+ * Strip placeholders before anything reads the values, derivations included.
+ * Callers pass `runtimeEnv` on to validation and turn a non-null `violation`
+ * into a boot failure; the message names the offending variables so the fix
+ * is obvious from the log.
+ */
+export const resolveConfigurationPlaceholders = ({
+  schema,
+  values,
+  derivationInputs = {},
+}: ResolveConfigurationPlaceholdersOptions): ConfigurationPlaceholderResolution => {
+  const runtimeEnv: RuntimeEnvValues = { ...values };
+  const reported: string[] = [];
+  const scan = (
+    entries: Record<string, EnvSchemaEntry>,
+    alwaysReport: boolean,
+  ) => {
+    for (const [name, entry] of Object.entries(entries)) {
+      // Read the input, not the accumulator: a variable listed in both
+      // `schema` and `derivationInputs` must be judged the same either way.
+      const value = values[name];
+      if (typeof value !== "string" || !isPlaceholderForVariable(name, value)) {
+        continue;
+      }
+      runtimeEnv[name] = undefined;
+      // Only a seeded literal is worth naming. An empty value is unset, and
+      // reporting it here would pre-empt the schema (or a derivation that
+      // falls back to another input) that already handles an absent value.
+      if (
+        value !== "" &&
+        (alwaysReport || entry.type !== OPTIONAL_SCHEMA_TYPE)
+      ) {
+        reported.push(name);
+      }
+    }
+  };
+  scan(schema, false);
+  scan(derivationInputs, true);
+  return {
+    runtimeEnv,
+    violation:
+      reported.length === 0
+        ? null
+        : `${reported.join(", ")} must be set to a real value; the configured value is a placeholder.`,
+  };
+};

--- a/apps/api/src/lib/s3-credentials.ts
+++ b/apps/api/src/lib/s3-credentials.ts
@@ -1,22 +1,19 @@
+import { isConfigurationPlaceholder } from "@/api/lib/configuration-placeholders";
+
 export type OptionalS3Credentials = {
   accessKeyId: string;
   secretAccessKey: string;
   sessionToken?: string;
 };
 
-// Sentinel strings used in task definitions to signal "no static credential
-// is set; resolve via the runtime IAM role". Match after trim + lowercase so
-// casing and trailing whitespace do not turn a placeholder into a credential.
-const STATIC_CREDENTIAL_PLACEHOLDERS: ReadonlySet<string> = new Set([
-  "",
-  "use-iam-role",
-]);
-
+// A credential made only of whitespace is unusable too, where a numeric or
+// URL variable would rather fail its own schema than read as unset.
 export const isUsableStaticCredential = (
   value: string | undefined,
 ): value is string =>
   value !== undefined &&
-  !STATIC_CREDENTIAL_PLACEHOLDERS.has(value.trim().toLowerCase());
+  value.trim() !== "" &&
+  !isConfigurationPlaceholder(value);
 
 export const credentialsFromEnvValues = (
   accessKeyId: string | undefined,

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -295,7 +295,7 @@ describe("environment doctor output", () => {
       }),
     ).toEqual({
       DB_PASSWORD: "",
-      DB_SSLMODE: "",
+      DB_SSLMODE: undefined,
       EMAIL_PROVIDER: undefined,
     });
   });
@@ -319,7 +319,79 @@ describe("environment doctor output", () => {
     );
   });
 
-  test("rejects an empty database SSL mode like API startup", () => {
+  test("rejects a placeholder database component by name", () => {
+    const input = validApiInput();
+    delete input["DATABASE_URL"];
+    Object.assign(input, {
+      DB_HOST: "localhost",
+      DB_NAME: "stella",
+      DB_PASSWORD: "PLACEHOLDER_SET_ME",
+      DB_PORT: "5432",
+      DB_SSLMODE: "require",
+      DB_USER: "postgres",
+    });
+
+    const result = validateDoctorEnvironment({ app: "api", input });
+    expect(result.status).toBe("invalid");
+    if (result.status === "invalid") {
+      expect(result.issues).toContain(
+        "DB_PASSWORD must be set to a real value; the configured value is a placeholder.",
+      );
+    }
+  });
+
+  test("ignores placeholder components when DATABASE_URL is supplied", () => {
+    const input = validApiInput();
+    Object.assign(input, {
+      DB_HOST: "localhost",
+      DB_NAME: "stella",
+      DB_PASSWORD: "PLACEHOLDER_SET_ME",
+      DB_PORT: "5432",
+      DB_USER: "UNCONFIGURED",
+    });
+
+    const result = validateDoctorEnvironment({ app: "api", input });
+    expect(result.status).toBe("valid");
+  });
+
+  test("defaults the SSL mode when the component holds a placeholder", () => {
+    const input = validApiInput();
+    delete input["DATABASE_URL"];
+    Object.assign(input, {
+      DB_HOST: "localhost",
+      DB_NAME: "stella",
+      DB_PASSWORD: "postgres",
+      DB_PORT: "5432",
+      DB_SSLMODE: "UNCONFIGURED",
+      DB_USER: "postgres",
+    });
+
+    const result = validateDoctorEnvironment({ app: "api", input });
+    expect(result.status).toBe("valid");
+    expect(result.values["DATABASE_URL"]).toBe(
+      "postgres://postgres:postgres@localhost:5432/stella?sslmode=require",
+    );
+  });
+
+  // The collab runtime hands raw values to createEnv, so the doctor must not
+  // read a placeholder there as an unset value and report the default.
+  test("reports a collab placeholder exactly as the collab runtime does", () => {
+    const result = validateDoctorEnvironment({
+      app: "collab",
+      input: {
+        STELLA_API_URL: "https://api.example.com",
+        STELLA_COLLAB_MODE: "UNCONFIGURED",
+        STELLA_COLLAB_SERVICE_TOKEN: "x".repeat(32),
+      },
+    });
+
+    expect(result.status).toBe("invalid");
+    if (result.status === "invalid") {
+      expect(result.issues.join(" ")).toContain("STELLA_COLLAB_MODE");
+    }
+  });
+
+  test("defaults an empty database SSL mode like API startup", () => {
     const input = validApiInput();
     delete input["DATABASE_URL"];
     Object.assign(input, {
@@ -332,12 +404,10 @@ describe("environment doctor output", () => {
     });
 
     const result = validateDoctorEnvironment({ app: "api", input });
-    expect(result.status).toBe("invalid");
-    if (result.status === "invalid") {
-      expect(result.issues).toContain(
-        "DATABASE_URL: invalid database component settings.",
-      );
-    }
+    expect(result.status).toBe("valid");
+    expect(result.values["DATABASE_URL"]).toBe(
+      "postgres://postgres:@localhost:5432/stella?sslmode=require",
+    );
   });
 
   test("rejects a non-PostgreSQL case-law database URL", () => {
@@ -470,6 +540,14 @@ describe("environment doctor output", () => {
         S3_ACCESS_KEY_ID: " use-iam-role ",
         S3_CREDENTIALS_PROVIDER: "env",
         S3_SECRET_ACCESS_KEY: "USE-IAM-ROLE",
+      },
+    },
+    {
+      expected: 'S3_CREDENTIALS_PROVIDER="env" requires static S3 credentials.',
+      overrides: {
+        S3_ACCESS_KEY_ID: "PLACEHOLDER_SET_ME",
+        S3_CREDENTIALS_PROVIDER: "env",
+        S3_SECRET_ACCESS_KEY: "UNCONFIGURED",
       },
     },
     {

--- a/scripts/env-tool.ts
+++ b/scripts/env-tool.ts
@@ -19,12 +19,14 @@ import {
   envBaseInvariantViolation,
   KNOWN_NODE_ENVS,
   NODE_ENV_KIND,
+  resolveApiEnvironmentPlaceholders,
 } from "../apps/api/src/env-base-schema";
 import { documentProcessingEnvInvariantViolation } from "../apps/api/src/env-document-processing-worker-schema";
 import {
   envApiInvariantViolation,
   resolveEmailProvider,
 } from "../apps/api/src/env-schema";
+import { EMPTY_VALUE_VARIABLES } from "../apps/api/src/lib/configuration-placeholders";
 import { envWebInvariantViolation } from "../apps/web/src/env-schema";
 import {
   AMBIENT_ENV_KEYS,
@@ -851,15 +853,11 @@ type DoctorValidationResult =
 const isEnvApp = (value: string): value is EnvApp =>
   Object.values(ENV_APP).some((app) => app === value);
 
-const EMPTY_DATABASE_COMPONENT_KEYS = new Set(["DB_PASSWORD", "DB_SSLMODE"]);
-
 export const normalizeEmptyEnvironment = (input: DoctorInput): DoctorInput => {
   const normalized: DoctorInput = {};
   for (const [name, value] of Object.entries(input)) {
     normalized[name] =
-      value === "" && !EMPTY_DATABASE_COMPONENT_KEYS.has(name)
-        ? undefined
-        : value;
+      value === "" && !EMPTY_VALUE_VARIABLES.has(name) ? undefined : value;
   }
   return normalized;
 };
@@ -880,16 +878,31 @@ const validateSchema = (
 };
 
 const validateApiEnvironment = (input: DoctorInput): DoctorValidationResult => {
-  const databaseUrl = Result.try(() => resolveDatabaseUrl(input));
+  // Mirrors apps/api/src/env-base.ts: placeholders go first, so the doctor
+  // and the runtime derive DATABASE_URL from the same values.
+  const placeholders = resolveApiEnvironmentPlaceholders({
+    schema: API_ENV_SCHEMA,
+    values: input,
+  });
+  if (placeholders.violation !== null) {
+    return {
+      status: "invalid",
+      issues: [placeholders.violation],
+      values: input,
+    };
+  }
+  const configured = placeholders.runtimeEnv;
+
+  const databaseUrl = Result.try(() => resolveDatabaseUrl(configured));
   if (Result.isError(databaseUrl)) {
     return {
       status: "invalid",
       issues: ["DATABASE_URL: invalid database component settings."],
-      values: input,
+      values: configured,
     };
   }
 
-  const nodeEnv = input["NODE_ENV"];
+  const nodeEnv = configured["NODE_ENV"];
   const nodeEnvKind = classifyNodeEnv(nodeEnv);
   if (nodeEnvKind === NODE_ENV_KIND.unknown) {
     return {
@@ -897,12 +910,12 @@ const validateApiEnvironment = (input: DoctorInput): DoctorValidationResult => {
       issues: [
         `NODE_ENV: "${nodeEnv}" is not one of ${KNOWN_NODE_ENVS.join(", ")}.`,
       ],
-      values: input,
+      values: configured,
     };
   }
 
   const runtimeInput = {
-    ...input,
+    ...configured,
     DATABASE_URL: databaseUrl.value,
     isDev: nodeEnvKind === NODE_ENV_KIND.local,
   };


### PR DESCRIPTION
## What

One shared sentinel set for configuration values that mean "not set" (the empty string, `use-iam-role`, and the placeholders provisioning tooling writes before a value is supplied). Optional values holding a sentinel read as absent; required values holding one fail validation with a message naming the variable. The environment doctor uses the same predicate, so the tooling and the runtime cannot drift.

## Tests

Unit and property tests over the sentinel set (random casing and padding), required-value rejection at each env boundary, credential detection unchanged, env tool doctor cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent handling of placeholder configuration values across API services, workers, database settings and S3 credentials.
  * Environment validation now identifies required settings containing placeholders and reports the affected variable.
  * Environment diagnostics now apply the same placeholder checks as runtime configuration.
  * Database connection settings now default `DB_SSLMODE` to `require` when unspecified.

* **Bug Fixes**
  * Improved detection of blank, whitespace-only and placeholder credentials.
  * Prevented invalid placeholder values from being used when deriving database connections, while respecting a supplied `DATABASE_URL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->