### PR TITLE
feat(workspace-ui): let a frame omit its end rail

### DIFF
--- a/.changeset/workspace-frame-optional-end-rail.md
+++ b/.changeset/workspace-frame-optional-end-rail.md
@@ -1,0 +1,6 @@
+---
+"@stll/workspace-ui": minor
+"@stll/ui": minor
+---
+
+A workspace frame that describes neither an end rail nor an inspector now mounts no end dock at all, so its content area runs to the inline-end edge instead of reserving an empty 48px rail.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -33,8 +33,10 @@ convenience; the subpaths are the real surface, and in-repo code uses those.
 ## Workspace shell
 
 `WorkspaceShell` is the complete desktop and tablet application frame. It
-keeps navigation, sticky top chrome, the active route, and a required
-inline-end dock as sibling surfaces inside one dynamic viewport. Route content
+keeps navigation, sticky top chrome, the active route, and an optional
+inline-end dock as sibling surfaces inside one dynamic viewport. A host with
+nothing for the inline-end edge omits `endDock`, and the content column
+extends to the frame's edge instead of reserving width for an empty rail. Route content
 is the sole scroller, so a feature cannot accidentally render an app inside
 the app.
 

--- a/packages/ui/src/components/workspace-shell.test.tsx
+++ b/packages/ui/src/components/workspace-shell.test.tsx
@@ -85,6 +85,27 @@ describe("WorkspaceShell", () => {
     expect(markup).toContain("Header");
     expect(markup).not.toContain('aria-label="Open navigation"');
   });
+
+  test("ends at the content column when the host has no end dock", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceShell
+        navigation={{
+          content: <nav data-test="navigation">Navigation</nav>,
+          mode: "responsive",
+        }}
+        topBar={() => <header data-test="top-bar">Header</header>}
+      >
+        <article data-test="content">Content</article>
+      </WorkspaceShell>,
+    );
+
+    // Nothing follows the content column: no rail element, and no width
+    // reserved beside it.
+    expect(markup).toMatch(
+      /<article data-test="content">Content<\/article><\/div><\/main><\/div>$/su,
+    );
+    expect(markup).not.toContain('data-slot="inspector-rail"');
+  });
 });
 
 describe("WorkspaceEndRail", () => {

--- a/packages/ui/src/components/workspace-shell.tsx
+++ b/packages/ui/src/components/workspace-shell.tsx
@@ -52,8 +52,12 @@ type WorkspaceShellProps = {
   navigation: WorkspaceNavigation;
   /** Sticky route chrome; managed navigation exposes its compact trigger here. */
   topBar: (context: WorkspaceTopBarContext) => ReactElement;
-  /** Permanent inline-end rail or inspector dock. */
-  endDock: ReactElement;
+  /**
+   * Inline-end rail or inspector dock. Omit it and the shell mounts no end
+   * dock at all: no rail, none of its inline-end width reservation, and the
+   * content column extends to the frame's inline-end edge.
+   */
+  endDock?: ReactElement | undefined;
   /** Active route content. */
   children: ReactNode;
 };
@@ -62,6 +66,9 @@ type WorkspaceShellProps = {
  * Stella's complete authenticated workspace frame. It owns the dynamic
  * viewport, sibling rail geometry, sticky top chrome, and sole content
  * scroller so product routes cannot create an app inside the app.
+ *
+ * The end dock is optional: a host with nothing to put on the inline-end edge
+ * omits it rather than reserving width for an empty rail.
  */
 export const WorkspaceShell = ({
   children,

--- a/packages/workspace-ui/src/workspace-frame.test.tsx
+++ b/packages/workspace-ui/src/workspace-frame.test.tsx
@@ -10,6 +10,7 @@ import {
   ApplicationRailHeader,
   ApplicationRailMenu,
 } from "@stll/ui/application-rail";
+import { SIDE_RAIL_WIDTH } from "@stll/ui/inspector";
 
 import { WorkspaceFrame } from "./workspace-frame";
 
@@ -137,6 +138,92 @@ test("renders the same stella rail primitive when the inspector pane is absent",
   expect(rendered).toContain('data-slot="inspector-rail"');
   expect(rendered).not.toContain('data-slot="inspector-dock"');
   expect(rendered).toContain("w-12");
+});
+
+const countOccurrences = (markup: string, needle: string) =>
+  markup.split(needle).length - 1;
+
+const describedNavigation = {
+  compact: {
+    content: <div />,
+    label: "Navigation",
+    onOpenChange: () => undefined,
+    open: false,
+    trigger: null,
+  },
+  items: [],
+  label: "Navigation",
+} as const;
+
+test("mounts no end dock for a host with neither an inspector nor an end rail", () => {
+  const rendered = renderToStaticMarkup(
+    <WorkspaceFrame
+      composition="described"
+      navigation={describedNavigation}
+      topBar={{}}
+    >
+      <div />
+    </WorkspaceFrame>,
+  );
+
+  expect(rendered).toContain('data-slot="workspace-shell"');
+  expect(rendered).not.toContain('data-slot="inspector-rail"');
+  expect(rendered).not.toContain('data-slot="inspector-dock"');
+  // The application rail is the only 48px strip left: the frame reserves no
+  // second one on the inline-end edge.
+  expect(countOccurrences(rendered, SIDE_RAIL_WIDTH)).toBe(1);
+});
+
+test("keeps the end rail when a host describes one without an inspector", () => {
+  const rendered = renderToStaticMarkup(
+    <WorkspaceFrame
+      composition="described"
+      endRail={{
+        chatAction: {
+          label: "Chat",
+          reason: "Unavailable",
+          status: "unavailable",
+        },
+        label: "Inspector",
+        topAction: <span />,
+      }}
+      navigation={describedNavigation}
+      topBar={{}}
+    >
+      <div />
+    </WorkspaceFrame>,
+  );
+
+  expect(rendered).toContain('data-slot="inspector-rail"');
+  expect(rendered).not.toContain('data-slot="inspector-dock"');
+  expect(countOccurrences(rendered, SIDE_RAIL_WIDTH)).toBe(2);
+});
+
+test("keeps the inspector dock when a host has an inspector but no end rail", () => {
+  const rendered = renderToStaticMarkup(
+    <WorkspaceFrame
+      composition="described"
+      inspector={{
+        pane: <div data-testid="pane" />,
+        resizeHandleLabel: "Resize",
+        resizeHandleProps,
+        showPaneContent: false,
+        width: 512,
+      }}
+      navigation={describedNavigation}
+      topBar={{}}
+    >
+      <div />
+    </WorkspaceFrame>,
+  );
+
+  expect(rendered).toContain('data-slot="inspector-dock"');
+  expect(rendered).toContain('data-testid="pane"');
+  // Without a rail there is nothing to collapse to, so the dock keeps the
+  // described pane width rather than the 48px rail footprint.
+  expect(rendered).toContain("width:512px");
+  expect(rendered).not.toContain('data-slot="inspector-rail"');
+  expect(countOccurrences(rendered, SIDE_RAIL_WIDTH)).toBe(1);
 });
 
 const sidebarNavigation = (

--- a/packages/workspace-ui/src/workspace-frame.tsx
+++ b/packages/workspace-ui/src/workspace-frame.tsx
@@ -120,7 +120,14 @@ export type WorkspaceFrameProps = {
       composition: "described";
       navigation: WorkspaceFrameNavigation;
       topBar: WorkspaceFrameTopBar;
-      endRail: WorkspaceFrameEndRail;
+      /**
+       * The permanent inline-end rail. Omitting it alongside `inspector`
+       * mounts no end dock at all: no rail, none of its 48px inline-end
+       * reservation, and the content area extends to the frame's edge. With
+       * an `inspector` but no rail, the dock keeps the full pane width and
+       * has no rail to collapse to.
+       */
+      endRail?: WorkspaceFrameEndRail;
       inspector?: WorkspaceFrameInspector;
     }
   | {
@@ -145,7 +152,9 @@ type DescribedWorkspaceFrameProps = Extract<
 /**
  * Stella's complete workspace frame. Hosts provide route descriptors and
  * actions; this component owns the shell, application rail, end rail, and
- * desktop inspector footprint.
+ * desktop inspector footprint. A `described` host with nothing for the
+ * inline-end edge omits both `endRail` and `inspector`, and the frame mounts
+ * no end dock at all.
  *
  * The two compositions mount different navigation primitives. `described`
  * renders `navigation.items` through the narrower `ApplicationRail` from
@@ -192,10 +201,14 @@ const DescribedWorkspaceFrame = ({
       <DescribedSidebar navigation={navigation} sidebar={navigation.sidebar} />
     );
 
+  const rail =
+    endRail === undefined ? undefined : <WorkspaceEndRail {...endRail} />;
+  // No inspector and no rail: no end dock either, so the content area runs to
+  // the frame's inline-end edge instead of reserving a dead rail strip.
   const endDock =
     inspector && inspectorPresentation === "desktop" ? (
       <InspectorDock
-        rail={<WorkspaceEndRail {...endRail} />}
+        rail={rail}
         resizeHandleLabel={inspector.resizeHandleLabel}
         resizeHandleProps={inspector.resizeHandleProps}
         showPaneContent={inspector.showPaneContent}
@@ -205,7 +218,7 @@ const DescribedWorkspaceFrame = ({
         {inspector.pane}
       </InspectorDock>
     ) : (
-      <WorkspaceEndRail {...endRail} />
+      rail
     );
 
   const shell = (


### PR DESCRIPTION
- `endRail` is now optional on the described composition: with no `inspector` either, the frame mounts no end dock, so the content area runs to the inline-end edge instead of reserving an empty 48px rail.
- `WorkspaceShell`'s `endDock` is optional for the same reason; `InspectorDock` and the host-responsive composition are unchanged, and an inspector with no rail keeps its pane width.
- Unit tests cover no-rail, rail-only, and inspector-only frames, asserting the rail width token appears exactly once when the end dock is gone.
