### PR TITLE
fix(api): grade a disrupted workflow reconcile tick as a transient

### DIFF
--- a/apps/api/src/lib/workflow-queue.test.ts
+++ b/apps/api/src/lib/workflow-queue.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { toSafeId } from "@/api/lib/branded-types";
+import { isTransientRedisConnectionError } from "@/api/lib/redis-client";
+import {
+  createWorkflowReconcileRunner,
+  handleWorkflowReconcileFailure,
+} from "@/api/lib/workflow-queue";
 import { resolveWorkflowTargetEntityIds } from "@/api/lib/workflow-targets";
+import {
+  installRecordingAnalytics,
+  installRecordingLogger,
+} from "@/api/tests/helpers/recording-telemetry";
+import type {
+  RecordingAnalytics,
+  RecordingLogger,
+} from "@/api/tests/helpers/recording-telemetry";
 
 const entityId = (value: string) => toSafeId<"entity">(value);
 
@@ -55,5 +68,96 @@ describe("workflow entity targeting", () => {
         inputOrder: [task, task, documentB],
       }),
     ).toEqual([task, documentB, documentA, link]);
+  });
+});
+
+// The runner hands its tick off to a floating promise chain, so an assertion
+// has to wait for that chain to settle rather than for the call to return.
+const settle = async (): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+};
+
+describe("workflow reconcile failures", () => {
+  let analytics: RecordingAnalytics;
+  let logs: RecordingLogger;
+
+  beforeEach(() => {
+    analytics = installRecordingAnalytics();
+    logs = installRecordingLogger();
+  });
+
+  afterEach(() => {
+    analytics.restore();
+    logs.restore();
+  });
+
+  test("warns without capturing when the tick's socket was dropped", () => {
+    // The transient and non-transient fixtures must classify differently, or
+    // both assertions below would pass through the same branch.
+    const transient = Object.assign(new Error("Connection closed"), {
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+    });
+    const defect = Object.assign(new Error("WRONGTYPE"), {
+      code: "ERR_REDIS_INVALID_TYPE",
+    });
+    expect(isTransientRedisConnectionError(transient)).toBe(true);
+    expect(isTransientRedisConnectionError(defect)).toBe(false);
+
+    handleWorkflowReconcileFailure(transient);
+    expect(analytics.exceptions()).toEqual([]);
+    expect(logs.at("WARN")).toMatchObject([
+      {
+        message: "workflow.reconcile_disrupted",
+        attributes: { "error.type": "Error" },
+      },
+    ]);
+    expect(logs.at("ERROR")).toEqual([]);
+
+    handleWorkflowReconcileFailure(defect);
+    expect(
+      analytics.exceptions().map((event) => event.properties),
+    ).toMatchObject([
+      { "error.class": "Error", "error.code": "ERR_REDIS_INVALID_TYPE" },
+    ]);
+    expect(logs.at("ERROR")).toMatchObject([
+      { message: "workflow.reconcile_failed" },
+    ]);
+    // The defect took the capture branch, so no second disruption warning.
+    expect(logs.at("WARN")).toHaveLength(1);
+  });
+
+  test("keeps the pending-cell sweep owed until a tick completes", async () => {
+    const scans: boolean[] = [];
+    let disrupted = true;
+    const runReconcile = createWorkflowReconcileRunner(
+      async ({ scanPendingCells }) => {
+        scans.push(scanPendingCells);
+        await (disrupted
+          ? Promise.reject(
+              Object.assign(new Error("Connection closed"), {
+                code: "ERR_REDIS_CONNECTION_CLOSED",
+              }),
+            )
+          : Promise.resolve());
+      },
+    );
+
+    runReconcile();
+    await settle();
+    // The disrupted tick never swept, so the next one must sweep again.
+    expect(scans).toEqual([true]);
+
+    disrupted = false;
+    runReconcile();
+    await settle();
+    expect(scans).toEqual([true, true]);
+
+    // One completed sweep discharges it; later ticks stay on the bounded scan.
+    runReconcile();
+    await settle();
+    expect(scans).toEqual([true, true, false]);
+    expect(analytics.exceptions()).toEqual([]);
   });
 });

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -41,6 +41,7 @@ import { createQueueWorkerErrorLogger } from "@/api/lib/queue-worker-error-log";
 import {
   createBullMqConnection,
   isRecoverableRedisPollError,
+  isTransientRedisConnectionError,
 } from "@/api/lib/redis-client";
 import { broadcastWorkspaceResourceSetUpdated } from "@/api/lib/resource-realtime";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -1129,6 +1130,53 @@ const createWorkflowWorker = ({
   return worker;
 };
 
+/**
+ * Grade one reconcile tick's failure.
+ *
+ * The tick opens on a Redis scan, which rejects with a closed-connection code
+ * when the socket dropped while idle. The client reconnects without an attempt
+ * cap and its holder replaces a client that closed anyway, so the next tick
+ * runs against a live connection and that rejection is an expected operational
+ * transient rather than a defect. Anything else is a fault the tick could not
+ * recover from and stays a captured exception. Same split the
+ * document-processing reconcile applies to its own tick.
+ *
+ * Exported for the test that pins the split.
+ */
+export const handleWorkflowReconcileFailure = (error: unknown): void => {
+  if (isTransientRedisConnectionError(error)) {
+    logger.warn("workflow.reconcile_disrupted", {
+      "error.type": errorTag(error),
+    });
+    return;
+  }
+  captureError(error);
+  logger.error("workflow.reconcile_failed", errorSystemFields(error));
+};
+
+/**
+ * Drive the reconcile cadence.
+ *
+ * The thorough pass — the unbounded DB sweep for pending cells whose lock has
+ * already lapsed — is owed once per process, and only a completed tick
+ * discharges it. A tick that rejects, including on the transient graded above,
+ * leaves it owed so the next tick repeats the sweep rather than deferring it to
+ * the next restart; later ticks look for pending cells only under a held Redis
+ * lock, so the sweep has no equivalent.
+ */
+export const createWorkflowReconcileRunner = (
+  reconcile: (options: ReconcileOrphanedWorkflowsOptions) => Promise<void>,
+) => {
+  let pendingCellSweepOwed = true;
+  const runTick = async (): Promise<void> => {
+    await reconcile({ scanPendingCells: pendingCellSweepOwed });
+    pendingCellSweepOwed = false;
+  };
+  return (): void => {
+    runTick().catch(handleWorkflowReconcileFailure);
+  };
+};
+
 /** Initialize every workflow worker. Call once at API startup. */
 export const initWorkflowWorkers = () => {
   const workers = WORKFLOW_WORKER_SPECS.map(createWorkflowWorker);
@@ -1138,17 +1186,11 @@ export const initWorkflowWorkers = () => {
   // already lapsed); the interval then catches orphans that form at
   // runtime — e.g. a job exhausts its retries while the lock is held —
   // without waiting for a restart.
-  const runReconcile = (scanPendingCells: boolean): void => {
-    reconcileOrphanedWorkflows({ scanPendingCells }).catch((error: unknown) => {
-      captureError(error);
-      logger.error("workflow.reconcile_failed", errorSystemFields(error));
-    });
-  };
-  runReconcile(true);
-  const reconcileTimer = setInterval(
-    () => runReconcile(false),
-    RECONCILE_INTERVAL_MS,
+  const runReconcile = createWorkflowReconcileRunner(
+    reconcileOrphanedWorkflows,
   );
+  runReconcile();
+  const reconcileTimer = setInterval(runReconcile, RECONCILE_INTERVAL_MS);
   // The reconcile cadence must not keep the process alive at shutdown.
   reconcileTimer.unref();
 


### PR DESCRIPTION
## Proposed change

Every workflow reconcile tick opens on a Redis scan for running workspaces
(`getRootWorkflowRunStateStore().scanRunningWorkspaceIds()`). A socket dropped
while idle makes that scan reject with `ERR_REDIS_CONNECTION_CLOSED` instead of
waiting for the reconnect. The client reconnects without an attempt cap and its
holder replaces a client that closed, so the next tick runs against a live
connection and that rejection is an expected operational transient rather than a
defect.

`handleWorkflowReconcileFailure` grades the tick's failure the way the
document-processing reconcile grades its own: WARN on the transient, capture and
log at ERROR for everything else. The queue worker error logger, the OCR
readiness read and the readiness heartbeat already classify the same code
through `isTransientRedisConnectionError`.

Downgrading the failure alone would have cost the boot sweep. Only the first
tick scans the whole cell table for `pending` cells whose lock has already
lapsed; interval ticks look for pending cells solely among workspaces holding a
Redis lock, so a disrupted first tick had no later equivalent.
`createWorkflowReconcileRunner` keeps that thorough pass owed until a tick
completes, so the next tick repeats it instead of deferring the sweep to the
next restart.

## Checklist

- [x] **BUILD ASSURANCE** | Typecheck and lint clean for `apps/api`.
- [x] **TESTING** | `apps/api/src/lib/workflow-queue.test.ts` pins both branches of the grading split and the owed-sweep invariant across a disrupted tick.
- [ ] DARK MODE SUPPORT | Not applicable, server-side only.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.
