### PR TITLE
fix(api): classify a timed-out Redis connection as a transient

### DIFF
--- a/apps/api/src/lib/queue-worker-error-log.test.ts
+++ b/apps/api/src/lib/queue-worker-error-log.test.ts
@@ -15,6 +15,7 @@ const withCode = (code: string): Error =>
   Object.assign(new Error("Connection closed"), { code });
 
 const TRANSIENT = "ERR_REDIS_CONNECTION_CLOSED";
+const CONNECT_TIMEOUT = "ERR_REDIS_CONNECTION_TIMEOUT";
 const POLL_BLIP = "ERR_REDIS_INVALID_RESPONSE";
 const START = new Date("2026-08-27T17:54:00.000Z");
 
@@ -47,7 +48,7 @@ describe("createQueueWorkerErrorLogger", () => {
     ).toBeUndefined();
   });
 
-  test.each([TRANSIENT, POLL_BLIP])(
+  test.each([TRANSIENT, CONNECT_TIMEOUT, POLL_BLIP])(
     "reports %s once per interval and counts the rest",
     (code) => {
       const log = createQueueWorkerErrorLogger("file_derivative.worker_error");

--- a/apps/api/src/lib/queue-worker-error-log.ts
+++ b/apps/api/src/lib/queue-worker-error-log.ts
@@ -13,8 +13,8 @@ import {
  * needs to read it, and make the error-rate metric report the retry rate
  * rather than the number of faults.
  *
- * Both codes suppressed here are ones this codebase already classifies as
- * expected operational transients rather than defects (`redis-client.ts`), so
+ * Every code suppressed here is one this codebase already classifies as an
+ * expected operational transient rather than a defect (`redis-client.ts`), so
  * the tally, not the occurrence, is the signal. Severity stays ERROR: a real
  * outage must still cross the error-rate alarm; only its volume is bounded.
  */

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -170,12 +170,16 @@ describe("isTransientRedisConnectionError", () => {
 
   // The classifier gates whether a periodic loop logs a Redis failure as an
   // expected transient or captures it as an exception; a drifted code string
-  // would silently disable it, so the exact Bun error code is pinned.
-  test("classifies a closed-connection rejection as transient", () => {
-    expect(
-      isTransientRedisConnectionError(withCode("ERR_REDIS_CONNECTION_CLOSED")),
-    ).toBe(true);
-  });
+  // would silently disable it, so the exact Bun error codes are pinned. Both
+  // mean the command met a connection that was not up: the closed socket the
+  // client had already observed, and the connect attempt that had not landed
+  // before `connectionTimeout`.
+  test.each(["ERR_REDIS_CONNECTION_CLOSED", "ERR_REDIS_CONNECTION_TIMEOUT"])(
+    "classifies a %s rejection as transient",
+    (code) => {
+      expect(isTransientRedisConnectionError(withCode(code))).toBe(true);
+    },
+  );
 
   test("leaves other failures and the poll blip unclassified", () => {
     expect(isTransientRedisConnectionError(withCode("ECONNREFUSED"))).toBe(

--- a/apps/api/src/lib/redis-error-classification.ts
+++ b/apps/api/src/lib/redis-error-classification.ts
@@ -23,21 +23,29 @@ export const isRecoverableRedisPollError = (error: unknown): boolean =>
   error instanceof Error &&
   safeErrorCode(error) === RECOVERABLE_REDIS_POLL_ERROR_CODE;
 
-// Bun's RedisClient reconnects a dropped socket, but a command issued against
-// the dead connection — the first touch after an idle window, or a command in
-// flight when the drop happens — rejects with ERR_REDIS_CONNECTION_CLOSED
-// instead of waiting for the reconnect. For a periodic loop whose next tick
-// retries anyway, that rejection is an expected operational transient, not a
-// defect; a persistent outage keeps failing and stays visible through the
-// loop's own error logging and the worker/broadcast error paths.
+// Bun's RedisClient reconnects a dropped socket, but a command that meets a
+// connection which is not up rejects instead of waiting for it to come back.
+// Which code it rejects with says only where the command sat when the
+// connection went: ERR_REDIS_CONNECTION_CLOSED once the client has observed
+// the drop — the first touch after an idle window, or a command in flight at
+// the drop — and ERR_REDIS_CONNECTION_TIMEOUT while a connect attempt is
+// still outstanding and passes `connectionTimeout`. For a periodic loop whose
+// next tick retries anyway, either rejection is an expected operational
+// transient, not a defect; a persistent outage keeps failing and stays visible
+// through the loop's own error logging and the worker/broadcast error paths.
 //
 // What makes this downgrade sound is that the connection always comes back:
 // `redis-client.ts` reconnects without an attempt cap, and the holders there
-// replace a client that closed anyway. Reintroduce a bounded ladder and this
-// code stops meaning "retry later" and starts meaning "this client is done",
-// at which point the downgrade would hide a permanent failure.
-const TRANSIENT_REDIS_CONNECTION_ERROR_CODE = "ERR_REDIS_CONNECTION_CLOSED";
+// replace a client that closed anyway. Reintroduce a bounded ladder and these
+// codes stop meaning "retry later" and start meaning "this client is done",
+// at which point the downgrade would hide a permanent failure. That is also
+// why ERR_REDIS_IDLE_TIMEOUT is not here: Bun does not reconnect after one,
+// and nothing sets `idleTimeout`, so it is unreachable rather than expected.
+const TRANSIENT_REDIS_CONNECTION_ERROR_CODES = new Set([
+  "ERR_REDIS_CONNECTION_CLOSED",
+  "ERR_REDIS_CONNECTION_TIMEOUT",
+]);
 
 export const isTransientRedisConnectionError = (error: unknown): boolean =>
   error instanceof Error &&
-  safeErrorCode(error) === TRANSIENT_REDIS_CONNECTION_ERROR_CODE;
+  TRANSIENT_REDIS_CONNECTION_ERROR_CODES.has(safeErrorCode(error) ?? "");


### PR DESCRIPTION
`isTransientRedisConnectionError` decides whether a Valkey failure is logged as
an expected operational transient or captured as a defect. It matched one code,
`ERR_REDIS_CONNECTION_CLOSED`.

A command that meets a connection which is not up rejects with that code once
the client has already observed the drop, and with
`ERR_REDIS_CONNECTION_TIMEOUT` while a connect attempt is still outstanding and
passes `connectionTimeout`. Both mean the same thing to a caller: the command
did not reach the server, and the next one may. Only the first was classified,
so the second took the defect path at every call site the predicate gates —
the readiness read and heartbeat, the job-claim and reconciliation handlers,
and the queue worker's error logger, which bounds a BullMQ worker's per-poll
`error` event to one line per 60s interval plus a tally.

The timeout is the code that repeats. A blocking poll gets it for as long as
the server stays unreachable, so it is the rejection whose volume most needs
bounding, and it was the one left unbounded: one line per poll, per worker, no
tally field. The closed code, which was bounded, is comparatively
self-limiting.

Matching both is sound for the same reason matching the closed code is: the
client factory reconnects without an attempt cap, so neither code means "this
client is done". That is the condition the classifier's comment already names,
and it does not distinguish the two.

Deliberately excluded:

- `ERR_REDIS_IDLE_TIMEOUT` — Bun does not reconnect after one, and nothing
  sets `idleTimeout`, so it is unreachable rather than expected.
- `ECONNREFUSED` — a refused connect is a configuration fault; the cold-start
  path retries it separately and a persistent one should stay loud.

Severity and the tally field are unchanged. A real disruption still crosses the
error-rate threshold; only its log volume is bounded.

## Verification

- `bun --filter @stll/api typecheck`
- `bunx oxfmt --check` and both oxlint configs on the changed files
- `bun run test -- src/lib/queue-worker-error-log.test.ts src/lib/redis-client.test.ts src/lib/document-processing-readiness.test.ts src/lib/document-processing-queue.test.ts` — 101 pass, 0 fail
- `bun scripts/ratchet.ts --check`

The predicate test pins both codes, and the logger's existing interval-bound
`test.each` runs over the timeout code as well.
