### PR TITLE
fix(api): render a valid court-weight expression when no entries are seeded

### DIFF
--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -75,6 +75,7 @@ runtime validation, or integration tests.
 
 - [`confine-redis-client`](./confine-redis-client.ts) (`confine-redis-client`): confines direct Redis client construction and imports to the owned infrastructure module.
 - [`no-bare-jsonb-cast`](./no-bare-jsonb-cast.ts) (`no-bare-jsonb-cast`): rejects bare PostgreSQL JSONB casts that bypass the typed JSONB expression helper.
+- [`no-hand-rolled-sql-case`](./no-hand-rolled-sql-case.ts) (`no-hand-rolled-sql-case`): rejects a SQL `CASE` whose branch list is generated in the interpolation, where an empty list renders a branchless `CASE`; the shared renderers return the fallback instead.
 - [`no-db-await-in-loop`](./no-db-await-in-loop.ts) (`no-db-await-in-loop`): catches database calls awaited serially in loops and unbounded `Promise.all` query fan-out.
 - [`no-direct-audit-log-insert`](./no-direct-audit-log-insert.ts) (`no-direct-audit-log-insert`): keeps audit-log insertion behind the canonical append-only audit service.
 - [`no-direct-buffer-cleanup-intent-delete`](./no-direct-buffer-cleanup-intent-delete.ts) (`no-direct-buffer-cleanup-intent-delete`): keeps publication-time cleanup-intent retirement behind the transaction-owned reconciliation helper; tests and the owning reconciliation module may delete directly.

--- a/.oxlint-plugins/__fixtures__/no-hand-rolled-sql-case.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-hand-rolled-sql-case.fixture.ts
@@ -1,0 +1,107 @@
+// Passive regression fixture for
+// `no-hand-rolled-sql-case/no-hand-rolled-sql-case`.
+//
+// Each `oxlint-disable-next-line` below suppresses a case the rule MUST flag:
+// a CASE whose branches are generated in the interpolation, which renders
+// `CASE ELSE …` (a syntax error) as soon as the list is empty. If the rule
+// regresses, the directive goes unused and
+// `--report-unused-disable-directives-severity=error` fails CI. The accepted
+// forms carry no directive, so a rule that over-reports fails here too.
+
+import { sql } from "drizzle-orm";
+
+const branches = ["WHEN court ~* 'apex' THEN 10"];
+const rows = [{ id: "a", weight: 4 }];
+const columnId = sql`id`;
+const fallbackColumn = sql`weight`;
+const condition = sql`court IS NOT NULL`;
+const toBranch = (row: { id: string; weight: number }): string =>
+  `WHEN id = '${row.id}' THEN ${row.weight}`;
+const columns = ["court", "weight"];
+const renderColumn = (column: string): string => `d.${column}`;
+
+// A joined branch list spliced into the text a query is built from.
+// oxlint-disable-next-line no-hand-rolled-sql-case/no-hand-rolled-sql-case
+const _joinedText = `CASE ${branches.join("\n")} ELSE 1 END`;
+
+// Mapped and joined in one interpolation; the list is still generated here.
+// oxlint-disable-next-line no-hand-rolled-sql-case/no-hand-rolled-sql-case
+const _mappedText = `CASE ${rows.map(toBranch).join("\n")} ELSE 1 END`;
+
+// The same shape inside a tagged SQL template.
+// oxlint-disable-next-line no-hand-rolled-sql-case/no-hand-rolled-sql-case
+const _taggedJoin = sql`CASE ${sql.join(
+  rows.map(({ id, weight }) => sql`WHEN ${id} THEN ${weight}`),
+  sql.raw(" "),
+)} ELSE ${fallbackColumn} END`;
+
+// The simple-CASE form: an empty branch list leaves `CASE id ELSE col END`,
+// which Postgres rejects for the same reason.
+// oxlint-disable-next-line no-hand-rolled-sql-case/no-hand-rolled-sql-case
+const _simpleCase = sql`CASE ${columnId} ${sql.join(
+  rows.map(({ id, weight }) => sql`WHEN ${id} THEN ${weight}`),
+  sql.raw(" "),
+)} ELSE ${fallbackColumn} END`;
+
+// A spread array literal builds the list in place too.
+// oxlint-disable-next-line no-hand-rolled-sql-case/no-hand-rolled-sql-case
+const _spreadBranches = `CASE ${[...branches].join(" ")} ELSE 1 END`;
+
+// A SQL comment between the keyword and the list hides nothing.
+// oxlint-disable-next-line no-hand-rolled-sql-case/no-hand-rolled-sql-case
+const _commented = `CASE /* ranked */ ${branches.join(" ")} ELSE 1 END`;
+
+// A real CASE preceded by a quoted keyword: masking the literal must not
+// swallow the CASE that follows it.
+// oxlint-disable-next-line no-hand-rolled-sql-case/no-hand-rolled-sql-case
+const _keywordInData = `SELECT 'END of list', CASE ${branches.join(" ")} ELSE 1 END`;
+
+// Accepted: every keyword sits inside string data, so there is no CASE here.
+// Unmasked, the literals would read as an opened and closed CASE around a
+// generated column list.
+const _quotedKeywords = `SELECT 'CASE', ${columns.map(renderColumn).join(", ")} WHERE marker = 'END'`;
+
+// Accepted: the same pair of keywords as quoted identifiers, which an unmasked
+// scan reads as a CASE opened and closed around the generated column list.
+const _quotedIdentifier = `SELECT "CASE", ${columns.map(renderColumn).join(", ")} AS "END" FROM decisions`;
+// Accepted: a dollar-quoted body, the third spelling Postgres reads as data.
+const _dollarQuoted = `SELECT $label$CASE$label$, ${columns.map(renderColumn).join(", ")} AS $label$END$label$ FROM decisions`;
+
+// Accepted: an escaped quote does not end the literal, so the keywords after
+// it are still data.
+const _escapedQuote = `SELECT 'it''s a CASE', ${columns.map(renderColumn).join(", ")} WHERE marker = 'END'`;
+
+// Accepted: the branches are written out, so there is no list to be empty.
+const _writtenOut = sql`CASE WHEN ${condition} THEN 1 ELSE 0 END`;
+
+// Accepted: a simple CASE whose operand is interpolated and whose branches
+// are literal text — the interpolation is a column, not a branch list.
+const _literalBranches = sql`CASE ${columnId} WHEN 'a' THEN 1 ELSE 0 END`;
+
+// Accepted: a generated list that is not a CASE's branches.
+const _notACase = sql`WHERE id IN (${sql.join(
+  rows.map(({ id }) => sql`${id}`),
+  sql.raw(", "),
+)})`;
+
+// Accepted: a generated list interpolated after the branches begin, where an
+// empty list cannot leave the CASE branchless.
+const _afterFirstBranch = `CASE WHEN a THEN 1 ${branches.join(" ")} ELSE 1 END`;
+
+export {
+  _afterFirstBranch,
+  _commented,
+  _dollarQuoted,
+  _escapedQuote,
+  _joinedText,
+  _keywordInData,
+  _literalBranches,
+  _mappedText,
+  _notACase,
+  _quotedIdentifier,
+  _quotedKeywords,
+  _simpleCase,
+  _spreadBranches,
+  _taggedJoin,
+  _writtenOut,
+};

--- a/.oxlint-plugins/no-hand-rolled-sql-case.ts
+++ b/.oxlint-plugins/no-hand-rolled-sql-case.ts
@@ -1,0 +1,232 @@
+// Build a `CASE` over a generated branch list through `sqlCaseExpression` or
+// `sqlCaseFragment`, never by interpolating the list into a template.
+//
+// A `CASE` needs at least one `WHEN`: `CASE ELSE 1 END` and `CASE id ELSE col
+// END` are both syntax errors, so a template that splices its branches in
+// renders an invalid statement the moment the list it iterates is empty. That
+// list is a query result, a registry table, or a batch — all of which can be
+// empty in an environment nobody tested — and the failure is a syntax error at
+// execution rather than a type error at the call site. Each site that spells
+// the `CASE` itself has to decide the empty case again, and the decision is
+// invisible in review, which is how a seeded-registry assumption reached the
+// ranking paths.
+//
+// `apps/api/src/lib/sql-case-expression.ts` owns both renderers and returns
+// the fallback alone for an empty list, so the decision exists once.
+//
+// Flagged (anywhere in apps/api but the owning module):
+//   sql`CASE ${branches.join(" ")} ELSE 1 END`
+//   sql`CASE ${sql.join(rows.map((r) => sql`WHEN ...`), sql.raw(" "))} END`
+//   sql`CASE ${table.id} ${sql.join(branches, sql.raw(" "))} ELSE ${col} END`
+//   `CASE ${entries.map(toBranch).join("\n")} ELSE ${fallback} END`
+//   sql.raw(`CASE ${[...branches].join(" ")} ELSE 1 END`)
+//
+// Allowed:
+//   sql`CASE WHEN ${cond} THEN 1 ELSE 0 END`   // branches written out
+//   sql`CASE ${col} WHEN 'a' THEN 1 ELSE 0 END`
+//   sql`SELECT 'CASE', ${cols.join(", ")} WHERE m = 'END'`  // keywords in data
+//   sqlCaseFragment({ branches: rows.map(...), fallback: sql`${col}` })
+//
+// Detection boundary: the branch list must be built in the interpolation
+// itself (`.map(...)`, `.join(...)`, `sql.join(...)`, or an array literal
+// spread). A list hoisted into a variable first is not matched — syntax
+// analysis cannot tell that variable from a column reference, and the
+// interpolation position alone would flag every simple `CASE ${col} WHEN`.
+// The rule is a guard against the shape, not a proof that no other spelling
+// exists.
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { filenameForContext, getPropertyName, isAstNode } from "./utils.ts";
+
+const RULE_NAME = "no-hand-rolled-sql-case";
+
+const OWNING_MODULE = "apps/api/src/lib/sql-case-expression.ts";
+const FIXTURE = `.oxlint-plugins/__fixtures__/${RULE_NAME}.fixture.ts`;
+
+/** A placeholder for an earlier interpolation, so keyword scanning is positional. */
+const INTERPOLATION = " ? ";
+
+/** The delimiter of a dollar-quoted string, `$$` or `$tag$`. */
+const DOLLAR_QUOTE = /^\$[A-Za-z_\d]*\$/u;
+
+/**
+ * Blank everything Postgres does not read as SQL: comments, single-quoted
+ * strings (`''` escapes a quote rather than ending the string), double-quoted
+ * identifiers, and dollar-quoted bodies. Scanning the raw text instead would
+ * read `SELECT 'CASE', ...` as an open CASE and `ELSE 'END'` as a closed one,
+ * so a query that only mentions the keywords in its data would be reported.
+ *
+ * Blanks keep the length of what they replace, so positions stay comparable
+ * with the unmasked text.
+ */
+const maskSqlNoise = (raw: string): string => {
+  const blank = (length: number): string => " ".repeat(length);
+  let masked = "";
+  let index = 0;
+
+  while (index < raw.length) {
+    const rest = raw.slice(index);
+    const comment = /^(?:--[^\n]*|\/\*[\S\s]*?(?:\*\/|$))/u.exec(rest);
+    if (comment) {
+      masked += blank(comment[0].length);
+      index += comment[0].length;
+      continue;
+    }
+    const dollarQuote = DOLLAR_QUOTE.exec(rest);
+    if (dollarQuote) {
+      const tag = dollarQuote[0];
+      const closing = raw.indexOf(tag, index + tag.length);
+      const end = closing === -1 ? raw.length : closing + tag.length;
+      masked += blank(end - index);
+      index = end;
+      continue;
+    }
+    const quote = raw.charAt(index);
+    if (quote !== "'" && quote !== '"') {
+      masked += quote;
+      index += 1;
+      continue;
+    }
+    // A doubled quote escapes one, so the string continues past it.
+    let cursor = index + 1;
+    while (cursor < raw.length) {
+      if (raw.charAt(cursor) !== quote) {
+        cursor += 1;
+        continue;
+      }
+      if (raw.charAt(cursor + 1) === quote) {
+        cursor += 2;
+        continue;
+      }
+      break;
+    }
+    const end = Math.min(cursor + 1, raw.length);
+    masked += blank(end - index);
+    index = end;
+  }
+
+  return masked;
+};
+
+/**
+ * Whether the text before an interpolation leaves it in the position where a
+ * `CASE`'s first `WHEN` branch has to appear: a `CASE` is open, and no `WHEN`
+ * or `END` has closed the gap between the keyword and this interpolation.
+ */
+const opensCaseBranches = (prefix: string): boolean => {
+  const text = maskSqlNoise(prefix);
+  const lastCase = text.toUpperCase().lastIndexOf("CASE");
+  if (lastCase === -1) {
+    return false;
+  }
+  // A hyphen counts as a word character here so prose in a help string
+  // ("case-law reconciliation") is not read as the SQL keyword.
+  const before = text.charAt(lastCase - 1);
+  const after = text.charAt(lastCase + 4);
+  if (/[\w$-]/u.test(before) || /[\w$-]/u.test(after)) {
+    return false;
+  }
+  return !/\b(?:WHEN|END)\b/iu.test(text.slice(lastCase + 4));
+};
+
+/** Whether the text after an interpolation closes the CASE it would open. */
+const closesCase = (suffix: string): boolean =>
+  /\bEND\b/iu.test(maskSqlNoise(suffix));
+
+const isArraySpread = (node: unknown): boolean =>
+  isAstNode(node) &&
+  node.type === "ArrayExpression" &&
+  Array.isArray(node.elements) &&
+  node.elements.some(
+    (element) => isAstNode(element) && element.type === "SpreadElement",
+  );
+
+/**
+ * A branch list built in place: `xs.map(...)`, `xs.join(...)`, `sql.join(...)`,
+ * or an array literal that spreads one.
+ */
+const isGeneratedBranchList = (node: unknown): boolean => {
+  if (isArraySpread(node)) {
+    return true;
+  }
+  if (!isAstNode(node) || node.type !== "CallExpression") {
+    return false;
+  }
+  const { callee } = node;
+  if (!isAstNode(callee) || callee.type !== "MemberExpression") {
+    return false;
+  }
+  const method = getPropertyName(callee.property);
+  return method === "map" || method === "join";
+};
+
+// A quasi's `value` is a plain `{ raw, cooked }` record rather than an AST
+// node, so it carries no `type` to narrow on and needs a guard of its own.
+const holdsRawText = (value: unknown): value is { raw: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "raw" in value &&
+  typeof value.raw === "string";
+
+/** The static text of a template quasi. */
+const rawTextOf = (quasi: unknown): string => {
+  const value = isAstNode(quasi) ? quasi.value : undefined;
+  return holdsRawText(value) ? value.raw : "";
+};
+
+export default eslintCompatPlugin({
+  meta: { name: RULE_NAME },
+  rules: {
+    [RULE_NAME]: {
+      meta: {
+        type: "problem",
+        messages: {
+          handRolledCase:
+            "Render a CASE over a generated branch list with " +
+            "`sqlCaseExpression` or `sqlCaseFragment` from " +
+            "`@/api/lib/sql-case-expression`. A branchless CASE is a syntax " +
+            "error, so an empty list breaks the statement at runtime; the " +
+            "helper returns the fallback instead.",
+        },
+      },
+      createOnce(context) {
+        return {
+          before() {
+            const filename = filenameForContext(context);
+            return (
+              (filename.includes("apps/api/src/") ||
+                filename.endsWith(FIXTURE)) &&
+              !filename.endsWith(OWNING_MODULE)
+            );
+          },
+          TemplateLiteral(node) {
+            const expressions = Array.isArray(node.expressions)
+              ? node.expressions
+              : [];
+            const quasis = Array.isArray(node.quasis) ? node.quasis : [];
+
+            const texts = quasis.map((quasi) => rawTextOf(quasi));
+            let prefix = "";
+            for (const [index, expression] of expressions.entries()) {
+              prefix += texts[index] ?? "";
+              // Both halves are required: the keyword alone appears in prose,
+              // and the CASE has to be closed for the branches to be a CASE's.
+              if (
+                opensCaseBranches(prefix) &&
+                closesCase(texts.slice(index + 1).join(INTERPOLATION)) &&
+                isGeneratedBranchList(expression)
+              ) {
+                context.report({
+                  node: expression,
+                  messageId: "handRolledCase",
+                });
+              }
+              prefix += INTERPOLATION;
+            }
+          },
+        };
+      },
+    },
+  },
+});

--- a/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
@@ -374,7 +374,9 @@ describe("courtWeightSql", () => {
 
   test("no entries renders the default weight for every court", () => {
     // An unmigrated table: nothing to rank by, and nothing to fall back to.
+    // A branchless `CASE` is a syntax error, so the weight stands alone and
+    // the statement still runs; `authority-sql.test.ts` executes it.
     const generated = courtWeightSql("citing_d.court", []);
-    expect(generated).toBe("CASE \n      ELSE 1 END");
+    expect(generated).toBe("1");
   });
 });

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -542,6 +542,30 @@ test("courtWeightEntries option drives the SQL instead of the legacy tiers", asy
   );
 });
 
+test("an unseeded registry recomputes at the default weight", async () => {
+  // A registry with no rows renders no CASE branches, and a branchless
+  // `CASE ... ELSE 1 END` is a syntax error: the whole recompute failed
+  // instead of weighing every citing court at the default nothing ranks.
+  await markAllDue();
+  try {
+    await sweep(1000, { courtWeightEntries: [] });
+
+    const unranked = citationScore([...CITED_CITATIONS], NOW, new Map());
+    expect(await authorityOf(citedId)).toBeCloseTo(unranked, 9);
+    // Not vacuous: the seeded registry ranks the same citations higher, so the
+    // equality above cannot pass on a sweep that ranked them after all.
+    expect(unranked).not.toBeCloseTo(
+      citationScore([...CITED_CITATIONS], NOW, SEED_MAP),
+      2,
+    );
+  } finally {
+    // The corpus is shared with every test below, so a failed assertion must
+    // not leave them reading authority computed against an empty registry.
+    await markAllDue();
+    await sweep(1000);
+  }
+});
+
 test("an unrankable corpus is detected before a sweep walks it", async () => {
   expect(await db.transaction(hasResolvedCitations)).toBe(true);
 });

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -39,8 +39,8 @@
  * internally: this keeps the function a `tx`-in/count-out unit that is safe to
  * exercise against a pglite fixture in tests. Production callers load the
  * current DB-seeded weights with `loadCitationCourtWeightEntries()` below
- * before calling in; omitting the option falls back to `courtWeightSql`'s
- * legacy hardcoded tiers.
+ * before calling in; there is no built-in list behind them, so an unseeded
+ * registry weighs every citing court at the default.
  */
 
 import { panic } from "better-result";

--- a/apps/api/src/handlers/case-law/citation-score.ts
+++ b/apps/api/src/handlers/case-law/citation-score.ts
@@ -33,6 +33,7 @@ import type {
   CourtWeightEntry,
   CourtWeightMap,
 } from "@/api/lib/case-law/court-weights";
+import { sqlCaseExpression } from "@/api/lib/sql-case-expression";
 
 /** Average (Julian) year, used for citation-age decay. A duration. */
 const MS_PER_YEAR = 365.25 * DAY_IN_MS;
@@ -144,33 +145,31 @@ export const citationScore = (
  * polarity cannot reach the database with no weight decided for it. NULL
  * falls to the ELSE branch, which is `unknown`'s weight by construction.
  */
-export const polarityWeightSql = (polarityColumn: string): string => {
-  const cases = Object.entries(POLARITY_AUTHORITY_WEIGHT)
-    .filter(([polarity]) => polarity !== POLARITY.UNKNOWN)
-    .map(
-      ([polarity, weight]) =>
-        `WHEN ${polarityColumn} = '${polarity}' THEN ${weight}`,
-    )
-    .join("\n      ");
-
-  return `CASE ${cases}\n      ELSE ${POLARITY_AUTHORITY_WEIGHT[POLARITY.UNKNOWN]} END`;
-};
+export const polarityWeightSql = (polarityColumn: string): string =>
+  sqlCaseExpression({
+    branches: Object.entries(POLARITY_AUTHORITY_WEIGHT)
+      .filter(([polarity]) => polarity !== POLARITY.UNKNOWN)
+      .map(
+        ([polarity, weight]) =>
+          `WHEN ${polarityColumn} = '${polarity}' THEN ${weight}`,
+      ),
+    fallback: POLARITY_AUTHORITY_WEIGHT[POLARITY.UNKNOWN],
+  });
 
 /**
  * The SQL CASE expression for court weights, rendered from the seeded
  * entries (highest tier first, so the first matching branch is the rank).
- * No entries renders a bare `ELSE`: every court weighs the default.
+ * No entries renders the default weight alone: an unseeded registry weighs
+ * every court the same rather than failing the statement.
  */
 export const courtWeightSql = (
   courtColumn: string,
   entries: readonly CourtWeightEntry[],
-): string => {
-  const cases = entries
-    .map((e) => {
+): string =>
+  sqlCaseExpression({
+    branches: entries.map((e) => {
       const src = e.pattern.source.replace(/'/gu, "''");
       return `WHEN ${courtColumn} ~* '${src}' THEN ${e.weight}`;
-    })
-    .join("\n      ");
-
-  return `CASE ${cases}\n      ELSE ${DEFAULT_WEIGHT} END`;
-};
+    }),
+    fallback: DEFAULT_WEIGHT,
+  });

--- a/apps/api/src/handlers/document-types/reorder.ts
+++ b/apps/api/src/handlers/document-types/reorder.ts
@@ -5,6 +5,7 @@ import { documentTypes } from "@/api/db/schema";
 import { reorderDocumentTypesBodySchema } from "@/api/handlers/document-types/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 const config = {
   description:
@@ -54,7 +55,12 @@ const reorderDocumentTypes = createSafeRootHandler(
         await tx
           .update(documentTypes)
           .set({
-            sortOrder: sql`(case ${sql.join(cases, sql` `)} end)`,
+            sortOrder: sqlCaseFragment({
+              branches: cases,
+              // The WHERE clause restricts the update to the ids the branches
+              // name, so the ELSE only ever renders; it never evaluates.
+              fallback: sql`${documentTypes.sortOrder}`,
+            }),
             updatedAt: now,
           })
           .where(

--- a/apps/api/src/handlers/time-entries/batch-update.ts
+++ b/apps/api/src/handlers/time-entries/batch-update.ts
@@ -15,6 +15,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
+import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 const batchUpdateBodySchema = t.Object({
   ids: t.Array(tSafeId("timeEntry"), { minItems: 1, maxItems: 200 }),
@@ -289,23 +290,23 @@ const batchUpdate = createSafeHandler(
             });
             const rateAtEntry =
               rateCases.length > 0
-                ? sql<number>`CASE ${sql.join(
-                    rateCases.map(
+                ? sqlCaseFragment({
+                    branches: rateCases.map(
                       ({ id, rateAtEntry: rate }) =>
                         sql`WHEN ${eq(timeEntries.id, id)} THEN ${rate}`,
                     ),
-                    sql.raw(" "),
-                  )} ELSE ${timeEntries.rateAtEntry} END`
+                    fallback: sql`${timeEntries.rateAtEntry}`,
+                  })
                 : undefined;
             const currency =
               rateCases.length > 0
-                ? sql<string>`CASE ${sql.join(
-                    rateCases.map(
+                ? sqlCaseFragment({
+                    branches: rateCases.map(
                       ({ id, currency: value }) =>
                         sql`WHEN ${eq(timeEntries.id, id)} THEN ${value}`,
                     ),
-                    sql.raw(" "),
-                  )} ELSE ${timeEntries.currency} END`
+                    fallback: sql`${timeEntries.currency}`,
+                  })
                 : undefined;
             const updated = await tx
               .update(timeEntries)

--- a/apps/api/src/handlers/views/reorder.ts
+++ b/apps/api/src/handlers/views/reorder.ts
@@ -17,6 +17,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { broadcastWorkspaceResourceChanges } from "@/api/lib/resource-realtime";
+import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 const config = {
   description:
@@ -110,7 +111,12 @@ const reorderViews = createSafeHandler(
         await tx
           .update(workspaceViews)
           .set({
-            position: sql`case ${sql.join(cases, sql` `)} end`,
+            position: sqlCaseFragment({
+              branches: cases,
+              // Every view in the workspace is validated to be in `viewIds`
+              // above, so the ELSE renders but never evaluates.
+              fallback: sql`${workspaceViews.position}`,
+            }),
           })
           .where(eq(workspaceViews.workspaceId, workspaceId));
 

--- a/apps/api/src/lib/case-law/court-weights.ts
+++ b/apps/api/src/lib/case-law/court-weights.ts
@@ -6,6 +6,7 @@
 import { arrayOrEmpty } from "@/api/lib/array";
 import { readCourtWeightRows } from "@/api/lib/case-law/case-law-config-store";
 import { logger } from "@/api/lib/observability/logger";
+import { SQL_NULL, sqlCaseExpression } from "@/api/lib/sql-case-expression";
 import { withTimeout } from "@/api/lib/with-timeout";
 
 // -- Types ---------------------------------------------------------------
@@ -193,9 +194,10 @@ type CourtTierSqlOptions = {
 /**
  * `courtWeightFromMap`'s tier lookup rendered as SQL, branch for branch: the
  * decision's own country first, then every jurisdiction's patterns, then the
- * default tier. A CASE with no ELSE evaluates to NULL when nothing matches,
- * which is what makes COALESCE the fallback chain the TypeScript walks with
- * `return`.
+ * default tier. A CASE whose ELSE is NULL evaluates to NULL when nothing
+ * matches, which is what makes COALESCE the fallback chain the TypeScript
+ * walks with `return`. An unseeded registry renders no branches at all, and
+ * both CASEs collapse to that NULL, leaving the default tier.
  *
  * Both CASEs are emitted from the same precedence-ordered list the TypeScript
  * walks, because a CASE takes its first true branch just as the lookup takes
@@ -213,10 +215,6 @@ export const courtTierSqlFromMap = ({
   map,
 }: CourtTierSqlOptions): string => {
   const ordered = flattenCourtWeightEntries(map);
-  if (ordered.length === 0) {
-    return String(DEFAULT_TIER);
-  }
-
   const scoped = ordered.map(
     (entry) =>
       `WHEN ${countryColumn} = ${sqlLiteral(entry.country)} AND ${courtColumn} ~* ${sqlLiteral(entry.pattern.source)} THEN ${entry.tier}`,
@@ -227,8 +225,8 @@ export const courtTierSqlFromMap = ({
   );
 
   return `COALESCE(
-      CASE ${scoped.join("\n      ")} END,
-      CASE ${anyCountry.join("\n      ")} END,
+      ${sqlCaseExpression({ branches: scoped, fallback: SQL_NULL })},
+      ${sqlCaseExpression({ branches: anyCountry, fallback: SQL_NULL })},
       ${DEFAULT_TIER}
     )`;
 };

--- a/apps/api/src/lib/infosoud/agenda-import.ts
+++ b/apps/api/src/lib/infosoud/agenda-import.ts
@@ -20,6 +20,7 @@ import {
   INFO_SOUD_TIME_ZONE,
   toHearingRecord,
 } from "@/api/lib/scouts/infosoud-hearings.logic";
+import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 type InfoSoudAgendaItem = {
   agendaKind: AgendaItemKind;
@@ -197,7 +198,11 @@ export const importInfoSoudAgendaItems = async ({
     await tx
       .update(entities)
       .set({
-        currentVersionId: sql`case ${entities.id} ${sql.join(currentVersionCases, sql` `)} else ${entities.currentVersionId} end`,
+        currentVersionId: sqlCaseFragment({
+          operand: sql`${entities.id}`,
+          branches: currentVersionCases,
+          fallback: sql`${entities.currentVersionId}`,
+        }),
       })
       .where(
         inArray(

--- a/apps/api/src/lib/legal-search/authority-sql.test.ts
+++ b/apps/api/src/lib/legal-search/authority-sql.test.ts
@@ -2,6 +2,10 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
+import {
+  courtWeight,
+  courtWeightSql,
+} from "@/api/handlers/case-law/citation-score";
 import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
 import {
   courtTierSqlFromMap,
@@ -236,6 +240,52 @@ test("Postgres resolves an overlapping court to the tier the lookup does", async
   );
   // The higher rank wins in both, though the map holds the lower one first.
   expect(Number(row?.v)).toBe(4);
+});
+
+test("an unseeded registry renders ranking SQL Postgres accepts", async () => {
+  // Every registry-driven expression is a CASE over rows, and a CASE needs a
+  // WHEN: an install whose registry table holds nothing has to rank at the
+  // default rather than fail the statement it is interpolated into. Rendered
+  // *and executed*, because the fault is a syntax error the renderer alone
+  // cannot show.
+  const empty: CourtWeightMap = new Map();
+  const courtTier = sql.raw(
+    courtTierSqlFromMap({
+      countryColumn: "d.country",
+      courtColumn: "d.court",
+      map: empty,
+    }),
+  );
+  const citingWeight = sql.raw(courtWeightSql("d.court", []));
+
+  const [row] = await db
+    .select({
+      tier: sql<number>`(${courtTier})::float8`,
+      weight: sql<number>`(${citingWeight})::float8`,
+      // The search path's whole score, which is where the tier lands.
+      blended: sql<number>`(${blendedRankSql({
+        authority: authorityLiteral(2),
+        courtTier,
+        lexicalRank: sql`0.5::float8`,
+      })})::float8`,
+    })
+    .from(sql`(VALUES ('Ústavní soud', 'CZE')) AS d(court, country)`);
+
+  // The same default the TypeScript lookup falls back to for a court no row
+  // ranks, which is every court while the registry is empty.
+  expect(Number(row?.tier)).toBe(
+    courtWeightFromMap(empty, "Ústavní soud", "CZE").tier,
+  );
+  expect(Number(row?.weight)).toBe(courtWeight("Ústavní soud", empty));
+  expect(Number(row?.blended)).toBeCloseTo(
+    0.5 + DEFAULT_AUTHORITY_WEIGHT * saturateAuthority(2),
+    12,
+  );
+  // Not vacuous: the seeded registry ranks this court above that default, so
+  // the assertions above cannot pass on a registry that ranked it after all.
+  expect(
+    courtWeightFromMap(courtWeightMapFromSeed(), "Ústavní soud", "CZE").tier,
+  ).toBeGreaterThan(Number(row?.tier));
 });
 
 // Every Postgres ranking path, and what it feeds the blend. A path that scores

--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -31,6 +31,7 @@ import {
   CORPUS_PROJECTION_LEASE_MAX_MS,
   CORPUS_PROJECTION_LEASE_MIN_MS,
 } from "@/api/lib/legal-search/corpus-index-projection-store";
+import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 type ProjectionIntentId = SafeId<"corpusIndexProjectionIntent">;
 
@@ -885,12 +886,13 @@ export const recoverExpiredCorpusProjectionIntentsTx = async <
         ),
       };
     });
-    const barrierSql = sql`CASE ${corpusIndexProjectionIntents.id} ${sql.join(
-      barriers.map(
+    const barrierSql = sqlCaseFragment({
+      operand: sql`${corpusIndexProjectionIntents.id}`,
+      branches: barriers.map(
         ({ id, barrier }) => sql`WHEN ${id} THEN ${barrier}::timestamptz`,
       ),
-      sql.raw(" "),
-    )} ELSE ${corpusIndexProjectionIntents.appendPublishBarrierAt} END`;
+      fallback: sql`${corpusIndexProjectionIntents.appendPublishBarrierAt}`,
+    });
     await tx
       .update(corpusIndexProjectionIntents)
       .set({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
@@ -16,6 +16,7 @@ import {
   entityIdsForCorpusProjectionWorkScope,
   type CorpusProjectionScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
+import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 export const CORPUS_PROJECTION_ERASURE_MAX_BATCH_SIZE = 256;
 export const CORPUS_PROJECTION_ERASURE_MAX_REVISIONS = 1024;
@@ -203,12 +204,13 @@ export const advanceCorpusProjectionErasuresTx = async <
         barrier: corpusIndexUnknownAppendBarrierAt(appendStartedAt, manifest),
       };
     });
-    const barrierSql = sql`CASE ${corpusIndexProjectionIntents.id} ${sql.join(
-      barriers.map(
+    const barrierSql = sqlCaseFragment({
+      operand: sql`${corpusIndexProjectionIntents.id}`,
+      branches: barriers.map(
         ({ id, barrier }) => sql`WHEN ${id} THEN ${barrier}::timestamptz`,
       ),
-      sql.raw(" "),
-    )} ELSE ${corpusIndexProjectionIntents.appendPublishBarrierAt} END`;
+      fallback: sql`${corpusIndexProjectionIntents.appendPublishBarrierAt}`,
+    });
     await tx
       .update(corpusIndexProjectionIntents)
       .set({

--- a/apps/api/src/lib/legal-search/pg-fts-query.ts
+++ b/apps/api/src/lib/legal-search/pg-fts-query.ts
@@ -3,6 +3,7 @@ import type { SQL } from "drizzle-orm";
 
 import type { FtsSearchConfig } from "@/api/lib/legal-search/fts-config";
 import { buildPlainSearchTsQuery } from "@/api/lib/search/query";
+import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 type PgFtsSearchSqlRefs = {
   language: SQL;
@@ -52,12 +53,12 @@ export const buildPgFtsSearchSql = ({
   const fallbackQuery = buildPlainSearchTsQuery("", {});
 
   return {
-    headlineQuery: sql`(CASE ${sql.join(
-      branches.map(
+    headlineQuery: sql`(${sqlCaseFragment({
+      branches: branches.map(
         ({ condition, tsQuery }) => sql`WHEN ${condition} THEN ${tsQuery}`,
       ),
-      sql` `,
-    )} ELSE ${fallbackQuery} END)`,
+      fallback: fallbackQuery,
+    })})`,
     predicate: sql`(${sql.join(
       branches.map(
         ({ condition, tsQuery }) =>
@@ -65,13 +66,13 @@ export const buildPgFtsSearchSql = ({
       ),
       sql` OR `,
     )})`,
-    rank: sql`(CASE ${sql.join(
-      branches.map(
+    rank: sql`(${sqlCaseFragment({
+      branches: branches.map(
         ({ condition, tsQuery }) =>
           sql`WHEN ${condition} THEN ts_rank(${refs.vector}, ${tsQuery})::float8`,
       ),
-      sql` `,
-    )} ELSE 0::float8 END)`,
+      fallback: sql`0::float8`,
+    })})`,
   };
 };
 

--- a/apps/api/src/lib/sql-case-expression.test.ts
+++ b/apps/api/src/lib/sql-case-expression.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import {
+  SQL_NULL,
+  sqlCaseExpression,
+  sqlCaseFragment,
+} from "@/api/lib/sql-case-expression";
+
+describe("sqlCaseExpression", () => {
+  test("an empty branch list renders the fallback alone, not an empty CASE", () => {
+    // `CASE ELSE 1 END` is a syntax error, so the expression a registry with
+    // no rows renders has to be the value the CASE would have taken.
+    expect(sqlCaseExpression({ branches: [], fallback: 1 })).toBe("1");
+    expect(sqlCaseExpression({ branches: [], fallback: SQL_NULL })).toBe(
+      "NULL",
+    );
+    expect(sqlCaseExpression({ branches: [], fallback: 1 })).not.toContain(
+      "CASE",
+    );
+  });
+
+  test("branches keep the order given, because the first true one wins", () => {
+    const rendered = sqlCaseExpression({
+      branches: ["WHEN c ~* 'apex' THEN 10", "WHEN c ~* 'district' THEN 2"],
+      fallback: 1,
+    });
+    expect(rendered.indexOf("THEN 10")).toBeLessThan(
+      rendered.indexOf("THEN 2"),
+    );
+    expect(rendered.startsWith("CASE WHEN c ~* 'apex' THEN 10")).toBe(true);
+    expect(rendered).toContain("ELSE 1 END");
+  });
+});
+
+// The rendered statement, as the driver would send it: the fragment's shape is
+// the whole contract here, and a Drizzle SQL object reveals nothing on its own.
+const rendered = (fragment: SQL): string =>
+  new PgDialect().sqlToQuery(fragment).sql;
+
+describe("sqlCaseFragment", () => {
+  test("no branches renders the fallback fragment, not an empty CASE", () => {
+    // `CASE id ELSE col END` is as invalid as `CASE ELSE 1 END`, so a batch
+    // that turned out to hold no rows has to render the column itself.
+    expect(
+      rendered(
+        sqlCaseFragment({
+          branches: [],
+          fallback: sql`0::float8`,
+          operand: sql`id`,
+        }),
+      ),
+    ).toBe("0::float8");
+    expect(
+      rendered(sqlCaseFragment({ branches: [], fallback: sql`0::float8` })),
+    ).not.toContain("CASE");
+  });
+
+  test("branches render in order, between the operand and the ELSE", () => {
+    const fragment = sqlCaseFragment({
+      branches: [sql`WHEN 'a' THEN 1`, sql`WHEN 'b' THEN 2`],
+      fallback: sql`0`,
+      operand: sql`id`,
+    });
+    expect(rendered(fragment)).toBe(
+      "CASE id WHEN 'a' THEN 1 WHEN 'b' THEN 2 ELSE 0 END",
+    );
+  });
+
+  test("a searched CASE omits the operand", () => {
+    expect(
+      rendered(
+        sqlCaseFragment({
+          branches: [sql`WHEN x IS NULL THEN 1`],
+          fallback: sql`0`,
+        }),
+      ),
+    ).toBe("CASE WHEN x IS NULL THEN 1 ELSE 0 END");
+  });
+});

--- a/apps/api/src/lib/sql-case-expression.ts
+++ b/apps/api/src/lib/sql-case-expression.ts
@@ -1,0 +1,80 @@
+/**
+ * One rule for rendering a SQL `CASE` over a list that can be empty.
+ *
+ * The registry-driven ranking expressions are generated from rows: court
+ * weights, court tiers, citation polarities. A `CASE` needs at least one
+ * `WHEN`, so a renderer that interpolates its branches straight into
+ * `CASE ${branches} ELSE ${fallback} END` emits a syntax error the moment the
+ * list it iterates is empty — an install whose registry table has not been
+ * seeded yet fails every query that ranks, instead of ranking everything at
+ * the default. Rendering through this helper makes the empty list produce the
+ * fallback on its own, which is the value the `CASE` would have taken anyway.
+ *
+ * Two renderers, one rule: `sqlCaseExpression` for the interpolated SQL text
+ * the ranking paths build, `sqlCaseFragment` for a Drizzle `SQL` composed from
+ * per-row branches. `no-hand-rolled-sql-case` keeps every other module out of
+ * the shape, so the emptiness decision cannot be made a second time.
+ */
+
+import { sql, type SQL } from "drizzle-orm";
+
+/** The fallback for a CASE whose miss falls through to an enclosing COALESCE. */
+export const SQL_NULL = "NULL";
+
+type SqlCaseExpressionOptions = {
+  /**
+   * `WHEN … THEN …` branches, in the order they must be evaluated: Postgres
+   * takes the first true branch, so the caller's precedence order is the
+   * ranking, and this helper preserves it as given.
+   */
+  branches: readonly string[];
+  /**
+   * The `ELSE` value, and the whole expression when there are no branches.
+   * Pass `SQL_NULL` for a `CASE` whose miss is meant to fall through to an
+   * enclosing `COALESCE`.
+   */
+  fallback: string | number;
+};
+
+export const sqlCaseExpression = ({
+  branches,
+  fallback,
+}: SqlCaseExpressionOptions): string =>
+  branches.length === 0
+    ? String(fallback)
+    : `CASE ${branches.join("\n      ")}\n      ELSE ${fallback} END`;
+
+type SqlCaseFragmentOptions = {
+  /** `WHEN … THEN …` fragments, in the order Postgres must evaluate them. */
+  branches: readonly SQL[];
+  /** The `ELSE` value, and the whole fragment when there are no branches. */
+  fallback: SQL;
+  /**
+   * The simple-`CASE` operand each branch's `WHEN` value is compared against
+   * (`CASE id WHEN … END`). Omit for a searched `CASE` whose branches carry
+   * their own predicates.
+   */
+  operand?: SQL;
+};
+
+/**
+ * `sqlCaseExpression` for callers composing a Drizzle `SQL` rather than text.
+ *
+ * The empty list returns the fallback fragment itself, so a per-row `CASE`
+ * built from a batch that turned out to hold no rows updates a column to the
+ * value it already has instead of rendering `CASE id ELSE col END`, which
+ * Postgres rejects for the same reason a branchless text `CASE` is rejected.
+ */
+export const sqlCaseFragment = ({
+  branches,
+  fallback,
+  operand,
+}: SqlCaseFragmentOptions): SQL => {
+  if (branches.length === 0) {
+    return fallback;
+  }
+  const subject = operand === undefined ? sql`` : sql` ${operand}`;
+  // Copied because `sql.join` takes a mutable chunk list, and the caller's
+  // branch list is readonly.
+  return sql`CASE${subject} ${sql.join([...branches], sql.raw(" "))} ELSE ${fallback} END`;
+};

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -672,6 +672,7 @@ export default defineConfig({
     // the files that own the schema objects, so the same spelling elsewhere
     // stays flagged.
     "no-bare-jsonb-cast/no-bare-jsonb-cast": "error",
+    "no-hand-rolled-sql-case/no-hand-rolled-sql-case": "error",
     "require-timestamptz-column/require-timestamptz-column": "error",
     "no-naive-timestamp-cast/no-naive-timestamp-cast": "error",
     "no-inline-timestamp-cursor-sql/no-inline-timestamp-cursor-sql": "error",
@@ -1024,6 +1025,7 @@ export default defineConfig({
     "./.oxlint-plugins/tagged-error-requires-message.ts",
     "./.oxlint-plugins/require-custom-jsonb-column.ts",
     "./.oxlint-plugins/no-bare-jsonb-cast.ts",
+    "./.oxlint-plugins/no-hand-rolled-sql-case.ts",
     "./.oxlint-plugins/require-derived-check-enum.ts",
     "./.oxlint-plugins/require-timestamptz-column.ts",
     "./.oxlint-plugins/no-naive-timestamp-cast.ts",

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -442,6 +442,28 @@ describe("Turbo cache input contract", () => {
     );
   });
 
+  test("landing's generated types survive a typecheck cache hit", () => {
+    // Ordering alone does not deliver the types: `astro check` writes them,
+    // and a task whose outputs are unrecorded replays its logs on a cache hit
+    // and writes nothing. The dependent lint then reads `astro:content` as
+    // `error` on any checkout that has not run the generator itself.
+    const turboConfig = readFileSync("turbo.json", "utf-8");
+    const landingTypecheckStart = turboConfig.indexOf(
+      '    "@stll/landing#typecheck":',
+    );
+    expect(landingTypecheckStart).toBeGreaterThan(-1);
+    const nextTaskStart = turboConfig.indexOf(
+      '    "lint":',
+      landingTypecheckStart,
+    );
+    expect(nextTaskStart).toBeGreaterThan(landingTypecheckStart);
+    const landingTypecheckConfig = turboConfig.slice(
+      landingTypecheckStart,
+      nextTaskStart,
+    );
+    expect(landingTypecheckConfig).toContain('"outputs": [".astro/**"]');
+  });
+
   test("keeps planner-wide inputs exactly aligned with their Turbo tasks", () => {
     const turboConfig = readFileSync("turbo.json", "utf-8");
     const typecheckStart = turboConfig.indexOf('    "typecheck":');

--- a/turbo.json
+++ b/turbo.json
@@ -70,7 +70,11 @@
     },
     "@stll/landing#typecheck": {
       "dependsOn": ["transit"],
-      "outputs": []
+      // `astro check` generates the content types that type-aware lint reads,
+      // so they are the task's outputs. Left unrecorded, a cache hit replays
+      // the logs and writes nothing, and the lint that depends on this task
+      // then resolves `astro:content` to `error` on a fresh checkout.
+      "outputs": [".astro/**"]
     },
     "lint": {
       "dependsOn": ["transit"],


### PR DESCRIPTION
## What

`fix(api): render a valid court-weight expression when no entries are seeded` — one helper renders every registry-driven CASE expression; with no branches it yields the fallback alone instead of an empty CASE. The search lateral, the citation-authority recompute and the tier expressions all go through it, so an empty registry degrades to the default tier rather than a syntax error.

## Tests

Helper unit tests (empty list, branch order preserved); the tier, citing-court and blended expressions rendered from an empty registry and executed against Postgres, each equal to the TypeScript default; a sweep with no entries materialises the same authority as the in-memory scorer; the existing citation-score expectation updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL generation for empty rule, court-weight, and ranking lists so valid fallback values are returned instead of invalid empty `CASE` expressions.
  * Preserved default court weights and tiers when no court-weight entries are configured.

* **Quality Improvements**
  * Added validation to detect unsafe hand-written SQL `CASE` expressions.
  * Standardised dynamic `CASE` expression handling across updates, imports, searches, and ranking calculations.

* **Tests**
  * Added regression and integration coverage for empty inputs, fallback values, and generated SQL validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->