### PR TITLE
chore: raise the pragmatic-drag-and-drop resolution to its dependents' floor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -955,7 +955,7 @@
     "better-call@1.4.0": "patches/better-call@1.4.0.patch",
   },
   "overrides": {
-    "@atlaskit/pragmatic-drag-and-drop": "3.0.0",
+    "@atlaskit/pragmatic-drag-and-drop": "3.1.0",
     "@emnapi/core": "1.9.1",
     "@emnapi/runtime": "1.9.1",
     "@expo/cli": "57.0.20",
@@ -1108,7 +1108,7 @@
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
-    "@atlaskit/pragmatic-drag-and-drop": ["@atlaskit/pragmatic-drag-and-drop@3.0.0", "", { "dependencies": { "@babel/runtime": "^7.0.0", "bind-event-listener": "^3.0.0", "raf-schd": "^4.0.3" } }, "sha512-EEKBELv757wrvhMHBAoFcXjfzGZ4Y2FJ2xnSsWovsOKywkN1Q4IWRH52hQpPmJnATLcmO9viVhoXWSXFBLKSLQ=="],
+    "@atlaskit/pragmatic-drag-and-drop": ["@atlaskit/pragmatic-drag-and-drop@3.1.0", "", { "dependencies": { "@babel/runtime": "^7.0.0", "bind-event-listener": "^3.0.0", "raf-schd": "^4.0.3" } }, "sha512-VU+2Oh6OgvC6D1xiX3lfm1gZJsaSPD+ZKjAHodOQ9IO6RfOvAyReLlK5ut9gIUpPmbD8d09wlCs7y4A6/I8c5Q=="],
 
     "@atlaskit/pragmatic-drag-and-drop-auto-scroll": ["@atlaskit/pragmatic-drag-and-drop-auto-scroll@3.2.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^3.1.0", "@babel/runtime": "^7.0.0" } }, "sha512-vuL+AJae6c6lkmFd63v7c/7J7seyi7ZA8uMLNe9GvvApySToun3Zlv8SfyZU0d+wcNG4+Ix6qpRb8jOobZgNNg=="],
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "vite": "catalog:"
   },
   "resolutions": {
-    "@atlaskit/pragmatic-drag-and-drop": "3.0.0",
+    "@atlaskit/pragmatic-drag-and-drop": "3.1.0",
     "@emnapi/core": "1.9.1",
     "@emnapi/runtime": "1.9.1",
     "@expo/cli": "57.0.20",


### PR DESCRIPTION
- Root `resolutions` pinned `@atlaskit/pragmatic-drag-and-drop` to `3.0.0`, below `apps/web`'s and `packages/ui`'s `^3.1.0` floor, failing `bun scripts/check-resolution-ranges.ts`.
- Raise the pin to `3.1.0` (the latest 3.x release) and update `bun.lock`.
