### PR TITLE
feat(ui): board chrome rows, sticky lane summaries and hover card actions

### DIFF
--- a/.changeset/kanban-notion-chrome.md
+++ b/.changeset/kanban-notion-chrome.md
@@ -1,0 +1,10 @@
+---
+"@stll/ui": minor
+---
+
+Kanban board chrome now reads as one tight stack of rows: the column headers
+and every lane's own row share an exported height, and a lane's row is pinned
+on both axes, so its name and what each of its columns holds stay readable all
+the way down the lane. Bands keep their caption at the visible edge while the
+board scrolls sideways, cards can reveal their actions on hover, and the "add a
+card" row is drawn as the card it adds.

--- a/packages/ui/src/kanban/board-chrome.playwright.spec.ts
+++ b/packages/ui/src/kanban/board-chrome.playwright.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+const fixturePath = "/src/kanban/fixtures/board-chrome.fixture.html";
+
+/** Sub-pixel layout rounding, not a caption that drifted off the edge. */
+const TOLERANCE_PX = 1;
+
+/** `KANBAN_COLUMN_WIDTH_PX`, the unit this suite scrolls the board by. */
+const COLUMN_WIDTH_PX = 300;
+
+// A hovering pointer, which the suite's default device does not have: with a
+// coarse pointer the hover-revealed actions are shown at all times, and the
+// test asserting they appear would pass without ever revealing anything.
+test.use({
+  viewport: { width: 1280, height: 800 },
+  isMobile: false,
+  hasTouch: false,
+  deviceScaleFactor: 1,
+});
+
+const openFixture = async (page: Page) => {
+  await page.goto(fixturePath);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () =>
+            document.documentElement.dataset["kanbanBoardChromeReady"] ?? "",
+        ),
+    )
+    .toBe("true");
+  return page.locator(".fixture-board");
+};
+
+const leftOf = async (locator: Locator) =>
+  await locator.evaluate((element) => element.getBoundingClientRect().left);
+
+const rightOf = async (locator: Locator) =>
+  await locator.evaluate((element) => element.getBoundingClientRect().right);
+
+/**
+ * The inline-start edge of what the board actually shows: a sticky child
+ * comes to rest against the scroll container's content box, inside the
+ * board's own inline padding.
+ */
+const contentLeftOf = async (board: Locator) =>
+  await board.evaluate((element) => {
+    const padding = Number.parseFloat(
+      getComputedStyle(element).paddingInlineStart,
+    );
+    return element.getBoundingClientRect().left + element.clientLeft + padding;
+  });
+
+const scrollInlineTo = async (board: Locator, left: number) => {
+  await board.evaluate((element, value) => {
+    element.scrollLeft = value;
+  }, left);
+  await board.page().evaluate(async () => {
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        resolve(null);
+      });
+    });
+  });
+};
+
+const opacityOf = async (locator: Locator) =>
+  await locator.evaluate((element) => getComputedStyle(element).opacity);
+
+test.describe("band caption on a board scrolled sideways", () => {
+  test("holds the visible edge until the band it names is gone", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const caption = page.locator("[data-kanban-band-caption]").first();
+    const bandCell = page
+      .locator('[data-kanban-band-row] [data-kanban-band="todo"]')
+      .first();
+
+    const contentLeft = await contentLeftOf(board);
+    const scrolled = COLUMN_WIDTH_PX * 1.5;
+
+    // Unscrolled, the caption leads its own band, where it was written.
+    expect(
+      Math.abs((await leftOf(caption)) - (await leftOf(bandCell))),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+
+    // Past the first column, with the band's second column still on screen.
+    await scrollInlineTo(board, scrolled);
+
+    // The band moved with the board, and its second column is still shown...
+    expect(
+      Math.abs((await leftOf(bandCell)) - (contentLeft - scrolled)),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+    expect(await rightOf(bandCell)).toBeGreaterThan(contentLeft);
+    // ...while its caption travelled the same distance the other way, to hold
+    // the edge the reader is actually looking at.
+    expect(Math.abs((await leftOf(caption)) - contentLeft)).toBeLessThanOrEqual(
+      TOLERANCE_PX,
+    );
+    expect(
+      Math.abs((await leftOf(caption)) - (await leftOf(bandCell)) - scrolled),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+
+    // Once the band itself is behind us, the caption leaves with it rather
+    // than naming whatever column happens to be under it now.
+    await scrollInlineTo(board, COLUMN_WIDTH_PX * 2.5);
+
+    expect(await rightOf(bandCell)).toBeLessThan(contentLeft);
+    expect(await rightOf(caption)).toBeLessThanOrEqual(contentLeft);
+  });
+});
+
+test.describe("hover-revealed card actions", () => {
+  test("reveals them on the card under the pointer and lets them be hit", async ({
+    page,
+  }) => {
+    await openFixture(page);
+    const card = page.locator('[data-card="open-1"]');
+    const actions = card.locator('[data-kanban-card-actions="hover"]');
+
+    expect(await opacityOf(actions)).toBe("0");
+
+    await card.hover();
+
+    // The reveal is a transition, so it lands a frame or two later.
+    await expect.poll(async () => await opacityOf(actions)).toBe("1");
+
+    // Visible is not the same as usable: the pinned identity row leads the
+    // same corner, so the trigger has to be what the pointer actually finds.
+    const hit = await actions.evaluate((element) => {
+      const { left, top, width, height } = element.getBoundingClientRect();
+      return element.contains(
+        document.elementFromPoint(left + width / 2, top + height / 2),
+      );
+    });
+
+    expect(hit).toBe(true);
+  });
+
+  test("leaves the actions of the cards the pointer is not on hidden", async ({
+    page,
+  }) => {
+    await openFixture(page);
+    const hovered = page
+      .locator('[data-card="open-1"] [data-kanban-card-actions="hover"]')
+      .first();
+    const other = page
+      .locator('[data-card="blocked-1"] [data-kanban-card-actions="hover"]')
+      .first();
+
+    await page.locator('[data-card="open-1"]').hover();
+    await expect.poll(async () => await opacityOf(hovered)).toBe("1");
+
+    expect(await opacityOf(other)).toBe("0");
+  });
+});

--- a/packages/ui/src/kanban/card-shell.test.tsx
+++ b/packages/ui/src/kanban/card-shell.test.tsx
@@ -30,8 +30,13 @@ describe("KanbanCardShell sticky header", () => {
     expect(markup).toContain('data-kanban-card-sticky-header=""');
     expect(markup).toContain(KANBAN_CARD_STICKY_TOP_CLASS);
     // The card passes behind the row: its own surface, over the card's own
-    // divider weight.
-    expect(markup).toContain("bg-card sticky");
+    // divider weight. `bg-card` alone would let a consumer define the surface
+    // with an alpha channel and read the held-back cards straight through it,
+    // so the card colour goes down as a layer over the opaque page ground.
+    expect(markup).toContain("bg-background");
+    expect(markup).toContain(
+      "bg-[linear-gradient(var(--color-card),var(--color-card))]",
+    );
     expect(markup).toContain("border-b");
     expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("body"));
   });
@@ -68,6 +73,69 @@ describe("KanbanCardShell sticky header", () => {
     expect(markup).toContain('role="button"');
     expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("body"));
     expect(markup.indexOf("body")).toBeLessThan(markup.indexOf("More"));
+  });
+
+  test("leaves an always-visible actions overlay exactly where the caller put it", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell actions={<button type="button">More</button>}>
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+
+    // The default is the behaviour every existing board relies on: the shell
+    // adds no wrapper, so a caller's own anchoring still decides the corner.
+    expect(markup).not.toContain("data-kanban-card-actions");
+    expect(markup).not.toContain("opacity-0");
+  });
+
+  test("reveals hover actions on hover, focus, an open menu, and coarse pointers", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell
+        actions={<button type="button">More</button>}
+        actionsVisibility="hover"
+      >
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+    const wrapper =
+      /<div[^>]*data-kanban-card-actions="hover"[^>]*>/u.exec(markup)?.[0] ??
+      "";
+
+    expect(wrapper).toContain("opacity-0");
+    expect(wrapper).toContain("group-hover/card:opacity-100");
+    // The hover group the wrapper answers to is on the shell's own wrapper.
+    expect(markup).toContain("group/card");
+    // Focus keeps them reachable from the keyboard, an open menu keeps its
+    // own trigger from vanishing under the popup, and a pointer that cannot
+    // hover would otherwise never reveal them at all.
+    expect(wrapper).toContain("focus-within:opacity-100");
+    expect(wrapper).toContain("has-[[aria-expanded=true]]:opacity-100");
+    expect(wrapper).toContain("[@media(hover:none)]:opacity-100");
+    // The fade is decoration; a reader who asked for less motion still gets
+    // the actions, just without the transition.
+    expect(wrapper).toContain("motion-reduce:transition-none");
+  });
+
+  test("puts hover actions over the pinned identity row that leads the corner", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell
+        actions={<button type="button">More</button>}
+        actionsVisibility="hover"
+        stickyHeader={<span>ACME-1</span>}
+      >
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+    const wrapper =
+      /<div[^>]*data-kanban-card-actions="hover"[^>]*>/u.exec(markup)?.[0] ??
+      "";
+
+    // Positioned in the same corner as the row, and later in the tree, so
+    // only a layer of its own keeps the trigger clickable.
+    expect(wrapper).toContain("absolute");
+    expect(wrapper).toContain("end-1.5");
+    expect(wrapper).toContain("z-10");
+    expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("More"));
   });
 
   test("never clips the card that bounds the pinned row", () => {

--- a/packages/ui/src/kanban/card-shell.tsx
+++ b/packages/ui/src/kanban/card-shell.tsx
@@ -9,10 +9,25 @@ export type KanbanCardShellProps = {
   /** Overlay slot pinned to the top-end corner (row actions). */
   actions?: ReactNode;
   /**
+   * Whether `actions` are drawn at all times or only once the card is under
+   * the pointer. `"hover"` also hands their placement to the shell, so the
+   * quiet actions of every board rest in the same corner and a caller passes
+   * bare icon buttons; `"always"` (the default) leaves a caller's own overlay
+   * exactly where it put it.
+   *
+   * A pointer that cannot hover would never reveal them, so a coarse pointer
+   * keeps them shown.
+   */
+  actionsVisibility?: "always" | "hover" | undefined;
+  /**
    * The card's identity row: whatever says which card this is, held at the top
    * of the card while the card scrolls past under it, and released where the
    * card ends. A card taller than the viewport otherwise loses its own name
    * halfway down. Omit it and the card renders exactly as it did before.
+   *
+   * The row runs the card's full width and the actions overlay leads the same
+   * corner over it, so leave the row's end side clear of anything the actions
+   * would cover.
    *
    * Booleans are excluded so `condition && <Row />` cannot reach the slot: a
    * `false` React renders as nothing would still leave the row's divider and
@@ -49,6 +64,7 @@ export type KanbanCardShellProps = {
 export const KanbanCardShell = ({
   children,
   actions,
+  actionsVisibility = "always",
   stickyHeader,
   active,
   onOpen,
@@ -67,7 +83,13 @@ export const KanbanCardShell = ({
         </div>
       )}
       {children}
-      {actions}
+      {actionsVisibility === "hover" && actions !== undefined ? (
+        <div className={HOVER_ACTIONS_CLASS} data-kanban-card-actions="hover">
+          {actions}
+        </div>
+      ) : (
+        actions
+      )}
     </>
   );
 
@@ -123,9 +145,31 @@ const ACTIVE_CLASS = "ring-primary/30 ring-2";
  * passes behind it instead of reading through it, ruled off with the card's own
  * border weight.
  *
+ * `bg-card` on its own is not enough: a consumer is free to define that token
+ * with an alpha channel, and a translucent pinned row lets the very cards it
+ * is holding back read through it. The card colour goes down as a flat
+ * gradient layer over the opaque page background instead, which is the card's
+ * own surface at full opacity whatever the token turns out to be.
+ *
  * No `z-index`: being positioned is already enough to paint over the card's
  * flow content, and taking a layer would put the row over the `actions`
  * overlay, which callers anchor to the same corner with no layer of its own.
  * Tree order settles the rest, and the row renders before `actions`.
  */
-const STICKY_HEADER_CLASS = "bg-card sticky mb-2 border-b pb-2";
+const STICKY_HEADER_CLASS =
+  "bg-background bg-[linear-gradient(var(--color-card),var(--color-card))] sticky mb-2 border-b pb-2";
+
+/**
+ * Where the shell puts the actions it reveals on hover.
+ *
+ * The overlay takes a layer of its own here, unlike the always-visible slot:
+ * it has to stay over the pinned identity row that leads the same corner, and
+ * the row's own comment explains why the row cannot take one instead. An open
+ * menu holds the actions on through its trigger's `aria-expanded`, or the
+ * trigger would disappear from under the popup it just opened.
+ *
+ * The fade is decoration: a reader who asked for less motion still gets the
+ * actions, they simply arrive at once.
+ */
+const HOVER_ACTIONS_CLASS =
+  "absolute end-1.5 top-1.5 z-10 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/card:opacity-100 focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100";

--- a/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
+++ b/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
@@ -102,6 +102,19 @@ test.describe("card sticky header", () => {
     await scrollTo(board, 300);
     await expectRestingOnAction(first, await bottomOf(action));
 
+    // Everything pinned above the card, in order: the board's header, then
+    // the lane's own row, then the cell's action, then this row. A card that
+    // counted only the action would park its row behind the lane row.
+    const header = page.locator("[data-kanban-board-header]");
+    const laneRow = page.locator("[data-kanban-lane-row]").first();
+
+    expect(
+      Math.abs((await topOf(laneRow)) - (await bottomOf(header))),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+    expect(
+      Math.abs((await topOf(action)) - (await bottomOf(laneRow))),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+
     // The card passes behind the row rather than reading through it.
     const background = await first.evaluate(
       (element) => getComputedStyle(element).backgroundColor,

--- a/packages/ui/src/kanban/cell-action.test.tsx
+++ b/packages/ui/src/kanban/cell-action.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "bun:test";
 
 import { KanbanCellAction } from "./cell-action";
+import { KANBAN_CHROME_ROW_HEIGHT } from "./layout-tokens";
 
 // Static markup carries no layout; these tests pin the structure and the
 // utilities that give every cell the same ending row.
@@ -20,15 +21,23 @@ const readButton = (markup: string) => {
 };
 
 describe("KanbanCellAction", () => {
-  test("renders one full-width ghost row on the card rhythm", () => {
+  test("renders one full-width row outlined as the card it adds", () => {
     const markup = renderToStaticMarkup(
       <KanbanCellAction>New card</KanbanCellAction>,
     );
     const classes = /class="([^"]*)"/u.exec(readButton(markup))?.[1] ?? "";
 
     expect(classes.split(" ")).toEqual(
-      expect.arrayContaining(["min-h-11", "w-full", "justify-start"]),
+      expect.arrayContaining([
+        KANBAN_CHROME_ROW_HEIGHT,
+        "border-dashed",
+        "w-full",
+        "justify-start",
+      ]),
     );
+    // The button's own size drops a step at `sm`, which would take the row
+    // off the board's chrome rhythm on every desktop width.
+    expect(classes.split(" ")).toContain(`sm:${KANBAN_CHROME_ROW_HEIGHT}`);
     expect(markup.indexOf("<svg")).toBeLessThan(markup.indexOf("New card"));
   });
 

--- a/packages/ui/src/kanban/cell-action.tsx
+++ b/packages/ui/src/kanban/cell-action.tsx
@@ -4,6 +4,7 @@ import { PlusIcon } from "lucide-react";
 
 import { Button } from "../components/button";
 import { cn } from "../lib/utils";
+import { KANBAN_CHROME_ROW_HEIGHT } from "./layout-tokens";
 
 export type KanbanCellActionProps = Omit<
   ComponentProps<typeof Button>,
@@ -11,12 +12,20 @@ export type KanbanCellActionProps = Omit<
 >;
 
 /**
- * The quiet action at the end of a cell: a full-width ghost row that adds a
- * card to that column and lane.
+ * The quiet action at the end of a cell: a full-width row that adds a card to
+ * that column and lane.
  *
  * Every board rendered its own copy of this row and the copies drifted in
  * height, tone, and icon size. One primitive keeps the footer of every cell on
  * the same rhythm as a card, so an empty cell and a full one end the same way.
+ *
+ * It is drawn as the outline of a card rather than as a button: the row stands
+ * where the next card will, so a dashed card-shaped slot says what pressing it
+ * produces, which a ghost button in the same place never did. It stays a
+ * `Button` underneath for the focus ring and the coarse-pointer touch target
+ * the variant already carries; only the height is restated per breakpoint,
+ * since the button's own size drops a step at `sm` and the row has to hold the
+ * board's chrome rhythm at every width.
  */
 export const KanbanCellAction = ({
   children,
@@ -25,7 +34,9 @@ export const KanbanCellAction = ({
 }: KanbanCellActionProps) => (
   <Button
     className={cn(
-      "text-muted-foreground hover:text-foreground min-h-11 w-full justify-start gap-1.5",
+      "border-border/70 text-muted-foreground hover:bg-muted/40 hover:text-foreground flex w-full items-center justify-start gap-1.5 rounded-lg border border-dashed px-3 text-sm",
+      KANBAN_CHROME_ROW_HEIGHT,
+      "sm:h-9",
       className,
     )}
     data-slot="kanban-cell-action"

--- a/packages/ui/src/kanban/column-band-header.tsx
+++ b/packages/ui/src/kanban/column-band-header.tsx
@@ -4,6 +4,7 @@ import { ChevronDownIcon } from "lucide-react";
 
 import { DirectionalIcon } from "../components/directional-icon";
 import { cn } from "../lib/utils";
+import { KANBAN_BAND_CAPTION_ROW_HEIGHT } from "./layout-tokens";
 
 /**
  * How a band toggle was activated. A pointer activation leaves the pointer
@@ -38,8 +39,9 @@ export type KanbanColumnBandHeaderProps = {
 };
 
 /**
- * The band line above a run of columns: one 28px row of toggle, swatch, name,
- * and count, so a band costs the board a caption's height and nothing more.
+ * The band line above a run of columns: one `KANBAN_BAND_CAPTION_ROW_HEIGHT`
+ * row of toggle, swatch, name, and count, so a band costs the board a
+ * caption's height and nothing more.
  * Folded, only the toggle remains in this line; the band's name moves down
  * into the narrow column body, where the height is already there.
  */
@@ -55,7 +57,8 @@ export const KanbanColumnBandHeader = ({
 }: KanbanColumnBandHeaderProps) => (
   <div
     className={cn(
-      "flex h-7 items-center gap-1",
+      "flex items-center gap-1",
+      KANBAN_BAND_CAPTION_ROW_HEIGHT,
       compact ? "justify-center" : "pe-1",
     )}
     data-collapsed={collapsed ? "" : undefined}

--- a/packages/ui/src/kanban/column-header.test.tsx
+++ b/packages/ui/src/kanban/column-header.test.tsx
@@ -3,20 +3,25 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "bun:test";
 
 import { KanbanColumnHeader } from "./column-header";
+import { KANBAN_CHROME_ROW_HEIGHT } from "./layout-tokens";
 
 // Static markup carries no layout; this test pins the classes that keep the
 // column top on the shared chrome row height and stop a long title from
 // growing it.
 
 describe("KanbanColumnHeader", () => {
-  test("carries the toolbar row height and truncates the title", () => {
+  test("carries the chrome row height and truncates the title", () => {
     const markup = renderToStaticMarkup(
       <KanbanColumnHeader title="A very long column name" />,
     );
     const rootClass = /class="([^"]*)"/u.exec(markup)?.[1] ?? "";
 
     expect(rootClass.split(" ")).toEqual(
-      expect.arrayContaining(["h-12", "items-center", "px-3"]),
+      expect.arrayContaining([
+        KANBAN_CHROME_ROW_HEIGHT,
+        "items-center",
+        "px-3",
+      ]),
     );
     expect(rootClass).not.toContain("py-2");
     expect(markup).toContain("truncate");

--- a/packages/ui/src/kanban/column-header.tsx
+++ b/packages/ui/src/kanban/column-header.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
-import { TOOLBAR_ROW_HEIGHT } from "../inspector/layout-tokens";
 import { cn } from "../lib/utils";
+import { KANBAN_CHROME_ROW_HEIGHT } from "./layout-tokens";
 
 export type KanbanColumnHeaderProps = {
   /** Colour swatch, or the control that changes it. */
@@ -24,10 +24,10 @@ export type KanbanColumnHeaderProps = {
  * The column header row: one rhythm for the swatch, the name, the count, the
  * calculation, and the column's controls, so every board's header lines up.
  *
- * Fixed at `TOOLBAR_ROW_HEIGHT`, the same height as the page header, the view
- * switcher, and the inspector rail's cells, so a column's top edge lines up
- * with every other chrome row above the board. The title clips instead of
- * wrapping so a long name can never grow the row past that height.
+ * Fixed at `KANBAN_CHROME_ROW_HEIGHT`, the height a lane's own rows take, so
+ * every chrome row on the board sits on one rhythm and a column's top edge
+ * lines up with the lane rows under it. The title clips instead of wrapping
+ * so a long name can never grow the row past that height.
  */
 export const KanbanColumnHeader = ({
   swatch,
@@ -41,7 +41,7 @@ export const KanbanColumnHeader = ({
   <div
     className={cn(
       "flex items-center gap-2 px-3",
-      TOOLBAR_ROW_HEIGHT,
+      KANBAN_CHROME_ROW_HEIGHT,
       className,
     )}
   >

--- a/packages/ui/src/kanban/fixtures/board-chrome.fixture.css
+++ b/packages/ui/src/kanban/fixtures/board-chrome.fixture.css
@@ -1,0 +1,3 @@
+@import "tailwindcss";
+@import "../../styles/theme.css";
+@source "../../";

--- a/packages/ui/src/kanban/fixtures/board-chrome.fixture.html
+++ b/packages/ui/src/kanban/fixtures/board-chrome.fixture.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Board chrome fixture</title>
+    <link rel="stylesheet" href="./board-chrome.fixture.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./board-chrome.fixture.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/src/kanban/fixtures/board-chrome.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/board-chrome.fixture.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from "react";
+import { createRoot } from "react-dom/client";
+
+import { KanbanCardShell } from "../card-shell";
+import { KanbanColumnHeader } from "../column-header";
+import { resolveKanbanGrouping } from "../grouping";
+import type { KanbanSchema } from "../grouping";
+import { buildKanbanBoardMatrix } from "../matrix";
+import { KanbanSubgroupBoard } from "../subgroup-board";
+
+type Row = { id: string; owner: string; status: string };
+type Property = { id: string };
+
+const band = { id: "todo", label: "To do" };
+
+const schema: KanbanSchema<Row, Property> = {
+  builtInGroups: [
+    {
+      id: "_status",
+      options: [
+        { band, label: "Open", value: "open" },
+        { band, label: "Blocked", value: "blocked" },
+        { label: "Done", value: "done" },
+      ],
+    },
+  ],
+  getPropertyId: ({ id }) => id,
+  getPropertyOptions: ({ id }) =>
+    id === "owner" ? [{ label: "Ada", value: "ada" }] : null,
+  properties: [{ id: "owner" }],
+};
+
+const rows: Row[] = [
+  { id: "open-1", owner: "ada", status: "open" },
+  { id: "blocked-1", owner: "ada", status: "blocked" },
+  { id: "done-1", owner: "ada", status: "done" },
+];
+
+const matrix = buildKanbanBoardMatrix({
+  group: resolveKanbanGrouping({ groupBy: "_status", schema }),
+  subgroup: resolveKanbanGrouping({ groupBy: "owner", schema }),
+  rows,
+  uncategorizedLabel: "No value",
+  resolveGroupValue: ({ grouping, row }) =>
+    grouping.type === "built-in" ? row.status : row.owner,
+});
+
+const BoardChromeFixture = () => {
+  useEffect(() => {
+    document.documentElement.dataset["kanbanBoardChromeReady"] = "true";
+    return () => {
+      delete document.documentElement.dataset["kanbanBoardChromeReady"];
+    };
+  }, []);
+
+  return (
+    // Narrower than the board's own columns at any viewport the suite runs
+    // at, so the board always has somewhere to scroll sideways to.
+    <div className="h-[420px] w-[500px]">
+      <KanbanSubgroupBoard
+        className="fixture-board"
+        isBandCollapsed={() => false}
+        isLaneCollapsed={() => false}
+        matrix={matrix}
+        renderCell={({ cell }) => (
+          <div className="flex flex-col gap-2">
+            {cell.rows.map((row) => (
+              <div data-card={row.id} key={row.id}>
+                <KanbanCardShell
+                  actions={
+                    <button data-card-actions={row.id} type="button">
+                      More
+                    </button>
+                  }
+                  actionsVisibility="hover"
+                >
+                  <span className="text-xs">{row.id}</span>
+                </KanbanCardShell>
+              </div>
+            ))}
+          </div>
+        )}
+        renderColumnHeader={({ column }) => (
+          <KanbanColumnHeader
+            title={column.type === "group" ? column.group.label : "Other"}
+          />
+        )}
+        renderLaneIdentity={({ group }) => (
+          <span data-lane={group.value}>{group.label}</span>
+        )}
+        onBandCollapsedChange={() => undefined}
+        onLaneCollapsedChange={() => undefined}
+      />
+    </div>
+  );
+};
+
+const root = document.querySelector("#root");
+
+if (root) {
+  createRoot(root).render(<BoardChromeFixture />);
+}

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -31,6 +31,12 @@ export {
 } from "./column-bands";
 export type { KanbanColumnHeaderProps } from "./column-header";
 export { KanbanColumnHeader } from "./column-header";
+export {
+  KANBAN_BAND_CAPTION_ROW_HEIGHT,
+  KANBAN_BAND_CAPTION_ROW_HEIGHT_PX,
+  KANBAN_CHROME_ROW_HEIGHT,
+  KANBAN_CHROME_ROW_HEIGHT_PX,
+} from "./layout-tokens";
 export type {
   KanbanCardDragSurfaceProps,
   KanbanDragHandleProps,
@@ -128,6 +134,8 @@ export type {
   KanbanSubgroupCellContext,
   KanbanSubgroupCollapsedBandCellContext,
   KanbanSubgroupColumnHeaderContext,
+  KanbanSubgroupLaneColumnActionContext,
+  KanbanSubgroupLaneColumnSummaryContext,
   KanbanSubgroupLaneIdentityContext,
 } from "./subgroup-board";
 export {

--- a/packages/ui/src/kanban/layout-tokens.test.ts
+++ b/packages/ui/src/kanban/layout-tokens.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  KANBAN_BAND_CAPTION_ROW_HEIGHT,
+  KANBAN_BAND_CAPTION_ROW_HEIGHT_PX,
+  KANBAN_CHROME_ROW_HEIGHT,
+  KANBAN_CHROME_ROW_HEIGHT_PX,
+} from "./layout-tokens";
+
+/** Tailwind's default spacing step, which every `h-*` utility is a count of. */
+const SPACING_STEP_PX = 4;
+
+const heightOf = (utility: string): number => {
+  const match = /^h-(?<steps>\d+(?:\.\d+)?)$/u.exec(utility);
+
+  if (!match?.groups) {
+    throw new Error(`not a spacing-scale height: ${utility}`);
+  }
+
+  return Number(match.groups["steps"]) * SPACING_STEP_PX;
+};
+
+// One of each pair draws the row and the other offsets everything pinned
+// under it, so the two drifting apart parks a sticky control a few pixels off
+// the row above it — visible, and traceable to nothing in particular.
+describe("kanban chrome row heights", () => {
+  test("state the same height as a class and as a measurement", () => {
+    expect(heightOf(KANBAN_CHROME_ROW_HEIGHT)).toBe(
+      KANBAN_CHROME_ROW_HEIGHT_PX,
+    );
+    expect(heightOf(KANBAN_BAND_CAPTION_ROW_HEIGHT)).toBe(
+      KANBAN_BAND_CAPTION_ROW_HEIGHT_PX,
+    );
+  });
+
+  test("keep a band's caption line shorter than the rows of chrome", () => {
+    expect(KANBAN_BAND_CAPTION_ROW_HEIGHT_PX).toBeLessThan(
+      KANBAN_CHROME_ROW_HEIGHT_PX,
+    );
+  });
+});

--- a/packages/ui/src/kanban/layout-tokens.ts
+++ b/packages/ui/src/kanban/layout-tokens.ts
@@ -1,0 +1,27 @@
+/**
+ * The heights the board's chrome rows are built from.
+ *
+ * A board stacks several rows of chrome above the first card — the band
+ * caption, the column headers, a lane's identity and its per-column
+ * summaries — and every one of them is pinned at some point, so their heights
+ * are what a card's own pinned row is offset by. Naming them once keeps the
+ * rows on a single rhythm and keeps the pixel value that offsets a sticky
+ * control in step with the class that draws the row.
+ */
+
+/**
+ * The column header row and a lane's rows: a *fixed* height, tighter than the
+ * inspector's 48px toolbar row, because a board shows three of these before
+ * the first card and each one costs the cards their space. Fixed rather than
+ * minimum: a row that grows with its content moves every offset below it.
+ */
+export const KANBAN_CHROME_ROW_HEIGHT = "h-9" as const;
+export const KANBAN_CHROME_ROW_HEIGHT_PX = 36 as const;
+
+/**
+ * The band caption line, one step shorter again: a band names a run of
+ * columns rather than holding controls of its own, so it reads as a label
+ * over the header row rather than a second row of chrome.
+ */
+export const KANBAN_BAND_CAPTION_ROW_HEIGHT = "h-7" as const;
+export const KANBAN_BAND_CAPTION_ROW_HEIGHT_PX = 28 as const;

--- a/packages/ui/src/kanban/sticky-lane-controls.playwright.spec.ts
+++ b/packages/ui/src/kanban/sticky-lane-controls.playwright.spec.ts
@@ -40,8 +40,8 @@ const scrollTo = async (board: Locator, top: number) => {
 
 /**
  * One lane's own pinned controls. The board renders a lane per section, and a
- * lane carries a pinned action per open column and a caption per folded band,
- * so each control is read inside the lane it belongs to.
+ * lane carries its own row, a pinned action per open column, and a caption per
+ * folded band, so each control is read inside the lane it belongs to.
  */
 const laneControls = (page: Page, lane: number) => {
   const section = page.locator("section").nth(lane);
@@ -52,6 +52,7 @@ const laneControls = (page: Page, lane: number) => {
     action: actions.first(),
     caption: section.locator("[data-kanban-collapsed-band-caption]").first(),
     plainAction: actions.nth(1),
+    row: section.locator("[data-kanban-lane-row]"),
   };
 };
 
@@ -66,35 +67,40 @@ const expectOpaque = async (control: Locator) => {
   expect(background).not.toContain("/");
 };
 
-/** Resting on the header: the control's top edge is the header's bottom. */
-const expectRestingOnHeader = async (
-  control: Locator,
-  headerBottom: number,
-) => {
-  expect(Math.abs((await topOf(control)) - headerBottom)).toBeLessThanOrEqual(
+/** Resting on what is pinned above: the control's top edge is that bottom. */
+const expectRestingUnder = async (control: Locator, pinnedBottom: number) => {
+  expect(Math.abs((await topOf(control)) - pinnedBottom)).toBeLessThanOrEqual(
     TOLERANCE_PX,
   );
 };
 
 test.describe("sticky lane controls", () => {
-  test("holds a lane's action and folded caption under the board header", async ({
+  test("holds a lane's row on the header and its controls under that row", async ({
     page,
   }) => {
     const board = await openFixture(page);
     const header = page.locator("[data-kanban-board-header]");
-    const { action, caption, plainAction } = laneControls(page, 0);
+    const { action, caption, plainAction, row } = laneControls(page, 0);
 
-    // Unscrolled, both sit where the lane starts: below the header, not on it.
+    // Unscrolled, all of them sit where the lane starts: below the header,
+    // not on it.
+    expect(await topOf(row)).toBeGreaterThan(await bottomOf(header));
     expect(await topOf(action)).toBeGreaterThan(await bottomOf(header));
     expect(await topOf(caption)).toBeGreaterThan(await bottomOf(header));
 
     await scrollTo(board, 600);
 
-    const headerBottom = await bottomOf(header);
-    await expectRestingOnHeader(action, headerBottom);
-    await expectRestingOnHeader(caption, headerBottom);
-    await expectRestingOnHeader(plainAction, headerBottom);
-    // Both the accented cell and the one on the neutral resting surface.
+    // The lane's own row is what comes to rest on the board's header...
+    await expectRestingUnder(row, await bottomOf(header));
+    // ...and everything the lane pins comes to rest under that row, rather
+    // than behind it.
+    const rowBottom = await bottomOf(row);
+    await expectRestingUnder(action, rowBottom);
+    await expectRestingUnder(caption, rowBottom);
+    await expectRestingUnder(plainAction, rowBottom);
+    // The lane row and both cells: the accented one and the one on the
+    // neutral resting surface.
+    await expectOpaque(row);
     await expectOpaque(action);
     await expectOpaque(plainAction);
     // Over that base, the row repaints the cell's own accent wash.
@@ -103,6 +109,21 @@ test.describe("sticky lane controls", () => {
         .locator("> div")
         .evaluate((element) => getComputedStyle(element).backgroundColor),
     ).not.toBe("rgba(0, 0, 0, 0)");
+  });
+
+  test("keeps a lane's per-column summaries in its row while the lane is open", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const { row } = laneControls(page, 0);
+    // The fixture keeps every lane open; the summaries used to appear only
+    // once a lane was collapsed, which is exactly when nobody needs them.
+    const summaries = row.locator("[data-kanban-lane-column-count]");
+
+    await scrollTo(board, 600);
+
+    expect(await summaries.count()).toBeGreaterThan(0);
+    await expect(summaries.first()).toBeVisible();
   });
 
   test("releases them where the lane ends and hands over to the next", async ({
@@ -120,11 +141,15 @@ test.describe("sticky lane controls", () => {
 
     const headerBottom = await bottomOf(header);
 
-    // The lane that ended took its controls with it...
+    // The lane that ended took its row and its controls with it...
+    expect(await topOf(scrolled.row)).toBeLessThan(headerBottom);
     expect(await topOf(scrolled.action)).toBeLessThan(headerBottom);
     expect(await topOf(scrolled.caption)).toBeLessThan(headerBottom);
     // ...and the lane now under the header holds its own.
-    await expectRestingOnHeader(next.action, headerBottom);
-    await expectRestingOnHeader(next.caption, headerBottom);
+    await expectRestingUnder(next.row, headerBottom);
+
+    const nextRowBottom = await bottomOf(next.row);
+    await expectRestingUnder(next.action, nextRowBottom);
+    await expectRestingUnder(next.caption, nextRowBottom);
   });
 });

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -5,8 +5,9 @@ import { describe, expect, test } from "bun:test";
 import { KanbanColumnBandHeader } from "./column-band-header";
 import type { KanbanSchema } from "./grouping";
 import { resolveKanbanGrouping } from "./grouping";
+import { KANBAN_CHROME_ROW_HEIGHT } from "./layout-tokens";
 import { buildKanbanBoardMatrix } from "./matrix";
-import { KANBAN_STICKY_TOP_VAR } from "./sticky-lane";
+import { KANBAN_STICKY_TOP_CLASS, KANBAN_STICKY_TOP_VAR } from "./sticky-lane";
 import { KanbanSubgroupBoard } from "./subgroup-board";
 
 type Row = { id: string; owner: string | null; status: string | null };
@@ -101,17 +102,94 @@ describe("KanbanSubgroupBoard", () => {
     const expanded = renderBoard(matrix, true);
 
     expect(collapsed).toContain("lane:lin:0");
-    // Only the collapsed (empty) lanes carry a count row; the open lane
-    // shows its cells instead.
-    expect(collapsed).toContain('data-kanban-lane-column-count="0"');
-    expect(collapsed).not.toContain('data-kanban-lane-column-count="1"');
     expect(collapsed).not.toContain("cell:lin:open:0");
     expect(collapsed).toContain('aria-expanded="false"');
     expect(expanded).toContain("cell:lin:open:0");
     expect(expanded).toContain("cell:lin:done:0");
-    // An open lane shows its cells; the count row stands in only while
-    // the lane is collapsed.
-    expect(expanded).not.toContain("data-kanban-lane-column-count");
+    // A lane's summaries stand beside its cells rather than in place of
+    // them, so an open lane carries them too: the row is pinned, and it is
+    // what tells a reader deep in a lane what each column holds.
+    expect(collapsed).toContain('data-kanban-lane-column-count="0"');
+    expect(expanded).toContain('data-kanban-lane-column-count="1"');
+  });
+
+  test("pins a lane's row on both axes and offsets its cells by it", () => {
+    const markup = renderBoard(matrix, true);
+    const laneRow =
+      /<div[^>]*data-kanban-lane-row=""[^>]*>/u.exec(markup)?.[0] ?? "";
+
+    // Under the board's header, and below it: the header is z-20.
+    expect(laneRow).toContain("sticky");
+    expect(laneRow).toContain(KANBAN_STICKY_TOP_CLASS);
+    expect(laneRow).toContain("z-10");
+    // Opaque, or the cards it holds back read through it.
+    expect(laneRow).toContain("bg-background");
+    // The identity holds the visible inline edge, and has to size to its own
+    // content to have any room to travel there.
+    expect(markup).toContain("sticky start-0 flex w-fit");
+    // The cells are told what the header *and* the lane row reach, or a
+    // card's own pinned row would come to rest behind the lane's.
+    expect(markup).toContain(`${KANBAN_STICKY_TOP_VAR}:72px`);
+  });
+
+  test("gives the lane toggle a finger's target on the 36px chrome row", () => {
+    const markup = renderBoard(matrix, true);
+    const toggle = /<button[^>]*aria-expanded="true"[^>]*>/u.exec(markup)?.[0];
+
+    // The row is fixed at 36px, under Stella's 44px minimum, so the toggle
+    // extends its touch surface the way the shared button does rather than
+    // growing the visible control and taking the row off the board's rhythm.
+    expect(toggle).toContain(KANBAN_CHROME_ROW_HEIGHT);
+    expect(toggle).toContain("relative");
+    expect(toggle).toContain("pointer-coarse:after:absolute");
+    expect(toggle).toContain("pointer-coarse:after:min-h-11");
+    // Centred on the toggle: growing downwards alone would reach into the
+    // summaries row under it.
+    expect(toggle).toContain("pointer-coarse:after:-inset-y-1");
+  });
+
+  test("hands a lane's per-column cell to the caller's summary and action", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanSubgroupBoard
+        isLaneCollapsed={() => false}
+        matrix={matrix}
+        renderCell={() => <span>cell</span>}
+        renderColumnHeader={() => <span>column</span>}
+        renderLaneColumnAction={({ column, lane }) => (
+          <button type="button">
+            {testLabel(
+              "add",
+              lane.value,
+              column.type === "group" ? column.group.value : "other",
+            )}
+          </button>
+        )}
+        renderLaneColumnSummary={({ column, count, lane }) => (
+          <span>
+            {testLabel(
+              "summary",
+              lane.value,
+              column.type === "group" ? column.group.value : "other",
+              count,
+            )}
+          </span>
+        )}
+        renderLaneIdentity={({ group: lane }) => <span>{lane.label}</span>}
+        onLaneCollapsedChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("summary:ada:open:1");
+    expect(markup).toContain("add:ada:open");
+    // The caller's summary replaces the default count rather than joining it.
+    expect(markup).not.toContain(
+      '<span class="text-muted-foreground text-xs tabular-nums">1</span></div>',
+    );
+    // Summary first, the action pushed to the cell's end.
+    expect(markup.indexOf("summary:ada:open:1")).toBeLessThan(
+      markup.indexOf("add:ada:open"),
+    );
+    expect(markup).toContain("ms-auto");
   });
 
   test("renders one board row when subgrouping is absent", () => {
@@ -305,6 +383,22 @@ describe("KanbanSubgroupBoard with column bands", () => {
     expect(folded).toContain('data-kanban-collapsed-band-count="2"');
   });
 
+  test("keeps an open band's caption at the visible edge of its own band", () => {
+    const markup = renderBanded(false);
+    const caption =
+      /<div[^>]*data-kanban-band-caption=""[^>]*>/u.exec(markup)?.[0] ?? "";
+
+    expect(caption).toContain("sticky");
+    expect(caption).toContain("start-0");
+    // Sized to its content, or it fills the band's header cell and has no
+    // room to travel at all; bounded by the band, past which a caption for
+    // that band means nothing.
+    expect(caption).toContain("w-fit");
+    expect(caption).toContain("max-w-full");
+    // It slides over its own band's columns, so it cannot be transparent.
+    expect(caption).toContain("bg-background");
+  });
+
   test("keeps a folded band's caption under the header down its lane", () => {
     const folded = renderToStaticMarkup(
       <KanbanSubgroupBoard
@@ -339,10 +433,13 @@ describe("KanbanSubgroupBoard with column bands", () => {
     // The band's column headers and cells are gone from the flow...
     expect(markup).not.toContain("column:open:1");
     expect(markup).not.toContain("cell:ada:open:1");
-    // ...replaced by one folded slot per lane carrying both hidden cells;
-    // the slot carries its own count, so the open lane adds no count row.
+    // ...replaced by one folded slot per lane carrying both hidden cells,
+    // and by a single centred total in the lane's row, since one slot cannot
+    // carry the per-column pair the open columns show.
     expect(markup).toContain("folded:ada:todo:2:2");
-    expect(markup).not.toContain("data-kanban-lane-column-count");
+    expect(markup).toMatch(
+      /data-kanban-band-collapsed=""><div class="[^"]*justify-center[^"]*" data-kanban-lane-column-count="2"/u,
+    );
     // Columns outside the band are untouched.
     expect(markup).toContain("column:done:1");
     expect(markup).toContain("cell:ada:done:1");

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -19,16 +19,46 @@ import {
 import type { KanbanColumnBandSpan } from "./column-bands";
 import { KANBAN_CARD_DRAG_MIME } from "./drag-interactions";
 import type { KanbanColumnBand, KanbanGroup } from "./grouping";
+import {
+  KANBAN_CHROME_ROW_HEIGHT,
+  KANBAN_CHROME_ROW_HEIGHT_PX,
+} from "./layout-tokens";
 import type {
   KanbanBoardCell,
   KanbanBoardColumn,
   KanbanBoardMatrix,
 } from "./matrix";
 import {
+  KANBAN_STICKY_TOP_CLASS,
   KANBAN_STICKY_TOP_VAR,
   KanbanCollapsedBandCaption,
 } from "./sticky-lane";
 import type { KanbanStickyTopStyle } from "./sticky-lane";
+
+/**
+ * How far a lane's own pinned row reaches: its identity line over the line of
+ * per-column summaries, each fixed at the chrome row height.
+ *
+ * Stated rather than measured, because both lines are fixed by construction —
+ * a caller's summary or action renders inside a row that cannot grow — and the
+ * cells below have to know the offset before the first paint, or every card's
+ * pinned identity row spends that frame parked where the lane row is about
+ * to be.
+ */
+const LANE_ROW_HEIGHT_PX = KANBAN_CHROME_ROW_HEIGHT_PX * 2;
+
+/**
+ * A finger's 44px target on a toggle the chrome row keeps at 36px.
+ *
+ * The same pseudo-element the shared `Button` extends its own targets with:
+ * the visible control keeps the row's height, and only the touch surface
+ * grows. It grows evenly above and below rather than downwards, so the extra
+ * reach stops well short of the controls a caller renders in the summaries
+ * under it — those sit at the far end of their own column, not under the
+ * lane's name.
+ */
+const LANE_TOGGLE_COARSE_TARGET_CLASS =
+  "relative pointer-coarse:after:absolute pointer-coarse:after:inset-x-0 pointer-coarse:after:-inset-y-1 pointer-coarse:after:min-h-11";
 
 const groupValueKey = (value: string | null): string =>
   value === null ? "null" : `value:${value.length}:${value}`;
@@ -53,6 +83,19 @@ export type KanbanSubgroupColumnHeaderContext = {
 export type KanbanSubgroupLaneIdentityContext = {
   group: KanbanGroup;
   count: number;
+};
+
+/** One column's cell in a lane's own row, and what that cell stands for. */
+export type KanbanSubgroupLaneColumnSummaryContext = {
+  lane: KanbanGroup;
+  column: KanbanBoardColumn;
+  /** Rows in this lane/column intersection, including zero. */
+  count: number;
+};
+
+export type KanbanSubgroupLaneColumnActionContext = {
+  lane: KanbanGroup;
+  column: KanbanBoardColumn;
 };
 
 export type KanbanSubgroupCellContext<TRow> = {
@@ -120,6 +163,22 @@ export type KanbanSubgroupBoardProps<TRow> = {
   renderLaneIdentity: (context: KanbanSubgroupLaneIdentityContext) => ReactNode;
   renderCell: (context: KanbanSubgroupCellContext<TRow>) => ReactNode;
   /**
+   * What a lane's own row says about one column: its count by default. The
+   * row is pinned, so this is the one line about a column that survives a
+   * scroll down a lane hundreds of cards tall — a calculation belongs here
+   * rather than at the end of a cell nobody reaches.
+   */
+  renderLaneColumnSummary?:
+    | ((context: KanbanSubgroupLaneColumnSummaryContext) => ReactNode)
+    | undefined;
+  /**
+   * The control at the end of a lane's cell for one column, such as adding a
+   * card straight into that intersection. None by default.
+   */
+  renderLaneColumnAction?:
+    | ((context: KanbanSubgroupLaneColumnActionContext) => ReactNode)
+    | undefined;
+  /**
    * The line above a band's columns. Defaults to `KanbanColumnBandHeader`
    * with the band's label and count.
    */
@@ -177,6 +236,11 @@ export type KanbanSubgroupBoardProps<TRow> = {
 /**
  * Reusable swimlane layout over the canonical two-axis Kanban matrix.
  *
+ * Every lane leads with a row of its own, pinned on both axes: its name at the
+ * visible inline edge, and beside each column what that column holds in this
+ * lane, so a reader deep inside a lane still knows which lane it is and what
+ * is around them.
+ *
  * Columns that carry band metadata render under a one-line band caption and
  * can be collapsed as a run: the band folds into one narrow slot in every
  * row, whose cells stay reachable (a host renders its drop target in them),
@@ -191,6 +255,8 @@ export const KanbanSubgroupBoard = <TRow,>({
   renderColumnHeader,
   renderLaneIdentity,
   renderCell,
+  renderLaneColumnSummary,
+  renderLaneColumnAction,
   renderBandHeader,
   renderCollapsedBandCell,
   formatBandToggleLabel,
@@ -564,7 +630,10 @@ export const KanbanSubgroupBoard = <TRow,>({
     const count = rowsIn(cellsOf(span, cells));
     return (
       <div
-        className="flex justify-center"
+        className={cn(
+          "flex items-center justify-center",
+          KANBAN_CHROME_ROW_HEIGHT,
+        )}
         data-kanban-lane-column-count={count}
       >
         <span className="text-muted-foreground text-xs tabular-nums">
@@ -574,8 +643,42 @@ export const KanbanSubgroupBoard = <TRow,>({
     );
   };
 
+  /** One column's cell in a lane's row: what it holds, then what it offers. */
+  const laneColumnCell = (
+    group: KanbanGroup,
+    column: KanbanBoardColumn,
+    count: number,
+  ): Rendered => (
+    <div
+      className={cn("flex items-center gap-1 px-3", KANBAN_CHROME_ROW_HEIGHT)}
+      data-kanban-lane-column-count={count}
+    >
+      {renderLaneColumnSummary ? (
+        renderLaneColumnSummary({ column, count, lane: group })
+      ) : (
+        <span className="text-muted-foreground text-xs tabular-nums">
+          {formatCount(count)}
+        </span>
+      )}
+      {renderLaneColumnAction === undefined ? null : (
+        <span className="ms-auto flex items-center">
+          {renderLaneColumnAction({ column, lane: group })}
+        </span>
+      )}
+    </div>
+  );
+
   const stickyTopStyle: KanbanStickyTopStyle = {
     [KANBAN_STICKY_TOP_VAR]: `${String(headerHeight)}px`,
+  };
+  /**
+   * What a lane's cells find pinned above them: the board's header and the
+   * lane's own row. Restating the offset rather than adding to the inherited
+   * one, because a custom property that reads itself is a cycle and resolves
+   * to nothing at all.
+   */
+  const laneCellsStickyTopStyle: KanbanStickyTopStyle = {
+    [KANBAN_STICKY_TOP_VAR]: `${String(headerHeight + LANE_ROW_HEIGHT_PX)}px`,
   };
 
   return (
@@ -585,7 +688,7 @@ export const KanbanSubgroupBoard = <TRow,>({
     >
       <div className="min-w-max">
         <div
-          className="bg-background sticky top-0 z-20 pt-2 pb-2"
+          className="bg-background sticky top-0 z-20"
           data-kanban-board-header=""
           ref={headerRef}
         >
@@ -637,7 +740,19 @@ export const KanbanSubgroupBoard = <TRow,>({
                       }
                     }}
                   >
-                    {bandHeader(band, span)}
+                    {/* The caption travels the width of its own band: a board
+                     * scrolled sideways keeps it at the visible edge until
+                     * the band it names is gone, rather than letting the name
+                     * leave while the columns under it are still on screen.
+                     * It has to size to its content to have any room to
+                     * travel, and stops at the band's own width, which is as
+                     * far as a caption for that band means anything. */}
+                    <div
+                      className="bg-background sticky start-0 z-10 w-fit max-w-full"
+                      data-kanban-band-caption=""
+                    >
+                      {bandHeader(band, span)}
+                    </div>
                   </div>
                 );
               })}
@@ -701,70 +816,91 @@ export const KanbanSubgroupBoard = <TRow,>({
               className="border-border/60 border-b py-1 first:pt-0 last:border-b-0"
               key={groupValueKey(group.value)}
             >
-              <div className="bg-background/95 sticky start-0 z-10 flex min-h-11 items-center backdrop-blur-sm">
-                <button
-                  aria-expanded={!collapsed}
-                  className="hover:bg-muted/60 flex min-h-11 items-center gap-2 rounded-lg px-2 text-start transition-[background-color]"
-                  onClick={() => setLaneCollapsed(group, count, !collapsed)}
-                  type="button"
+              {/* The lane's own row, pinned on both axes: its name holds the
+               * visible inline edge of a board scrolled sideways, and the
+               * whole row comes to rest under the board's header so a reader
+               * halfway down a lane still has its name and what each of its
+               * columns holds. The summaries stand beside the cells rather
+               * than in place of them, which is why a lane shows them open as
+               * well as collapsed. */}
+              <div
+                className={cn(
+                  "bg-background sticky z-10",
+                  KANBAN_STICKY_TOP_CLASS,
+                )}
+                data-kanban-lane-row=""
+              >
+                <div
+                  className={cn(
+                    "sticky start-0 flex w-fit items-center",
+                    KANBAN_CHROME_ROW_HEIGHT,
+                  )}
                 >
-                  <DirectionalIcon
+                  <button
+                    aria-expanded={!collapsed}
                     className={cn(
-                      "text-muted-foreground size-4 shrink-0 transition-transform",
-                      collapsed && "-rotate-90",
+                      "hover:bg-muted/60 flex items-center gap-2 rounded-lg px-2 text-start transition-[background-color]",
+                      KANBAN_CHROME_ROW_HEIGHT,
+                      LANE_TOGGLE_COARSE_TARGET_CLASS,
                     )}
-                    flip={collapsed}
-                    icon={ChevronDownIcon}
-                  />
-                  {renderLaneIdentity({ group, count })}
-                  <span className="text-muted-foreground text-xs tabular-nums">
-                    {formatCount(count)}
-                  </span>
-                </button>
-              </div>
+                    onClick={() => setLaneCollapsed(group, count, !collapsed)}
+                    type="button"
+                  >
+                    <DirectionalIcon
+                      className={cn(
+                        "text-muted-foreground size-4 shrink-0 transition-transform",
+                        collapsed && "-rotate-90",
+                      )}
+                      flip={collapsed}
+                      icon={ChevronDownIcon}
+                    />
+                    {renderLaneIdentity({ group, count })}
+                    <span className="text-muted-foreground text-xs tabular-nums">
+                      {formatCount(count)}
+                    </span>
+                  </button>
+                </div>
 
-              {/* Per-column counts stand in for the cells only while the
-               * lane is collapsed. An open lane shows its cells, and a
-               * folded band's slot already carries its own count, so the
-               * extra row would only push the cards down. */}
-              {collapsed &&
-                renderRow({
-                  label: "Lane column counts",
-                  renderColumn: (column) => {
-                    const columnRows = cellFor(column)?.rows.length ?? 0;
-                    return (
-                      <div
-                        className="px-3"
-                        data-kanban-lane-column-count={columnRows}
-                      >
-                        <span className="text-muted-foreground text-xs tabular-nums">
-                          {formatCount(columnRows)}
-                        </span>
-                      </div>
-                    );
-                  },
+                {renderRow({
+                  label: "Lane column summaries",
+                  renderColumn: (column) =>
+                    laneColumnCell(
+                      group,
+                      column,
+                      cellFor(column)?.rows.length ?? 0,
+                    ),
+                  // A folded band stands for several columns at once, so its
+                  // slot can only carry the total; there is no room for the
+                  // per-column pair the open columns show.
                   renderFoldedBand: (_band, span) => foldedCount(span, cells),
                 })}
+              </div>
 
-              {!collapsed &&
-                renderRow({
-                  className: "pb-1",
-                  renderColumn: (column, band) => {
-                    const cell = cellFor(column);
-                    return cell === undefined ? null : (
-                      <>
-                        {renderCell({
-                          band,
-                          cell,
-                          count: cell.rows.length,
-                          laneValue: group.value,
-                        })}
-                      </>
-                    );
-                  },
-                  renderFoldedBand: (band, span) =>
-                    foldedCell(band, span, cells, group.value),
-                })}
+              {/* The cells find the lane's row pinned above them as well as
+               * the board's header, so they are told the total reach rather
+               * than the header's alone. */}
+              {!collapsed && (
+                <div style={laneCellsStickyTopStyle}>
+                  {renderRow({
+                    className: "pb-1",
+                    renderColumn: (column, band) => {
+                      const cell = cellFor(column);
+                      return cell === undefined ? null : (
+                        <>
+                          {renderCell({
+                            band,
+                            cell,
+                            count: cell.rows.length,
+                            laneValue: group.value,
+                          })}
+                        </>
+                      );
+                    },
+                    renderFoldedBand: (band, span) =>
+                      foldedCell(band, span, cells, group.value),
+                  })}
+                </div>
+              )}
             </section>
           );
         })}


### PR DESCRIPTION
- Exported `KANBAN_CHROME_ROW_HEIGHT` / `KANBAN_BAND_CAPTION_ROW_HEIGHT` (and
  their pixel twins); the column header and lane rows now share them, and the
  board header drops its own padding.
- A lane's row is one sticky unit on both axes and carries per-column
  summaries for open lanes too, with `renderLaneColumnSummary` and
  `renderLaneColumnAction` render props; the lane's cells are offset by it, so
  a card's pinned identity row still comes to rest under everything above it.
- A band's caption sticks to the visible inline edge until its band scrolls
  out.
- `KanbanCardShell` gains `actionsVisibility="hover"`, and its pinned identity
  row is painted opaque rather than relying on a possibly translucent
  `bg-card`.
- `KanbanCellAction` is drawn as the dashed outline of the card it adds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned Kanban board chrome with aligned column headers and lane rows.
  - Lane names, controls and column content remain visible while scrolling horizontally and vertically.
  - Band captions stay at the visible edge while their sections remain on screen.
  - Added optional per-lane, per-column summaries and actions.
  - Added hover-revealed card actions, including keyboard and touch-friendly support.
  - The “add a card” area now matches the appearance of a card.

- **Bug Fixes**
  - Improved layering and positioning of sticky headers, lane rows and card actions for clearer board navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->