### PR TITLE
feat(api): reconcile pending work for queues without a sweep

### DIFF
--- a/apps/api/drizzle/20260903120000_queue_reconciler_indexes/migration.sql
+++ b/apps/api/drizzle/20260903120000_queue_reconciler_indexes/migration.sql
@@ -1,0 +1,61 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent builds
+-- (which take no lock those timeouts guard), then restore and reopen a
+-- transaction for Drizzle's migration row. Same shape as
+-- 20260901190000_case_law_decisions_country_court_date_idx.
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+
+-- Each build drops only its own index by name first: a cancelled concurrent
+-- build leaves an INVALID index behind, and IF NOT EXISTS would then skip
+-- recreating it.
+
+DROP INDEX CONCURRENTLY IF EXISTS "document_review_runs_queued_worker_idx";
+--> statement-breakpoint
+-- The reconciler walks runs still waiting for a worker in creation order,
+-- keyset-paginated, and stops at its page. Without this the walk sorts the
+-- whole run history on every sweep. Partial on the two columns the sweep
+-- filters, so the index stays the size of the outstanding work: a table-
+-- executed run is paced by the files-table property DAG and was never handed
+-- to that queue.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "document_review_runs_queued_worker_idx"
+  ON "document_review_runs" ("created_at", "id")
+  WHERE "status" = 'queued' AND "executor" = 'worker';
+--> statement-breakpoint
+
+DROP INDEX CONCURRENTLY IF EXISTS "bilingual_translation_runs_queued_idx";
+--> statement-breakpoint
+-- Same walk, same reason, for bilingual runs.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "bilingual_translation_runs_queued_idx"
+  ON "bilingual_translation_runs" ("created_at", "id")
+  WHERE "status" = 'queued';
+--> statement-breakpoint
+
+DROP INDEX CONCURRENTLY IF EXISTS "style_sets_pending_package_cleanup_idx";
+--> statement-breakpoint
+-- The cleanup reconciler walks the rows that still name a superseded package,
+-- oldest first. Those are a vanishing fraction of the table, so the partial
+-- predicate is what keeps the sweep off a full scan.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "style_sets_pending_package_cleanup_idx"
+  ON "style_sets" ("updated_at", "id")
+  WHERE "cleanup_s3_key" IS NOT NULL;
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/bilingual.ts
+++ b/apps/api/src/db/schema/bilingual.ts
@@ -106,6 +106,11 @@ export const bilingualTranslationRuns = p.pgTable(
       .uniqueIndex("bilingual_translation_runs_active_document_uidx")
       .on(table.workspaceId, table.entityId, table.fileFieldId)
       .where(sql`${table.status} IN (${RUN_ACTIVE_STATUS_SQL_VALUES})`),
+    // The reconciler's keyset walk over runs still waiting for a worker.
+    p
+      .index("bilingual_translation_runs_queued_idx")
+      .on(table.createdAt, table.id)
+      .where(sql`${table.status} = 'queued'`),
     p.check(
       "bilingual_translation_runs_status_values_check",
       sql`${table.status} IN (${RUN_STATUS_SQL_VALUES})`,

--- a/apps/api/src/db/schema/document-reviews.ts
+++ b/apps/api/src/db/schema/document-reviews.ts
@@ -163,6 +163,13 @@ export const documentReviewRuns = p.pgTable(
       .uniqueIndex("document_review_runs_active_document_uidx")
       .on(table.workspaceId, table.entityId, table.fileFieldId)
       .where(sql`${table.status} IN (${RUN_ACTIVE_STATUS_SQL_VALUES})`),
+    // The reconciler's keyset walk over runs still waiting for a worker.
+    // Table-executed runs are paced by the files-table property DAG and were
+    // never handed to that queue, so they stay out of the index.
+    p
+      .index("document_review_runs_queued_worker_idx")
+      .on(table.createdAt, table.id)
+      .where(sql`${table.status} = 'queued' AND ${table.executor} = 'worker'`),
     p.check(
       "document_review_runs_status_values_check",
       sql`${table.status} IN (${RUN_STATUS_SQL_VALUES})`,

--- a/apps/api/src/db/schema/style-sets.ts
+++ b/apps/api/src/db/schema/style-sets.ts
@@ -1,3 +1,5 @@
+import { sql } from "drizzle-orm";
+
 import {
   organization,
   orgPolicies,
@@ -33,6 +35,13 @@ export const styleSets = p.pgTable(
     p
       .index("style_sets_organization_id_updated_at_idx")
       .on(table.organizationId, table.updatedAt, table.id),
+    // The cleanup reconciler's keyset walk over packages a replacement left
+    // behind. Partial so it stays the size of the outstanding work, not of
+    // the table.
+    p
+      .index("style_sets_pending_package_cleanup_idx")
+      .on(table.updatedAt, table.id)
+      .where(sql`${table.cleanupS3Key} IS NOT NULL`),
     ...orgPolicies(),
   ],
 );

--- a/apps/api/src/lib/bilingual/run-queue.test.ts
+++ b/apps/api/src/lib/bilingual/run-queue.test.ts
@@ -1,0 +1,208 @@
+/**
+ * A `queued` bilingual run whose job never reached the queue has nothing left
+ * to drive it, and the row cannot tell that apart from a run still waiting its
+ * turn. What is asserted here is the part no type can hold: that such a run is
+ * handed back exactly once, that a run the queue still owns is left alone, and
+ * that a terminal run is never resurrected. Driven against a real (PGlite)
+ * database with a stubbed queue.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { inArray } from "drizzle-orm";
+
+import { bilingualTranslationRuns } from "@/api/db/schema";
+import { reconcileQueuedBilingualRuns } from "@/api/lib/bilingual/run-queue";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+
+const { testDb, ids } = await getRlsFixture();
+
+type StubJobState = "active" | "completed" | "failed" | "waiting";
+
+type AddedJob = { data: unknown; jobId: string; name: string };
+
+const added: AddedJob[] = [];
+const priorJobs = new Map<string, StubJobState>();
+const removedJobIds: string[] = [];
+const retriedJobIds: string[] = [];
+
+const queue = {
+  add: async (name: string, data: unknown, options: { jobId: string }) => {
+    added.push({ data, jobId: options.jobId, name });
+    priorJobs.set(options.jobId, "waiting");
+  },
+  getJob: async (jobId: string) => {
+    const state = priorJobs.get(jobId);
+    if (state === undefined) {
+      return undefined;
+    }
+    return {
+      getState: async () => state,
+      remove: async () => {
+        priorJobs.delete(jobId);
+        removedJobIds.push(jobId);
+      },
+      retry: async () => {
+        retriedJobIds.push(jobId);
+      },
+    };
+  },
+};
+
+const seededRunIds: SafeId<"bilingualTranslationRun">[] = [];
+
+type SeedRunOptions = {
+  createdAt?: Date;
+  requestedBy?: string | null;
+  status?: "queued" | "running" | "completed" | "failed" | "cancelled";
+};
+
+/** One run per call, on its own file field: at most one run per document may
+ *  be active, so sharing a field would collide instead of seeding. */
+const runValues = ({
+  createdAt = new Date(),
+  requestedBy = ids.userA1,
+  status = "queued",
+}: SeedRunOptions = {}) => {
+  const runId = createSafeId<"bilingualTranslationRun">();
+  seededRunIds.push(runId);
+  return {
+    id: runId,
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    entityId: ids.entityA1,
+    fileFieldId: createSafeId<"field">(),
+    entityVersionId: ids.entityVersionA1,
+    sourceLang: "cs",
+    targetLang: "en",
+    glossary: [],
+    createdAt,
+    requestedBy,
+    status,
+  };
+};
+
+const seedRun = async (
+  options: SeedRunOptions = {},
+): Promise<SafeId<"bilingualTranslationRun">> => {
+  const values = runValues(options);
+  await testDb.insert(bilingualTranslationRuns).values(values);
+  return values.id;
+};
+
+const jobIdFor = (runId: SafeId<"bilingualTranslationRun">) =>
+  createBullMqJobId(ids.wsA1, runId);
+
+describe("queued bilingual run reconciliation", () => {
+  beforeEach(() => {
+    added.length = 0;
+    removedJobIds.length = 0;
+    retriedJobIds.length = 0;
+    priorJobs.clear();
+  });
+
+  afterEach(async () => {
+    if (seededRunIds.length > 0) {
+      await testDb
+        .delete(bilingualTranslationRuns)
+        .where(inArray(bilingualTranslationRuns.id, seededRunIds));
+    }
+    seededRunIds.length = 0;
+  });
+
+  afterAll(async () => {
+    await releaseRlsFixture();
+  });
+
+  test("hands a run no job owns back to the queue exactly once", async () => {
+    const runId = await seedRun();
+
+    const first = await reconcileQueuedBilingualRuns({ db: testDb, queue });
+    const second = await reconcileQueuedBilingualRuns({ db: testDb, queue });
+
+    expect(first).toEqual({ handedOff: 1, scanned: 1, unattributed: 0 });
+    // The row is still `queued` — only the worker's claim moves it — so the
+    // second sweep sees it again and must recognise its own job.
+    expect(second).toEqual({ handedOff: 0, scanned: 1, unattributed: 0 });
+    expect(added).toEqual([
+      {
+        data: {
+          organizationId: ids.orgA,
+          runId,
+          userId: ids.userA1,
+          workspaceId: ids.wsA1,
+        },
+        jobId: jobIdFor(runId),
+        name: "run-bilingual-translation",
+      },
+    ]);
+  });
+
+  test("leaves finished and running runs alone", async () => {
+    await seedRun({ status: "completed" });
+    await seedRun({ status: "failed" });
+    await seedRun({ status: "cancelled" });
+    await seedRun({ status: "running" });
+
+    const result = await reconcileQueuedBilingualRuns({ db: testDb, queue });
+
+    expect(result).toEqual({ handedOff: 0, scanned: 0, unattributed: 0 });
+    expect(added).toEqual([]);
+  });
+
+  test("reclaims a retained terminal record instead of adding under its id", async () => {
+    const completedJobRun = await seedRun();
+    const failedJobRun = await seedRun();
+    priorJobs.set(jobIdFor(completedJobRun), "completed");
+    priorJobs.set(jobIdFor(failedJobRun), "failed");
+
+    const result = await reconcileQueuedBilingualRuns({ db: testDb, queue });
+
+    expect(result.handedOff).toBe(2);
+    expect(removedJobIds).toEqual([jobIdFor(completedJobRun)]);
+    expect(retriedJobIds).toEqual([jobIdFor(failedJobRun)]);
+    expect(added.map(({ jobId }) => jobId)).toEqual([
+      jobIdFor(completedJobRun),
+    ]);
+  });
+
+  test("counts a run whose requester is gone instead of dropping it", async () => {
+    await seedRun({ requestedBy: null });
+
+    const result = await reconcileQueuedBilingualRuns({ db: testDb, queue });
+
+    expect(result).toEqual({ handedOff: 0, scanned: 1, unattributed: 1 });
+    expect(added).toEqual([]);
+  });
+
+  test("pages past a full page of queue-owned runs to reach an orphan", async () => {
+    // One page is 100 rows, and a run the queue owns keeps its `queued` row,
+    // so a sweep bounded by the first page would never inspect row 101.
+    const base = Date.now() - 60 * 60 * 1000;
+    const owned = Array.from({ length: 150 }, (_, index) =>
+      runValues({ createdAt: new Date(base + index) }),
+    );
+    await testDb.insert(bilingualTranslationRuns).values(owned);
+    for (const { id } of owned) {
+      priorJobs.set(jobIdFor(id), "waiting");
+    }
+    const orphan = await seedRun({ createdAt: new Date(base + 1000) });
+
+    const result = await reconcileQueuedBilingualRuns({ db: testDb, queue });
+
+    expect(result).toEqual({ handedOff: 1, scanned: 151, unattributed: 0 });
+    expect(added.map(({ jobId }) => jobId)).toEqual([jobIdFor(orphan)]);
+  });
+});

--- a/apps/api/src/lib/bilingual/run-queue.ts
+++ b/apps/api/src/lib/bilingual/run-queue.ts
@@ -49,6 +49,12 @@ import { checkTranslationConsistency } from "@/api/lib/bilingual/rows";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
+import {
+  QUEUE_REQUEUE_OUTCOME,
+  requeueDeterministicJob,
+} from "@/api/lib/bullmq-requeue";
+import type { RequeueableQueue } from "@/api/lib/bullmq-requeue";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { createEntityVersionFromBuffer } from "@/api/lib/entity-versions/create-entity-version-from-buffer";
 import { loadEntityVersionDocxBuffer } from "@/api/lib/entity-versions/load-entity-version-docx-buffer";
 import { validateDocxBuffer } from "@/api/lib/entity-versions/validate-docx-buffer";
@@ -56,6 +62,12 @@ import { errorTag } from "@/api/lib/errors/utils";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
 import { startNonOverlappingInterval } from "@/api/lib/non-overlapping-interval";
 import { logger } from "@/api/lib/observability/logger";
+import {
+  RECONCILE_SCAN_PAGE_SIZE,
+  reconcileCursorTimestamp,
+  scanPendingRows,
+} from "@/api/lib/queue-reconcile-scan";
+import type { ReconcileScanResult } from "@/api/lib/queue-reconcile-scan";
 import { createQueueWorkerErrorLogger } from "@/api/lib/queue-worker-error-log";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -99,17 +111,25 @@ const getQueue = createLazyBullMqQueue<BilingualRunJobData>({
   },
 });
 
-export const enqueueBilingualRun = async ({
+/** One job, described exactly as the queue takes it. The run id IS the job
+ *  identity: a duplicate enqueue collapses onto the job already in flight
+ *  instead of scheduling a second metered execution. */
+const runJob = ({
   runId,
   workspaceId,
   organizationId,
   userId,
-}: EnqueueBilingualRunArgs): Promise<void> => {
-  await getQueue().add(
-    JOB_NAME,
-    { runId, workspaceId, organizationId, userId },
-    { jobId: createBullMqJobId(workspaceId, runId) },
-  );
+}: EnqueueBilingualRunArgs) => ({
+  name: JOB_NAME,
+  data: { runId, workspaceId, organizationId, userId },
+  opts: { jobId: createBullMqJobId(workspaceId, runId) },
+});
+
+export const enqueueBilingualRun = async (
+  args: EnqueueBilingualRunArgs,
+): Promise<void> => {
+  const { data, name, opts } = runJob(args);
+  await getQueue().add(name, data, opts);
 };
 
 /** Flip abandoned runs to `failed` so the read endpoint stops reporting them
@@ -135,6 +155,113 @@ export const reconcileStuckBilingualRuns = async (): Promise<number> => {
     )
     .returning({ id: bilingualTranslationRuns.id });
   return recovered.length;
+};
+
+/** The (timestamp, id) keyset this sweep's walk pages on. */
+const bilingualRunCursorCodec = createTimestampIdCursorCodec({
+  column: bilingualTranslationRuns.createdAt,
+  brandId: brandPersistedBilingualTranslationRunId,
+});
+
+type QueuedBilingualRunRow = {
+  createdCursor: string;
+  id: SafeId<"bilingualTranslationRun">;
+  organizationId: SafeId<"organization">;
+  requestedBy: string | null;
+  workspaceId: SafeId<"workspace">;
+};
+
+type ReconcileQueuedBilingualRunsOptions = {
+  db?: Pick<typeof rootDb, "select">;
+  queue?: RequeueableQueue<BilingualRunJobData>;
+};
+
+type ReconcileQueuedBilingualRunsResult = ReconcileScanResult & {
+  /**
+   * `requested_by` is nulled when the requester's account is deleted, and the
+   * job carries an actor. Counted rather than dropped quietly; the staleness
+   * janitor above fails those rows once they age out.
+   */
+  unattributed: number;
+};
+
+/**
+ * Hand `queued` runs back to the queue when nothing owns them anymore.
+ *
+ * The run row commits before its job is added, so a crash in between — or a
+ * queue that lost its waiting jobs — leaves a run no worker will ever pick up,
+ * and the row alone cannot tell that apart from a run still waiting its turn.
+ * Repeating the enqueue is safe: the job id is derived from the run id and
+ * only a `queued` row is claimable, so a duplicate delivery is a no-op rather
+ * than a second metered execution.
+ *
+ * The walk pages forward on a keyset cursor rather than re-reading one fixed
+ * page: a run the queue still owns keeps its `queued` row, so a sweep bounded
+ * by the first page would inspect the same healthy backlog every tick and
+ * never reach the orphan behind it.
+ */
+export const reconcileQueuedBilingualRuns = async ({
+  db = rootDb,
+  queue = getQueue(),
+}: ReconcileQueuedBilingualRunsOptions = {}): Promise<ReconcileQueuedBilingualRunsResult> => {
+  let unattributed = 0;
+
+  const after = (cursor: QueuedBilingualRunRow | null) => {
+    if (cursor === null) {
+      return undefined;
+    }
+    return bilingualRunCursorCodec.keysetAfter({
+      cursor: {
+        timestamp: reconcileCursorTimestamp(cursor.createdCursor),
+        id: cursor.id,
+      },
+      idColumn: bilingualTranslationRuns.id,
+      direction: "ascending",
+    });
+  };
+
+  const readPage = async (cursor: QueuedBilingualRunRow | null) =>
+    await db
+      .select({
+        createdCursor: bilingualRunCursorCodec.cursorValue,
+        id: bilingualTranslationRuns.id,
+        organizationId: bilingualTranslationRuns.organizationId,
+        requestedBy: bilingualTranslationRuns.requestedBy,
+        workspaceId: bilingualTranslationRuns.workspaceId,
+      })
+      .from(bilingualTranslationRuns)
+      .where(and(eq(bilingualTranslationRuns.status, "queued"), after(cursor)))
+      .orderBy(
+        asc(bilingualTranslationRuns.createdAt),
+        asc(bilingualTranslationRuns.id),
+      )
+      .limit(RECONCILE_SCAN_PAGE_SIZE);
+
+  const handle = async (run: QueuedBilingualRunRow): Promise<boolean> => {
+    if (run.requestedBy === null) {
+      unattributed += 1;
+      return false;
+    }
+    const { data, name, opts } = runJob({
+      organizationId: run.organizationId,
+      runId: run.id,
+      userId: brandPersistedUserId(run.requestedBy),
+      workspaceId: run.workspaceId,
+    });
+    const outcome = await Result.tryPromise({
+      try: async () =>
+        await requeueDeterministicJob({ data, jobId: opts.jobId, name, queue }),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(outcome)) {
+      captureError(outcome.error, { runId: run.id });
+      return false;
+    }
+    return outcome.value === QUEUE_REQUEUE_OUTCOME.REQUEUED;
+  };
+
+  const scan = await scanPendingRows({ handle, readPage });
+  return { ...scan, unattributed };
 };
 
 export const initBilingualRunWorker = () => {

--- a/apps/api/src/lib/bullmq-requeue.ts
+++ b/apps/api/src/lib/bullmq-requeue.ts
@@ -1,0 +1,99 @@
+import { withTimeout } from "@/api/lib/with-timeout";
+
+/**
+ * Deadline on one queue command.
+ *
+ * The client does not time these out on its own, so a broker that accepts the
+ * connection and then stops answering leaves every command pending. A sweep
+ * runs many of them, and its scheduler lease is measured in minutes: without a
+ * bound the whole tick would sit on the first unanswered command and be killed
+ * with nothing recorded. Failing fast instead makes the stall a captured error
+ * per row, and the next tick retries. Matches the bound the other queue
+ * handoffs use.
+ */
+const QUEUE_OPERATION_TIMEOUT_MS = 2000;
+
+/**
+ * What one re-enqueue did. `queue-owned` is a healthy outcome rather than a
+ * skipped one: a live job is already driving the row, so a sweep that counted
+ * it as recovered work would report a backlog it never had.
+ */
+export const QUEUE_REQUEUE_OUTCOME = {
+  QUEUE_OWNED: "queue-owned",
+  REQUEUED: "requeued",
+} as const;
+
+export type QueueRequeueOutcome =
+  (typeof QUEUE_REQUEUE_OUTCOME)[keyof typeof QUEUE_REQUEUE_OUTCOME];
+
+/** Structural, so both a real job and a plain fake satisfy it. */
+type RequeueableJob = {
+  getState: () => Promise<string>;
+  remove: () => Promise<void>;
+  retry: () => Promise<void>;
+};
+
+/** The queue surface one re-enqueue needs, so a caller can pass a plain fake. */
+export type RequeueableQueue<DataType> = {
+  add: (
+    name: string,
+    data: DataType,
+    options: { jobId: string },
+  ) => Promise<unknown>;
+  getJob: (jobId: string) => Promise<RequeueableJob | null | undefined>;
+};
+
+type RequeueDeterministicJobOptions<DataType> = {
+  data: DataType;
+  jobId: string;
+  name: string;
+  queue: RequeueableQueue<DataType>;
+};
+
+/**
+ * Hand one persisted row back to its queue under the row's own job id.
+ *
+ * `add` alone is not the idempotent operation a reconciler needs. The queue
+ * ignores an `add` whose id it still holds, and retention keeps terminal
+ * records long after the row they ran for was reopened, so re-adding under
+ * such an id is dropped without an error and the row stays pending forever. A
+ * terminal record is therefore retried or reclaimed, while a job in any live
+ * state is left alone: it is the enqueue this sweep would otherwise duplicate.
+ */
+export const requeueDeterministicJob = async <DataType>({
+  data,
+  jobId,
+  name,
+  queue,
+}: RequeueDeterministicJobOptions<DataType>): Promise<QueueRequeueOutcome> => {
+  const bounded = async <T>(
+    label: string,
+    command: () => Promise<T>,
+  ): Promise<T> =>
+    await withTimeout(async () => await command(), {
+      label: `queue-requeue.${label}`,
+      timeoutMs: QUEUE_OPERATION_TIMEOUT_MS,
+    });
+
+  const existing = await bounded(
+    "get-job",
+    async () => await queue.getJob(jobId),
+  );
+  if (existing) {
+    const state = await bounded(
+      "get-state",
+      async () => await existing.getState(),
+    );
+    if (state === "failed") {
+      await bounded("retry-job", async () => await existing.retry());
+      return QUEUE_REQUEUE_OUTCOME.REQUEUED;
+    }
+    if (state !== "completed") {
+      return QUEUE_REQUEUE_OUTCOME.QUEUE_OWNED;
+    }
+    await bounded("remove-job", async () => await existing.remove());
+  }
+
+  await bounded("add-job", async () => await queue.add(name, data, { jobId }));
+  return QUEUE_REQUEUE_OUTCOME.REQUEUED;
+};

--- a/apps/api/src/lib/document-review/run-queue.test.ts
+++ b/apps/api/src/lib/document-review/run-queue.test.ts
@@ -1,0 +1,304 @@
+/**
+ * A `queued` review run whose job never reached the queue has nothing left to
+ * drive it, and the row cannot tell that apart from a run still waiting its
+ * turn. What is asserted here is the part no type can hold: that such a run is
+ * handed back exactly once, that a run the queue still owns is left alone, and
+ * that a terminal run is never resurrected. Driven against a real (PGlite)
+ * database with a stubbed queue.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { inArray } from "drizzle-orm";
+
+import { documentReviewRuns } from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { NEUTRAL_PERSPECTIVE } from "@/api/lib/document-review/contract";
+import type { DocumentReviewRunBasis } from "@/api/lib/document-review/run-contract";
+import {
+  DOCUMENT_REVIEW_RUN_EXECUTOR,
+  PLAYBOOK_PIN_PROVENANCE,
+} from "@/api/lib/document-review/run-contract";
+import { reconcileQueuedDocumentReviewRuns } from "@/api/lib/document-review/run-queue";
+import { installRecordingAnalytics } from "@/api/tests/helpers/recording-telemetry";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+
+const { testDb, ids } = await getRlsFixture();
+
+type StubJobState = "active" | "completed" | "failed" | "waiting";
+
+type AddedJob = { data: unknown; jobId: string; name: string };
+
+const added: AddedJob[] = [];
+const priorJobs = new Map<string, StubJobState>();
+const removedJobIds: string[] = [];
+const retriedJobIds: string[] = [];
+
+const queue = {
+  add: async (name: string, data: unknown, options: { jobId: string }) => {
+    added.push({ data, jobId: options.jobId, name });
+    priorJobs.set(options.jobId, "waiting");
+  },
+  getJob: async (jobId: string) => {
+    const state = priorJobs.get(jobId);
+    if (state === undefined) {
+      return undefined;
+    }
+    return {
+      getState: async () => state,
+      remove: async () => {
+        priorJobs.delete(jobId);
+        removedJobIds.push(jobId);
+      },
+      retry: async () => {
+        retriedJobIds.push(jobId);
+      },
+    };
+  },
+};
+
+const BASIS: DocumentReviewRunBasis = {
+  playbook: {
+    definitionId: null,
+    versionId: null,
+    provenance: PLAYBOOK_PIN_PROVENANCE.EPHEMERAL,
+    definitionSnapshot: {
+      name: "Reconciler fixture",
+      positions: { version: 3, items: [] },
+    },
+  },
+  references: [],
+  perspective: NEUTRAL_PERSPECTIVE,
+};
+
+const seededRunIds: SafeId<"documentReviewRun">[] = [];
+
+type SeedRunOptions = {
+  createdAt?: Date;
+  executor?: (typeof DOCUMENT_REVIEW_RUN_EXECUTOR)[keyof typeof DOCUMENT_REVIEW_RUN_EXECUTOR];
+  requestedBy?: string | null;
+  status?: "queued" | "running" | "completed" | "failed" | "cancelled";
+};
+
+/** One run per call, on its own file field: at most one run per document may
+ *  be active, so sharing a field would collide instead of seeding. */
+const runValues = ({
+  createdAt = new Date(),
+  executor = DOCUMENT_REVIEW_RUN_EXECUTOR.WORKER,
+  requestedBy = ids.userA1,
+  status = "queued",
+}: SeedRunOptions = {}) => {
+  const runId = createSafeId<"documentReviewRun">();
+  seededRunIds.push(runId);
+  return {
+    id: runId,
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    entityId: ids.entityA1,
+    fileFieldId: createSafeId<"field">(),
+    entityVersionId: ids.entityVersionA1,
+    contentSha256: "a".repeat(64),
+    basis: BASIS,
+    createdAt,
+    executor,
+    requestedBy,
+    status,
+  };
+};
+
+const seedRun = async (
+  options: SeedRunOptions = {},
+): Promise<SafeId<"documentReviewRun">> => {
+  const values = runValues(options);
+  await testDb.insert(documentReviewRuns).values(values);
+  return values.id;
+};
+
+const jobIdFor = (runId: SafeId<"documentReviewRun">) =>
+  createBullMqJobId(ids.wsA1, runId);
+
+describe("queued document review run reconciliation", () => {
+  beforeEach(() => {
+    added.length = 0;
+    removedJobIds.length = 0;
+    retriedJobIds.length = 0;
+    priorJobs.clear();
+  });
+
+  afterEach(async () => {
+    if (seededRunIds.length > 0) {
+      await testDb
+        .delete(documentReviewRuns)
+        .where(inArray(documentReviewRuns.id, seededRunIds));
+    }
+    seededRunIds.length = 0;
+  });
+
+  afterAll(async () => {
+    await releaseRlsFixture();
+  });
+
+  test("hands a run no job owns back to the queue exactly once", async () => {
+    const runId = await seedRun();
+
+    const first = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue,
+    });
+    const second = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue,
+    });
+
+    expect(first).toEqual({ handedOff: 1, scanned: 1, unattributed: 0 });
+    // The row is still `queued` — only the worker's claim moves it — so the
+    // second sweep sees it again and must recognise its own job.
+    expect(second).toEqual({ handedOff: 0, scanned: 1, unattributed: 0 });
+    expect(added).toEqual([
+      {
+        data: {
+          contractVersion: 2,
+          organizationId: ids.orgA,
+          runId,
+          userId: ids.userA1,
+          workspaceId: ids.wsA1,
+        },
+        jobId: jobIdFor(runId),
+        name: "run-document-review",
+      },
+    ]);
+  });
+
+  test("leaves finished runs and table-executed runs alone", async () => {
+    await seedRun({ status: "completed" });
+    await seedRun({ status: "failed" });
+    await seedRun({ status: "cancelled" });
+    await seedRun({ status: "running" });
+    await seedRun({ executor: DOCUMENT_REVIEW_RUN_EXECUTOR.TABLE });
+
+    const result = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue,
+    });
+
+    expect(result).toEqual({ handedOff: 0, scanned: 0, unattributed: 0 });
+    expect(added).toEqual([]);
+  });
+
+  test("reclaims a retained terminal record instead of adding under its id", async () => {
+    const completedJobRun = await seedRun();
+    const failedJobRun = await seedRun();
+    priorJobs.set(jobIdFor(completedJobRun), "completed");
+    priorJobs.set(jobIdFor(failedJobRun), "failed");
+
+    const result = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue,
+    });
+
+    expect(result.handedOff).toBe(2);
+    expect(removedJobIds).toEqual([jobIdFor(completedJobRun)]);
+    expect(retriedJobIds).toEqual([jobIdFor(failedJobRun)]);
+    expect(added.map(({ jobId }) => jobId)).toEqual([
+      jobIdFor(completedJobRun),
+    ]);
+  });
+
+  test("counts a run whose requester is gone instead of dropping it", async () => {
+    await seedRun({ requestedBy: null });
+
+    const result = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue,
+    });
+
+    expect(result).toEqual({ handedOff: 0, scanned: 1, unattributed: 1 });
+    expect(added).toEqual([]);
+  });
+
+  test("pages past a full page of queue-owned runs to reach an orphan", async () => {
+    // One page is 100 rows, and a run the queue owns keeps its `queued` row,
+    // so a sweep bounded by the first page would never inspect row 101.
+    const base = Date.now() - 60 * 60 * 1000;
+    const owned = Array.from({ length: 150 }, (_, index) =>
+      runValues({ createdAt: new Date(base + index) }),
+    );
+    await testDb.insert(documentReviewRuns).values(owned);
+    for (const { id } of owned) {
+      priorJobs.set(jobIdFor(id), "waiting");
+    }
+    const orphan = await seedRun({ createdAt: new Date(base + 1000) });
+
+    const result = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue,
+    });
+
+    expect(result).toEqual({ handedOff: 1, scanned: 151, unattributed: 0 });
+    expect(added.map(({ jobId }) => jobId)).toEqual([jobIdFor(orphan)]);
+  });
+
+  test("stops at the per-tick handoff limit on a page of orphans", async () => {
+    // A full page of rows that all need handing back. Whether a row hands off
+    // is only known once its handler returns, so capacity has to be taken
+    // before each handler starts or the whole page would be enqueued at once.
+    const base = Date.now() - 60 * 60 * 1000;
+    const orphans = Array.from({ length: 100 }, (_, index) =>
+      runValues({ createdAt: new Date(base + index) }),
+    );
+    await testDb.insert(documentReviewRuns).values(orphans);
+
+    const result = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue,
+    });
+
+    expect(result).toEqual({ handedOff: 50, scanned: 50, unattributed: 0 });
+    expect(added).toHaveLength(50);
+  });
+
+  test("gives up on a queue command that never answers", async () => {
+    // A broker that accepts the connection and then stops replying settles no
+    // command on its own. Unbounded, one such row would hold the sweep until
+    // its scheduler lease expired and nothing would be recorded at all.
+    const runId = await seedRun();
+    const analytics = installRecordingAnalytics();
+    const stalled = {
+      add: async () => undefined,
+      getJob: async () =>
+        await new Promise<undefined>(() => {
+          // Never settles: a broker that accepts the connection and answers
+          // nothing leaves the command pending for the life of the process.
+        }),
+    };
+
+    const result = await reconcileQueuedDocumentReviewRuns({
+      db: testDb,
+      queue: stalled,
+    });
+    analytics.restore();
+
+    expect(result).toEqual({ handedOff: 0, scanned: 1, unattributed: 0 });
+    // The stall is reported as one captured failure against the row, not lost
+    // as a tick that ran out of lease with nothing to show.
+    expect(
+      analytics
+        .exceptions()
+        .map(({ properties: { $exception_type, ...context } }) => [
+          $exception_type,
+          context["runId"],
+        ]),
+    ).toEqual([["TimeoutError", runId]]);
+  });
+});

--- a/apps/api/src/lib/document-review/run-queue.ts
+++ b/apps/api/src/lib/document-review/run-queue.ts
@@ -18,7 +18,7 @@
 
 import { panic, Result } from "better-result";
 import { Worker } from "bullmq";
-import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, lt, or, sql } from "drizzle-orm";
 
 import { DAY_IN_MS } from "@stll/time";
 
@@ -41,6 +41,12 @@ import type { AIUsageMetering } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
+import {
+  QUEUE_REQUEUE_OUTCOME,
+  requeueDeterministicJob,
+} from "@/api/lib/bullmq-requeue";
+import type { RequeueableQueue } from "@/api/lib/bullmq-requeue";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import {
   buildDocumentReviewFindingRow,
   recountDocumentReviewFindingProgress,
@@ -69,6 +75,12 @@ import type { ReviewRunPlan } from "@/api/lib/document-review/run-plan";
 import { errorTag } from "@/api/lib/errors/utils";
 import { startNonOverlappingInterval } from "@/api/lib/non-overlapping-interval";
 import { logger } from "@/api/lib/observability/logger";
+import {
+  RECONCILE_SCAN_PAGE_SIZE,
+  reconcileCursorTimestamp,
+  scanPendingRows,
+} from "@/api/lib/queue-reconcile-scan";
+import type { ReconcileScanResult } from "@/api/lib/queue-reconcile-scan";
 import { createQueueWorkerErrorLogger } from "@/api/lib/queue-worker-error-log";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -239,6 +251,121 @@ export const reconcileStuckDocumentReviewRuns = async (): Promise<number> => {
     )
     .returning({ id: documentReviewRuns.id });
   return recovered.length;
+};
+
+/** The (timestamp, id) keyset this sweep's walk pages on. */
+const reviewRunCursorCodec = createTimestampIdCursorCodec({
+  column: documentReviewRuns.createdAt,
+  brandId: brandPersistedDocumentReviewRunId,
+});
+
+type QueuedReviewRunRow = {
+  createdCursor: string;
+  id: SafeId<"documentReviewRun">;
+  organizationId: SafeId<"organization">;
+  requestedBy: string | null;
+  workspaceId: SafeId<"workspace">;
+};
+
+type ReconcileQueuedDocumentReviewRunsOptions = {
+  db?: Pick<typeof rootDb, "select">;
+  queue?: RequeueableQueue<DocumentReviewRunJobDataV2>;
+};
+
+type ReconcileQueuedDocumentReviewRunsResult = ReconcileScanResult & {
+  /**
+   * `requested_by` is nulled when the requester's account is deleted, and the
+   * job carries an actor. Counted rather than dropped quietly, so a population
+   * this sweep cannot repair stays visible; the staleness janitor above fails
+   * those rows once they age out.
+   */
+  unattributed: number;
+};
+
+/**
+ * Hand `queued` runs back to the queue when nothing owns them anymore.
+ *
+ * The row is created inside the request's transaction and the job is added
+ * after it commits, so a crash in between — or a queue that lost its waiting
+ * jobs — leaves a run that no worker will ever pick up. Nothing observes that
+ * from the row: a run waiting for a live job and a run whose job is gone are
+ * the same `queued`. Re-adding is safe to repeat because the job id is derived
+ * from the run id and only a `queued` row is claimable, so a duplicate
+ * delivery is a no-op rather than a second metered execution.
+ *
+ * The walk pages forward on a keyset cursor rather than re-reading one fixed
+ * page: a run the queue still owns keeps its `queued` row, so a sweep bounded
+ * by the first page would inspect the same healthy backlog every tick and
+ * never reach the orphan behind it.
+ *
+ * Table-executed runs are excluded: they are paced by the files-table property
+ * DAG and were never handed to this queue.
+ */
+export const reconcileQueuedDocumentReviewRuns = async ({
+  db = rootDb,
+  queue = getQueue(),
+}: ReconcileQueuedDocumentReviewRunsOptions = {}): Promise<ReconcileQueuedDocumentReviewRunsResult> => {
+  let unattributed = 0;
+
+  const after = (cursor: QueuedReviewRunRow | null) => {
+    if (cursor === null) {
+      return undefined;
+    }
+    return reviewRunCursorCodec.keysetAfter({
+      cursor: {
+        timestamp: reconcileCursorTimestamp(cursor.createdCursor),
+        id: cursor.id,
+      },
+      idColumn: documentReviewRuns.id,
+      direction: "ascending",
+    });
+  };
+
+  const readPage = async (cursor: QueuedReviewRunRow | null) =>
+    await db
+      .select({
+        createdCursor: reviewRunCursorCodec.cursorValue,
+        id: documentReviewRuns.id,
+        organizationId: documentReviewRuns.organizationId,
+        requestedBy: documentReviewRuns.requestedBy,
+        workspaceId: documentReviewRuns.workspaceId,
+      })
+      .from(documentReviewRuns)
+      .where(
+        and(
+          eq(documentReviewRuns.status, "queued"),
+          eq(documentReviewRuns.executor, DOCUMENT_REVIEW_RUN_EXECUTOR.WORKER),
+          after(cursor),
+        ),
+      )
+      .orderBy(asc(documentReviewRuns.createdAt), asc(documentReviewRuns.id))
+      .limit(RECONCILE_SCAN_PAGE_SIZE);
+
+  const handle = async (run: QueuedReviewRunRow): Promise<boolean> => {
+    if (run.requestedBy === null) {
+      unattributed += 1;
+      return false;
+    }
+    const { data, name, opts } = runJob({
+      organizationId: run.organizationId,
+      runId: run.id,
+      userId: brandPersistedUserId(run.requestedBy),
+      workspaceId: run.workspaceId,
+    });
+    const outcome = await Result.tryPromise({
+      try: async () =>
+        await requeueDeterministicJob({ data, jobId: opts.jobId, name, queue }),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(outcome)) {
+      captureError(outcome.error, { runId: run.id });
+      return false;
+    }
+    return outcome.value === QUEUE_REQUEUE_OUTCOME.REQUEUED;
+  };
+
+  const scan = await scanPendingRows({ handle, readPage });
+  return { ...scan, unattributed };
 };
 
 export const initDocumentReviewRunWorker = () => {

--- a/apps/api/src/lib/queue-reconcile-scan.ts
+++ b/apps/api/src/lib/queue-reconcile-scan.ts
@@ -1,0 +1,135 @@
+/**
+ * The walk a queue reconciler makes over its own pending rows.
+ *
+ * A fixed first page cannot drain: a row the queue still owns keeps its
+ * pending marker, so it refills the same page every tick and a row behind it
+ * is never inspected. The sweep therefore pages forward on a keyset cursor
+ * within one tick and stops on its own terms — enough rows handed back, the
+ * table exhausted, or the page ceiling reached — rather than on the first
+ * page's contents.
+ */
+
+import { panic } from "better-result";
+
+import { parsePgTimestampCursorValue } from "@/api/lib/db-pagination";
+import type { ParsedPgTimestampCursor } from "@/api/lib/db-pagination";
+
+/** Rows read per page. */
+export const RECONCILE_SCAN_PAGE_SIZE = 100;
+
+/** Rows handed back per tick, so a backlog drains without a queue storm. */
+const RECONCILE_HANDOFF_MAX = 50;
+
+/**
+ * Rows inspected at once. Each inspection is a couple of queue round trips, so
+ * a whole page in flight would put a page's worth of commands on the broker
+ * for a sweep that runs beside live traffic.
+ */
+const RECONCILE_SCAN_CONCURRENCY = 10;
+
+/**
+ * Pages one tick may walk. Bounds the work when nothing needs handing back,
+ * which is the steady state: without it a large healthy backlog would cost one
+ * queue lookup per row on every tick.
+ */
+const RECONCILE_MAX_PAGES = 20;
+
+export type ReconcileScanResult = {
+  handedOff: number;
+  scanned: number;
+};
+
+/**
+ * The cursor timestamp a page's keyset comparison is anchored on.
+ *
+ * A `Date` read back from the database cannot be that anchor: Postgres keeps
+ * microseconds and a `Date` carries milliseconds, so the truncated value
+ * re-admits the row the cursor came from (the walk never advances) or steps
+ * over the row beside it (an orphan is never inspected). The page therefore
+ * projects its cursor with `pgTimestampCursorValue` and re-anchors that text
+ * here. Unparseable is impossible — the value comes straight from that
+ * projection in the same query — so it is a programmer error, not a cursor to
+ * recover from.
+ */
+export const reconcileCursorTimestamp = (
+  cursorValue: string,
+): ParsedPgTimestampCursor =>
+  parsePgTimestampCursorValue(cursorValue) ??
+  panic("Reconciliation cursor is not a database timestamp");
+
+type ScanPendingRowsOptions<Row> = {
+  /**
+   * Acts on one row and reports whether it counted as a handoff. Every row it
+   * receives counts as inspected whatever it answers, so a row it cannot act
+   * on — an unusable actor, a queue lookup that failed — advances the cursor
+   * instead of pinning the sweep to the page it sits on.
+   */
+  handle: (row: Row) => Promise<boolean>;
+  /** Reads the next page after `cursor`, ordered by the same key. */
+  readPage: (cursor: Row | null) => Promise<readonly Row[]>;
+};
+
+export const scanPendingRows = async <Row>({
+  handle,
+  readPage,
+}: ScanPendingRowsOptions<Row>): Promise<ReconcileScanResult> => {
+  let handedOff = 0;
+  let scanned = 0;
+  /**
+   * Handoffs started but not yet known to have failed. Capacity is taken
+   * before a handler runs, not counted after it returns: whether a row hands
+   * off is only knowable once its handler is done, so a page started all at
+   * once would already have made every one of its handoffs by the time the
+   * limit was checked. A handler that turns out not to have handed off gives
+   * its reservation back, so a page the queue already owns costs none of the
+   * budget.
+   */
+  let reserved = 0;
+
+  const runPage = async (rows: readonly Row[]): Promise<void> => {
+    let next = 0;
+
+    const runNext = async (): Promise<void> => {
+      if (reserved >= RECONCILE_HANDOFF_MAX) {
+        return;
+      }
+      const row = rows.at(next);
+      if (row === undefined) {
+        return;
+      }
+      next += 1;
+      reserved += 1;
+      const didHandOff = await handle(row);
+      scanned += 1;
+      if (didHandOff) {
+        handedOff += 1;
+      } else {
+        reserved -= 1;
+      }
+      await runNext();
+    };
+
+    await Promise.all(
+      Array.from({ length: RECONCILE_SCAN_CONCURRENCY }, runNext),
+    );
+  };
+
+  const walk = async (cursor: Row | null, page: number): Promise<void> => {
+    if (page >= RECONCILE_MAX_PAGES || reserved >= RECONCILE_HANDOFF_MAX) {
+      return;
+    }
+    const rows = await readPage(cursor);
+    const last = rows.at(-1);
+    if (last === undefined) {
+      return;
+    }
+    await runPage(rows);
+    if (rows.length < RECONCILE_SCAN_PAGE_SIZE) {
+      return;
+    }
+    await walk(last, page + 1);
+  };
+
+  await walk(null, 0);
+  return { handedOff, scanned };
+};

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -12,12 +12,14 @@ import {
   type RegisteredSchedulerTaskName,
 } from "@/api/lib/scheduler/registry";
 import { computeNextRunAt } from "@/api/lib/scheduler/schedule";
+import { RECONCILE_BILINGUAL_RUNS_TASK } from "@/api/lib/scheduler/tasks/bilingual-run-reconcile";
 import { RECONCILE_BUFFER_INTENTS_TASK } from "@/api/lib/scheduler/tasks/buffer-intent-reconciliation";
 import { RECONCILE_CASE_LAW_CORPUS_UPLOAD_INTENTS_TASK } from "@/api/lib/scheduler/tasks/case-law-corpus-upload-cleanup";
 import { BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK } from "@/api/lib/scheduler/tasks/case-law-redaction-tombstone-backfill";
 import { CHAT_THREAD_COMPACTOR_TASK } from "@/api/lib/scheduler/tasks/chat-thread-compactor";
 import { EXPIRE_DESKTOP_EDIT_SESSIONS_TASK } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
 import { DISPATCH_DOCUMENT_OCR_TASK } from "@/api/lib/scheduler/tasks/document-processing-ocr";
+import { RECONCILE_DOCUMENT_REVIEW_RUNS_TASK } from "@/api/lib/scheduler/tasks/document-review-run-reconcile";
 import { REPAIR_FILE_DERIVATIVES_TASK } from "@/api/lib/scheduler/tasks/file-derivative-repair";
 import { RECONCILE_FLOW_RUN_ORPHANS_TASK } from "@/api/lib/scheduler/tasks/flow-run-orphan-reconcile";
 import { INFO_SOUD_SYNC_TRACKED_CASES_TASK } from "@/api/lib/scheduler/tasks/infosoud";
@@ -26,6 +28,7 @@ import { MEMORY_EXTRACTOR_TASK } from "@/api/lib/scheduler/tasks/memory-extracto
 import { REPAIR_CHAT_SEARCH_INDEX_TASK } from "@/api/lib/scheduler/tasks/search-chat-index";
 import { REPAIR_SEARCH_PROJECTIONS_TASK } from "@/api/lib/scheduler/tasks/search-projection-repair";
 import { REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK } from "@/api/lib/scheduler/tasks/search-semantic-timestamps";
+import { RECONCILE_STYLE_SET_PACKAGE_CLEANUPS_TASK } from "@/api/lib/scheduler/tasks/style-set-package-cleanup-reconcile";
 import { CLEAN_TEMPLATE_DELETION_OBJECTS_TASK } from "@/api/lib/scheduler/tasks/template-deletion-cleanup";
 import { WORK_ATTENTION_SCOUT_TASK } from "@/api/lib/scheduler/tasks/work-attention-scout";
 import { BACKFILL_WORK_OBLIGATIONS_TASK } from "@/api/lib/scheduler/tasks/work-obligation-backfill";
@@ -230,6 +233,28 @@ export const DECLARED_SCHEDULER_JOBS = [
     payloadUpdate: "preserve",
     schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
     task: REPAIR_FILE_DERIVATIVES_TASK,
+  },
+  {
+    description: "Re-drive document review runs no queued job owns anymore",
+    id: "documentReviews.reconcileQueuedRuns.fiveMinute",
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
+    task: RECONCILE_DOCUMENT_REVIEW_RUNS_TASK,
+  },
+  {
+    description:
+      "Re-drive bilingual translation runs no queued job owns anymore",
+    id: "bilingualTranslations.reconcileQueuedRuns.fiveMinute",
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
+    task: RECONCILE_BILINGUAL_RUNS_TASK,
+  },
+  {
+    description: "Delete style set packages a replacement left behind",
+    id: "styleSets.reconcilePackageCleanups.fiveMinute",
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
+    task: RECONCILE_STYLE_SET_PACKAGE_CLEANUPS_TASK,
   },
   {
     description: "Delete template objects recorded by committed deletions",

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -1,5 +1,9 @@
 import { createBullMqDispatchTask } from "@/api/lib/scheduler/bullmq";
 import {
+  RECONCILE_BILINGUAL_RUNS_TASK,
+  reconcileBilingualRuns,
+} from "@/api/lib/scheduler/tasks/bilingual-run-reconcile";
+import {
   RECONCILE_BUFFER_INTENTS_TASK,
   reconcileBufferIntents,
 } from "@/api/lib/scheduler/tasks/buffer-intent-reconciliation";
@@ -23,6 +27,10 @@ import {
   DISPATCH_DOCUMENT_OCR_TASK,
   dispatchDocumentOcr,
 } from "@/api/lib/scheduler/tasks/document-processing-ocr";
+import {
+  RECONCILE_DOCUMENT_REVIEW_RUNS_TASK,
+  reconcileDocumentReviewRuns,
+} from "@/api/lib/scheduler/tasks/document-review-run-reconcile";
 import {
   REPAIR_FILE_DERIVATIVES_TASK,
   repairFileDerivatives,
@@ -59,6 +67,10 @@ import {
   REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK,
   repairSearchSemanticTimestampsTask,
 } from "@/api/lib/scheduler/tasks/search-semantic-timestamps";
+import {
+  RECONCILE_STYLE_SET_PACKAGE_CLEANUPS_TASK,
+  reconcileStyleSetPackageCleanups,
+} from "@/api/lib/scheduler/tasks/style-set-package-cleanup-reconcile";
 import {
   CLEAN_TEMPLATE_DELETION_OBJECTS_TASK,
   cleanTemplateDeletionObjects,
@@ -103,6 +115,9 @@ const SCHEDULER_TASKS = {
   [CLEAN_TEMPLATE_DELETION_OBJECTS_TASK]: cleanTemplateDeletionObjects,
   [REPAIR_FILE_DERIVATIVES_TASK]: repairFileDerivatives,
   [RECONCILE_FLOW_RUN_ORPHANS_TASK]: reconcileFlowRunOrphans,
+  [RECONCILE_DOCUMENT_REVIEW_RUNS_TASK]: reconcileDocumentReviewRuns,
+  [RECONCILE_BILINGUAL_RUNS_TASK]: reconcileBilingualRuns,
+  [RECONCILE_STYLE_SET_PACKAGE_CLEANUPS_TASK]: reconcileStyleSetPackageCleanups,
 } as const satisfies Record<string, SchedulerTask>;
 
 export type RegisteredSchedulerTaskName = keyof typeof SCHEDULER_TASKS;

--- a/apps/api/src/lib/scheduler/tasks/bilingual-run-reconcile.ts
+++ b/apps/api/src/lib/scheduler/tasks/bilingual-run-reconcile.ts
@@ -1,0 +1,24 @@
+import { panic } from "better-result";
+
+import { reconcileQueuedBilingualRuns } from "@/api/lib/bilingual/run-queue";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+
+export const RECONCILE_BILINGUAL_RUNS_TASK =
+  "bilingualTranslations.reconcileQueuedRuns" as const;
+
+/** Re-drive bilingual runs the queue is not holding a job for anymore. */
+export const reconcileBilingualRuns: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  if (signal.aborted) {
+    panic("SchedulerAborted");
+  }
+  const { handedOff, scanned, unattributed } =
+    await reconcileQueuedBilingualRuns();
+  logger.info("scheduler.bilingual_runs_reconciled", {
+    "bilingualRuns.requeued": handedOff,
+    "bilingualRuns.scanned": scanned,
+    "bilingualRuns.unattributed": unattributed,
+  });
+};

--- a/apps/api/src/lib/scheduler/tasks/document-review-run-reconcile.ts
+++ b/apps/api/src/lib/scheduler/tasks/document-review-run-reconcile.ts
@@ -1,0 +1,24 @@
+import { panic } from "better-result";
+
+import { reconcileQueuedDocumentReviewRuns } from "@/api/lib/document-review/run-queue";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+
+export const RECONCILE_DOCUMENT_REVIEW_RUNS_TASK =
+  "documentReviews.reconcileQueuedRuns" as const;
+
+/** Re-drive review runs the queue is not holding a job for anymore. */
+export const reconcileDocumentReviewRuns: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  if (signal.aborted) {
+    panic("SchedulerAborted");
+  }
+  const { handedOff, scanned, unattributed } =
+    await reconcileQueuedDocumentReviewRuns();
+  logger.info("scheduler.document_review_runs_reconciled", {
+    "documentReviewRuns.requeued": handedOff,
+    "documentReviewRuns.scanned": scanned,
+    "documentReviewRuns.unattributed": unattributed,
+  });
+};

--- a/apps/api/src/lib/scheduler/tasks/style-set-package-cleanup-reconcile.ts
+++ b/apps/api/src/lib/scheduler/tasks/style-set-package-cleanup-reconcile.ts
@@ -1,0 +1,23 @@
+import { panic } from "better-result";
+
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+import { reconcilePendingStyleSetPackageCleanups } from "@/api/lib/style-set-package-cleanup-queue";
+
+export const RECONCILE_STYLE_SET_PACKAGE_CLEANUPS_TASK =
+  "styleSets.reconcilePackageCleanups" as const;
+
+/** Re-drive package deletions a style set row still records as owed. */
+export const reconcileStyleSetPackageCleanups: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  if (signal.aborted) {
+    panic("SchedulerAborted");
+  }
+  const { handedOff, scanned } =
+    await reconcilePendingStyleSetPackageCleanups();
+  logger.info("scheduler.style_set_package_cleanups_reconciled", {
+    "styleSetPackageCleanups.enqueued": handedOff,
+    "styleSetPackageCleanups.scanned": scanned,
+  });
+};

--- a/apps/api/src/lib/style-set-package-cleanup-queue.db.test.ts
+++ b/apps/api/src/lib/style-set-package-cleanup-queue.db.test.ts
@@ -1,0 +1,280 @@
+/**
+ * A style set that still names a superseded package is owed a deletion. If the
+ * job that would run it was lost, nothing else observes that: the object stays
+ * in storage and the column it left behind blocks the next replacement. What
+ * is asserted here is who may release that column — the job, once the object
+ * is actually gone, never the sweep that only enqueued it — and that the sweep
+ * pages past packages a live job already covers. Driven against a real
+ * (PGlite) database with a stubbed queue and a fake object store.
+ */
+
+import { panic } from "better-result";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq, inArray } from "drizzle-orm";
+
+import { styleSets } from "@/api/db/schema";
+import { envBase } from "@/api/env-base";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import {
+  deleteUnreferencedStyleSetPackage,
+  reconcilePendingStyleSetPackageCleanups,
+} from "@/api/lib/style-set-package-cleanup-queue";
+import { startFakeS3 } from "@/api/tests/helpers/fake-s3";
+import type { FakeS3 } from "@/api/tests/helpers/fake-s3";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+
+const { testDb, ids } = await getRlsFixture();
+
+type StubJobState = "active" | "completed" | "delayed" | "failed";
+
+type AddedJob = { data: unknown; delay: number; jobId: string; name: string };
+
+const added: AddedJob[] = [];
+const priorJobs = new Map<string, StubJobState>();
+
+const cleanupQueue = {
+  add: async (
+    name: string,
+    data: unknown,
+    options: { delay: number; jobId: string },
+  ) => {
+    added.push({ data, delay: options.delay, jobId: options.jobId, name });
+    priorJobs.set(options.jobId, "delayed");
+  },
+  getJob: async (jobId: string) => {
+    const state = priorJobs.get(jobId);
+    if (state === undefined) {
+      return undefined;
+    }
+    return {
+      getState: async () => state,
+      remove: async () => {
+        priorJobs.delete(jobId);
+      },
+    };
+  },
+};
+
+const SETTLED_AT = new Date(Date.now() - 60 * 60 * 1000);
+
+const bucket = envBase.S3_BUCKET;
+let fake: FakeS3;
+
+/** The packages surviving in the store. */
+const storedKeys = (): string[] =>
+  [...fake.objects.keys()].map((id) => id.slice(bucket.length + 1));
+
+const seededStyleSetIds: SafeId<"styleSet">[] = [];
+
+type SeedStyleSetOptions = {
+  cleanupS3Key?: string | null;
+  s3Key?: string;
+  updatedAt?: Date;
+};
+
+const styleSetValues = ({
+  cleanupS3Key = null,
+  s3Key,
+  updatedAt = SETTLED_AT,
+}: SeedStyleSetOptions = {}) => {
+  const styleSetId = createSafeId<"styleSet">();
+  seededStyleSetIds.push(styleSetId);
+  return {
+    id: styleSetId,
+    organizationId: ids.orgA,
+    name: "Reconciler fixture",
+    fileName: "styles.docx",
+    s3Key: s3Key ?? `style-sets/${styleSetId}/current.docx`,
+    cleanupS3Key,
+    sizeBytes: 12,
+    createdBy: ids.userA1,
+    updatedAt,
+  };
+};
+
+const seedStyleSet = async (
+  options: SeedStyleSetOptions = {},
+): Promise<SafeId<"styleSet">> => {
+  const values = styleSetValues(options);
+  await testDb.insert(styleSets).values(values);
+  return values.id;
+};
+
+/** Panics rather than reporting a missing row as a released marker: the row is
+ *  seeded by the test, so its absence is a broken fixture, and reading it as
+ *  `null` would let every marker assertion pass without exercising anything. */
+const readCleanupKey = async (styleSetId: SafeId<"styleSet">) => {
+  const [row] = await testDb
+    .select({ cleanupS3Key: styleSets.cleanupS3Key })
+    .from(styleSets)
+    .where(eq(styleSets.id, styleSetId));
+  if (row === undefined) {
+    panic(`expected the seeded style set ${styleSetId}`);
+  }
+  return row.cleanupS3Key;
+};
+
+const jobIdFor = (s3Key: string) =>
+  createBullMqJobId("delete-style-set-package", s3Key);
+
+describe("pending style set package cleanup reconciliation", () => {
+  beforeAll(() => {
+    fake = startFakeS3();
+  });
+
+  beforeEach(() => {
+    added.length = 0;
+    priorJobs.clear();
+    fake.objects.clear();
+  });
+
+  afterEach(async () => {
+    if (seededStyleSetIds.length > 0) {
+      await testDb
+        .delete(styleSets)
+        .where(inArray(styleSets.id, seededStyleSetIds));
+    }
+    seededStyleSetIds.length = 0;
+  });
+
+  afterAll(async () => {
+    try {
+      fake.stop();
+    } finally {
+      await releaseRlsFixture();
+    }
+  });
+
+  test("enqueues an owed deletion and leaves the marker for the job", async () => {
+    const cleanupS3Key = "style-sets/owed/superseded.docx";
+    const styleSetId = await seedStyleSet({ cleanupS3Key });
+
+    const result = await reconcilePendingStyleSetPackageCleanups({
+      cleanupQueue,
+      db: testDb,
+    });
+
+    expect(result).toEqual({ handedOff: 1, scanned: 1 });
+    expect(added).toEqual([
+      {
+        data: { s3Key: cleanupS3Key, styleSetId },
+        // The download URL handed out before the replacement has already
+        // expired for a row this old, so the deletion runs immediately.
+        delay: 0,
+        jobId: jobIdFor(cleanupS3Key),
+        name: "delete-style-set-package",
+      },
+    ]);
+    // The job may run before any write here lands, and a marker released
+    // ahead of the deletion is the only record of the retry, gone.
+    expect(await readCleanupKey(styleSetId)).toBe(cleanupS3Key);
+  });
+
+  test("releases the marker once the job has deleted the object", async () => {
+    const cleanupS3Key = "style-sets/deleted/superseded.docx";
+    const styleSetId = await seedStyleSet({ cleanupS3Key });
+    fake.put(bucket, cleanupS3Key, "style set package");
+
+    await deleteUnreferencedStyleSetPackage(cleanupS3Key, testDb);
+
+    expect(storedKeys()).toEqual([]);
+    expect(await readCleanupKey(styleSetId)).toBeNull();
+  });
+
+  test("leaves the marker for the next sweep when the job skipped", async () => {
+    // Something still serves this key, so the deletion is refused. The marker
+    // is the durable record that it is still owed and must survive.
+    const servedKey = "style-sets/served/live.docx";
+    await seedStyleSet({ s3Key: servedKey });
+    const owingStyleSetId = await seedStyleSet({ cleanupS3Key: servedKey });
+    fake.put(bucket, servedKey, "style set package");
+
+    await deleteUnreferencedStyleSetPackage(servedKey, testDb);
+
+    expect(storedKeys()).toEqual([servedKey]);
+    expect(await readCleanupKey(owingStyleSetId)).toBe(servedKey);
+
+    const result = await reconcilePendingStyleSetPackageCleanups({
+      cleanupQueue,
+      db: testDb,
+    });
+
+    expect(result).toEqual({ handedOff: 1, scanned: 1 });
+    expect(added.map(({ jobId }) => jobId)).toEqual([jobIdFor(servedKey)]);
+  });
+
+  test("leaves rows that owe nothing and rows still inside the handoff window", async () => {
+    await seedStyleSet();
+    await seedStyleSet({
+      cleanupS3Key: "style-sets/fresh/superseded.docx",
+      updatedAt: new Date(),
+    });
+
+    const result = await reconcilePendingStyleSetPackageCleanups({
+      cleanupQueue,
+      db: testDb,
+    });
+
+    expect(result).toEqual({ handedOff: 0, scanned: 0 });
+    expect(added).toEqual([]);
+  });
+
+  test("does not spend budget on a deletion a live job already covers", async () => {
+    const cleanupS3Key = "style-sets/live/superseded.docx";
+    await seedStyleSet({ cleanupS3Key });
+    priorJobs.set(jobIdFor(cleanupS3Key), "delayed");
+
+    const result = await reconcilePendingStyleSetPackageCleanups({
+      cleanupQueue,
+      db: testDb,
+    });
+
+    expect(added).toEqual([]);
+    expect(result).toEqual({ handedOff: 0, scanned: 1 });
+  });
+
+  test("pages past more covered rows than a tick may hand off", async () => {
+    // A cleanup waits out the whole download TTL, so a healthy row keeps a
+    // live delayed job long after it leaves the settle window. More such rows
+    // than the per-tick handoff limit therefore sit ahead of a stranded one on
+    // the keyset, and counting them as handoffs would end the tick before it
+    // ever reached it.
+    const base = SETTLED_AT.getTime();
+    const covered = Array.from({ length: 60 }, (_, index) =>
+      styleSetValues({
+        cleanupS3Key: `style-sets/covered/${index}.docx`,
+        updatedAt: new Date(base + index),
+      }),
+    );
+    await testDb.insert(styleSets).values(covered);
+    for (const { cleanupS3Key } of covered) {
+      priorJobs.set(jobIdFor(cleanupS3Key ?? ""), "delayed");
+    }
+    const strandedKey = "style-sets/stranded/superseded.docx";
+    await seedStyleSet({
+      cleanupS3Key: strandedKey,
+      updatedAt: new Date(base + 1000),
+    });
+
+    const result = await reconcilePendingStyleSetPackageCleanups({
+      cleanupQueue,
+      db: testDb,
+    });
+
+    expect(added.map(({ jobId }) => jobId)).toEqual([jobIdFor(strandedKey)]);
+    expect(result).toEqual({ handedOff: 1, scanned: 61 });
+  });
+});

--- a/apps/api/src/lib/style-set-package-cleanup-queue.ts
+++ b/apps/api/src/lib/style-set-package-cleanup-queue.ts
@@ -1,16 +1,30 @@
+import { Result } from "better-result";
 import { Worker } from "bullmq";
-import { eq, or } from "drizzle-orm";
+import { and, asc, eq, isNotNull, lt } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
 import { styleSets } from "@/api/db/schema";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
+import { QUEUE_REQUEUE_OUTCOME } from "@/api/lib/bullmq-requeue";
+import type { QueueRequeueOutcome } from "@/api/lib/bullmq-requeue";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
+import {
+  RECONCILE_SCAN_PAGE_SIZE,
+  reconcileCursorTimestamp,
+  scanPendingRows,
+} from "@/api/lib/queue-reconcile-scan";
+import type { ReconcileScanResult } from "@/api/lib/queue-reconcile-scan";
 import { createQueueWorkerErrorLogger } from "@/api/lib/queue-worker-error-log";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { getS3 } from "@/api/lib/s3";
+import { brandPersistedStyleSetId } from "@/api/lib/safe-id-boundaries";
 import { STYLE_SET_DOWNLOAD_TTL_SECONDS } from "@/api/lib/style-sets";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 const QUEUE_NAME = "style-set-package-cleanup";
 const CLEANUP_JOB_NAME = "delete-style-set-package";
@@ -61,13 +75,16 @@ export const enqueueStyleSetPackageCleanup = async ({
   s3Key,
   styleSetId,
   delayMs = STYLE_SET_DOWNLOAD_TTL_SECONDS * 1000,
-}: EnqueueStyleSetPackageCleanupOptions): Promise<void> =>
+}: EnqueueStyleSetPackageCleanupOptions): Promise<void> => {
+  // The request path only needs the claim to exist; which of the two ways it
+  // came to exist changes nothing it does next.
   await enqueueStyleSetPackageCleanupJob({
     cleanupQueue: getQueue(),
     delayMs,
     s3Key,
     styleSetId,
   });
+};
 
 export const enqueueStyleSetPackageCleanupJob = async ({
   cleanupQueue,
@@ -79,7 +96,7 @@ export const enqueueStyleSetPackageCleanupJob = async ({
   delayMs: number;
   s3Key: string;
   styleSetId: string;
-}): Promise<void> => {
+}): Promise<QueueRequeueOutcome> => {
   // The job id is derived from the key, so a claim for a key this queue has
   // already handled collides with the retained record of that run. Both
   // terminal states have to be reclaimed, not just `failed`: a claim placed
@@ -87,13 +104,16 @@ export const enqueueStyleSetPackageCleanupJob = async ({
   // and `removeOnComplete` keeps that record, so a later replacement of the
   // same key would `add()` a duplicate id, BullMQ would ignore it, and the
   // superseded object would be left with no runnable cleanup. A job still
-  // waiting, delayed, or active needs no re-add: it is the claim.
+  // waiting, delayed, or active needs no re-add: it is the claim, and saying
+  // so is what keeps a sweep from spending its per-tick budget on rows that
+  // are already covered — a cleanup waits out the whole download TTL, so a
+  // healthy row keeps a live job far longer than a sweep's settle window.
   const jobId = createBullMqJobId(CLEANUP_JOB_NAME, s3Key);
   const existingJob = await cleanupQueue.getJob(jobId);
   if (existingJob) {
     const state = await existingJob.getState();
     if (state !== "completed" && state !== "failed") {
-      return;
+      return QUEUE_REQUEUE_OUTCOME.QUEUE_OWNED;
     }
     await existingJob.remove();
   }
@@ -103,6 +123,144 @@ export const enqueueStyleSetPackageCleanupJob = async ({
     { s3Key, styleSetId },
     { delay: Math.max(0, delayMs), jobId },
   );
+  return QUEUE_REQUEUE_OUTCOME.REQUEUED;
+};
+
+/**
+ * How long a row may name a superseded package before the sweep takes it over.
+ * Only has to outlast the request that enqueues the cleanup, so the sweep
+ * never races a handoff that is still running.
+ */
+const RECONCILE_SETTLE_MS = 5 * 60 * 1000;
+
+/**
+ * Deadline on one sweep handoff. The three queue commands behind it are
+ * unbounded on their own, and a sweep that sat on an unanswered one would
+ * spend its whole scheduler lease on a single row. Matches the bound the
+ * other queue handoffs use.
+ */
+const QUEUE_HANDOFF_TIMEOUT_MS = 2000;
+
+/** The (timestamp, id) keyset this sweep's walk pages on. */
+const styleSetCleanupCursorCodec = createTimestampIdCursorCodec({
+  column: styleSets.updatedAt,
+  brandId: brandPersistedStyleSetId,
+});
+
+type PendingCleanupRow = {
+  cleanupS3Key: string | null;
+  id: SafeId<"styleSet">;
+  updatedAt: Date;
+  updatedCursor: string;
+};
+
+type ReconcilePendingStyleSetPackageCleanupsOptions = {
+  cleanupQueue?: StyleSetPackageCleanupQueue;
+  db?: Pick<typeof rootDb, "select">;
+};
+
+/**
+ * Re-drive package cleanups a row still owes.
+ *
+ * `cleanup_s3_key` is the durable record that a superseded package is waiting
+ * to be deleted: the replacement transaction writes it and the request enqueues
+ * the job after committing. A crash or a lost job in between strands the object
+ * in storage, and the column it left behind also blocks the next replacement of
+ * that style set, so the row needs no new state to be recoverable — it already
+ * names exactly the work that is owed. The enqueue is keyed by the object key,
+ * so repeating it collapses onto the job already waiting.
+ *
+ * The sweep only enqueues. Releasing the marker is the job's to do once the
+ * object is actually gone: with a delay this sweep may compute as zero, the job
+ * can run and skip before any release here lands, and the release would then
+ * have thrown away the only record that the deletion is still owed.
+ */
+export const reconcilePendingStyleSetPackageCleanups = async ({
+  cleanupQueue = getQueue(),
+  db = rootDb,
+}: ReconcilePendingStyleSetPackageCleanupsOptions = {}): Promise<ReconcileScanResult> => {
+  const settledBefore = new Date(Date.now() - RECONCILE_SETTLE_MS);
+
+  const after = (cursor: PendingCleanupRow | null) => {
+    if (cursor === null) {
+      return undefined;
+    }
+    return styleSetCleanupCursorCodec.keysetAfter({
+      cursor: {
+        timestamp: reconcileCursorTimestamp(cursor.updatedCursor),
+        id: cursor.id,
+      },
+      idColumn: styleSets.id,
+      direction: "ascending",
+    });
+  };
+
+  const readPage = async (cursor: PendingCleanupRow | null) =>
+    await db
+      .select({
+        cleanupS3Key: styleSets.cleanupS3Key,
+        id: styleSets.id,
+        updatedAt: styleSets.updatedAt,
+        updatedCursor: styleSetCleanupCursorCodec.cursorValue,
+      })
+      .from(styleSets)
+      .where(
+        and(
+          isNotNull(styleSets.cleanupS3Key),
+          lt(styleSets.updatedAt, settledBefore),
+          after(cursor),
+        ),
+      )
+      .orderBy(asc(styleSets.updatedAt), asc(styleSets.id))
+      .limit(RECONCILE_SCAN_PAGE_SIZE);
+
+  const handle = async ({
+    cleanupS3Key,
+    id,
+    updatedAt,
+  }: PendingCleanupRow): Promise<boolean> => {
+    if (cleanupS3Key === null) {
+      return false;
+    }
+    const outcome = await Result.tryPromise({
+      // Bounded here rather than inside the handoff itself: the request path
+      // shares that helper and owns its own failure handling, while a sweep
+      // that sat on an unanswered queue command would spend its whole lease on
+      // one row and record nothing.
+      try: async () =>
+        await withTimeout(
+          async () =>
+            await enqueueStyleSetPackageCleanupJob({
+              cleanupQueue,
+              // The download URL handed out before the replacement is still
+              // live until this deadline; deleting sooner would break it.
+              delayMs:
+                updatedAt.getTime() +
+                STYLE_SET_DOWNLOAD_TTL_SECONDS * 1000 -
+                Date.now(),
+              s3Key: cleanupS3Key,
+              styleSetId: id,
+            }),
+          {
+            label: "style-set-package-cleanup.reconcile-handoff",
+            timeoutMs: QUEUE_HANDOFF_TIMEOUT_MS,
+          },
+        ),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(outcome)) {
+      captureError(outcome.error, { styleSetId: id });
+      return false;
+    }
+    // Only a job this sweep actually added spends budget. A key the queue
+    // already holds is covered work, and a cleanup sits delayed for the whole
+    // download TTL — far longer than the settle window — so counting those
+    // would let a run of healthy rows exhaust the tick before it reached the
+    // stranded row behind them.
+    return outcome.value === QUEUE_REQUEUE_OUTCOME.REQUEUED;
+  };
+
+  return await scanPendingRows({ handle, readPage });
 };
 
 export const deleteQueuedStyleSetPackages = async (
@@ -125,30 +283,38 @@ export const deleteQueuedStyleSetPackages = async (
 };
 
 /**
- * Delete a package object unless a style set still names it.
+ * Delete a package object unless a style set still serves it.
  *
  * The check is what makes a cleanup job safe to enqueue *before* the object
  * exists: an abandoned write is deleted, while a write whose row committed is
- * left alone, and no ordering between the two decides the outcome. It also
- * keeps a stale job from deleting a package the row still points at when the
- * outbox column could not be cleared.
+ * left alone, and no ordering between the two decides the outcome. Only
+ * `s3_key` protects an object. A `cleanup_s3_key` naming it is the opposite
+ * signal — the row is asking for exactly this deletion — so the job clears
+ * that marker once the object is gone, and only for the key it deleted. The
+ * marker is what the sweep rediscovers, so releasing it before the deletion
+ * lands would destroy the only durable record of the retry.
  */
 export const deleteUnreferencedStyleSetPackage = async (
   s3Key: string,
-  db: Pick<typeof rootDb, "select"> = rootDb,
+  db: Pick<typeof rootDb, "select" | "update"> = rootDb,
 ): Promise<void> => {
-  const [referencing] = await db
+  const [serving] = await db
     .select({ id: styleSets.id })
     .from(styleSets)
-    .where(or(eq(styleSets.s3Key, s3Key), eq(styleSets.cleanupS3Key, s3Key)))
+    .where(eq(styleSets.s3Key, s3Key))
     .limit(1);
-  if (referencing) {
+  if (serving) {
     logger.debug("style_set_package_cleanup.still_referenced", {
-      styleSetId: referencing.id,
+      styleSetId: serving.id,
     });
     return;
   }
   await getS3().delete(s3Key);
+  // audit: skip — cleanup metadata on the already-audited style set.
+  await db
+    .update(styleSets)
+    .set({ cleanupS3Key: null })
+    .where(eq(styleSets.cleanupS3Key, s3Key));
 };
 
 export const initStyleSetPackageCleanupWorker = () => {

--- a/apps/api/src/lib/style-set-package-cleanup-reference.test.ts
+++ b/apps/api/src/lib/style-set-package-cleanup-reference.test.ts
@@ -69,15 +69,17 @@ describe("style set package cleanup reference check", () => {
     });
 
     await deleteUnreferencedStyleSetPackage(liveKey, testDb);
-    // Still recorded in the row's cleanup outbox: not this job's to delete.
-    await deleteUnreferencedStyleSetPackage(replacedKey, testDb);
     expect(storedKeys()).toEqual([liveKey, replacedKey]);
 
-    await testDb
-      .update(styleSets)
-      .set({ cleanupS3Key: null })
-      .where(eq(styleSets.id, styleSetId));
+    // Recorded in the row's cleanup outbox: the row is asking for exactly this
+    // deletion, and the job releases the marker once the object is gone.
     await deleteUnreferencedStyleSetPackage(replacedKey, testDb);
     expect(storedKeys()).toEqual([liveKey]);
+
+    const [row] = await testDb
+      .select({ cleanupS3Key: styleSets.cleanupS3Key })
+      .from(styleSets)
+      .where(eq(styleSets.id, styleSetId));
+    expect(row?.cleanupS3Key).toBeNull();
   });
 });


### PR DESCRIPTION
## What

`feat(api): reconcile pending work for queues without a sweep` — three scheduled reconcilers (document review runs, bilingual translation runs, style-set package cleanups) that rediscover pending rows without a live job and re-enqueue them idempotently, keyed by the row id, in bounded batches, with a `scheduler.<name>_reconciled` event per tick. A shared helper handles the case where a retained terminal job record still holds the deterministic id, which otherwise makes a re-enqueue a silent no-op.

## Tests

Per reconciler against Postgres with a stubbed queue: a pending row with no job is enqueued exactly once, a second sweep adds nothing, terminal rows are untouched, a retained terminal record is reclaimed rather than added under; scheduler registry suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery for queued document review and bilingual translation runs when worker jobs are no longer active.
  - Added automatic retrying of pending style-set package clean-up tasks.
  - Recovery tasks run regularly in the background and avoid duplicating active work.

- **Bug Fixes**
  - Completed or failed jobs are handled safely during recovery.
  - Style-set package clean-up markers are cleared only after successful deletion, allowing refused deletions to be retried.

- **Tests**
  - Added coverage for queue recovery, retries, pagination, missing requesters, terminal runs, and package deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->