### PR TITLE
fix(api): keep broker clients reconnecting after the connection closes

### DIFF
--- a/apps/api/src/lib/bullmq-queue.ts
+++ b/apps/api/src/lib/bullmq-queue.ts
@@ -1,11 +1,13 @@
 import { Queue } from "bullmq";
 import type { QueueOptions } from "bullmq";
-import type { RedisOptions } from "bun";
 
-import { createBullMqConnection } from "@/api/lib/redis-client";
+import {
+  createBullMqConnection,
+  type RedisClientOverrides,
+} from "@/api/lib/redis-client";
 
 type LazyBullMqQueueOptions = Omit<QueueOptions, "connection"> & {
-  connectionOptions?: RedisOptions;
+  connectionOptions?: RedisClientOverrides;
   name: string;
 };
 

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -44,6 +44,7 @@ import {
 } from "@/api/lib/document-processing-queue-policy";
 import { createReconciliationProgress } from "@/api/lib/document-processing-reconciliation-progress";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import { isTransientRedisConnectionError } from "@/api/lib/redis-error-classification";
 
 const queueSource = await Bun.file(
   new URL("document-processing-queue.ts", import.meta.url),
@@ -1126,6 +1127,55 @@ describe("worker interruption lifecycle", () => {
  * saturated phase as drained and lets the batch worker exit mid-drain, so
  * each phase states its own saturation and this only collects the answers.
  */
+/**
+ * The class this pins: a closed broker connection used to end the loop's
+ * usefulness for the rest of the process's life, because nothing behind the
+ * phase ever reconnected. Recovery is the connection's own property now, so
+ * the loop only has to survive the tick that saw the failure and run the next
+ * one against the replacement.
+ */
+describe("reconciliation across a closed broker connection", () => {
+  test("the tick after a closed-connection failure reports real counts", async () => {
+    const connectionClosed = Object.assign(new Error("Connection closed"), {
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+    });
+    // The classifier is what decides this failure is worth another tick; a
+    // drifted code would make the assertions below pass for the wrong reason.
+    expect(isTransientRedisConnectionError(connectionClosed)).toBe(true);
+
+    let ticks = 0;
+    const errors: unknown[] = [];
+    const runTick = async () =>
+      await runDocumentProcessingReconciliationPhases({
+        onPhaseError: (error) => {
+          errors.push(error);
+        },
+        phases: [
+          {
+            name: "repair",
+            run: async () => {
+              ticks += 1;
+              if (ticks === 1) {
+                throw connectionClosed;
+              }
+              return await Promise.resolve({ count: 3, hasMore: false });
+            },
+          },
+        ],
+      });
+
+    const first = await runTick();
+    const second = await runTick();
+
+    expect(errors).toEqual([connectionClosed]);
+    // A failed phase proves nothing about its own backlog, so the tick that
+    // hit the closed connection reports work left behind...
+    expect(first.repair).toEqual({ count: 0, hasMore: true });
+    // ...and the next one drains for real instead of repeating the failure.
+    expect(second.repair).toEqual({ count: 3, hasMore: false });
+  });
+});
+
 describe("reconciliationLeftWorkBehind", () => {
   const resultsOf = async (
     phases: Parameters<

--- a/apps/api/src/lib/document-processing-readiness.test.ts
+++ b/apps/api/src/lib/document-processing-readiness.test.ts
@@ -18,12 +18,123 @@ process.env["GOTENBERG_PASSWORD"] ??= "test";
 let readinessGet = async (): Promise<string | null> => null;
 
 const {
+  createSingleFlightBeat,
   isDocumentOcrWorkerAvailable,
   readDocumentOcrWorkerAvailability,
   refreshDocumentOcrWorkerReadiness,
 } = await import("@/api/lib/document-processing-readiness");
 
 const createReadinessClient = () => ({ get: readinessGet });
+
+/**
+ * The class these pin: the heartbeat's wait is bounded, but a deadline
+ * cancels nothing. If the single-flight slot were released when the caller
+ * gave up rather than when the work finished, every interval during a broker
+ * outage would attach another continuation to the same pending connect, and
+ * each one would send its own lease write the moment the socket came back.
+ */
+describe("readiness heartbeat scheduling", () => {
+  /** A beat whose work and caller-visible deadline settle independently. */
+  const pendingBeat = () => {
+    const state = {
+      releaseConnect: (): void => undefined,
+      sends: 0,
+      starts: 0,
+      timeOut: (_error: Error): void => undefined,
+    };
+    const beat = createSingleFlightBeat(() => {
+      state.starts += 1;
+      const connected = new Promise<void>((resolve) => {
+        state.releaseConnect = resolve;
+      });
+      const chain = connected.then((): number => {
+        state.sends += 1;
+        return state.sends;
+      });
+      const observed = new Promise<never>((_resolve, reject) => {
+        state.timeOut = reject;
+      });
+      // The chain is what holds the slot; `observed` is only the caller's
+      // view of it, exactly as `withTimeout` leaves them in production.
+      return { chain, observed };
+    });
+    return { beat, state };
+  };
+
+  test("a beat whose caller timed out keeps the slot until its write settles", async () => {
+    const { beat, state } = pendingBeat();
+
+    const first = beat.start();
+    expect(first).not.toBeNull();
+    // The interval gives up after its deadline while the connect is still
+    // climbing. Nothing about the underlying write has changed.
+    state.timeOut(
+      new Error("document OCR readiness heartbeat exceeded 2000ms"),
+    );
+    await first?.catch(() => undefined);
+
+    expect(beat.start()).toBeNull();
+    expect(state.starts).toBe(1);
+    expect(state.sends).toBe(0);
+
+    // The connect comes back: exactly one write, from the one retained beat.
+    state.releaseConnect();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(state.sends).toBe(1);
+
+    // The work settled, so the next interval beats again.
+    const next = beat.start();
+    expect(next).not.toBeNull();
+    expect(state.starts).toBe(2);
+    state.timeOut(new Error("done"));
+    await next?.catch(() => undefined);
+  });
+
+  test("a beat that is still connecting blocks the next interval", async () => {
+    let starts = 0;
+    let releaseConnect: () => void = () => undefined;
+    const beat = createSingleFlightBeat(() => {
+      starts += 1;
+      const chain = new Promise<void>((resolve) => {
+        releaseConnect = resolve;
+      });
+      return { chain, observed: chain };
+    });
+
+    const first = beat.start();
+    // Two more intervals fire while the first beat is still connecting.
+    expect(first).not.toBeNull();
+    expect(beat.start()).toBeNull();
+    expect(beat.start()).toBeNull();
+    expect(starts).toBe(1);
+
+    releaseConnect();
+    await first;
+
+    const fourth = beat.start();
+    expect(fourth).not.toBeNull();
+    expect(starts).toBe(2);
+    releaseConnect();
+    await fourth;
+  });
+
+  test("a failed beat still releases the next interval", async () => {
+    let starts = 0;
+    const beat = createSingleFlightBeat(() => {
+      starts += 1;
+      const chain = Promise.reject(new Error("connect ECONNREFUSED"));
+      return { chain, observed: chain };
+    });
+
+    // A rejection that left the slot taken would silence the heartbeat for
+    // the life of the process, which the lease TTL cannot survive.
+    await beat.start()?.catch(() => undefined);
+    await beat.start()?.catch(() => undefined);
+
+    expect(starts).toBe(2);
+  });
+});
 
 describe("document OCR worker readiness", () => {
   let analytics: RecordingAnalytics;
@@ -48,9 +159,16 @@ describe("document OCR worker readiness", () => {
       "connectionTimeout: DOCUMENT_OCR_REDIS_COMMAND_TIMEOUT_MS",
     );
     expect(source).toContain("enableOfflineQueue: false");
-    expect(source.match(/createDocumentOcrReadinessClient\(\)/gu)).toHaveLength(
-      2,
-    );
+    // The fail-fast factory is the only place a client is built here, and
+    // both long-lived readiness clients are held through the lazy holder:
+    // a bare client whose connection closes can never be reopened, so its
+    // holder would keep reading a socket that is not coming back.
+    expect(source.match(/createRedisClient\(/gu)).toHaveLength(1);
+    expect(
+      source.match(
+        /createLazyRedisClient\(\s*createDocumentOcrReadinessClient,?\s*\)/gu,
+      ),
+    ).toHaveLength(2);
   });
 
   test("reports availability only from a live shared lease", async () => {

--- a/apps/api/src/lib/document-processing-readiness.ts
+++ b/apps/api/src/lib/document-processing-readiness.ts
@@ -5,6 +5,7 @@ import { detached } from "@/api/lib/detached";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import {
+  createLazyRedisClient,
   createRedisClient,
   isTransientRedisConnectionError,
 } from "@/api/lib/redis-client";
@@ -34,12 +35,10 @@ const createDocumentOcrReadinessClient = () =>
     enableOfflineQueue: false,
   });
 
-let readinessReader: ReturnType<typeof createRedisClient> | null = null;
-
-const getReadinessReader = () => {
-  readinessReader ??= createDocumentOcrReadinessClient();
-  return readinessReader;
-};
+// Both readiness clients are process-lifetime, so each is held through the
+// lazy holder rather than as a bare client: a connection that closes is
+// dropped with it and the next command builds a replacement.
+const readinessReader = createLazyRedisClient(createDocumentOcrReadinessClient);
 
 export const readDocumentOcrWorkerAvailability = async (
   readLease: () => Promise<string | null>,
@@ -58,14 +57,13 @@ export const isDocumentOcrWorkerAvailable = async (
 ): Promise<boolean> => {
   const availability = await Result.tryPromise({
     try: async () =>
-      await readDocumentOcrWorkerAvailability(
-        async () =>
-          await (
-            createClient === createDocumentOcrReadinessClient
-              ? getReadinessReader()
-              : createClient()
-          ).get(DOCUMENT_OCR_WORKER_READINESS_KEY),
-      ),
+      await readDocumentOcrWorkerAvailability(async () => {
+        const client =
+          createClient === createDocumentOcrReadinessClient
+            ? await readinessReader.ready()
+            : createClient();
+        return await client.get(DOCUMENT_OCR_WORKER_READINESS_KEY);
+      }),
     catch: (cause) => cause,
   });
   if (Result.isError(availability)) {
@@ -84,6 +82,22 @@ export const isDocumentOcrWorkerAvailable = async (
   return availability.value;
 };
 
+const HEARTBEAT_TIMEOUT_LABEL = "document OCR readiness heartbeat";
+
+/** Apply the lease constants. Unbounded: the caller decides its own deadline. */
+const writeReadinessLease = async (
+  writeLease: (
+    key: CoordinationKey,
+    value: string,
+    ttlSeconds: number,
+  ) => Promise<unknown>,
+): Promise<unknown> =>
+  await writeLease(
+    DOCUMENT_OCR_WORKER_READINESS_KEY,
+    DOCUMENT_OCR_WORKER_READINESS_VALUE,
+    DOCUMENT_OCR_WORKER_READINESS_TTL_SECONDS,
+  );
+
 export const refreshDocumentOcrWorkerReadiness = async (
   writeLease: (
     key: CoordinationKey,
@@ -92,26 +106,64 @@ export const refreshDocumentOcrWorkerReadiness = async (
   ) => Promise<unknown>,
   timeoutMs = DOCUMENT_OCR_REDIS_COMMAND_TIMEOUT_MS,
 ): Promise<void> => {
-  await withTimeout(
-    async () =>
-      await writeLease(
-        DOCUMENT_OCR_WORKER_READINESS_KEY,
-        DOCUMENT_OCR_WORKER_READINESS_VALUE,
-        DOCUMENT_OCR_WORKER_READINESS_TTL_SECONDS,
-      ),
-    {
-      label: "document OCR readiness heartbeat",
-      timeoutMs,
+  const write = writeReadinessLease(writeLease);
+  await withTimeout(async () => await write, {
+    label: HEARTBEAT_TIMEOUT_LABEL,
+    timeoutMs,
+  });
+};
+
+/**
+ * One beat, split into the work and the caller's view of it. They are not the
+ * same promise: a deadline bounds how long the caller waits, but it cancels
+ * nothing, so the write and the connect behind it keep running after the
+ * caller has given up on them.
+ */
+export type SingleFlightBeat = {
+  /**
+   * The underlying work. This alone decides when the slot is free, because a
+   * slot released on the caller's deadline would let the next interval attach
+   * a second continuation to the same pending connect.
+   */
+  chain: Promise<unknown>;
+  /** What the caller awaits and reports on; may settle before `chain`. */
+  observed: Promise<unknown>;
+};
+
+/**
+ * One beat at a time, its connect included. `start` returns the caller's view
+ * of the beat it started, or null when one was already running, so a caller
+ * cannot observe "in flight" and act on it separately.
+ */
+export const createSingleFlightBeat = (runBeat: () => SingleFlightBeat) => {
+  let inFlight: Promise<unknown> | null = null;
+  return {
+    start: (): Promise<unknown> | null => {
+      if (inFlight !== null) {
+        return null;
+      }
+      const { chain, observed } = runBeat();
+      const release = (): void => {
+        inFlight = null;
+      };
+      // Released on either outcome: a failed beat has to free the slot too,
+      // or one failure would silence the heartbeat for the life of the
+      // process. Swallowing here is not losing the failure — it reaches the
+      // caller through `observed`.
+      inFlight = chain.then(release, release);
+      return observed;
     },
-  );
+  };
 };
 
 export const startDocumentOcrWorkerReadiness = () => {
-  const client = createDocumentOcrReadinessClient();
-  let writeInFlight: Promise<unknown> | null = null;
-  const refresh = async (): Promise<void> => {
-    await refreshDocumentOcrWorkerReadiness(async (key, value, ttlSeconds) => {
-      const write = client.send(
+  const heartbeatClient = createLazyRedisClient(
+    createDocumentOcrReadinessClient,
+  );
+  const beat = createSingleFlightBeat(() => {
+    const chain = writeReadinessLease(async (key, value, ttlSeconds) => {
+      const client = await heartbeatClient.ready();
+      const reply: unknown = await client.send(
         "SET",
         coordinationSetArguments({
           key,
@@ -119,33 +171,37 @@ export const startDocumentOcrWorkerReadiness = () => {
           ttl: { unit: "seconds", value: ttlSeconds },
         }),
       );
-      writeInFlight = write;
-      const markSettled = (): void => {
-        if (writeInFlight === write) {
-          writeInFlight = null;
-        }
-      };
-      detached(
-        write.then(markSettled, markSettled),
-        "document-processing.readiness-heartbeat-settlement",
-      );
-      await write;
+      return reply;
     });
-  };
+    return {
+      chain,
+      // The deadline bounds only what this interval waits for and logs. The
+      // connect and write keep going, and `chain` is what holds the slot, so
+      // a beat that timed out while connecting still blocks the next one.
+      observed: withTimeout(async () => await chain, {
+        label: HEARTBEAT_TIMEOUT_LABEL,
+        timeoutMs: DOCUMENT_OCR_REDIS_COMMAND_TIMEOUT_MS,
+      }),
+    };
+  });
   const heartbeat = (): void => {
-    if (writeInFlight !== null) {
+    const started = beat.start();
+    if (started === null) {
       return;
     }
     // A dropped Redis socket rejects the first write after an idle window;
     // the 90s lease outlives one missed 30s beat, and the next beat writes
-    // on a reconnected socket. Other failures keep flowing to `detached`'s
-    // exception capture.
+    // on a reconnected socket. Anything else is a defect and is captured.
     detached(
-      refresh().catch((error: unknown) => {
-        if (!isTransientRedisConnectionError(error)) {
-          throw error;
+      started.catch((error: unknown) => {
+        if (isTransientRedisConnectionError(error)) {
+          logger.warn("document_processing.readiness_heartbeat_disrupted", {
+            "error.type": errorTag(error),
+          });
+          return;
         }
-        logger.warn("document_processing.readiness_heartbeat_disrupted", {
+        captureError(error);
+        logger.error("document_processing.readiness_heartbeat_failed", {
           "error.type": errorTag(error),
         });
       }),
@@ -163,7 +219,7 @@ export const startDocumentOcrWorkerReadiness = () => {
   return {
     close: (): void => {
       clearInterval(interval);
-      client.close();
+      heartbeatClient.close();
     },
   };
 };

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -17,9 +17,16 @@ const {
   connectWithColdStartRetries,
   createBullMqConnection,
   createLazyRedisClient,
+  createRedisClient,
   isRecoverableRedisPollError,
   isTransientRedisConnectionError,
+  redisClientOptions,
 } = await import("@/api/lib/redis-client");
+
+const REDIS_URL = "redis://127.0.0.1:6379";
+// Bun reads `maxRetries` as a u32, so the ceiling is the value rather than an
+// arbitrary large number: `Number.MAX_SAFE_INTEGER` is rejected outright.
+const U32_CEILING = 4_294_967_295;
 
 describe("BullMQ Redis connection", () => {
   test("lets BullMQ own connection startup", () => {
@@ -32,6 +39,61 @@ describe("BullMQ Redis connection", () => {
       expect.anything(),
       { lazyConnect: true },
     ]);
+  });
+});
+
+/**
+ * The class these pin: a long-lived client that stops reconnecting is one its
+ * holder can never use again, because a closed Bun client cannot be reopened.
+ * Both halves have to hold — the ladder must not run out, and the close
+ * callback the BullMQ adapter and the holders hang their recovery on has to
+ * actually reach Bun's setter.
+ */
+describe("the reconnect policy", () => {
+  test("the reconnect ladder is unbounded", () => {
+    expect(redisClientOptions(REDIS_URL).maxRetries).toBe(U32_CEILING);
+  });
+
+  test("no call site can reintroduce a bounded ladder", () => {
+    const options = redisClientOptions(REDIS_URL, {
+      // Type-level half of the same guard: the overrides parameter omits
+      // `maxRetries`, so a bounded ladder cannot come back through a caller.
+      // @ts-expect-error -- maxRetries is not an override a caller may pass
+      maxRetries: 20,
+      enableOfflineQueue: false,
+    });
+
+    // The policy is applied after the spread, so even a cast past the type
+    // does not land.
+    expect(options.maxRetries).toBe(U32_CEILING);
+    expect(options.enableOfflineQueue).toBe(false);
+  });
+
+  test("a reconnecting client does not buffer commands for the whole outage", () => {
+    // The two policies are a pair: an unbounded ladder plus Bun's default
+    // offline queue would buffer every command issued during an outage, so a
+    // caller blocks for its whole length instead of failing and retrying, and
+    // the backlog is replayed against a server that has since moved on.
+    expect(redisClientOptions(REDIS_URL).enableOfflineQueue).toBe(false);
+    // A caller whose framework owns buffering across a reconnect (the BullMQ
+    // adapter) can still opt back in; `maxRetries` above cannot.
+    expect(
+      redisClientOptions(REDIS_URL, { enableOfflineQueue: true })
+        .enableOfflineQueue,
+    ).toBe(true);
+  });
+
+  test("assigning onclose reaches Bun's setter", () => {
+    const client = createRedisClient();
+
+    // Through `[[Set]]`, the way BullMQ's adapter registers its own callback.
+    Reflect.set(client, "onclose", () => undefined);
+
+    // A class field installs an own data property that shadows the prototype
+    // setter, and a callback stored there never fires — which is how BullMQ's
+    // adapter would lose the close event it schedules its reconnects on.
+    expect(Object.getOwnPropertyDescriptor(client, "onclose")).toBeUndefined();
+    client.close();
   });
 });
 
@@ -139,9 +201,11 @@ describe("isTransientRedisConnectionError", () => {
 describe("createLazyRedisClient", () => {
   /** A stand-in for the real client, recording its own lifecycle. */
   const fakeClient = () => {
+    const closeHandlers = new Set<() => void>();
     const client = {
       close: () => {
         client.closed += 1;
+        client.fireClose();
       },
       closed: 0,
       connect: async () => {
@@ -150,6 +214,18 @@ describe("createLazyRedisClient", () => {
       },
       connectResult: async () => await Promise.resolve(),
       connects: 0,
+      /** Drive the close callback the way Bun does when a socket ends. */
+      fireClose: () => {
+        for (const handler of [...closeHandlers]) {
+          handler();
+        }
+      },
+      onClose: (handler: () => void) => {
+        closeHandlers.add(handler);
+        return () => {
+          closeHandlers.delete(handler);
+        };
+      },
     };
     return client;
   };
@@ -210,6 +286,27 @@ describe("createLazyRedisClient", () => {
     expect(after).not.toBe(before);
     expect(clients).toHaveLength(2);
     expect(clients.at(0)?.closed).toBe(1);
+    expect(clients.at(1)?.connects).toBe(1);
+  });
+
+  test("a lazy client rebuilds after its connection closes", async () => {
+    const clients: ReturnType<typeof fakeClient>[] = [];
+    const lazy = createLazyRedisClient(() => {
+      const client = fakeClient();
+      clients.push(client);
+      return client;
+    });
+
+    const before = await lazy.ready();
+    // Nothing closed the holder: the socket ended on its own, and a closed Bun
+    // client cannot be reopened.
+    before.fireClose();
+    const after = await lazy.ready();
+
+    // Keeping the closed client would send every later command here into a
+    // socket that never comes back.
+    expect(after).not.toBe(before);
+    expect(clients).toHaveLength(2);
     expect(clients.at(1)?.connects).toBe(1);
   });
 

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -16,41 +16,111 @@ export {
   isTransientRedisConnectionError,
 } from "@/api/lib/redis-error-classification";
 
+/**
+ * Every client built here is long-lived, and Bun caps its reconnect ladder at
+ * `maxRetries` (default 20, ≈31s of the 50ms→2s capped backoff). A client that
+ * exhausts the ladder closes for good and cannot be revived in place, so its
+ * holder would keep issuing commands into a socket that will never come back.
+ * Reconnect without a cap instead and let the holder own the give-up decision:
+ * a broker restart longer than the ladder is an outage to ride out, not a
+ * reason to stop trying. Bun's backoff is unchanged, so this adds no load.
+ *
+ * The value is Bun's u32 ceiling; the option is read as a u32 and
+ * `Number.MAX_SAFE_INTEGER` is rejected with `ERR_OUT_OF_RANGE`.
+ */
+const RECONNECT_ATTEMPT_LIMIT = 4_294_967_295;
+
+/**
+ * The connection options a caller may tune. `maxRetries` is not among them:
+ * a bounded ladder is what closes a long-lived client for good, so it is set
+ * once here rather than left open to a per-call-site override.
+ */
+export type RedisClientOverrides = Omit<RedisOptions, "maxRetries">;
+
+/**
+ * The options every client here is constructed with. A named value rather
+ * than an inline object literal because Bun's RedisClient does not expose
+ * what it was built with, so this is the only place the reconnect policy can
+ * be read back and asserted.
+ */
+export const redisClientOptions = (
+  url: string,
+  overrides?: RedisClientOverrides,
+): RedisOptions => ({
+  // An unbounded reconnect ladder and an unbounded offline queue do not
+  // belong on the same client: a client that keeps reconnecting for the whole
+  // outage would also keep buffering every command issued during it, so
+  // callers block instead of failing and the backlog is replayed against a
+  // server that has since forgotten the state they were written for. Fail the
+  // command instead and let the caller decide — a periodic loop records the
+  // failure and retries on its next tick, a request path degrades. Every
+  // request-path client here already opts out explicitly; this makes that the
+  // default rather than something each new call site has to remember.
+  enableOfflineQueue: false,
+  ...redisConnectionOptions(url),
+  ...overrides,
+  maxRetries: RECONNECT_ATTEMPT_LIMIT,
+});
+
 class ConfiguredRedisClient extends RedisClient implements BunRedisRawClient {
+  readonly #closeHandlers = new Set<() => void>();
   readonly #connectHandlers = new Set<() => void>();
 
-  override onclose: (error?: Error) => void = () => undefined;
-  // Declared as a non-null field so the class satisfies `BunRedisRawClient`
-  // (Bun types the inherited `onconnect` as nullable). The field's own-property
-  // is removed in the constructor before the real callback is registered — see
+  // Declared as non-null fields so the class satisfies `BunRedisRawClient`
+  // (Bun types both inherited callbacks as nullable). Their own-properties are
+  // removed in the constructor before the real callbacks are registered — see
   // there for why the runtime path cannot be a plain field assignment.
+  override onclose: (error?: Error) => void = () => undefined;
   override onconnect: () => void = () => undefined;
   readonly url: string;
 
   constructor(
     url = envDocumentProcessingWorker.REDIS_URL,
-    overrides?: RedisOptions,
+    overrides?: RedisClientOverrides,
   ) {
-    super(url, { ...redisConnectionOptions(url), ...overrides });
+    super(url, redisClientOptions(url, overrides));
     this.url = url;
-    // Register one owned dispatcher on Bun's native `onconnect` setter so a
-    // pub/sub subscriber can observe reconnects. Two facts (both verified
-    // against a mock RESP3 server) shape this: (1) `onconnect` must be reached
-    // through `[[Set]]` so Bun registers the callback — the class field above
-    // defines an own data property that shadows the prototype setter, and a
-    // callback stored that way never fires; deleting the own property first
+    // Register one owned dispatcher on each of Bun's native `onconnect` /
+    // `onclose` setters, so a pub/sub subscriber can observe reconnects and a
+    // holder can observe a client going away for good. Two facts (both
+    // verified against a mock RESP3 server) shape this: (1) the callback must
+    // be reached through `[[Set]]` so Bun registers it — the class fields
+    // above define own data properties that shadow the prototype setters, and
+    // a callback stored that way never fires; deleting the own property first
     // makes the setter reachable. (2) Bun's RedisClient is not an EventTarget,
     // so a direct `this.onconnect = …` is the only real option, but the
     // prefer-add-event-listener lint rule bans that syntax — `Reflect.set`
     // performs the same `[[Set]]` without the banned member-assignment form.
-    // The dispatcher fans every (re)connection out to the handlers registered
-    // via `onReconnect`.
+    //
+    // The shadow matters beyond this class: BullMQ's Bun adapter assigns
+    // `raw.onclose` to drive its own reconnect scheduling, and an own data
+    // property left in place would swallow that assignment silently.
     Reflect.deleteProperty(this, "onconnect");
     Reflect.set(this, "onconnect", () => {
       for (const handler of this.#connectHandlers) {
         handler();
       }
     });
+    Reflect.deleteProperty(this, "onclose");
+    Reflect.set(this, "onclose", () => {
+      for (const handler of this.#closeHandlers) {
+        handler();
+      }
+    });
+  }
+
+  /**
+   * Register `handler` to run when this client's connection closes, whether
+   * from an explicit `close()` or from Bun giving up on the socket. A closed
+   * Bun client cannot be reopened, so a holder that wants to keep working past
+   * one has to build a replacement (see `createLazyRedisClient`). Returns a
+   * disposer that removes the handler.
+   */
+  onClose(handler: () => void): () => void {
+    this.#closeHandlers.add(handler);
+    return () => {
+      this.#closeHandlers.delete(handler);
+    };
   }
 
   /**
@@ -70,7 +140,7 @@ class ConfiguredRedisClient extends RedisClient implements BunRedisRawClient {
 }
 
 export const createRedisClient = (
-  overrides?: RedisOptions,
+  overrides?: RedisClientOverrides,
 ): ConfiguredRedisClient =>
   new ConfiguredRedisClient(envDocumentProcessingWorker.REDIS_URL, overrides);
 
@@ -82,17 +152,16 @@ export const createRedisClient = (
 // on the first failure, with no retry of its own for that initial attempt.
 // Retry a handful of times with a short capped backoff so that expected,
 // self-recovering cold-start blips log at warn instead of paging as an
-// error; once retries are exhausted the error is rethrown so BullMQ's own
-// (unchanged) error handling still surfaces a persistent outage loudly.
+// error; the last attempt is left unguarded so a persistent outage still
+// reaches BullMQ's own (unchanged) error handling loudly.
 const COLD_START_CONNECT_RETRY_DELAYS_MS = [200, 500, 1000, 2000];
 
 export const connectWithColdStartRetries = async (
   connectOnce: () => Promise<void>,
 ): Promise<void> => {
-  for (let attempt = 0; ; attempt += 1) {
-    // catch returns the raw cause unchanged so a final, retries-exhausted
-    // rethrow preserves the original error identity (code, syscall, class)
-    // for whichever consumer's `worker.on("error")` handler logs it loudly.
+  for (const delayMs of COLD_START_CONNECT_RETRY_DELAYS_MS) {
+    // catch returns the raw cause unchanged so the warning below reports the
+    // original error identity (code, syscall, class).
     // oxlint-disable-next-line no-await-in-loop -- each retry must observe whether the connection came up before deciding to wait and try again
     const result = await Result.tryPromise({
       try: connectOnce,
@@ -101,10 +170,6 @@ export const connectWithColdStartRetries = async (
     if (result.isOk()) {
       return;
     }
-    const delayMs = COLD_START_CONNECT_RETRY_DELAYS_MS[attempt];
-    if (delayMs === undefined) {
-      throw result.error;
-    }
     logger.warn(
       "redis.cold_start_reconnect",
       connectionErrorFields(result.error),
@@ -112,17 +177,33 @@ export const connectWithColdStartRetries = async (
     // oxlint-disable-next-line no-await-in-loop -- retries are intentionally sequential backoff, not parallel work
     await sleep(delayMs);
   }
+  // One attempt per delay, then a final unguarded one: its rejection is the
+  // caller's, with the original error identity intact for whichever
+  // consumer's `worker.on("error")` handler logs the outage.
+  await connectOnce();
 };
 
-/** The two capabilities a lazily connected client has to expose. */
+/** The capabilities a lazily connected client has to expose. */
 type ManagedRedisClient = {
   close: () => void;
   connect: () => Promise<void>;
+  onClose: (handler: () => void) => () => void;
 };
 
 type LazyRedisClient<Client> = {
   close: () => void;
   ready: () => Promise<Client>;
+};
+
+/** One client, and the readiness of the connect attempt that built it. */
+type ClientAttempt<Client> = {
+  /**
+   * Settle `ready` as a failure without waiting for the connect to return,
+   * so a close during the ladder rejects the callers waiting on it.
+   */
+  abandon: (error: RedisClientClosedError) => void;
+  client: Client;
+  ready: Promise<Client>;
 };
 
 /**
@@ -133,50 +214,79 @@ type LazyRedisClient<Client> = {
  * built with the offline queue disabled, where such a command rejects
  * immediately instead of waiting for the socket.
  *
- * The connect runs once per client while it succeeds, and a rejected
- * attempt is discarded so the next caller retries rather than inheriting a
- * cached rejection. `close` drops the client and that memo together: a
- * caller after a shutdown builds and connects a fresh one instead of
- * receiving a resolved promise for a closed client, and a `ready()` still
- * in flight across a `close` fails rather than handing out the client it
- * was connecting.
+ * The connect runs once per client while it succeeds, and a failed attempt is
+ * discarded so the next caller builds and connects a fresh client rather than
+ * inheriting a cached rejection. The attempt is also discarded when the
+ * connection closes, whether from `close()` or from Bun ending the socket: a
+ * closed Bun client cannot be reopened, so keeping it would make every later
+ * `ready()` hand out a dead socket. That is what lets the holder outlive a
+ * broker restart longer than the client's own reconnect ladder.
+ *
+ * A `close()` while a connect is still climbing rejects the callers waiting on
+ * it, rather than handing them the client it was connecting.
  */
 export const createLazyRedisClient = <Client extends ManagedRedisClient>(
   createClient: () => Client,
 ): LazyRedisClient<Client> => {
-  let client: Client | null = null;
-  let connected: Promise<void> | null = null;
+  let current: ClientAttempt<Client> | null = null;
+
+  const startAttempt = (): ClientAttempt<Client> => {
+    const client = createClient();
+    const abandoned = Promise.withResolvers<never>();
+    const connected = connectWithColdStartRetries(async () => {
+      await client.connect();
+    }).then(() => client);
+    const attempt: ClientAttempt<Client> = {
+      abandon: abandoned.reject,
+      client,
+      // Whichever settles first wins, so a close is what rejects a waiting
+      // caller, at the close itself rather than through a check after the
+      // connect has run its course.
+      ready: Promise.race([connected, abandoned.promise]),
+    };
+    // A closed Bun client cannot be reopened, so the attempt goes with it and
+    // the next caller builds a replacement. Guarded on identity: a close
+    // arriving after this attempt was already replaced must not drop its
+    // successor, which would leave the new client connecting twice over.
+    client.onClose(() => {
+      if (current === attempt) {
+        current = null;
+      }
+    });
+    return attempt;
+  };
+
   return {
     close: () => {
-      client?.close();
-      client = null;
-      connected = null;
+      const closing = current;
+      current = null;
+      if (closing === null) {
+        return;
+      }
+      closing.abandon(
+        new RedisClientClosedError({
+          message: "Redis client closed while connecting",
+        }),
+      );
+      closing.client.close();
     },
     ready: async () => {
-      client ??= createClient();
-      const target = client;
-      if (connected === null) {
-        const attempt: Promise<void> = connectWithColdStartRetries(async () => {
-          await target.connect();
-        }).catch((error: unknown) => {
-          // Only this attempt may clear its own memo. A close and a later
-          // caller can install another client's attempt while this ladder
-          // is still climbing, and clearing that one would leave the new
-          // client connecting twice over.
-          if (connected === attempt) {
-            connected = null;
-          }
-          throw error;
-        });
-        connected = attempt;
+      current ??= startAttempt();
+      const attempt = current;
+      const outcome = await Result.tryPromise({
+        try: async () => await attempt.ready,
+        catch: (cause: unknown) => cause,
+      });
+      if (Result.isOk(outcome)) {
+        return outcome.value;
       }
-      await connected;
-      if (client !== target) {
-        throw new RedisClientClosedError({
-          message: "Redis client closed while connecting",
-        });
+      // A failure is not memoized: the next caller builds and connects a
+      // fresh client instead of inheriting this one's rejection. Re-awaiting
+      // the settled attempt hands this caller the original failure unchanged.
+      if (current === attempt) {
+        current = null;
       }
-      return target;
+      return await attempt.ready;
     },
   };
 };
@@ -213,9 +323,13 @@ const withColdStartConnectRetries = (
  * introduce a prefix, and do not add unhashtagged keys anywhere else.
  */
 export const createBullMqConnection = (
-  overrides?: RedisOptions,
+  overrides?: RedisClientOverrides,
 ): ReturnType<typeof createBunRedisClient> => {
-  const raw = createRedisClient(overrides);
+  // BullMQ's adapter owns command buffering across a reconnect (it schedules
+  // its own and replays what it holds), so the connection keeps the offline
+  // queue the factory otherwise defaults off. A queue that wants its enqueues
+  // to fail fast still says so through `overrides`.
+  const raw = createRedisClient({ enableOfflineQueue: true, ...overrides });
   const connection = createBunRedisClient(raw, {
     // Railway's Redis proxy can trigger Bun's eager adapter read path before
     // BullMQ has completed its own readiness flow. Let BullMQ connect lazily.

--- a/apps/api/src/lib/redis-error-classification.ts
+++ b/apps/api/src/lib/redis-error-classification.ts
@@ -23,14 +23,19 @@ export const isRecoverableRedisPollError = (error: unknown): boolean =>
   error instanceof Error &&
   safeErrorCode(error) === RECOVERABLE_REDIS_POLL_ERROR_CODE;
 
-// Bun's RedisClient auto-reconnects a dropped socket, but a command issued
-// against the dead connection — the first touch after an idle window, or a
-// command in flight when the drop happens — rejects with
-// ERR_REDIS_CONNECTION_CLOSED instead of waiting for the reconnect. For a
-// periodic loop whose next tick retries anyway, that rejection is an
-// expected operational transient, not a defect; a persistent outage keeps
-// failing and stays visible through the loop's own error logging and the
-// worker/broadcast error paths.
+// Bun's RedisClient reconnects a dropped socket, but a command issued against
+// the dead connection — the first touch after an idle window, or a command in
+// flight when the drop happens — rejects with ERR_REDIS_CONNECTION_CLOSED
+// instead of waiting for the reconnect. For a periodic loop whose next tick
+// retries anyway, that rejection is an expected operational transient, not a
+// defect; a persistent outage keeps failing and stays visible through the
+// loop's own error logging and the worker/broadcast error paths.
+//
+// What makes this downgrade sound is that the connection always comes back:
+// `redis-client.ts` reconnects without an attempt cap, and the holders there
+// replace a client that closed anyway. Reintroduce a bounded ladder and this
+// code stops meaning "retry later" and starts meaning "this client is done",
+// at which point the downgrade would hide a permanent failure.
 const TRANSIENT_REDIS_CONNECTION_ERROR_CODE = "ERR_REDIS_CONNECTION_CLOSED";
 
 export const isTransientRedisConnectionError = (error: unknown): boolean =>

--- a/apps/api/src/lib/workflow/root-run-state-store.ts
+++ b/apps/api/src/lib/workflow/root-run-state-store.ts
@@ -1,12 +1,30 @@
-import { createRedisClient } from "@/api/lib/redis-client";
+import {
+  createLazyRedisClient,
+  createRedisClient,
+} from "@/api/lib/redis-client";
 import { createWorkflowRunStateStore } from "@/api/lib/workflow/run-state-store";
+
+// The store binds one connection for its lifetime, and this one is the
+// process-wide instance every workflow path reaches for. Bind it to the
+// holder rather than to a client, so a connection that closes is replaced on
+// the next command instead of stranding the store on a dead socket.
+const rootRedis = createLazyRedisClient(() => createRedisClient());
+
+const sendRootCommand = async (
+  command: string,
+  args: string[],
+): Promise<unknown> => {
+  const reply: unknown = await (await rootRedis.ready()).send(command, args);
+  return reply;
+};
 
 let rootWorkflowRunStateStore: ReturnType<
   typeof createWorkflowRunStateStore
 > | null = null;
 
 export const getRootWorkflowRunStateStore = () => {
-  rootWorkflowRunStateStore ??=
-    createWorkflowRunStateStore(createRedisClient());
+  rootWorkflowRunStateStore ??= createWorkflowRunStateStore({
+    send: sendRootCommand,
+  });
   return rootWorkflowRunStateStore;
 };

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -88,7 +88,7 @@
     "files": {}
   },
   "throw-outside-boundary": {
-    "count": 885,
+    "count": 881,
     "files": {
       "apps/api/src/handlers/case-law/corpus-index.ts": 12,
       "apps/api/src/handlers/case-law/decisions/latest.ts": 3,
@@ -222,7 +222,6 @@
       "apps/api/src/lib/legal-search/corpus-index-client.ts": 23,
       "apps/api/src/lib/legal-search/corpus-index-pagination.ts": 1,
       "apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts": 4,
-      "apps/api/src/lib/legal-search/corpus-index-provider.ts": 2,
       "apps/api/src/lib/legal-search/corpus-pack.ts": 6,
       "apps/api/src/lib/legal-search/corpus-storage.ts": 4,
       "apps/api/src/lib/legal-search/ingestion-normalization.ts": 4,
@@ -234,7 +233,6 @@
       "apps/api/src/lib/ocr-searchable-pdf-worker.ts": 1,
       "apps/api/src/lib/organization-storage-teardown.ts": 4,
       "apps/api/src/lib/rate-limit/redis-context.ts": 3,
-      "apps/api/src/lib/redis-client.ts": 2,
       "apps/api/src/lib/s3-presign.ts": 8,
       "apps/api/src/lib/s3.ts": 12,
       "apps/api/src/lib/scheduler/bullmq.ts": 1,


### PR DESCRIPTION
Long-lived broker clients stopped after the runtime's default retry budget, and the close callback was shadowed by a class field, so neither the queue adapter nor the lazy holders could replace a closed client.

- force an effectively unbounded reconnect ladder in the one client factory; the options type no longer accepts `maxRetries`
- route `onclose` through the same dispatcher as `onconnect` and expose `onClose`
- lazy holders rebuild after a close; the workflow state store, the readiness heartbeat and the SSE subscriber go through a holder
- tests pin the setter reachability, the unbounded ladder, the rebuild, a reconciliation tick after a closed connection, and subscriber replacement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when Redis connections close unexpectedly, allowing services to reconnect and continue processing.
  - Prevented transient connection failures from interrupting document-processing readiness checks.
  - Prevented duplicate readiness heartbeats during connection delays or failures.
  - Improved recovery for workflow state operations after a Redis connection is replaced.
  - Updated queue connection handling for more consistent Redis reconnect behaviour.
  - Ensured failed processing cycles are retried correctly after temporary Redis outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->