### PR TITLE
feat(api): re-enqueue report exports and deadline scouts from the scheduler

### DIFF
--- a/apps/api/drizzle/20260903130000_report_export_request/migration.sql
+++ b/apps/api/drizzle/20260903130000_report_export_request/migration.sql
@@ -1,0 +1,79 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- What the export was asked for. Until now the format and the AI-narrative
+-- flag existed only on the queued job, so an export whose job the queue no
+-- longer holds could not be handed back: the row records that work is owed
+-- but not what to run. Persisting both makes the row the whole request.
+--
+-- Nullable with no default. A default would be a claim about rows written
+-- before this migration, and it would be wrong for exactly the rows that
+-- matter: an export that asked for `pdf` or turned the narrative off carried
+-- that only on its job, so backfilling 'docx'/true would relabel it and the
+-- reconciler would hand a different request back to the queue. NULL says "the
+-- request was never recorded", which the sweep can act on honestly. Every new
+-- write sets both columns.
+--
+-- Adding a nullable column with no default writes no row.
+ALTER TABLE "report_exports"
+  ADD COLUMN IF NOT EXISTS "format" text;--> statement-breakpoint
+ALTER TABLE "report_exports"
+  ADD COLUMN IF NOT EXISTS "ai_narrative" boolean;--> statement-breakpoint
+
+-- Drizzle's `text({ enum })` is compile-time only, and the worker branches on
+-- this value to pick the conversion and name the artifact, so the column
+-- states the rule itself. NULL is admitted: it is the pre-migration "no
+-- request recorded" state, not a format.
+--
+-- Dropped by name and re-added in one statement rather than added outright:
+-- every statement ahead of the transaction split below has to be repeatable,
+-- because a cancelled or failed concurrent index build leaves the migration
+-- unrecorded and the next `db:migrate` replays this file from the top. A bare
+-- ADD CONSTRAINT would abort on duplicate_object and the invalid-index repair
+-- below would never be reached.
+--
+-- Validating rather than NOT VALID + VALIDATE: the column was just created and
+-- holds NULL in every existing row, so the scan has nothing to reject.
+-- stella-migration-safety: reviewed drop-constraint - drops only this check constraint by name and re-adds it unchanged in the same statement, so no row data is touched and a replay of this file is a no-op. The constraint does not exist before this migration.
+ALTER TABLE "report_exports"
+  DROP CONSTRAINT IF EXISTS "report_exports_format_values_check",
+  -- squawk-ignore constraint-missing-not-valid
+  ADD CONSTRAINT "report_exports_format_values_check"
+  CHECK ("format" IS NULL OR "format" IN ('docx', 'pdf'));--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent build
+-- (which takes no lock those timeouts guard), then restore and reopen a
+-- transaction for Drizzle's migration row. Same shape as
+-- 20260903120000_queue_reconciler_indexes.
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+
+-- The build drops its own index by name first: a cancelled concurrent build
+-- leaves an INVALID index behind, and IF NOT EXISTS would then skip
+-- recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "report_exports_queued_idx";
+--> statement-breakpoint
+-- The reconciler walks exports still waiting for a worker in creation order,
+-- keyset-paginated, and stops at its page. Without this the walk sorts the
+-- whole export history on every sweep. Partial on the column the sweep
+-- filters, so the index stays the size of the outstanding work rather than of
+-- every export ever run.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "report_exports_queued_idx"
+  ON "report_exports" ("created_at", "id")
+  WHERE "status" = 'queued';
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/reports.ts
+++ b/apps/api/src/db/schema/reports.ts
@@ -32,6 +32,20 @@ export type ReportExportStatus = (typeof REPORT_EXPORT_STATUSES)[number];
 export const REPORT_EXPORT_MODES = ["workspace", "download"] as const;
 export type ReportExportMode = (typeof REPORT_EXPORT_MODES)[number];
 
+/** Delivery format chosen at export time. The fill pipeline always builds a
+ *  DOCX; `pdf` converts it before delivery. Persisted (rather than carried on
+ *  the job alone) so an export whose job the queue lost can be rebuilt from
+ *  the row. */
+export const REPORT_EXPORT_FORMATS = ["docx", "pdf"] as const;
+export type ReportExportFormat = (typeof REPORT_EXPORT_FORMATS)[number];
+
+/** The CHECK the database enforces is built from the value list above, so a
+ *  new format cannot widen the type without widening the constraint. */
+const REPORT_EXPORT_FORMAT_SQL_VALUES = sql.join(
+  REPORT_EXPORT_FORMATS.map((value) => sql.raw(`'${value}'`)),
+  sql`, `,
+);
+
 /** At-most-once delivery state for the export's privacy-safe status email.
  *  `sending` is claimed atomically before the external call, so a crash may
  *  omit an email but can never duplicate one. Historical rows default to
@@ -82,6 +96,17 @@ export const reportExports = p.pgTable(
       .notNull()
       .default("queued"),
     mode: p.text("mode", { enum: REPORT_EXPORT_MODES }).notNull(),
+    // The request the job was built from. Without these two the worker's
+    // payload is the only record of what was asked for, so a job the queue
+    // lost cannot be re-enqueued from the row.
+    //
+    // Nullable with no default, and null only on rows written before the
+    // columns existed: those exports carried their request on the job alone,
+    // so any default here would be a guess the reconciler would then act on.
+    // Null means "the request was never recorded", which the sweep fails
+    // rather than rebuilds. Every write sets both.
+    format: p.text("format", { enum: REPORT_EXPORT_FORMATS }),
+    aiNarrative: p.boolean("ai_narrative"),
     error: p.text("error"),
     resultEntityId: safeUuid<"entity">("result_entity_id").references(
       (): AnyPgColumn => entities.id,
@@ -119,6 +144,15 @@ export const reportExports = p.pgTable(
       .index("report_exports_workspace_requester_created_idx")
       .on(table.workspaceId, table.requestedBy, table.createdAt, table.id),
     p.index("report_exports_result_field_idx").on(table.resultFieldId),
+    // The reconciler's keyset walk over exports still waiting for a worker.
+    p
+      .index("report_exports_queued_idx")
+      .on(table.createdAt, table.id)
+      .where(sql`${table.status} = 'queued'`),
+    p.check(
+      "report_exports_format_values_check",
+      sql`${table.format} IS NULL OR ${table.format} IN (${REPORT_EXPORT_FORMAT_SQL_VALUES})`,
+    ),
     p
       .index("report_exports_pending_notification_idx")
       .on(table.createdAt, table.id)

--- a/apps/api/src/handlers/reports/export-view.ts
+++ b/apps/api/src/handlers/reports/export-view.ts
@@ -21,7 +21,6 @@ import { t } from "elysia";
 import { reportExports } from "@/api/db/schema";
 import { isReportRowCountOverCap } from "@/api/handlers/reports/build-report-data";
 import { getBuiltinReportTemplate } from "@/api/handlers/reports/builtin-templates";
-import { enqueueReportExport } from "@/api/handlers/reports/report-export-queue";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
@@ -30,6 +29,7 @@ import { queryEntities } from "@/api/lib/entities/query-entities";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { extractLangFromRequest } from "@/api/lib/locale";
+import { enqueueReportExport } from "@/api/lib/report-export-enqueue";
 import { excludedEntityKindsForView } from "@/api/lib/views";
 import { parseStoredViewLayout } from "@/api/lib/views-schema";
 
@@ -160,6 +160,11 @@ const exportViewReport = createSafeHandler(
       );
     }
 
+    // Resolved once and written to the row as well as the job, so a job the
+    // queue loses can be rebuilt from the row alone.
+    const format = body.format ?? "docx";
+    const aiNarrative = body.aiNarrative ?? true;
+
     const exportId = yield* Result.await(
       safeDb(async (tx) => {
         const [inserted] = await tx
@@ -171,6 +176,8 @@ const exportViewReport = createSafeHandler(
             viewId: view.id,
             layout,
             mode: body.mode,
+            format,
+            aiNarrative,
             notificationLang: extractLangFromRequest(request),
             notificationStatus: "pending",
             status: "queued",
@@ -207,8 +214,8 @@ const exportViewReport = createSafeHandler(
           workspaceId,
           organizationId,
           userId: user.id,
-          format: body.format ?? "docx",
-          aiNarrative: body.aiNarrative ?? true,
+          format,
+          aiNarrative,
         }),
       catch: (cause) => cause,
     });

--- a/apps/api/src/handlers/reports/report-export-queue.ts
+++ b/apps/api/src/handlers/reports/report-export-queue.ts
@@ -19,7 +19,7 @@ import { and, eq, inArray } from "drizzle-orm";
 
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
 import { reportExports } from "@/api/db/schema";
-import type { ReportTemplateRef } from "@/api/db/schema";
+import type { ReportExportFormat, ReportTemplateRef } from "@/api/db/schema";
 import { env } from "@/api/env";
 import type { AssembledReport } from "@/api/handlers/reports/build-report-data";
 import { buildReportData } from "@/api/handlers/reports/build-report-data";
@@ -38,8 +38,6 @@ import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack
 import { assertUsageAvailableForHandler } from "@/api/lib/api-handlers";
 import { createBackgroundAuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
-import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
-import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import {
   buildAiConditionDecider,
   buildAiFieldGenerator,
@@ -52,8 +50,9 @@ import { startNonOverlappingInterval } from "@/api/lib/non-overlapping-interval"
 import { logger } from "@/api/lib/observability/logger";
 import { createQueueWorkerErrorLogger } from "@/api/lib/queue-worker-error-log";
 import { createBullMqConnection } from "@/api/lib/redis-client";
+import { REPORT_EXPORT_QUEUE_NAME } from "@/api/lib/report-export-enqueue";
+import type { ReportExportJobData } from "@/api/lib/report-export-enqueue";
 import { listPendingReportExportNotifications } from "@/api/lib/report-export-notification-recovery";
-import { recoverStuckReportExports } from "@/api/lib/report-export-recovery";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
 import { writeS3ObjectWithRetry } from "@/api/lib/s3";
 import {
@@ -74,67 +73,10 @@ import {
 import { parseStoredViewLayout } from "@/api/lib/views-schema";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 
-const QUEUE_NAME = "report-exports";
-const JOB_NAME = "export-report";
 const WORKER_CONCURRENCY = 2;
-// One attempt: the fill runs metered AI and (in workspace mode) creates a
-// document; a BullMQ retry would double both. Failures are persisted on the row.
-const JOB_ATTEMPTS = 1;
 const ERROR_MESSAGE_MAX_CHARS = 1000;
 const DOCX_TO_PDF_ERROR = "Failed to convert the report to PDF.";
 const NOTIFICATION_RECONCILE_INTERVAL_MS = 60_000;
-
-/** Delivery format chosen at export time. Carried on the job (not the export
- *  row): the worker needs it to convert + name the artifact, and the status
- *  endpoint derives the download filename from the stored key's extension, so
- *  no schema column is required. */
-export type ReportExportFormat = "docx" | "pdf";
-
-type ReportExportJobData = {
-  exportId: string;
-  workspaceId: string;
-  organizationId: string;
-  userId: string;
-  format: ReportExportFormat;
-  /** Include AI-drafted narrative sections. Carried on the job (not the export
-   *  row): the worker needs it to gate the AI generators + template sections.
-   *  Optional for back-compat with jobs enqueued before this field existed;
-   *  absent means "on". */
-  aiNarrative?: boolean;
-};
-
-export type EnqueueReportExportArgs = {
-  exportId: SafeId<"reportExport">;
-  workspaceId: SafeId<"workspace">;
-  organizationId: SafeId<"organization">;
-  userId: SafeId<"user">;
-  format: ReportExportFormat;
-  aiNarrative: boolean;
-};
-
-const getQueue = createLazyBullMqQueue<ReportExportJobData>({
-  name: QUEUE_NAME,
-  defaultJobOptions: {
-    attempts: JOB_ATTEMPTS,
-    removeOnComplete: 100,
-    removeOnFail: 500,
-  },
-});
-
-export const enqueueReportExport = async ({
-  exportId,
-  workspaceId,
-  organizationId,
-  userId,
-  format,
-  aiNarrative,
-}: EnqueueReportExportArgs): Promise<void> => {
-  await getQueue().add(
-    JOB_NAME,
-    { exportId, workspaceId, organizationId, userId, format, aiNarrative },
-    { jobId: createBullMqJobId(workspaceId, exportId) },
-  );
-};
 
 /** Human-readable failure string persisted on the export row. */
 export const toExportErrorMessage = (cause: unknown): string => {
@@ -148,24 +90,10 @@ export const toExportErrorMessage = (cause: unknown): string => {
 };
 
 export const initReportExportWorker = () => {
-  // Heal exports stranded by a previous process's hard death before serving new
-  // ones. Fire-and-forget: a sweep failure must not block worker startup, and
-  // the next boot re-attempts it.
-  recoverStuckReportExports()
-    .then((count) => {
-      if (count > 0) {
-        logger.warn("report_export.recovered_stuck", { count: String(count) });
-      }
-      return count;
-    })
-    .catch((error: unknown) => {
-      captureError(error, { operation: "report_export.recover_stuck" });
-    });
-
   const workerConnection = createBullMqConnection();
 
   const worker = new Worker<ReportExportJobData>(
-    QUEUE_NAME,
+    REPORT_EXPORT_QUEUE_NAME,
     async (job) => {
       await processReportExportJob(job.data);
     },
@@ -542,8 +470,7 @@ const runExport = async ({
   // Download mode: write under the root exports/ prefix (S3 lifecycle prefix
   // filters anchor at the key start, so the scratch prefix must lead the key;
   // org/workspace segments keep the key tenant-scoped); the status endpoint
-  // presigns it. The stored key's extension is what the status endpoint uses
-  // to name the download, so no format column is needed on the export row.
+  // presigns it and names the download from the stored key's extension.
   const key = `exports/${actor.organizationId}/${actor.workspaceId}/${actor.exportId}.${delivery.ext}`;
   await writeS3ObjectWithRetry({
     contentType: delivery.mimeType,

--- a/apps/api/src/lib/document-deadline-scout-recovery.db.test.ts
+++ b/apps/api/src/lib/document-deadline-scout-recovery.db.test.ts
@@ -1,0 +1,231 @@
+/**
+ * A run whose deadline scout is `pending` has work owed to a queue, and
+ * nothing on the row says whether a job is already carrying it. What is
+ * asserted here is that the sweep dispatches such a run, and that repeating
+ * the sweep does not enqueue it a second time — the property the scheduler
+ * depends on now that it drives this beside the document processing worker.
+ * Driven against a real (PGlite) database with a stubbed queue.
+ */
+
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+
+import type { rootDb } from "@/api/db/root";
+import { documentProcessingRuns } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { DOCUMENT_OCR_PROCESSOR_VERSION } from "@/api/lib/document-processing-contract";
+import { enqueueDocumentDeadlineScoutJob } from "@/api/lib/document-processing-enqueue";
+import type { DocumentDeadlineScoutJobData } from "@/api/lib/document-processing-enqueue";
+import { recoverDocumentDeadlineScoutDispatches } from "@/api/lib/document-processing-queue";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+const added: { data: DocumentDeadlineScoutJobData; jobId: string }[] = [];
+const liveJobIds = new Set<string>();
+
+/** The real handoff over a stubbed queue, so the idempotency under test is
+ *  the one production runs rather than a re-implementation. */
+const scoutQueue = {
+  add: async (
+    _name: string,
+    data: DocumentDeadlineScoutJobData,
+    options: { jobId: string },
+  ) => {
+    added.push({ data, jobId: options.jobId });
+    liveJobIds.add(options.jobId);
+  },
+  getJob: async (jobId: string) =>
+    liveJobIds.has(jobId)
+      ? {
+          getState: async () => "waiting" as const,
+          remove: async () => {
+            liveJobIds.delete(jobId);
+          },
+          retry: async () => undefined,
+        }
+      : undefined,
+};
+
+const sweep = async () =>
+  await recoverDocumentDeadlineScoutDispatches({
+    database: asTestRaw<typeof rootDb>(testDb),
+    enqueueDocumentDeadlineScout: async (job) =>
+      await enqueueDocumentDeadlineScoutJob({ scoutQueue, job }),
+  });
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+}, 120_000);
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+beforeEach(async () => {
+  added.length = 0;
+  liveJobIds.clear();
+  await testDb.delete(documentProcessingRuns);
+});
+
+const insertPendingScoutRun = async (): Promise<
+  SafeId<"documentProcessingRun">
+> => {
+  const runId = toSafeId<"documentProcessingRun">(Bun.randomUUIDv7());
+  await testDb.insert(documentProcessingRuns).values({
+    id: runId,
+    entityId: ids.entityA1,
+    entityVersionId: ids.entityVersionA1,
+    fieldId: ids.fileFieldA1,
+    kind: "ocr",
+    organizationId: ids.orgA,
+    processorVersion: DOCUMENT_OCR_PROCESSOR_VERSION,
+    requestedBy: null,
+    requestSource: "upload",
+    sourceFileId: ids.fileObjectA1,
+    sourceSha256Hex: "c".repeat(64),
+    workspaceId: ids.wsA1,
+    // A succeeded run is the only state a scout dispatch is owed from.
+    status: "succeeded",
+    finishedAt: new Date(),
+    deadlineScoutStatus: "pending",
+  });
+  return runId;
+};
+
+test("dispatches a pending scout no job owns, and only once", async () => {
+  const runId = await insertPendingScoutRun();
+
+  const first = await sweep();
+  const second = await sweep();
+
+  expect(first.count).toBe(1);
+  expect(second.count).toBe(1);
+  // The row stays `pending` until the scout worker claims it, so the second
+  // sweep selects it again and must recognise the job it already added.
+  expect(added).toEqual([
+    { data: { sourceRunId: runId }, jobId: added.at(0)?.jobId ?? "" },
+  ]);
+});
+
+test("leaves a run whose scout is already settled alone", async () => {
+  const runId = await insertPendingScoutRun();
+  await testDb
+    .update(documentProcessingRuns)
+    .set({ deadlineScoutStatus: "succeeded" })
+    .where(eq(documentProcessingRuns.id, runId));
+
+  const result = await sweep();
+
+  expect(result.count).toBe(0);
+  expect(added).toEqual([]);
+});
+
+/** Older than the dispatch lease, so the sweep nominates it as expired. */
+const EXPIRED_LEASE_MS = 10 * 60 * 1000;
+
+const insertExpiredScoutClaim = async (): Promise<
+  SafeId<"documentProcessingRun">
+> => {
+  const runId = await insertPendingScoutRun();
+  await testDb
+    .update(documentProcessingRuns)
+    .set({
+      deadlineScoutClaimedAt: new Date(Date.now() - EXPIRED_LEASE_MS),
+      deadlineScoutStatus: "running",
+    })
+    .where(eq(documentProcessingRuns.id, runId));
+  return runId;
+};
+
+/**
+ * A database handle that runs `claim` once, immediately before the first
+ * UPDATE the sweep issues: the window between selecting an expired dispatch
+ * and resetting it, in which the other sweep's reset can let a worker take a
+ * fresh claim on the same row.
+ */
+const databaseClaimingBeforeFirstUpdate = (claim: () => Promise<void>) => {
+  let armed = true;
+  const deferred = <Chain extends object>(chain: Chain): Chain =>
+    new Proxy(chain, {
+      get: (target, property, receiver) => {
+        const value: unknown = Reflect.get(target, property, receiver);
+        if (typeof value !== "function") {
+          return value;
+        }
+        // Awaiting the chain is what runs the statement, so the claim lands
+        // between the sweep's select and its update. The real `then` is
+        // called afterwards, unwrapped, so the query itself is untouched.
+        if (property === "then") {
+          return async (...args: unknown[]) => {
+            if (armed) {
+              armed = false;
+              await claim();
+            }
+            return await Reflect.apply(value, target, args);
+          };
+        }
+        return (...args: unknown[]) => {
+          const next: unknown = Reflect.apply(value, target, args);
+          return typeof next === "object" && next !== null
+            ? deferred(next)
+            : next;
+        };
+      },
+    });
+  return asTestRaw<typeof rootDb>({
+    select: testDb.select.bind(testDb),
+    update: (table: Parameters<typeof testDb.update>[0]) =>
+      deferred(testDb.update(table)),
+  });
+};
+
+test("does not reset a claim taken between the select and the update", async () => {
+  // The scheduler sweep and the processing worker's own reconciliation loop
+  // both select this row as expired. The first resets it, a worker claims a
+  // fresh attempt, and an id-only update from the second would push that live
+  // claim back to `pending`: the worker's settlement predicate would then
+  // reject its own result and the metered scan would replay every sweep.
+  const runId = await insertExpiredScoutClaim();
+  const freshClaimedAt = new Date();
+  const database = databaseClaimingBeforeFirstUpdate(async () => {
+    await testDb
+      .update(documentProcessingRuns)
+      .set({
+        deadlineScoutClaimedAt: freshClaimedAt,
+        deadlineScoutStatus: "running",
+      })
+      .where(eq(documentProcessingRuns.id, runId));
+  });
+
+  const result = await recoverDocumentDeadlineScoutDispatches({
+    database,
+    enqueueDocumentDeadlineScout: async (job) =>
+      await enqueueDocumentDeadlineScoutJob({ scoutQueue, job }),
+  });
+
+  const [row] = await testDb
+    .select({
+      claimedAt: documentProcessingRuns.deadlineScoutClaimedAt,
+      status: documentProcessingRuns.deadlineScoutStatus,
+    })
+    .from(documentProcessingRuns)
+    .where(eq(documentProcessingRuns.id, runId));
+  expect(row?.status).toBe("running");
+  expect(row?.claimedAt?.getTime()).toBe(freshClaimedAt.getTime());
+  // Nothing transitioned, so the sweep reports no effect rather than counting
+  // a row it did not move.
+  expect(result.count).toBe(0);
+  expect(added).toEqual([]);
+});

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -1574,11 +1574,31 @@ export type DocumentProcessingReconciliationDependencies = {
   }) => Promise<boolean>;
 };
 
-const recoverDocumentDeadlineScoutDispatches = async (
-  dependencies: DocumentProcessingReconciliationDependencies,
-): Promise<ReconciliationPhaseResult> => {
+/** The two dependencies this sweep needs, so the scheduler can run it without
+ *  assembling the whole reconciliation set and a test can drive it with a
+ *  stubbed queue. */
+type RecoverDocumentDeadlineScoutDispatchesOptions = {
+  database?: DocumentProcessingReconciliationDependencies["database"];
+  enqueueDocumentDeadlineScout?: DocumentProcessingReconciliationDependencies["enqueueDocumentDeadlineScout"];
+};
+
+/**
+ * Return expired scout dispatches to `pending` and hand every pending one to
+ * the scout queue.
+ *
+ * Exported because the scout worker and this dispatcher live in different
+ * processes: the worker starts with the API server, while the reconciliation
+ * loop that used to be the dispatcher's only driver runs in the document
+ * processing worker. Wherever that worker is absent, `pending` rows had
+ * nothing to dispatch them. The scheduler runs it too; the enqueue is keyed by
+ * the source run, so the two drivers converge rather than duplicating work.
+ */
+export const recoverDocumentDeadlineScoutDispatches = async ({
+  database = rootDb,
+  enqueueDocumentDeadlineScout: enqueueScout = enqueueDocumentDeadlineScout,
+}: RecoverDocumentDeadlineScoutDispatchesOptions = {}): Promise<ReconciliationPhaseResult> => {
   const staleBefore = new Date(Date.now() - DEADLINE_SCOUT_LEASE_TIMEOUT_MS);
-  const staleDispatches = await dependencies.database
+  const staleDispatches = await database
     .select({ id: documentProcessingRuns.id })
     .from(documentProcessingRuns)
     .where(
@@ -1592,24 +1612,38 @@ const recoverDocumentDeadlineScoutDispatches = async (
       asc(documentProcessingRuns.id),
     )
     .limit(RECONCILE_BATCH_SIZE);
-  if (staleDispatches.length > 0) {
-    await dependencies.database
-      .update(documentProcessingRuns)
-      .set({
-        deadlineScoutClaimedAt: null,
-        deadlineScoutErrorCode: "worker_lease_expired",
-        deadlineScoutStatus: "pending",
-        updatedAt: new Date(),
-      })
-      .where(
-        inArray(
-          documentProcessingRuns.id,
-          staleDispatches.map(({ id }) => id),
-        ),
-      );
-  }
+  // Compare-and-set on the state the select matched, not on the id alone.
+  // This sweep runs in the scheduler and in the processing worker's own
+  // reconciliation loop, so two of them can select the same expired dispatch.
+  // Once the first resets it a worker claims a fresh attempt, and an id-only
+  // update from the second would push that live claim back to `pending`: the
+  // worker's settlement predicate then rejects its own result and the metered
+  // scan is replayed on every later sweep. Re-asserting `running` and the same
+  // expired claim makes the second update match nothing.
+  const reclaimedDispatches =
+    staleDispatches.length === 0
+      ? []
+      : await database
+          .update(documentProcessingRuns)
+          .set({
+            deadlineScoutClaimedAt: null,
+            deadlineScoutErrorCode: "worker_lease_expired",
+            deadlineScoutStatus: "pending",
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              inArray(
+                documentProcessingRuns.id,
+                staleDispatches.map(({ id }) => id),
+              ),
+              eq(documentProcessingRuns.deadlineScoutStatus, "running"),
+              lt(documentProcessingRuns.deadlineScoutClaimedAt, staleBefore),
+            ),
+          )
+          .returning({ id: documentProcessingRuns.id });
 
-  const staleCensusRuns = await dependencies.database
+  const staleCensusRuns = await database
     .select({ id: scoutRuns.id })
     .from(scoutRuns)
     .where(
@@ -1621,23 +1655,31 @@ const recoverDocumentDeadlineScoutDispatches = async (
     )
     .orderBy(asc(scoutRuns.startedAt), asc(scoutRuns.id))
     .limit(RECONCILE_BATCH_SIZE);
-  if (staleCensusRuns.length > 0) {
-    await dependencies.database
-      .update(scoutRuns)
-      .set({
-        error: "worker_lease_expired",
-        finishedAt: new Date(),
-        status: SCOUT_RUN_STATUS.FAILED,
-      })
-      .where(
-        inArray(
-          scoutRuns.id,
-          staleCensusRuns.map(({ id }) => id),
-        ),
-      );
-  }
+  // Same compare-and-set, so a census run that restarted between the select
+  // and this update is not retired out from under its worker.
+  const failedCensusRuns =
+    staleCensusRuns.length === 0
+      ? []
+      : await database
+          .update(scoutRuns)
+          .set({
+            error: "worker_lease_expired",
+            finishedAt: new Date(),
+            status: SCOUT_RUN_STATUS.FAILED,
+          })
+          .where(
+            and(
+              inArray(
+                scoutRuns.id,
+                staleCensusRuns.map(({ id }) => id),
+              ),
+              eq(scoutRuns.status, SCOUT_RUN_STATUS.RUNNING),
+              lt(scoutRuns.startedAt, staleBefore),
+            ),
+          )
+          .returning({ id: scoutRuns.id });
 
-  const pending = await dependencies.database
+  const pending = await database
     .select({ sourceRunId: documentProcessingRuns.id })
     .from(documentProcessingRuns)
     .where(eq(documentProcessingRuns.deadlineScoutStatus, "pending"))
@@ -1652,7 +1694,7 @@ const recoverDocumentDeadlineScoutDispatches = async (
     limit: DEADLINE_SCOUT_DISPATCH_CONCURRENCY,
     operation: async ({ sourceRunId }) =>
       await Result.tryPromise(async () => {
-        await dependencies.enqueueDocumentDeadlineScout({ sourceRunId });
+        await enqueueScout({ sourceRunId });
       }),
   });
   for (const result of results) {
@@ -1662,9 +1704,11 @@ const recoverDocumentDeadlineScoutDispatches = async (
   }
 
   return {
+    // Rows actually transitioned, not rows selected: a candidate another
+    // sweep already reclaimed is not this sweep's effect.
     count:
-      staleDispatches.length +
-      staleCensusRuns.length +
+      reclaimedDispatches.length +
+      failedCensusRuns.length +
       results.filter(Result.isOk).length,
     hasMore:
       cappedSelectionHasMore({

--- a/apps/api/src/lib/report-export-enqueue.db.test.ts
+++ b/apps/api/src/lib/report-export-enqueue.db.test.ts
@@ -1,0 +1,273 @@
+/**
+ * A `queued` export whose job never reached the queue has nothing left to
+ * drive it, and the row cannot tell that apart from an export still waiting
+ * its turn. What is asserted here is the part no type can hold: that such an
+ * export is handed back exactly once, carrying the format and narrative flag
+ * the request was made with, and that a finished export is never resurrected.
+ * Driven against a real (PGlite) database with a stubbed queue.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq, inArray } from "drizzle-orm";
+
+import { reportExports } from "@/api/db/schema";
+import type { ReportExportFormat, ReportExportStatus } from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { reconcileQueuedReportExports } from "@/api/lib/report-export-enqueue";
+import type { ViewLayout } from "@/api/lib/views-schema";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+
+const { testDb, ids } = await getRlsFixture();
+
+type StubJobState = "active" | "completed" | "failed" | "waiting";
+
+type AddedJob = { data: unknown; jobId: string; name: string };
+
+const added: AddedJob[] = [];
+const priorJobs = new Map<string, StubJobState>();
+
+const queue = {
+  add: async (name: string, data: unknown, options: { jobId: string }) => {
+    added.push({ data, jobId: options.jobId, name });
+    priorJobs.set(options.jobId, "waiting");
+  },
+  getJob: async (jobId: string) => {
+    const state = priorJobs.get(jobId);
+    if (state === undefined) {
+      return undefined;
+    }
+    return {
+      getState: async () => state,
+      remove: async () => {
+        priorJobs.delete(jobId);
+      },
+      retry: async () => {
+        priorJobs.set(jobId, "waiting");
+      },
+    };
+  },
+};
+
+const LAYOUT: ViewLayout = {
+  type: "table",
+  version: 1,
+  calculations: [],
+  columnOrder: [],
+  columnPinning: [],
+  filters: [],
+  hiddenProperties: [],
+  sorts: [],
+};
+
+const seededExportIds: SafeId<"reportExport">[] = [];
+
+type SeedExportOptions = {
+  aiNarrative?: boolean | null;
+  createdAt?: Date;
+  format?: ReportExportFormat | null;
+  requestedBy?: string | null;
+  status?: ReportExportStatus;
+};
+
+const exportValues = ({
+  aiNarrative = true,
+  createdAt = new Date(),
+  format = "docx",
+  requestedBy = ids.userA1,
+  status = "queued",
+}: SeedExportOptions = {}) => {
+  const exportId = createSafeId<"reportExport">();
+  seededExportIds.push(exportId);
+  return {
+    id: exportId,
+    workspaceId: ids.wsA1,
+    requestedBy,
+    templateRef: { type: "builtin", key: "due-diligence" } as const,
+    layout: LAYOUT,
+    mode: "download" as const,
+    format,
+    aiNarrative,
+    status,
+    createdAt,
+  };
+};
+
+const seedExport = async (
+  options: SeedExportOptions = {},
+): Promise<SafeId<"reportExport">> => {
+  const values = exportValues(options);
+  await testDb.insert(reportExports).values(values);
+  return values.id;
+};
+
+const jobIdFor = (exportId: SafeId<"reportExport">) =>
+  createBullMqJobId(ids.wsA1, exportId);
+
+describe("queued report export reconciliation", () => {
+  beforeEach(() => {
+    added.length = 0;
+    priorJobs.clear();
+  });
+
+  afterEach(async () => {
+    if (seededExportIds.length > 0) {
+      await testDb
+        .delete(reportExports)
+        .where(inArray(reportExports.id, seededExportIds));
+    }
+    seededExportIds.length = 0;
+  });
+
+  afterAll(async () => {
+    await releaseRlsFixture();
+  });
+
+  test("hands an export no job owns back to the queue exactly once, with the request it was made with", async () => {
+    const exportId = await seedExport({ aiNarrative: false, format: "pdf" });
+
+    const first = await reconcileQueuedReportExports({ db: testDb, queue });
+    const second = await reconcileQueuedReportExports({ db: testDb, queue });
+
+    expect(first).toEqual({
+      handedOff: 1,
+      scanned: 1,
+      unattributed: 0,
+      unrecoverable: 0,
+    });
+    // The row is still `queued` — only the worker's claim moves it — so the
+    // second sweep sees it again and must recognise its own job.
+    expect(second).toEqual({
+      handedOff: 0,
+      scanned: 1,
+      unattributed: 0,
+      unrecoverable: 0,
+    });
+    expect(added).toEqual([
+      {
+        data: {
+          exportId,
+          workspaceId: ids.wsA1,
+          organizationId: ids.orgA,
+          userId: ids.userA1,
+          format: "pdf",
+          aiNarrative: false,
+        },
+        jobId: jobIdFor(exportId),
+        name: "export-report",
+      },
+    ]);
+  });
+
+  test("leaves finished exports alone", async () => {
+    await seedExport({ status: "completed" });
+    await seedExport({ status: "failed" });
+    await seedExport({ status: "running" });
+
+    const result = await reconcileQueuedReportExports({ db: testDb, queue });
+
+    expect(result).toEqual({
+      handedOff: 0,
+      scanned: 0,
+      unattributed: 0,
+      unrecoverable: 0,
+    });
+    expect(added).toEqual([]);
+  });
+
+  test("counts an export whose requester is gone instead of dropping it", async () => {
+    await seedExport({ requestedBy: null });
+
+    const result = await reconcileQueuedReportExports({ db: testDb, queue });
+
+    expect(result).toEqual({
+      handedOff: 0,
+      scanned: 1,
+      unattributed: 1,
+      unrecoverable: 0,
+    });
+    expect(added).toEqual([]);
+  });
+
+  test("fails a queued export whose request was never recorded", async () => {
+    // Rows written before the columns existed carry their format and
+    // narrative flag on the job alone. Handing one back would mean inventing
+    // options and running a different export than the one asked for.
+    const exportId = await seedExport({ aiNarrative: null, format: null });
+
+    const result = await reconcileQueuedReportExports({ db: testDb, queue });
+
+    expect(result).toEqual({
+      handedOff: 0,
+      scanned: 1,
+      unattributed: 0,
+      unrecoverable: 1,
+    });
+    expect(added).toEqual([]);
+    const [row] = await testDb
+      .select({ error: reportExports.error, status: reportExports.status })
+      .from(reportExports)
+      .where(eq(reportExports.id, exportId));
+    // Terminal and legible, so the requester stops polling a row nothing will
+    // pick up and knows to run it again.
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toContain("run it again");
+  });
+
+  test("pages past a full page of queue-owned exports to reach an orphan", async () => {
+    // One page is 100 rows, and an export the queue owns keeps its `queued`
+    // row, so a sweep bounded by the first page would never inspect row 101.
+    const base = Date.now() - 60 * 60 * 1000;
+    const owned = Array.from({ length: 150 }, (_, index) =>
+      exportValues({ createdAt: new Date(base + index) }),
+    );
+    await testDb.insert(reportExports).values(owned);
+    for (const { id } of owned) {
+      priorJobs.set(jobIdFor(id), "waiting");
+    }
+    const orphan = await seedExport({ createdAt: new Date(base + 1000) });
+
+    const result = await reconcileQueuedReportExports({ db: testDb, queue });
+
+    expect(result).toEqual({
+      handedOff: 1,
+      scanned: 151,
+      unattributed: 0,
+      unrecoverable: 0,
+    });
+    expect(added.map(({ jobId }) => jobId)).toEqual([jobIdFor(orphan)]);
+  });
+
+  test("stops at the per-tick handoff limit on a page of orphans", async () => {
+    // A full page of exports that all need handing back. Whether a row hands
+    // off is only known once its handler returns, so capacity has to be taken
+    // before each handler starts or the whole page would be enqueued at once —
+    // a queue storm of metered fills rather than a paced drain.
+    const base = Date.now() - 60 * 60 * 1000;
+    const orphans = Array.from({ length: 100 }, (_, index) =>
+      exportValues({ createdAt: new Date(base + index) }),
+    );
+    await testDb.insert(reportExports).values(orphans);
+
+    const result = await reconcileQueuedReportExports({ db: testDb, queue });
+
+    expect(result).toEqual({
+      handedOff: 50,
+      scanned: 50,
+      unattributed: 0,
+      unrecoverable: 0,
+    });
+    expect(added).toHaveLength(50);
+  });
+});

--- a/apps/api/src/lib/report-export-enqueue.ts
+++ b/apps/api/src/lib/report-export-enqueue.ts
@@ -1,0 +1,236 @@
+/**
+ * Queue identity for view→report exports: the names, the job payload, the
+ * handoff, and the sweep that hands an export back when nothing owns it.
+ *
+ * Separate from the worker in the reports handler slice so the scheduler can
+ * drive the sweep without importing a handler, and so a caller that only needs
+ * to enqueue does not pull in the fill pipeline. The worker imports the queue
+ * name and payload from here; nothing here imports the worker.
+ */
+
+import { Result } from "better-result";
+import { and, asc, eq } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import { reportExports, workspaces } from "@/api/db/schema";
+import type { ReportExportFormat } from "@/api/db/schema";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
+import {
+  QUEUE_REQUEUE_OUTCOME,
+  requeueDeterministicJob,
+} from "@/api/lib/bullmq-requeue";
+import type { RequeueableQueue } from "@/api/lib/bullmq-requeue";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
+import {
+  RECONCILE_SCAN_PAGE_SIZE,
+  reconcileCursorTimestamp,
+  scanPendingRows,
+} from "@/api/lib/queue-reconcile-scan";
+import type { ReconcileScanResult } from "@/api/lib/queue-reconcile-scan";
+import { brandPersistedReportExportId } from "@/api/lib/safe-id-boundaries";
+
+export const REPORT_EXPORT_QUEUE_NAME = "report-exports";
+const REPORT_EXPORT_JOB_NAME = "export-report";
+// One attempt: the fill runs metered AI and (in workspace mode) creates a
+// document; a BullMQ retry would double both. Failures are persisted on the row.
+const JOB_ATTEMPTS = 1;
+
+export type ReportExportJobData = {
+  exportId: string;
+  workspaceId: string;
+  organizationId: string;
+  userId: string;
+  format: ReportExportFormat;
+  /** Include AI-drafted narrative sections: the worker needs it to gate the AI
+   *  generators + template sections. Optional for back-compat with jobs
+   *  enqueued before this field existed; absent means "on". */
+  aiNarrative?: boolean;
+};
+
+type EnqueueReportExportArgs = {
+  exportId: SafeId<"reportExport">;
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  format: ReportExportFormat;
+  aiNarrative: boolean;
+};
+
+export const getReportExportQueue = createLazyBullMqQueue<ReportExportJobData>({
+  name: REPORT_EXPORT_QUEUE_NAME,
+  defaultJobOptions: {
+    attempts: JOB_ATTEMPTS,
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
+
+export const enqueueReportExport = async ({
+  exportId,
+  workspaceId,
+  organizationId,
+  userId,
+  format,
+  aiNarrative,
+}: EnqueueReportExportArgs): Promise<void> => {
+  await getReportExportQueue().add(
+    REPORT_EXPORT_JOB_NAME,
+    { exportId, workspaceId, organizationId, userId, format, aiNarrative },
+    { jobId: createBullMqJobId(workspaceId, exportId) },
+  );
+};
+
+/** The (timestamp, id) keyset this sweep's walk pages on. */
+const reportExportCursorCodec = createTimestampIdCursorCodec({
+  column: reportExports.createdAt,
+  brandId: brandPersistedReportExportId,
+});
+
+type QueuedReportExportRow = {
+  aiNarrative: boolean | null;
+  createdCursor: string;
+  format: ReportExportFormat | null;
+  id: SafeId<"reportExport">;
+  organizationId: SafeId<"organization">;
+  requestedBy: string | null;
+  workspaceId: SafeId<"workspace">;
+};
+
+type ReconcileQueuedReportExportsOptions = {
+  db?: Pick<typeof rootDb, "select" | "update">;
+  queue?: RequeueableQueue<ReportExportJobData>;
+};
+
+/** Shown to the requester when the row cannot say what to run. */
+const UNRECORDED_REQUEST_ERROR =
+  "This export was queued before its options were recorded and cannot be restarted. Please run it again.";
+
+type ReconcileQueuedReportExportsResult = ReconcileScanResult & {
+  /**
+   * `requested_by` is nulled when the requester's account is deleted, and the
+   * job carries an actor. Counted rather than dropped quietly, so a population
+   * this sweep cannot repair stays visible; the staleness janitor fails those
+   * rows once they age out.
+   */
+  unattributed: number;
+  /**
+   * Rows queued before `format`/`ai_narrative` existed, whose request lived
+   * only on a job the queue no longer has. Guessing the missing options would
+   * run a different export than the one asked for, so these are failed here
+   * instead: the requester is told to run it again rather than left polling a
+   * row nothing will ever pick up.
+   */
+  unrecoverable: number;
+};
+
+/**
+ * Hand `queued` exports back to the queue when nothing owns them anymore.
+ *
+ * The row is created inside the request's transaction and the job is added
+ * after it commits, so a crash in between — or a queue that lost its waiting
+ * jobs — leaves an export no worker will ever pick up, and the row cannot tell
+ * that apart from one still waiting its turn. Re-adding is safe to repeat: the
+ * job id is derived from the export id and only a `queued` row runs, so a
+ * duplicate delivery is a no-op rather than a second metered fill.
+ *
+ * The walk pages forward on a keyset cursor rather than re-reading one fixed
+ * page: an export the queue still owns keeps its `queued` row, so a sweep
+ * bounded by the first page would inspect the same healthy backlog every tick
+ * and never reach the orphan behind it.
+ *
+ * The owning organization is joined from the workspace rather than read off
+ * the export: the request took it from the session, and the workspace is the
+ * only durable record of which organization the export belongs to.
+ *
+ * A row whose request was never recorded is failed rather than handed back.
+ * Those predate the columns and kept their options on the job alone, so the
+ * sweep has nothing to rebuild from and any default it picked could run a
+ * different export than the one asked for.
+ */
+export const reconcileQueuedReportExports = async ({
+  db = rootDb,
+  queue = getReportExportQueue(),
+}: ReconcileQueuedReportExportsOptions = {}): Promise<ReconcileQueuedReportExportsResult> => {
+  let unattributed = 0;
+  let unrecoverable = 0;
+
+  const after = (cursor: QueuedReportExportRow | null) => {
+    if (cursor === null) {
+      return undefined;
+    }
+    return reportExportCursorCodec.keysetAfter({
+      cursor: {
+        timestamp: reconcileCursorTimestamp(cursor.createdCursor),
+        id: cursor.id,
+      },
+      idColumn: reportExports.id,
+      direction: "ascending",
+    });
+  };
+
+  const readPage = async (cursor: QueuedReportExportRow | null) =>
+    await db
+      .select({
+        aiNarrative: reportExports.aiNarrative,
+        createdCursor: reportExportCursorCodec.cursorValue,
+        format: reportExports.format,
+        id: reportExports.id,
+        organizationId: workspaces.organizationId,
+        requestedBy: reportExports.requestedBy,
+        workspaceId: reportExports.workspaceId,
+      })
+      .from(reportExports)
+      .innerJoin(workspaces, eq(workspaces.id, reportExports.workspaceId))
+      .where(and(eq(reportExports.status, "queued"), after(cursor)))
+      .orderBy(asc(reportExports.createdAt), asc(reportExports.id))
+      .limit(RECONCILE_SCAN_PAGE_SIZE);
+
+  const handle = async (row: QueuedReportExportRow): Promise<boolean> => {
+    const { aiNarrative, format, requestedBy } = row;
+    if (requestedBy === null) {
+      unattributed += 1;
+      return false;
+    }
+    if (format === null || aiNarrative === null) {
+      unrecoverable += 1;
+      // audit: skip — terminal bookkeeping on the already-audited export row.
+      // Guarded on `queued` so a row a worker claimed in the meantime keeps
+      // the state that worker is driving.
+      await db
+        .update(reportExports)
+        .set({ status: "failed", error: UNRECORDED_REQUEST_ERROR })
+        .where(
+          and(eq(reportExports.id, row.id), eq(reportExports.status, "queued")),
+        );
+      return false;
+    }
+    const outcome = await Result.tryPromise({
+      try: async () =>
+        await requeueDeterministicJob({
+          data: {
+            exportId: row.id,
+            workspaceId: row.workspaceId,
+            organizationId: row.organizationId,
+            userId: requestedBy,
+            format,
+            aiNarrative,
+          },
+          jobId: createBullMqJobId(row.workspaceId, row.id),
+          name: REPORT_EXPORT_JOB_NAME,
+          queue,
+        }),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(outcome)) {
+      captureError(outcome.error, { exportId: row.id });
+      return false;
+    }
+    return outcome.value === QUEUE_REQUEUE_OUTCOME.REQUEUED;
+  };
+
+  const scan = await scanPendingRows({ handle, readPage });
+  return { ...scan, unattributed, unrecoverable };
+};

--- a/apps/api/src/lib/report-export-recovery.db.test.ts
+++ b/apps/api/src/lib/report-export-recovery.db.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The janitor's `running` branch cannot decide on age alone. The worker sets
+ * `running` once and never heartbeats, so a large export that legitimately
+ * takes hours looks exactly like one whose worker died half an hour ago. What
+ * is asserted here is that the queue, not the clock, settles it: a row whose
+ * job is still active survives its cutoff, and only a row the queue has no job
+ * for is failed. Driven against a real (PGlite) database with a stubbed queue.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+
+import type { rootDb } from "@/api/db/root";
+import { reportExports } from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { recoverStuckReportExports } from "@/api/lib/report-export-recovery";
+import type { StuckExportJobQueue } from "@/api/lib/report-export-recovery";
+import type { ViewLayout } from "@/api/lib/views-schema";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+
+const { testDb, ids } = await getRlsFixture();
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+
+const LAYOUT: ViewLayout = {
+  type: "table",
+  version: 1,
+  calculations: [],
+  columnOrder: [],
+  columnPinning: [],
+  filters: [],
+  hiddenProperties: [],
+  sorts: [],
+};
+
+/** A job the queue reports in the given state; `null` means the queue has no
+ *  record of it at all. */
+const queueHolding = (
+  jobs: ReadonlyMap<string, string | null>,
+): StuckExportJobQueue => ({
+  getJob: async (jobId: string) => {
+    const state = jobs.get(jobId);
+    if (state === undefined || state === null) {
+      return undefined;
+    }
+    return { getState: async () => state };
+  },
+});
+
+/** `updated_at` is `$onUpdate`-managed, so the age has to be written in a
+ *  second statement that sets it explicitly. */
+const seedRunningExport = async (
+  updatedAt: Date,
+): Promise<SafeId<"reportExport">> => {
+  const exportId = createSafeId<"reportExport">();
+  await testDb.insert(reportExports).values({
+    id: exportId,
+    workspaceId: ids.wsA1,
+    requestedBy: ids.userA1,
+    templateRef: { type: "builtin", key: "due-diligence" },
+    layout: LAYOUT,
+    mode: "download",
+    format: "docx",
+    aiNarrative: true,
+    status: "running",
+  });
+  await testDb
+    .update(reportExports)
+    .set({ updatedAt })
+    .where(eq(reportExports.id, exportId));
+  return exportId;
+};
+
+const statusOf = async (exportId: SafeId<"reportExport">) => {
+  const [row] = await testDb
+    .select({ error: reportExports.error, status: reportExports.status })
+    .from(reportExports)
+    .where(eq(reportExports.id, exportId));
+  return row;
+};
+
+const recover = async (queue: StuckExportJobQueue) =>
+  await recoverStuckReportExports({
+    db: asTestRaw<typeof rootDb>(testDb),
+    queue,
+  });
+
+describe("stuck report export recovery", () => {
+  beforeEach(async () => {
+    await testDb.delete(reportExports);
+  });
+
+  afterAll(async () => {
+    await releaseRlsFixture();
+  });
+
+  test("leaves a long-running export alone while its job is active", async () => {
+    const exportId = await seedRunningExport(new Date(Date.now() - HOUR_IN_MS));
+
+    const recovered = await recover(
+      queueHolding(
+        new Map([[createBullMqJobId(ids.wsA1, exportId), "active"]]),
+      ),
+    );
+
+    expect(recovered).toBe(0);
+    // A 500-row export draws a metered draft per contract; the row's age says
+    // when the fill started, not that it stopped.
+    expect((await statusOf(exportId))?.status).toBe("running");
+  });
+
+  test("fails an export past its cutoff that the queue has no job for", async () => {
+    const exportId = await seedRunningExport(new Date(Date.now() - HOUR_IN_MS));
+
+    const recovered = await recover(queueHolding(new Map()));
+
+    expect(recovered).toBe(1);
+    const row = await statusOf(exportId);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toContain("Please try again");
+  });
+
+  test("fails an export whose job the queue has already finished", async () => {
+    const exportId = await seedRunningExport(new Date(Date.now() - HOUR_IN_MS));
+
+    const recovered = await recover(
+      queueHolding(
+        new Map([[createBullMqJobId(ids.wsA1, exportId), "completed"]]),
+      ),
+    );
+
+    expect(recovered).toBe(1);
+    expect((await statusOf(exportId))?.status).toBe("failed");
+  });
+
+  test("leaves an export inside its cutoff alone whatever the queue says", async () => {
+    const exportId = await seedRunningExport(new Date());
+
+    const recovered = await recover(queueHolding(new Map()));
+
+    expect(recovered).toBe(0);
+    expect((await statusOf(exportId))?.status).toBe("running");
+  });
+});

--- a/apps/api/src/lib/report-export-recovery.ts
+++ b/apps/api/src/lib/report-export-recovery.ts
@@ -5,29 +5,41 @@
  * catch. A `kill -9` / OOM emits no `failed` event, and BullMQ's own stalled
  * recovery re-delivers the job — but the queue's idempotency guard (only
  * `queued` rows run) makes that re-delivery a no-op, so the row would sit
- * `running` forever. A boot sweep closes that gap.
+ * `running` forever. A scheduled sweep closes that gap.
  *
- * The two states age at different rates. A `running` row survives its worker
- * only through a hard death, so half an hour of silence is conclusive. A
- * `queued` row is still processable — its job persists in the queue across
- * restarts and the sweep runs before the worker starts — so failing it on the
- * short threshold would kill a backlogged-but-alive export. Only a queued row
- * whose job is gone (queue data loss) is truly stuck, which the DB cannot
- * observe directly; a day of silence is the conservative proxy, far beyond
- * any real backlog at the worker's concurrency.
+ * The two states age at different rates, and neither is decided by age alone.
+ *
+ * A `running` row is set once, at the start of a fill that legitimately runs
+ * for a long time: a large view draws a metered AI draft per contract and
+ * nothing heartbeats the row, so its `updated_at` says when the work started,
+ * not whether it is still going. Age therefore only nominates a candidate; the
+ * queue settles it. A job still `active` is a worker mid-fill and the row is
+ * left alone. Only a job the queue no longer has, or one it has already
+ * finished, proves the row outlived its worker.
+ *
+ * A `queued` row is still processable — its job persists in the queue across
+ * restarts, and the reconciler hands it back whenever no job owns it — so
+ * failing it on the short threshold would kill a backlogged-but-alive export.
+ * A queued row still sitting after a day has outlived every requeue the
+ * reconciler could give it; a day of silence is the conservative proxy, far
+ * beyond any real backlog at the worker's concurrency.
  *
  * Owner-level, cross-workspace DB access lives here (a narrow lib helper) so the
  * report handler slice never imports the RLS-exempt root db directly, mirroring
  * the workflow orphan reconciler.
  */
 
-import { and, eq, lt, or } from "drizzle-orm";
+import { Result } from "better-result";
+import { and, asc, eq, inArray, lt } from "drizzle-orm";
 
 import { DAY_IN_MS } from "@stll/time";
 
 import { rootDb } from "@/api/db/root";
 import type { ReportExportStatus } from "@/api/db/schema";
 import { reportExports } from "@/api/db/schema";
+import { captureError } from "@/api/lib/analytics/capture";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 /** A `running` row this old lost its worker to a hard death. */
 const STUCK_RUNNING_MS = 30 * 60 * 1000;
@@ -40,10 +52,22 @@ const STUCK_EXPORT_ERROR =
   "Report export did not complete in time and was marked failed. Please try again.";
 
 /**
- * Whether an export row is presumed abandoned (dead worker for `running`,
- * lost job for `queued`). Pure so the exact rule the recovery UPDATE encodes
- * (per-status staleness thresholds) is unit-testable;
- * {@link recoverStuckReportExports}'s SQL `where` mirrors it.
+ * Rows the janitor inspects per tick. A `running` export past its cutoff is an
+ * exceptional population, and each one costs a queue lookup, so the sweep
+ * takes a bounded batch and leaves any remainder for the next tick.
+ */
+const STUCK_RUNNING_SCAN_MAX = 25;
+
+/** Deadline on one queue command, matching the bound the handoffs use: an
+ *  unanswered lookup must not hold the whole tick. */
+const QUEUE_OPERATION_TIMEOUT_MS = 2000;
+
+/**
+ * Whether an export row is old enough to be *considered* abandoned. Pure so
+ * the per-status staleness thresholds are unit-testable;
+ * {@link recoverStuckReportExports} mirrors this in SQL. For `running` rows it
+ * is a nomination, not a verdict: age alone cannot tell a dead worker from a
+ * long fill, so the queue decides those.
  */
 export const isStuckReportExport = (
   row: { status: ReportExportStatus; updatedAt: Date },
@@ -59,38 +83,128 @@ export const isStuckReportExport = (
   return false;
 };
 
+/** The queue surface the janitor needs to tell a live fill from a dead one,
+ *  structural so a test can pass a plain fake. */
+export type StuckExportJobQueue = {
+  getJob: (
+    jobId: string,
+  ) => Promise<{ getState: () => Promise<string> } | null | undefined>;
+};
+
+type RecoverStuckReportExportsOptions = {
+  db?: Pick<typeof rootDb, "select" | "update">;
+  now?: Date;
+  queue: StuckExportJobQueue;
+};
+
+/** BullMQ states a job is finished in. Anything else is work in progress. */
+const TERMINAL_JOB_STATES = new Set(["completed", "failed"]);
+
 /**
- * Boot janitor: mark every abandoned export failed. Runs cross-workspace via
- * `rootDb` (RLS-exempt internal infrastructure, like the workflow orphan
- * reconciler) with a single indexed UPDATE whose `where` mirrors
- * {@link isStuckReportExport}. Idempotent and safe to call repeatedly.
- * Returns how many rows it recovered.
+ * Whether the queue has stopped driving this export.
+ *
+ * Only a job that is absent, or one the queue has already finished, proves the
+ * row outlived its worker. A lookup that errors or never answers proves
+ * nothing, so the row is left for the next tick: failing a healthy export and
+ * emailing its requester is far worse than recovering it five minutes later.
  */
-export const recoverStuckReportExports = async (
-  now: Date = new Date(),
-): Promise<number> => {
+const hasLostItsJob = async (
+  queue: StuckExportJobQueue,
+  jobId: string,
+): Promise<boolean> => {
+  const inspected = await Result.tryPromise({
+    try: async () =>
+      await withTimeout(
+        async () => {
+          const job = await queue.getJob(jobId);
+          return job === null || job === undefined
+            ? null
+            : await job.getState();
+        },
+        {
+          label: "report-export-janitor.get-job",
+          timeoutMs: QUEUE_OPERATION_TIMEOUT_MS,
+        },
+      ),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(inspected)) {
+    captureError(inspected.error, { jobId });
+    return false;
+  }
+  return inspected.value === null || TERMINAL_JOB_STATES.has(inspected.value);
+};
+
+/**
+ * Janitor: mark every abandoned export failed. Runs cross-workspace via
+ * `rootDb` (RLS-exempt internal infrastructure, like the workflow orphan
+ * reconciler). Idempotent and safe to call repeatedly. Returns how many rows
+ * it recovered.
+ */
+export const recoverStuckReportExports = async ({
+  db = rootDb,
+  now = new Date(),
+  queue,
+}: RecoverStuckReportExportsOptions): Promise<number> => {
   const runningCutoff = new Date(now.getTime() - STUCK_RUNNING_MS);
   const queuedCutoff = new Date(now.getTime() - STUCK_QUEUED_MS);
+
   // audit: skip — janitor bookkeeping on already-audited export rows; flips
   // abandoned exports to failed so the status endpoint can surface them
   // instead of polling a stuck row forever.
-  const recovered = await rootDb
+  const recoveredQueued = await db
     .update(reportExports)
     .set({ status: "failed", error: STUCK_EXPORT_ERROR })
     .where(
-      or(
-        and(
-          eq(reportExports.status, "running"),
-          // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
-          lt(reportExports.updatedAt, runningCutoff),
-        ),
-        and(
-          eq(reportExports.status, "queued"),
-          // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
-          lt(reportExports.updatedAt, queuedCutoff),
-        ),
+      and(
+        eq(reportExports.status, "queued"),
+        // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
+        lt(reportExports.updatedAt, queuedCutoff),
       ),
     )
     .returning({ id: reportExports.id });
-  return recovered.length;
+
+  const runningCandidates = await db
+    .select({
+      id: reportExports.id,
+      workspaceId: reportExports.workspaceId,
+    })
+    .from(reportExports)
+    .where(
+      and(
+        eq(reportExports.status, "running"),
+        // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
+        lt(reportExports.updatedAt, runningCutoff),
+      ),
+    )
+    .orderBy(asc(reportExports.updatedAt), asc(reportExports.id))
+    .limit(STUCK_RUNNING_SCAN_MAX);
+
+  const verdicts = await Promise.all(
+    runningCandidates.map(
+      async (row) =>
+        await hasLostItsJob(queue, createBullMqJobId(row.workspaceId, row.id)),
+    ),
+  );
+  const abandoned = runningCandidates
+    .filter((_, index) => verdicts.at(index) === true)
+    .map(({ id }) => id);
+  if (abandoned.length === 0) {
+    return recoveredQueued.length;
+  }
+
+  // Still guarded on `running`: the queue lookups above are the window in
+  // which the worker can finish and write its own terminal state.
+  const recoveredRunning = await db
+    .update(reportExports)
+    .set({ status: "failed", error: STUCK_EXPORT_ERROR })
+    .where(
+      and(
+        inArray(reportExports.id, abandoned),
+        eq(reportExports.status, "running"),
+      ),
+    )
+    .returning({ id: reportExports.id });
+
+  return recoveredQueued.length + recoveredRunning.length;
 };

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -18,6 +18,7 @@ import { RECONCILE_CASE_LAW_CORPUS_UPLOAD_INTENTS_TASK } from "@/api/lib/schedul
 import { BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK } from "@/api/lib/scheduler/tasks/case-law-redaction-tombstone-backfill";
 import { CHAT_THREAD_COMPACTOR_TASK } from "@/api/lib/scheduler/tasks/chat-thread-compactor";
 import { EXPIRE_DESKTOP_EDIT_SESSIONS_TASK } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
+import { RECOVER_DOCUMENT_DEADLINE_SCOUTS_TASK } from "@/api/lib/scheduler/tasks/document-deadline-scout-recovery";
 import { DISPATCH_DOCUMENT_OCR_TASK } from "@/api/lib/scheduler/tasks/document-processing-ocr";
 import { RECONCILE_DOCUMENT_REVIEW_RUNS_TASK } from "@/api/lib/scheduler/tasks/document-review-run-reconcile";
 import { REPAIR_FILE_DERIVATIVES_TASK } from "@/api/lib/scheduler/tasks/file-derivative-repair";
@@ -163,6 +164,13 @@ export const DECLARED_SCHEDULER_JOBS = [
       everyMs: envBase.DOCUMENT_OCR_BATCH_INTERVAL_MINUTES * 60_000,
     },
     task: DISPATCH_DOCUMENT_OCR_TASK,
+  },
+  {
+    description: "Dispatch document deadline scouts nothing has picked up",
+    id: "documentProcessing.recoverDeadlineScouts.fiveMinute",
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
+    task: RECOVER_DOCUMENT_DEADLINE_SCOUTS_TASK,
   },
   {
     description:

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -25,6 +25,7 @@ import { RECONCILE_FLOW_RUN_ORPHANS_TASK } from "@/api/lib/scheduler/tasks/flow-
 import { INFO_SOUD_SYNC_TRACKED_CASES_TASK } from "@/api/lib/scheduler/tasks/infosoud";
 import { MEMORY_CURATOR_TASK } from "@/api/lib/scheduler/tasks/memory-curator";
 import { MEMORY_EXTRACTOR_TASK } from "@/api/lib/scheduler/tasks/memory-extractor";
+import { RECONCILE_REPORT_EXPORTS_TASK } from "@/api/lib/scheduler/tasks/report-export-reconcile";
 import { REPAIR_CHAT_SEARCH_INDEX_TASK } from "@/api/lib/scheduler/tasks/search-chat-index";
 import { REPAIR_SEARCH_PROJECTIONS_TASK } from "@/api/lib/scheduler/tasks/search-projection-repair";
 import { REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK } from "@/api/lib/scheduler/tasks/search-semantic-timestamps";
@@ -248,6 +249,14 @@ export const DECLARED_SCHEDULER_JOBS = [
     mode: "recurring",
     schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
     task: RECONCILE_BILINGUAL_RUNS_TASK,
+  },
+  {
+    description:
+      "Re-drive report exports no queued job owns anymore, and fail the ones that outlived it",
+    id: "reportExports.reconcileQueued.fiveMinute",
+    mode: "recurring",
+    schedule: { type: "interval", everyMs: 5 * 60 * 1000 },
+    task: RECONCILE_REPORT_EXPORTS_TASK,
   },
   {
     description: "Delete style set packages a replacement left behind",

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -56,6 +56,10 @@ import {
   extractMemoriesFromCompactions,
 } from "@/api/lib/scheduler/tasks/memory-extractor";
 import {
+  RECONCILE_REPORT_EXPORTS_TASK,
+  reconcileReportExports,
+} from "@/api/lib/scheduler/tasks/report-export-reconcile";
+import {
   REPAIR_CHAT_SEARCH_INDEX_TASK,
   repairChatSearchIndex,
 } from "@/api/lib/scheduler/tasks/search-chat-index";
@@ -118,6 +122,7 @@ const SCHEDULER_TASKS = {
   [RECONCILE_DOCUMENT_REVIEW_RUNS_TASK]: reconcileDocumentReviewRuns,
   [RECONCILE_BILINGUAL_RUNS_TASK]: reconcileBilingualRuns,
   [RECONCILE_STYLE_SET_PACKAGE_CLEANUPS_TASK]: reconcileStyleSetPackageCleanups,
+  [RECONCILE_REPORT_EXPORTS_TASK]: reconcileReportExports,
 } as const satisfies Record<string, SchedulerTask>;
 
 export type RegisteredSchedulerTaskName = keyof typeof SCHEDULER_TASKS;

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -24,6 +24,10 @@ import {
   expireDesktopEditSessions,
 } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
 import {
+  RECOVER_DOCUMENT_DEADLINE_SCOUTS_TASK,
+  recoverDocumentDeadlineScouts,
+} from "@/api/lib/scheduler/tasks/document-deadline-scout-recovery";
+import {
   DISPATCH_DOCUMENT_OCR_TASK,
   dispatchDocumentOcr,
 } from "@/api/lib/scheduler/tasks/document-processing-ocr";
@@ -123,6 +127,7 @@ const SCHEDULER_TASKS = {
   [RECONCILE_BILINGUAL_RUNS_TASK]: reconcileBilingualRuns,
   [RECONCILE_STYLE_SET_PACKAGE_CLEANUPS_TASK]: reconcileStyleSetPackageCleanups,
   [RECONCILE_REPORT_EXPORTS_TASK]: reconcileReportExports,
+  [RECOVER_DOCUMENT_DEADLINE_SCOUTS_TASK]: recoverDocumentDeadlineScouts,
 } as const satisfies Record<string, SchedulerTask>;
 
 export type RegisteredSchedulerTaskName = keyof typeof SCHEDULER_TASKS;

--- a/apps/api/src/lib/scheduler/tasks/document-deadline-scout-recovery.ts
+++ b/apps/api/src/lib/scheduler/tasks/document-deadline-scout-recovery.ts
@@ -1,0 +1,30 @@
+import { panic } from "better-result";
+
+import { recoverDocumentDeadlineScoutDispatches } from "@/api/lib/document-processing-queue";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+
+export const RECOVER_DOCUMENT_DEADLINE_SCOUTS_TASK =
+  "documentProcessing.recoverDeadlineScouts" as const;
+
+/**
+ * Dispatch document deadline scouts nothing has picked up.
+ *
+ * The scout worker starts with the API server, but the only driver of this
+ * sweep was the document processing worker's reconciliation loop, so a
+ * `pending` scout accumulated in every deployment shape without that process.
+ * The scheduler runs wherever the API does, which is where the scouts are
+ * consumed.
+ */
+export const recoverDocumentDeadlineScouts: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  if (signal.aborted) {
+    panic("SchedulerAborted");
+  }
+  const { count, hasMore } = await recoverDocumentDeadlineScoutDispatches();
+  logger.info("scheduler.document_deadline_scouts_recovered", {
+    "documentDeadlineScouts.dispatched": count,
+    "documentDeadlineScouts.hasMore": hasMore,
+  });
+};

--- a/apps/api/src/lib/scheduler/tasks/report-export-reconcile.ts
+++ b/apps/api/src/lib/scheduler/tasks/report-export-reconcile.ts
@@ -1,0 +1,40 @@
+import { panic } from "better-result";
+
+import {
+  getReportExportQueue,
+  reconcileQueuedReportExports,
+} from "@/api/lib/report-export-enqueue";
+import { recoverStuckReportExports } from "@/api/lib/report-export-recovery";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+
+export const RECONCILE_REPORT_EXPORTS_TASK =
+  "reportExports.reconcileQueued" as const;
+
+/**
+ * Re-drive report exports the queue is not holding a job for anymore.
+ *
+ * The staleness janitor runs first: an export that has sat `queued` past its
+ * threshold has already outlived every requeue this sweep could give it, and
+ * failing it first keeps the reconciler from handing back a job for a row the
+ * same tick is about to close.
+ */
+export const reconcileReportExports: SchedulerTask = async ({
+  logger,
+  signal,
+}) => {
+  if (signal.aborted) {
+    panic("SchedulerAborted");
+  }
+  const recovered = await recoverStuckReportExports({
+    queue: getReportExportQueue(),
+  });
+  const { handedOff, scanned, unattributed, unrecoverable } =
+    await reconcileQueuedReportExports();
+  logger.info("scheduler.report_exports_reconciled", {
+    "reportExports.recovered": recovered,
+    "reportExports.requeued": handedOff,
+    "reportExports.scanned": scanned,
+    "reportExports.unattributed": unattributed,
+    "reportExports.unrecoverable": unrecoverable,
+  });
+};


### PR DESCRIPTION
Report exports keep their requested format and narrative flag on the row, so a queued export whose job is missing can be handed back to the queue by the scheduled sweep. Deadline-scout recovery runs from the scheduler as well.

- `report_exports.format` and `report_exports.ai_narrative` with a validating check, plus a partial index for the queued scan
- queue identity and the sweep move to `lib/report-export-enqueue.ts`; the handler keeps the worker
- scheduled tasks `reportExports.reconcileQueued` and `documentProcessing.recoverDeadlineScouts`
- tests cover the requeue with persisted options, paging past queue-owned rows, the per-tick handoff limit, and scout recovery
