### PR TITLE
chore(ci): raise a root resolution to its dependents' floor in the dependabot autofix

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -57,6 +57,26 @@ jobs:
           scripts/dependabot-empty-changeset.ts
           scripts/changeset-guard.ts
           scripts/changeset-policy.json
+          scripts/check-resolution-ranges.ts
+          scripts/check-resolutions-only-change.ts
+          scripts/fix-resolution-ranges.ts
+          scripts/json-text-edit.ts
+          scripts/resolution-ranges.ts
+
+      # A bump can move a dependent's declared floor above a root `resolutions`
+      # pin. bun applies the pin anyway, so the graph installs and only breaks
+      # at build/runtime; the resolution-range guard fails the PR for it. The
+      # fixer raises each pin to the lowest version every dependent accepts,
+      # re-resolving bun.lock between passes so a floor that only the refreshed
+      # lockfile exposes is repaired too, and fails (non-zero) on a conflict no
+      # version satisfies or a cascade still unresolved at the pass cap.
+      - name: Raise resolutions to their dependents' floors
+        run: >-
+          bun --no-install --no-env-file scripts/fix-resolution-ranges.ts
+          --max-passes 4
+
+      - name: Resolution range guard
+        run: bun --no-install --no-env-file scripts/check-resolution-ranges.ts
 
       - name: Add missing empty dev dependency changeset
         env:
@@ -78,10 +98,10 @@ jobs:
             exit 1
           fi
 
-          unexpected_tracked="$(git diff --name-only "$HEAD_SHA" -- . ':(exclude)bun.lock' ":(exclude)$EMPTY_CHANGESET_PATH")"
+          unexpected_tracked="$(git diff --name-only "$HEAD_SHA" -- . ':(exclude)bun.lock' ':(exclude)package.json' ":(exclude)$EMPTY_CHANGESET_PATH")"
           unexpected_untracked="$(git ls-files --others --exclude-standard -- . ":(exclude)$EMPTY_CHANGESET_PATH")"
           if [[ -n "${unexpected_tracked}${unexpected_untracked}" ]]; then
-            echo "::error::Autofix changed files outside bun.lock and $EMPTY_CHANGESET_PATH."
+            echo "::error::Autofix changed files outside bun.lock, package.json and $EMPTY_CHANGESET_PATH."
             git status --short
             exit 1
           fi
@@ -92,7 +112,9 @@ jobs:
             exit 1
           fi
 
-          git diff --check -- bun.lock
+          bun --no-install --no-env-file scripts/check-resolutions-only-change.ts --ref "$HEAD_SHA"
+
+          git diff --check -- bun.lock package.json
 
       - name: Push autofixes
         uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/scripts/autofix-workflow.test.ts
+++ b/scripts/autofix-workflow.test.ts
@@ -10,6 +10,16 @@ const HELPER_TEST_URL = new URL(
   import.meta.url,
 );
 const CHANGESET_GUARD_URL = new URL("changeset-guard.ts", import.meta.url);
+const RESOLUTION_SCRIPTS = [
+  "scripts/check-resolution-ranges.ts",
+  "scripts/check-resolutions-only-change.ts",
+  "scripts/fix-resolution-ranges.ts",
+  "scripts/json-text-edit.ts",
+  "scripts/resolution-ranges.ts",
+] as const;
+const RESOLUTION_SOURCE_URLS = RESOLUTION_SCRIPTS.map(
+  (script) => new URL(script.replace("scripts/", ""), import.meta.url),
+);
 
 describe("Dependabot Bun autofix boundary", () => {
   test("keeps the runner read-only and hands off only verified autofixes", async () => {
@@ -49,7 +59,7 @@ describe("Dependabot Bun autofix boundary", () => {
       "bun --no-env-file dedupe --lockfile-only --ignore-scripts",
     );
     expect(workflow).toContain(
-      `git diff --name-only "$HEAD_SHA" -- . ':(exclude)bun.lock' ":(exclude)$EMPTY_CHANGESET_PATH"`,
+      `git diff --name-only "$HEAD_SHA" -- . ':(exclude)bun.lock' ':(exclude)package.json' ":(exclude)$EMPTY_CHANGESET_PATH"`,
     );
     expect(workflow).toContain(
       `git ls-files --others --exclude-standard -- . ":(exclude)$EMPTY_CHANGESET_PATH"`,
@@ -70,13 +80,7 @@ describe("Dependabot Bun autofix boundary", () => {
       "bun --no-install --no-env-file scripts/dependabot-empty-changeset.ts",
     );
 
-    const [helper, helperTest, changesetGuard] = await Promise.all([
-      Bun.file(HELPER_URL).text(),
-      Bun.file(HELPER_TEST_URL).text(),
-      Bun.file(CHANGESET_GUARD_URL).text(),
-    ]);
-    expect(helper).not.toContain('from "better-result"');
-    expect(changesetGuard).not.toContain('from "better-result"');
+    const helperTest = await Bun.file(HELPER_TEST_URL).text();
     const externalTestImports = [...helperTest.matchAll(/from "([^"]+)"/gu)]
       .flatMap((match) => {
         const specifier = match.at(1);
@@ -89,6 +93,59 @@ describe("Dependabot Bun autofix boundary", () => {
           !specifier.startsWith("."),
       );
     expect(externalTestImports).toEqual([]);
+
+    const sources = await Promise.all(
+      [HELPER_URL, CHANGESET_GUARD_URL, ...RESOLUTION_SOURCE_URLS].map(
+        async (url) => await Bun.file(url).text(),
+      ),
+    );
+    // The job never installs, so every script it runs must resolve without
+    // node_modules.
+    for (const source of sources) {
+      expect(source).not.toContain('from "better-result"');
+    }
+  });
+
+  test("repairs a resolution pin that a bump pushed below its dependents' floor", async () => {
+    const workflow = await Bun.file(WORKFLOW_URL).text();
+    const trustedSourcesStep = workflow.indexOf(
+      "- name: Verify trusted autofix sources",
+    );
+    const fixStep = workflow.indexOf(
+      "- name: Raise resolutions to their dependents' floors",
+    );
+    const guardStep = workflow.indexOf("- name: Resolution range guard");
+    const restrictionStep = workflow.indexOf(
+      "- name: Restrict generated changes",
+    );
+
+    // The fixer runs only after its own sources are verified against the base,
+    // so a Dependabot PR cannot smuggle in a modified fixer.
+    for (const script of RESOLUTION_SCRIPTS) {
+      expect(workflow.indexOf(script)).toBeGreaterThan(trustedSourcesStep);
+      expect(workflow.indexOf(script)).toBeLessThan(fixStep);
+    }
+    expect(fixStep).toBeGreaterThan(trustedSourcesStep);
+    expect(guardStep).toBeGreaterThan(fixStep);
+    expect(restrictionStep).toBeGreaterThan(guardStep);
+
+    expect(workflow).toContain(
+      "bun --no-install --no-env-file scripts/fix-resolution-ranges.ts",
+    );
+    expect(workflow).toContain("--max-passes 4");
+    // The lockfile refresh between passes lives in the fixer, which the
+    // trusted-sources step pins to the base revision.
+    const fixer = await Bun.file(
+      new URL("fix-resolution-ranges.ts", import.meta.url),
+    ).text();
+    expect(fixer).toContain(`"install", "--lockfile-only", "--ignore-scripts"`);
+    expect(workflow).toContain(
+      "bun --no-install --no-env-file scripts/check-resolution-ranges.ts",
+    );
+    expect(workflow).toContain(
+      `bun --no-install --no-env-file scripts/check-resolutions-only-change.ts --ref "$HEAD_SHA"`,
+    );
+    expect(workflow).toContain("git diff --check -- bun.lock package.json");
   });
 
   test("adds a deterministic empty changeset for published dev dependency updates", async () => {

--- a/scripts/check-resolution-ranges.ts
+++ b/scripts/check-resolution-ranges.ts
@@ -16,215 +16,53 @@
 // What it checks: for every exact-version resolution `name -> v`, it scans the
 // whole dependency graph (every workspace package.json + every package entry
 // in bun.lock) for the ranges declared against `name`, and fails if `v` sits
-// below the floor of any of them.
-//
-// Deliberately one-directional (too OLD only): an intentional forward override
-// (e.g. forcing a security patch NEWER than a lax range allows) is fine and is
-// not flagged; only holding a dependency back below what a dependent requires —
-// the failure mode above — is an error. Non-semver specifiers (`workspace:`,
-// `catalog:`, `npm:`, git/file) and ranges too complex to reduce to a single
-// floor (unions, upper-bounded windows) are skipped: the guard is conservative
-// by construction, so it never false-positives on a shape it cannot reason
-// about — it only fires on the unambiguous "pinned below a declared floor" case.
+// below the floor of any of them. The graph analysis, the skipped shapes and
+// the allowlist live in ./resolution-ranges, shared with the autofix that
+// raises an offending pin to its floor.
 
-import { panic } from "better-result";
 import path from "node:path";
+
+import {
+  analyzeResolutionRanges,
+  loadResolutionGraph,
+  type ResolutionViolation,
+} from "./resolution-ranges";
 
 const ROOT = path.resolve(import.meta.dir, "..");
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const readJson = async (filePath: string): Promise<Record<string, unknown>> =>
-  JSON.parse(await Bun.file(filePath).text());
-
-const DEPENDENCY_FIELDS = [
-  "dependencies",
-  "devDependencies",
-  "peerDependencies",
-  "optionalDependencies",
-] as const;
-
-const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u;
-
-// The minimum version that satisfies a range, for the caret/tilde/gte/exact
-// shapes package.json deps overwhelmingly use. Returns null for anything we
-// can't safely reduce to one floor (unions `||`, an explicit upper bound `<`,
-// wildcards `*`/`x`, or a non-semver specifier), which the caller then skips.
-const rangeFloor = (range: string): string | null => {
-  const trimmed = range.trim();
-  if (trimmed === "" || /[|<*x:]/iu.test(trimmed)) {
-    return null;
-  }
-  const match = /^[\^~>=v\s]*(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/u.exec(
-    trimmed,
-  );
-  if (match === null) {
-    return null;
-  }
-  const candidate = match[1] ?? "";
-  // Guard against a mis-parse: the extracted version must actually satisfy the
-  // range it came from before we treat it as that range's floor.
-  return Bun.semver.satisfies(candidate, range) ? candidate : null;
-};
-
-// A single place — a workspace package.json or a bun.lock package entry — that
-// declares a version range for some dependency.
-type RangeSource = { range: string; declaredBy: string };
-
-const rangesByPackage = new Map<string, RangeSource[]>();
-
-const addRange = (name: string, range: string, declaredBy: string): void => {
-  const existing = rangesByPackage.get(name);
-  if (existing) {
-    existing.push({ range, declaredBy });
-  } else {
-    rangesByPackage.set(name, [{ range, declaredBy }]);
-  }
-};
-
-const collectFromDependencyFields = (
-  container: Record<string, unknown>,
-  declaredBy: string,
-): void => {
-  for (const field of DEPENDENCY_FIELDS) {
-    const deps = container[field];
-    if (!isRecord(deps)) {
-      continue;
-    }
-    for (const [name, range] of Object.entries(deps)) {
-      if (typeof range === "string") {
-        addRange(name, range, declaredBy);
+if (import.meta.main) {
+  const violations = analyzeResolutionRanges(await loadResolutionGraph(ROOT));
+  if (violations.length > 0) {
+    // Report one line per package so a two-layer cascade reads clearly, naming
+    // the dependent that demands the highest floor.
+    const byPackage = new Map<string, ResolutionViolation>();
+    for (const violation of violations) {
+      const existing = byPackage.get(violation.packageName);
+      if (!existing || Bun.semver.order(violation.floor, existing.floor) > 0) {
+        byPackage.set(violation.packageName, violation);
       }
     }
+    console.error(
+      [
+        "resolution/override pins a dependency below a dependent's required floor:",
+        "",
+        ...[...byPackage.values()].map(
+          ({ floor, kind, packageName, pinned, requiredBy: [binding] }) =>
+            `  - ${packageName} is pinned to ${pinned}, but ${binding.declaredBy} (${kind}) requires "${binding.range}" (floor ${floor}).`,
+        ),
+        "",
+        "A resolution/override silently held this package back below what a",
+        "dependent imports from it; that surfaces as a MISSING_EXPORT at build",
+        "or runtime, not at install. Raise the pin in the root package.json",
+        "resolutions to a version satisfying the range(s) above, then reinstall:",
+        "",
+        "    bun scripts/fix-resolution-ranges.ts",
+      ].join("\n"),
+    );
+    process.exit(1);
   }
-};
 
-const rootPkg = await readJson(path.join(ROOT, "package.json"));
-
-// bun.lock is JSON-with-trailing-commas ("JSONC"-flavored); a plain JSON.parse
-// fails on it. Trailing commas only ever appear directly before a closing
-// `}`/`]` and cannot occur inside bun.lock's string values, so stripping them
-// is a safe, structure-preserving normalize (same approach as
-// scripts/check-lockfile-workspace-versions.ts).
-const lockText = await Bun.file(path.join(ROOT, "bun.lock")).text();
-const parsedLock: unknown = JSON.parse(lockText.replace(/,(\s*[}\]])/gu, "$1"));
-if (!isRecord(parsedLock)) {
-  panic("bun.lock did not parse into an object");
-}
-
-// Ranges declared by each workspace package (its own package.json fields, as
-// mirrored in bun.lock's `workspaces` map — `""` is the repo root).
-const lockWorkspaces = parsedLock["workspaces"];
-if (isRecord(lockWorkspaces)) {
-  for (const [dir, entry] of Object.entries(lockWorkspaces)) {
-    if (isRecord(entry)) {
-      collectFromDependencyFields(
-        entry,
-        `workspace ${dir === "" ? "<root>" : dir}`,
-      );
-    }
-  }
-}
-
-// Ranges declared by every resolved (transitive) package. Each `packages`
-// entry is `[specifier, registry, meta, integrity]`; the range-bearing fields
-// live on `meta` (index 2). The key is the dependent's identifier.
-const lockPackages = parsedLock["packages"];
-if (isRecord(lockPackages)) {
-  for (const [key, entry] of Object.entries(lockPackages)) {
-    if (Array.isArray(entry) && isRecord(entry[2])) {
-      collectFromDependencyFields(entry[2], key);
-    }
-  }
-}
-
-// Intentional below-floor overrides, grandfathered with the reason each is
-// safe. A NEW below-floor pin must be fixed (raise the version to satisfy its
-// dependents), NOT added here — this list is only for overrides that are
-// deliberately, knowingly held below what some dependents declare.
-const ALLOWED_BELOW_FLOOR = new Map<string, string>([
-  [
-    "@emnapi/core",
-    "Pinned to 1.9.1 (with @emnapi/runtime) to hold the @stll napi/emnapi " +
-      "WASM ABI at one version; some third-party wasm sidecars declare ^1.11 " +
-      "but run against 1.9.1 here. See the @stll napi architecture notes.",
-  ],
-  [
-    "@emnapi/runtime",
-    "Pinned to 1.9.1 (with @emnapi/core) for the @stll napi/emnapi WASM ABI.",
-  ],
-]);
-
-type Violation = {
-  name: string;
-  resolved: string;
-  floor: string;
-  range: string;
-  declaredBy: string;
-};
-
-const violations: Violation[] = [];
-
-const checkOverrideMap = (overrides: unknown, kind: string): void => {
-  if (!isRecord(overrides)) {
-    return;
-  }
-  for (const [name, resolved] of Object.entries(overrides)) {
-    if (ALLOWED_BELOW_FLOOR.has(name)) {
-      continue; // grandfathered intentional override (see ALLOWED_BELOW_FLOOR)
-    }
-    // Only an exact-version override can be compared to a range floor; a range
-    // or non-semver specifier (`workspace:`, `catalog:`, `npm:…`) is skipped.
-    if (typeof resolved !== "string" || !VERSION_PATTERN.test(resolved)) {
-      continue;
-    }
-    for (const { range, declaredBy } of rangesByPackage.get(name) ?? []) {
-      const floor = rangeFloor(range);
-      if (floor !== null && Bun.semver.order(resolved, floor) < 0) {
-        violations.push({
-          name,
-          resolved,
-          floor,
-          range,
-          declaredBy: `${declaredBy} (${kind})`,
-        });
-      }
-    }
-  }
-};
-
-checkOverrideMap(rootPkg["resolutions"], "resolutions");
-checkOverrideMap(rootPkg["overrides"], "overrides");
-
-if (violations.length > 0) {
-  // Report one line per (package, floor) so a two-layer cascade reads clearly,
-  // naming a representative dependent that demands the highest floor.
-  const byPackage = new Map<string, Violation>();
-  for (const violation of violations) {
-    const existing = byPackage.get(violation.name);
-    if (!existing || Bun.semver.order(violation.floor, existing.floor) > 0) {
-      byPackage.set(violation.name, violation);
-    }
-  }
-  console.error(
-    [
-      "resolution/override pins a dependency below a dependent's required floor:",
-      "",
-      ...[...byPackage.values()].map(
-        (v) =>
-          `  - ${v.name} is pinned to ${v.resolved}, but ${v.declaredBy} requires "${v.range}" (floor ${v.floor}).`,
-      ),
-      "",
-      "A resolution/override silently held this package back below what a",
-      "dependent imports from it; that surfaces as a MISSING_EXPORT at build",
-      "or runtime, not at install. Raise the pin in the root package.json",
-      "resolutions to a version satisfying the range(s) above, then reinstall.",
-    ].join("\n"),
+  console.log(
+    "resolution-range check: no resolution pins a dependency below a dependent's floor. OK.",
   );
-  process.exit(1);
 }
-
-console.log(
-  "resolution-range check: no resolution pins a dependency below a dependent's floor. OK.",
-);

--- a/scripts/check-resolutions-only-change.test.ts
+++ b/scripts/check-resolutions-only-change.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runCheckResolutionsOnlyChange } from "./check-resolutions-only-change";
+
+const MANIFEST = `{
+  "name": "stella",
+  "resolutions": {
+    "alpha": "3.0.0"
+  }
+}
+`;
+
+const git = (root: string, args: readonly string[]): void => {
+  const result = Bun.spawnSync(["git", ...args], { cwd: root });
+  if (result.exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed`);
+  }
+};
+
+describe("committed-versus-working manifest guard", () => {
+  let root = "";
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "resolutions-guard-"));
+    git(root, ["init", "--quiet"]);
+    git(root, ["config", "user.email", "guard@example.test"]);
+    git(root, ["config", "user.name", "guard"]);
+    await Bun.write(path.join(root, "package.json"), MANIFEST);
+    git(root, ["add", "package.json"]);
+    git(root, ["commit", "--quiet", "-m", "manifest"]);
+  });
+
+  afterEach(async () => {
+    await rm(root, { force: true, recursive: true });
+  });
+
+  const write = async (manifest: string): Promise<void> => {
+    await Bun.write(path.join(root, "package.json"), manifest);
+  };
+
+  // The guard throws on inputs it must not even compare; a test boundary is
+  // where catching that is appropriate.
+  const failure = async (args: readonly string[]): Promise<string> => {
+    try {
+      await runCheckResolutionsOnlyChange(args, root);
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+    return "";
+  };
+
+  it("passes when the working tree matches the commit", async () => {
+    expect(await runCheckResolutionsOnlyChange([], root)).toBe(0);
+  });
+
+  it("passes when only a pin was raised", async () => {
+    await write(MANIFEST.replace('"3.0.0"', '"3.4.0"'));
+
+    expect(await runCheckResolutionsOnlyChange([], root)).toBe(0);
+  });
+
+  it("fails when anything else moved", async () => {
+    await write(MANIFEST.replace('"stella"', '"not-stella"'));
+
+    expect(await runCheckResolutionsOnlyChange([], root)).toBe(1);
+  });
+
+  it("resolves an explicit commit SHA", async () => {
+    const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: root })
+      .stdout.toString()
+      .trim();
+    await write(MANIFEST.replace('"3.0.0"', '"3.4.0"'));
+
+    expect(await runCheckResolutionsOnlyChange(["--ref", head], root)).toBe(0);
+  });
+
+  it("refuses a ref that is not HEAD or a full commit SHA", async () => {
+    expect(await failure(["--ref", "main"])).toContain(
+      "expected HEAD or a full commit SHA",
+    );
+  });
+
+  it("refuses a manifest that is no longer a regular file", async () => {
+    git(root, ["rm", "--quiet", "--cached", "package.json"]);
+    await rm(path.join(root, "package.json"));
+    await Bun.write(path.join(root, "elsewhere.json"), MANIFEST);
+    Bun.spawnSync(["ln", "-s", "elsewhere.json", "package.json"], {
+      cwd: root,
+    });
+    git(root, ["add", "package.json"]);
+    git(root, ["commit", "--quiet", "-m", "symlink"]);
+
+    expect(await failure([])).toContain("is not a regular file");
+  });
+});

--- a/scripts/check-resolutions-only-change.ts
+++ b/scripts/check-resolutions-only-change.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+// Autofix boundary: the workflow may push a root package.json edit ONLY when
+// that edit is an override pin raised to a dependent's floor. Everything else —
+// a new dependency, a changed script, a reordered key, a reformat, a lowered
+// pin — is a change the autofix has no mandate to make on a Dependabot PR, and
+// fails the job.
+//
+// The verdict is structural, not textual: the pin changes are replayed onto the
+// committed manifest and the result must equal the working tree byte for byte,
+// so no unrelated byte can ride along.
+
+import path from "node:path";
+
+import { inspectManifestChange } from "./resolution-ranges";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const REF_PATTERN = /^(?:HEAD|[0-9a-f]{40})$/u;
+const REGULAR_FILE_MODE = "100644";
+const MANIFEST = "package.json";
+
+class ResolutionChangeCheckError extends Error {
+  readonly _tag = "ResolutionChangeCheckError";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ResolutionChangeCheckError";
+  }
+}
+
+const gitOutput = (args: readonly string[], root: string): string => {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new ResolutionChangeCheckError(`git ${args.join(" ")} failed`);
+  }
+  return result.stdout.toString();
+};
+
+const parseRef = (args: readonly string[]): string => {
+  if (args.length === 0) {
+    return "HEAD";
+  }
+  const [flag, value, ...rest] = args;
+  if (flag !== "--ref" || value === undefined || rest.length > 0) {
+    throw new ResolutionChangeCheckError(
+      "Usage: check-resolutions-only-change.ts [--ref <sha>]",
+    );
+  }
+  if (!REF_PATTERN.test(value)) {
+    throw new ResolutionChangeCheckError(
+      `Refusing to compare against ${value}: expected HEAD or a full commit SHA`,
+    );
+  }
+  return value;
+};
+
+export const runCheckResolutionsOnlyChange = async (
+  args: readonly string[],
+  root: string = ROOT,
+): Promise<number> => {
+  const ref = parseRef(args);
+  // A PR that turns package.json into a symlink would otherwise have the fixer
+  // write through it; only a regular tracked blob is comparable.
+  const entry = gitOutput(["ls-tree", "-z", ref, "--", MANIFEST], root);
+  if (entry.slice(0, entry.indexOf(" ")) !== REGULAR_FILE_MODE) {
+    throw new ResolutionChangeCheckError(
+      `${MANIFEST} at ${ref} is not a regular file`,
+    );
+  }
+  const committed = gitOutput(["show", `${ref}:${MANIFEST}`], root);
+  const working = await Bun.file(path.join(root, MANIFEST)).text();
+
+  const verdict = inspectManifestChange(committed, working);
+  switch (verdict.status) {
+    case "unchanged":
+      process.stdout.write("package.json guard: unchanged. OK.\n");
+      return 0;
+    case "pins-raised":
+      process.stdout.write(
+        [
+          ...verdict.changes.map(
+            ({ from, kind, packageName, to }) =>
+              `package.json guard: ${kind}.${packageName} raised ${from} -> ${to}.`,
+          ),
+          "package.json guard: only raised pins changed. OK.",
+          "",
+        ].join("\n"),
+      );
+      return 0;
+    case "rejected":
+      process.stderr.write(
+        `package.json guard: ${verdict.reason}. Only a raised root resolution may be generated here.\n`,
+      );
+      return 1;
+    default: {
+      const unreachable: never = verdict;
+      return unreachable;
+    }
+  }
+};
+
+if (import.meta.main) {
+  process.exit(await runCheckResolutionsOnlyChange(process.argv.slice(2)));
+}

--- a/scripts/fix-resolution-ranges.ts
+++ b/scripts/fix-resolution-ranges.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+// Raises a root `resolutions`/`overrides` pin that sits below a dependent's
+// declared floor to the lowest version every dependent accepts, so the
+// resolution-range guard never leaves a Dependabot bun update red for a human
+// to hand-edit.
+//
+// Runs to a bounded fixed point. Raising pin A and regenerating the lockfile
+// republishes A's own metadata, which can expose a floor for another pinned
+// package B that no earlier pass could see; one repair pass would leave that
+// cascade for the guard to fail on. Each pass therefore rewrites the pins,
+// refreshes bun.lock, and re-reads the graph until nothing is left to raise.
+// The pass cap keeps a pathological graph from looping in CI.
+//
+// Refuses to write when no single version satisfies the dependents: a real
+// conflict is a decision, not a mechanical bump.
+
+import path from "node:path";
+
+import {
+  analyzeResolutionRanges,
+  applyOverridePins,
+  loadResolutionGraph,
+  planResolutionRepairs,
+} from "./resolution-ranges";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const DEFAULT_MAX_PASSES = 4;
+const PASS_BOUNDS = { max: 10, min: 1 } as const;
+
+class ResolutionFixError extends Error {
+  readonly _tag = "ResolutionFixError";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ResolutionFixError";
+  }
+}
+
+/**
+ * Re-resolves bun.lock against the rewritten pins. `--lockfile-only` keeps the
+ * pass from materializing dependencies and `--ignore-scripts` from running any
+ * hook the update carries.
+ */
+const installLockfileOnly = (root: string): void => {
+  const result = Bun.spawnSync(
+    ["bun", "--no-env-file", "install", "--lockfile-only", "--ignore-scripts"],
+    { cwd: root, stdout: "inherit", stderr: "inherit" },
+  );
+  if (result.exitCode !== 0) {
+    throw new ResolutionFixError(
+      `bun install --lockfile-only failed with exit code ${String(result.exitCode)}`,
+    );
+  }
+};
+
+export type RefreshLockfile = (root: string) => Promise<void> | void;
+
+export type FixResolutionRangesOptions = {
+  readonly maxPasses?: number;
+  /** Seam for tests: the real hook re-resolves bun.lock with bun install. */
+  readonly refresh?: RefreshLockfile;
+  readonly root: string;
+};
+
+export const runFixResolutionRanges = async ({
+  maxPasses = DEFAULT_MAX_PASSES,
+  refresh = installLockfileOnly,
+  root,
+}: FixResolutionRangesOptions): Promise<number> => {
+  // One pass per call rather than a loop: the passes are strictly sequential
+  // (each reads the lockfile the previous one refreshed) and the cap bounds
+  // the depth.
+  const runPass = async (pass: number): Promise<number> => {
+    const { declared, rootManifest } = await loadResolutionGraph(root);
+    const violations = analyzeResolutionRanges({ declared, rootManifest });
+    if (violations.length === 0) {
+      process.stdout.write(
+        `resolution-range fix: every pin meets its dependents' floors after ${String(pass)} pass(es).\n`,
+      );
+      return 0;
+    }
+
+    const repairs = planResolutionRepairs({ declared, violations });
+    const conflicts = repairs.filter((repair) => repair.status === "conflict");
+    if (conflicts.length > 0) {
+      const lines = [
+        "resolution-range fix: no single version satisfies every dependent.",
+        "",
+      ];
+      for (const { blockedBy, packageName, pinned, target } of conflicts) {
+        lines.push(
+          `  - ${packageName} is pinned to ${pinned}; raising it to ${target} would break:`,
+        );
+        for (const { declaredBy, range } of blockedBy) {
+          lines.push(`      ${declaredBy} requires "${range}"`);
+        }
+      }
+      lines.push(
+        "",
+        "Resolve the conflicting requirements by hand; nothing was written.",
+        "",
+      );
+      process.stderr.write(lines.join("\n"));
+      return 1;
+    }
+
+    if (pass >= maxPasses) {
+      process.stderr.write(
+        [
+          `resolution-range fix: still repairing after ${String(maxPasses)} pass(es), giving up.`,
+          "",
+          ...violations.map(
+            ({ floor, packageName, pinned }) =>
+              `  - ${packageName} is pinned to ${pinned} and wants ${floor}`,
+          ),
+          "",
+          "Each pass exposed another floor; resolve the cascade by hand.",
+          "",
+        ].join("\n"),
+      );
+      return 1;
+    }
+
+    const raises = repairs.filter((repair) => repair.status === "raise");
+    const manifestPath = path.join(root, "package.json");
+    const before = await Bun.file(manifestPath).text();
+    const after = applyOverridePins(
+      before,
+      raises.map(({ kind, packageName, to }) => ({
+        kind,
+        packageName,
+        version: to,
+      })),
+    );
+    await Bun.write(manifestPath, after);
+    process.stdout.write(
+      `${raises
+        .map(
+          ({ from, kind, packageName, requiredBy: [binding], to }) =>
+            `resolution-range fix: raised ${kind}.${packageName} ${from} -> ${to} (${binding.declaredBy} requires "${binding.range}").`,
+        )
+        .join("\n")}\n`,
+    );
+    // Refresh before the next read: a raised pin republishes that package's own
+    // metadata, which is where a further floor can appear.
+    await refresh(root);
+    return runPass(pass + 1);
+  };
+
+  return runPass(0);
+};
+
+const parseMaxPasses = (args: readonly string[]): number => {
+  if (args.length === 0) {
+    return DEFAULT_MAX_PASSES;
+  }
+  const [flag, value, ...rest] = args;
+  if (flag !== "--max-passes" || value === undefined || rest.length > 0) {
+    throw new ResolutionFixError(
+      "Usage: fix-resolution-ranges.ts [--max-passes <1-10>]",
+    );
+  }
+  const maxPasses = Number(value);
+  if (
+    !Number.isInteger(maxPasses) ||
+    maxPasses < PASS_BOUNDS.min ||
+    maxPasses > PASS_BOUNDS.max
+  ) {
+    throw new ResolutionFixError(`--max-passes must be 1-10, got ${value}`);
+  }
+  return maxPasses;
+};
+
+if (import.meta.main) {
+  process.exit(
+    await runFixResolutionRanges({
+      maxPasses: parseMaxPasses(process.argv.slice(2)),
+      root: ROOT,
+    }),
+  );
+}

--- a/scripts/json-text-edit.ts
+++ b/scripts/json-text-edit.ts
@@ -1,0 +1,137 @@
+// Surgical edits to a JSON document's *text*.
+//
+// Two repo guards must change a handful of string values inside a JSON file and
+// leave every other byte identical: the bun.lock workspace-version synchronizer
+// and the root package.json resolution fixer. `JSON.parse` + `JSON.stringify`
+// reformats the whole file (and bun.lock is not even strict JSON); a regex
+// matches nested lookalikes. Walking the structure to the exact string token,
+// then splicing, is the only approach that is both precise and format-preserving.
+//
+// No third-party imports: the autofix workflow runs consumers of this module
+// with `bun --no-install` on a checkout that has no node_modules.
+
+export type JsonStringToken = {
+  readonly end: number;
+  readonly start: number;
+  readonly value: string;
+};
+
+export type JsonTextReplacement = {
+  readonly end: number;
+  readonly start: number;
+  readonly value: string;
+};
+
+export type DirectPropertyOptions = {
+  readonly label: string;
+  readonly missingMessage?: string;
+  readonly objectStart: number;
+  readonly property: string;
+  readonly text: string;
+};
+
+const skipWhitespace = (text: string, start: number): number => {
+  let index = start;
+  while (index < text.length && /\s/u.test(text[index] ?? "")) {
+    index += 1;
+  }
+  return index;
+};
+
+export const stringTokenAt = (text: string, start: number): JsonStringToken => {
+  if (text[start] !== '"') {
+    throw new TypeError(`expected JSON string at offset ${start}`);
+  }
+  let index = start + 1;
+  while (index < text.length) {
+    const character = text[index];
+    if (character === "\\") {
+      index += 2;
+      continue;
+    }
+    if (character === '"') {
+      const end = index + 1;
+      return {
+        end,
+        start,
+        value: JSON.parse(text.slice(start, end)),
+      };
+    }
+    index += 1;
+  }
+  throw new TypeError(`unterminated JSON string at offset ${start}`);
+};
+
+/**
+ * Offset of the value of `property` declared directly on the object starting at
+ * `objectStart`. Nested objects are skipped by depth, so a same-named property
+ * one level down can never be mistaken for the requested one.
+ */
+export const directPropertyValue = ({
+  label,
+  missingMessage,
+  objectStart,
+  property,
+  text,
+}: DirectPropertyOptions): number => {
+  if (text[objectStart] !== "{") {
+    throw new TypeError(`expected object at offset ${objectStart}`);
+  }
+  let depth = 1;
+  let index = objectStart + 1;
+  while (index < text.length && depth > 0) {
+    const character = text[index];
+    if (character === '"') {
+      const token = stringTokenAt(text, index);
+      if (depth === 1) {
+        const colon = skipWhitespace(text, token.end);
+        if (text[colon] === ":" && token.value === property) {
+          return skipWhitespace(text, colon + 1);
+        }
+      }
+      index = token.end;
+      continue;
+    }
+    if (character === "{" || character === "[") {
+      depth += 1;
+    } else if (character === "}" || character === "]") {
+      depth -= 1;
+    }
+    index += 1;
+  }
+  throw new TypeError(
+    missingMessage ??
+      `${label} is missing property ${JSON.stringify(property)}`,
+  );
+};
+
+export const rootObjectStart = (text: string, label: string): number => {
+  const start = skipWhitespace(text, 0);
+  if (text[start] !== "{") {
+    throw new TypeError(`${label} must contain a root object`);
+  }
+  return start;
+};
+
+/**
+ * Splices replacements back to front so earlier offsets stay valid. Overlapping
+ * spans are a caller bug and would corrupt the document, so they throw.
+ */
+export const applyReplacements = (
+  text: string,
+  replacements: readonly JsonTextReplacement[],
+): string => {
+  const ordered = [...replacements].sort(
+    (left, right) => right.start - left.start,
+  );
+  let output = text;
+  let previousStart = text.length;
+  for (const replacement of ordered) {
+    if (replacement.end > previousStart) {
+      throw new TypeError("overlapping JSON text replacements");
+    }
+    previousStart = replacement.start;
+    output = `${output.slice(0, replacement.start)}${replacement.value}${output.slice(replacement.end)}`;
+  }
+  return output;
+};

--- a/scripts/lockfile-workspace-versions.ts
+++ b/scripts/lockfile-workspace-versions.ts
@@ -1,87 +1,14 @@
+import {
+  applyReplacements,
+  directPropertyValue,
+  rootObjectStart,
+  stringTokenAt,
+  type JsonTextReplacement,
+} from "./json-text-edit";
+
 type WorkspaceVersions = Readonly<Record<string, string>>;
 
-type StringToken = {
-  end: number;
-  start: number;
-  value: string;
-};
-
-const skipWhitespace = (text: string, start: number): number => {
-  let index = start;
-  while (index < text.length && /\s/u.test(text[index] ?? "")) {
-    index += 1;
-  }
-  return index;
-};
-
-const stringTokenAt = (text: string, start: number): StringToken => {
-  if (text[start] !== '"') {
-    throw new TypeError(`expected JSON string at offset ${start}`);
-  }
-  let index = start + 1;
-  while (index < text.length) {
-    const character = text[index];
-    if (character === "\\") {
-      index += 2;
-      continue;
-    }
-    if (character === '"') {
-      const end = index + 1;
-      return {
-        end,
-        start,
-        value: JSON.parse(text.slice(start, end)),
-      };
-    }
-    index += 1;
-  }
-  throw new TypeError(`unterminated JSON string at offset ${start}`);
-};
-
-const directPropertyValue = (
-  text: string,
-  objectStart: number,
-  property: string,
-  missingMessage?: string,
-): number => {
-  if (text[objectStart] !== "{") {
-    throw new TypeError(`expected object at offset ${objectStart}`);
-  }
-  let depth = 1;
-  let index = objectStart + 1;
-  while (index < text.length && depth > 0) {
-    const character = text[index];
-    if (character === '"') {
-      const token = stringTokenAt(text, index);
-      if (depth === 1) {
-        const colon = skipWhitespace(text, token.end);
-        if (text[colon] === ":" && token.value === property) {
-          return skipWhitespace(text, colon + 1);
-        }
-      }
-      index = token.end;
-      continue;
-    }
-    if (character === "{" || character === "[") {
-      depth += 1;
-    } else if (character === "}" || character === "]") {
-      depth -= 1;
-    }
-    index += 1;
-  }
-  throw new TypeError(
-    missingMessage ??
-      `bun.lock is missing property ${JSON.stringify(property)}`,
-  );
-};
-
-const rootObjectStart = (text: string): number => {
-  const start = skipWhitespace(text, 0);
-  if (text[start] !== "{") {
-    throw new TypeError("bun.lock must contain a root object");
-  }
-  return start;
-};
+const LABEL = "bun.lock";
 
 /**
  * Updates only workspace self-versions in Bun's text lockfile.
@@ -95,46 +22,42 @@ export const syncLockfileWorkspaceVersions = (
   lockText: string,
   workspaceVersions: WorkspaceVersions,
 ): string => {
-  const rootStart = rootObjectStart(lockText);
-  const workspacesStart = directPropertyValue(
-    lockText,
-    rootStart,
-    "workspaces",
-  );
+  const rootStart = rootObjectStart(lockText, LABEL);
+  const workspacesStart = directPropertyValue({
+    label: LABEL,
+    objectStart: rootStart,
+    property: "workspaces",
+    text: lockText,
+  });
   if (lockText[workspacesStart] !== "{") {
     throw new TypeError("bun.lock workspaces property must be an object");
   }
-  const replacements = Object.entries(workspaceVersions).map(
-    ([workspace, version]) => {
-      const workspaceStart = directPropertyValue(
-        lockText,
-        workspacesStart,
-        workspace,
-        `bun.lock has no workspace entry for ${workspace}`,
-      );
-      if (lockText[workspaceStart] !== "{") {
-        throw new TypeError(
-          `bun.lock workspace ${workspace} must be an object`,
-        );
-      }
-      const versionStart = directPropertyValue(
-        lockText,
-        workspaceStart,
-        "version",
-      );
-      const token = stringTokenAt(lockText, versionStart);
-      return {
-        end: token.end,
-        start: token.start,
-        value: JSON.stringify(version),
-      };
-    },
-  );
+  const replacements: JsonTextReplacement[] = Object.entries(
+    workspaceVersions,
+  ).map(([workspace, version]) => {
+    const workspaceStart = directPropertyValue({
+      label: LABEL,
+      missingMessage: `bun.lock has no workspace entry for ${workspace}`,
+      objectStart: workspacesStart,
+      property: workspace,
+      text: lockText,
+    });
+    if (lockText[workspaceStart] !== "{") {
+      throw new TypeError(`bun.lock workspace ${workspace} must be an object`);
+    }
+    const versionStart = directPropertyValue({
+      label: LABEL,
+      objectStart: workspaceStart,
+      property: "version",
+      text: lockText,
+    });
+    const token = stringTokenAt(lockText, versionStart);
+    return {
+      end: token.end,
+      start: token.start,
+      value: JSON.stringify(version),
+    };
+  });
 
-  replacements.sort((left, right) => right.start - left.start);
-  let output = lockText;
-  for (const replacement of replacements) {
-    output = `${output.slice(0, replacement.start)}${replacement.value}${output.slice(replacement.end)}`;
-  }
-  return output;
+  return applyReplacements(lockText, replacements);
 };

--- a/scripts/resolution-ranges.test.ts
+++ b/scripts/resolution-ranges.test.ts
@@ -1,0 +1,582 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  runFixResolutionRanges,
+  type RefreshLockfile,
+} from "./fix-resolution-ranges";
+import {
+  analyzeResolutionRanges,
+  applyOverridePins,
+  collectDeclaredRanges,
+  inspectManifestChange,
+  lockRangeSources,
+  planResolutionRepairs,
+  rangeFloor,
+  type DeclaredRanges,
+  type ResolutionViolation,
+} from "./resolution-ranges";
+
+const declaredRanges = (
+  entries: Readonly<Record<string, Readonly<Record<string, string>>>>,
+): DeclaredRanges =>
+  collectDeclaredRanges(
+    Object.entries(entries).map(([declaredBy, dependencies]) => ({
+      declaredBy,
+      manifest: { dependencies },
+    })),
+  );
+
+const analyze = (
+  resolutions: Readonly<Record<string, string>>,
+  entries: Readonly<Record<string, Readonly<Record<string, string>>>>,
+): readonly ResolutionViolation[] =>
+  analyzeResolutionRanges({
+    allowedBelowFloor: new Map(),
+    declared: declaredRanges(entries),
+    rootManifest: { resolutions },
+  });
+
+const MANIFEST = `{
+  "name": "stella",
+  "resolutions": {
+    "alpha": "3.0.0",
+    "beta": "1.0.0"
+  },
+  "devDependencies": {
+    "alpha": "3.0.0"
+  }
+}
+`;
+
+describe("range floors", () => {
+  const cases = [
+    { range: "^3.1.0", floor: "3.1.0" },
+    { range: "~2.4.5", floor: "2.4.5" },
+    { range: ">=1.2.3", floor: "1.2.3" },
+    { range: "4.5.6", floor: "4.5.6" },
+    { range: "  ^0.1.2 ", floor: "0.1.2" },
+    { range: "^1.0.0-beta.1", floor: "1.0.0-beta.1" },
+    { range: "^2.0.0 || ^3.0.0", floor: null },
+    { range: ">=3.0.0 <4.0.0", floor: null },
+    { range: "3.x", floor: null },
+    { range: "*", floor: null },
+    { range: "workspace:*", floor: null },
+    { range: "catalog:", floor: null },
+    { range: "npm:other@^1.0.0", floor: null },
+    { range: "", floor: null },
+  ] as const;
+
+  for (const { range, floor } of cases) {
+    it(`reduces ${JSON.stringify(range)} to ${String(floor)}`, () => {
+      expect(rangeFloor(range)).toBe(floor);
+    });
+  }
+});
+
+describe("resolution range analysis", () => {
+  it("flags a pin below a dependent's floor", () => {
+    const violations = analyze(
+      { alpha: "3.0.0" },
+      { "workspace apps/web": { alpha: "^3.1.0" } },
+    );
+
+    expect(violations).toEqual([
+      {
+        floor: "3.1.0",
+        kind: "resolutions",
+        packageName: "alpha",
+        pinned: "3.0.0",
+        requiredBy: [
+          { declaredBy: "workspace apps/web", floor: "3.1.0", range: "^3.1.0" },
+        ],
+      },
+    ]);
+  });
+
+  it("accepts a pin exactly at the floor", () => {
+    expect(
+      analyze(
+        { alpha: "3.1.0" },
+        { "workspace apps/web": { alpha: "^3.1.0" } },
+      ),
+    ).toEqual([]);
+  });
+
+  it("accepts a pin above the floor (a deliberate forward override)", () => {
+    expect(
+      analyze(
+        { alpha: "4.2.0" },
+        { "workspace apps/web": { alpha: "^3.1.0" } },
+      ),
+    ).toEqual([]);
+  });
+
+  it("reports the highest floor first across several dependents", () => {
+    const [violation] = analyze(
+      { alpha: "3.0.0" },
+      {
+        "alpha-consumer@1.0.0": { alpha: ">=3.4.0" },
+        "workspace apps/web": { alpha: "^3.1.0" },
+        "workspace packages/ui": { alpha: "~3.2.0" },
+      },
+    );
+
+    expect(violation?.floor).toBe("3.4.0");
+    expect(violation?.requiredBy.map(({ range }) => range)).toEqual([
+      ">=3.4.0",
+      "~3.2.0",
+      "^3.1.0",
+    ]);
+  });
+
+  it("skips shapes it cannot reduce to one floor", () => {
+    expect(
+      analyze(
+        { alpha: "3.0.0" },
+        {
+          "workspace apps/web": { alpha: "^3.1.0 || ^4.0.0" },
+          "workspace packages/ui": { alpha: "workspace:*" },
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it("skips a pin that is not an exact version", () => {
+    expect(
+      analyze(
+        { alpha: "^3.0.0" },
+        { "workspace apps/web": { alpha: "^3.1.0" } },
+      ),
+    ).toEqual([]);
+  });
+
+  it("skips an allowlisted below-floor override", () => {
+    expect(
+      analyzeResolutionRanges({
+        allowedBelowFloor: new Map([["alpha", "held at 3.0.0 on purpose"]]),
+        declared: declaredRanges({ "workspace apps/web": { alpha: "^3.1.0" } }),
+        rootManifest: { resolutions: { alpha: "3.0.0" } },
+      }),
+    ).toEqual([]);
+  });
+
+  it("checks overrides alongside resolutions", () => {
+    const violations = analyzeResolutionRanges({
+      allowedBelowFloor: new Map(),
+      declared: declaredRanges({ "workspace apps/web": { alpha: "^3.1.0" } }),
+      rootManifest: { overrides: { alpha: "3.0.0" } },
+    });
+
+    expect(violations.at(0)?.kind).toBe("overrides");
+  });
+
+  it("reads ranges from workspaces and resolved packages in bun.lock", () => {
+    const declared = collectDeclaredRanges(
+      lockRangeSources({
+        workspaces: {
+          "": { devDependencies: { alpha: "^3.1.0" } },
+          "apps/web": { dependencies: { alpha: "^3.2.0" } },
+        },
+        packages: {
+          "beta@1.0.0": [
+            "beta@1.0.0",
+            "",
+            { peerDependencies: { alpha: "^3.3.0" } },
+            "sha",
+          ],
+        },
+      }),
+    );
+
+    expect(declared.get("alpha")).toEqual([
+      { declaredBy: "workspace <root>", range: "^3.1.0" },
+      { declaredBy: "workspace apps/web", range: "^3.2.0" },
+      { declaredBy: "beta@1.0.0", range: "^3.3.0" },
+    ]);
+  });
+});
+
+describe("resolution repair planning", () => {
+  const plan = (
+    resolutions: Readonly<Record<string, string>>,
+    entries: Readonly<Record<string, Readonly<Record<string, string>>>>,
+  ) => {
+    const declared = declaredRanges(entries);
+    return planResolutionRepairs({
+      declared,
+      violations: analyzeResolutionRanges({
+        allowedBelowFloor: new Map(),
+        declared,
+        rootManifest: { resolutions },
+      }),
+    });
+  };
+
+  it("raises the pin to the highest floor every dependent accepts", () => {
+    expect(
+      plan(
+        { alpha: "3.0.0" },
+        {
+          "workspace apps/web": { alpha: "^3.1.0" },
+          "workspace packages/ui": { alpha: "^3.4.0" },
+        },
+      ),
+    ).toEqual([
+      {
+        status: "raise",
+        from: "3.0.0",
+        kind: "resolutions",
+        packageName: "alpha",
+        requiredBy: [
+          {
+            declaredBy: "workspace packages/ui",
+            floor: "3.4.0",
+            range: "^3.4.0",
+          },
+          { declaredBy: "workspace apps/web", floor: "3.1.0", range: "^3.1.0" },
+        ],
+        to: "3.4.0",
+      },
+    ]);
+  });
+
+  it("refuses a floor that no single version can satisfy", () => {
+    const [repair] = plan(
+      { alpha: "3.0.0" },
+      {
+        "workspace apps/web": { alpha: "^3.4.0" },
+        "workspace packages/ui": { alpha: "3.1.0" },
+      },
+    );
+
+    expect(repair?.status).toBe("conflict");
+    expect(repair).toMatchObject({
+      blockedBy: [{ declaredBy: "workspace packages/ui", range: "3.1.0" }],
+      packageName: "alpha",
+      target: "3.4.0",
+    });
+  });
+
+  it("refuses to raise out of an upper-bounded range the pin satisfies today", () => {
+    const [repair] = plan(
+      { alpha: "3.0.0" },
+      {
+        "workspace apps/web": { alpha: "^3.4.0" },
+        "workspace packages/ui": { alpha: ">=3.0.0 <3.1.0" },
+      },
+    );
+
+    expect(repair?.status).toBe("conflict");
+    expect(repair).toMatchObject({
+      blockedBy: [
+        { declaredBy: "workspace packages/ui", range: ">=3.0.0 <3.1.0" },
+      ],
+    });
+  });
+
+  it("ignores a range the current pin already fails and cannot reach", () => {
+    const [repair] = plan(
+      { alpha: "3.0.0" },
+      {
+        "workspace apps/web": { alpha: "^3.4.0" },
+        "legacy@1.0.0": { alpha: "^1.0.0" },
+      },
+    );
+
+    expect(repair).toMatchObject({ status: "raise", to: "3.4.0" });
+  });
+});
+
+describe("manifest pin rewriting", () => {
+  it("writes the floor and leaves every other byte untouched", () => {
+    expect(
+      applyOverridePins(MANIFEST, [
+        { kind: "resolutions", packageName: "alpha", version: "3.4.0" },
+      ]),
+    ).toBe(MANIFEST.replace('"alpha": "3.0.0",', '"alpha": "3.4.0",'));
+  });
+
+  it("never touches a same-named key outside the override map", () => {
+    const rewritten = applyOverridePins(MANIFEST, [
+      { kind: "resolutions", packageName: "alpha", version: "3.4.0" },
+    ]);
+
+    expect(rewritten).toContain('"devDependencies": {\n    "alpha": "3.0.0"');
+  });
+
+  it("rewrites several pins at once", () => {
+    expect(
+      applyOverridePins(MANIFEST, [
+        { kind: "resolutions", packageName: "alpha", version: "3.4.0" },
+        { kind: "resolutions", packageName: "beta", version: "1.2.0" },
+      ]),
+    ).toBe(
+      MANIFEST.replace('"alpha": "3.0.0",', '"alpha": "3.4.0",').replace(
+        '"beta": "1.0.0"',
+        '"beta": "1.2.0"',
+      ),
+    );
+  });
+
+  it("refuses a pin the manifest does not declare", () => {
+    expect(() =>
+      applyOverridePins(MANIFEST, [
+        { kind: "resolutions", packageName: "gamma", version: "1.0.0" },
+      ]),
+    ).toThrow("package.json resolutions has no entry for gamma");
+  });
+
+  it("refuses an override map the manifest does not declare", () => {
+    expect(() =>
+      applyOverridePins(MANIFEST, [
+        { kind: "overrides", packageName: "alpha", version: "1.0.0" },
+      ]),
+    ).toThrow("package.json has no overrides object");
+  });
+});
+
+describe("generated manifest change boundary", () => {
+  const raised = (from: string, to: string): string =>
+    MANIFEST.replace(`"alpha": "${from}",`, () => `"alpha": "${to}",`);
+
+  it("accepts an unchanged manifest", () => {
+    expect(inspectManifestChange(MANIFEST, MANIFEST)).toEqual({
+      status: "unchanged",
+    });
+  });
+
+  it("accepts a raised pin", () => {
+    expect(inspectManifestChange(MANIFEST, raised("3.0.0", "3.4.0"))).toEqual({
+      status: "pins-raised",
+      changes: [
+        {
+          from: "3.0.0",
+          kind: "resolutions",
+          packageName: "alpha",
+          to: "3.4.0",
+        },
+      ],
+    });
+  });
+
+  const rejections = [
+    {
+      name: "a lowered pin",
+      after: raised("3.0.0", "2.9.0"),
+      reason: "was not raised",
+    },
+    {
+      name: "a change to another field",
+      after: MANIFEST.replace('"name": "stella"', '"name": "not-stella"'),
+      reason: "changed outside resolutions",
+    },
+    {
+      name: "a dependency added next to the pins",
+      after: MANIFEST.replace(
+        '"beta": "1.0.0"',
+        '"beta": "1.0.0",\n    "gamma": "1.0.0"',
+      ),
+      reason: "keys were added, removed or reordered",
+    },
+    {
+      name: "reformatting around an unchanged pin",
+      after: MANIFEST.replace('"name": "stella",', '"name":   "stella",'),
+      reason: "without changing any pin",
+    },
+    {
+      name: "reformatting that rides along with a raised pin",
+      after: raised("3.0.0", "3.4.0").replace(
+        '"name": "stella",',
+        '"name":   "stella",',
+      ),
+      reason: "outside the pinned versions",
+    },
+    {
+      name: "a manifest that stopped being JSON",
+      after: `${MANIFEST}trailing`,
+      reason: "not a JSON object",
+    },
+  ] as const;
+
+  for (const { name, after, reason } of rejections) {
+    it(`rejects ${name}`, () => {
+      const verdict = inspectManifestChange(MANIFEST, after);
+
+      expect(verdict.status).toBe("rejected");
+      expect(verdict.status === "rejected" ? verdict.reason : "").toContain(
+        reason,
+      );
+    });
+  }
+
+  it("accepts every raise the rewriter produces", () => {
+    // Any pin the fixer can write must survive the boundary check: the two
+    // sides are one contract, so drift between them would silently red a
+    // Dependabot PR the autofix just repaired.
+    let state = 7919;
+    const random = (bound: number): number => {
+      state = (state * 16_807) % 2_147_483_647;
+      return state % bound;
+    };
+
+    for (let iteration = 0; iteration < 128; iteration += 1) {
+      const version = `${3 + random(3)}.${random(20)}.${random(20)}`;
+      if (Bun.semver.order(version, "3.0.0") <= 0) {
+        continue;
+      }
+      const after = applyOverridePins(MANIFEST, [
+        { kind: "resolutions", packageName: "alpha", version },
+      ]);
+
+      expect(inspectManifestChange(MANIFEST, after)).toEqual({
+        status: "pins-raised",
+        changes: [
+          {
+            from: "3.0.0",
+            kind: "resolutions",
+            packageName: "alpha",
+            to: version,
+          },
+        ],
+      });
+    }
+  });
+});
+
+describe("fix-resolution-ranges entry point", () => {
+  const withRepo = async (
+    manifest: string,
+    lock: string,
+    run: (root: string) => Promise<void>,
+  ): Promise<void> => {
+    const root = await mkdtemp(path.join(tmpdir(), "resolution-ranges-"));
+    try {
+      await Bun.write(path.join(root, "package.json"), manifest);
+      await Bun.write(path.join(root, "bun.lock"), lock);
+      await run(root);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  };
+
+  const lockWith = (...dependencies: readonly string[]): string => `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "apps/web": {
+      "name": "@stll/web",
+      "dependencies": { ${dependencies.join(", ")} },
+    },
+  },
+}
+`;
+
+  const alpha = (range: string): string => `"alpha": "${range}"`;
+  const beta = (range: string): string => `"beta": "${range}"`;
+
+  // The real hook re-resolves bun.lock; a test drives what the next pass reads.
+  const refreshWith = (
+    locks: readonly string[],
+  ): { calls: () => number; refresh: RefreshLockfile } => {
+    let calls = 0;
+    return {
+      calls: () => calls,
+      refresh: async (root: string) => {
+        const lock = locks.at(calls) ?? locks.at(-1) ?? "";
+        calls += 1;
+        await Bun.write(path.join(root, "bun.lock"), lock);
+      },
+    };
+  };
+
+  const neverRefresh: RefreshLockfile = () => undefined;
+
+  it("raises the pin in place and leaves the rest of the manifest alone", async () => {
+    await withRepo(MANIFEST, lockWith(alpha("^3.4.0")), async (root) => {
+      expect(
+        await runFixResolutionRanges({ refresh: neverRefresh, root }),
+      ).toBe(0);
+      expect(await Bun.file(path.join(root, "package.json")).text()).toBe(
+        MANIFEST.replace('"alpha": "3.0.0",', '"alpha": "3.4.0",'),
+      );
+    });
+  });
+
+  it("writes nothing when every pin already meets its floor", async () => {
+    await withRepo(MANIFEST, lockWith(alpha("^3.0.0")), async (root) => {
+      expect(
+        await runFixResolutionRanges({ refresh: neverRefresh, root }),
+      ).toBe(0);
+      expect(await Bun.file(path.join(root, "package.json")).text()).toBe(
+        MANIFEST,
+      );
+    });
+  });
+
+  it("fails without writing when the floors conflict", async () => {
+    const lock = `{
+  "workspaces": {
+    "apps/web": { "dependencies": { "alpha": "^3.4.0" } },
+    "packages/ui": { "dependencies": { "alpha": "3.1.0" } },
+  },
+}
+`;
+
+    await withRepo(MANIFEST, lock, async (root) => {
+      expect(
+        await runFixResolutionRanges({ refresh: neverRefresh, root }),
+      ).toBe(1);
+      expect(await Bun.file(path.join(root, "package.json")).text()).toBe(
+        MANIFEST,
+      );
+    });
+  });
+
+  it("repairs a floor that only the refreshed lockfile exposes", async () => {
+    // Raising alpha republishes its own metadata, and the refreshed lockfile
+    // declares a floor for beta that no earlier pass could see.
+    const cascade = refreshWith([
+      lockWith(alpha("^3.4.0"), beta("^1.5.0")),
+      lockWith(alpha("^3.4.0"), beta("^1.5.0")),
+    ]);
+
+    await withRepo(MANIFEST, lockWith(alpha("^3.4.0")), async (root) => {
+      expect(
+        await runFixResolutionRanges({ refresh: cascade.refresh, root }),
+      ).toBe(0);
+      expect(cascade.calls()).toBe(2);
+      expect(await Bun.file(path.join(root, "package.json")).text()).toBe(
+        MANIFEST.replace('"alpha": "3.0.0",', '"alpha": "3.4.0",').replace(
+          '"beta": "1.0.0"',
+          '"beta": "1.5.0"',
+        ),
+      );
+    });
+  });
+
+  it("gives up at the pass cap instead of chasing an endless cascade", async () => {
+    // Every refresh raises the floor again, so the fixed point never arrives.
+    const endless = refreshWith([
+      lockWith(alpha("^3.5.0")),
+      lockWith(alpha("^3.6.0")),
+      lockWith(alpha("^3.7.0")),
+    ]);
+
+    await withRepo(MANIFEST, lockWith(alpha("^3.4.0")), async (root) => {
+      expect(
+        await runFixResolutionRanges({
+          maxPasses: 2,
+          refresh: endless.refresh,
+          root,
+        }),
+      ).toBe(1);
+      expect(endless.calls()).toBe(2);
+      // Two repairs landed, and the third floor the cap refused stays unfixed.
+      expect(await Bun.file(path.join(root, "package.json")).text()).toBe(
+        MANIFEST.replace('"alpha": "3.0.0",', '"alpha": "3.5.0",'),
+      );
+    });
+  });
+});

--- a/scripts/resolution-ranges.ts
+++ b/scripts/resolution-ranges.ts
@@ -1,0 +1,536 @@
+// Graph analysis behind the resolution-range guard and its autofix.
+//
+// A root `resolutions`/`overrides` entry force-overrides a package's version
+// everywhere, ignoring the ranges its dependents declare. bun applies the
+// override without erroring even when it pins the package BELOW a dependent's
+// floor, so the mistake is silent at install and only surfaces later as a
+// MISSING_EXPORT at build or runtime. This module reduces the graph to the
+// unambiguous "pinned below a declared floor" cases and computes the version
+// that repairs each one.
+//
+// Deliberately one-directional (too OLD only): an intentional forward override
+// (forcing a security patch NEWER than a lax range allows) is fine and is not
+// flagged. Non-semver specifiers (`workspace:`, `catalog:`, `npm:`, git/file)
+// and ranges too complex to reduce to a single floor (unions, upper-bounded
+// windows) are skipped, so the guard never false-positives on a shape it
+// cannot reason about.
+//
+// No third-party imports: the autofix workflow runs the CLIs built on this
+// module with `bun --no-install` on a checkout that has no node_modules.
+
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  applyReplacements,
+  directPropertyValue,
+  rootObjectStart,
+  stringTokenAt,
+  type JsonTextReplacement,
+} from "./json-text-edit";
+
+const OVERRIDE_KINDS = ["resolutions", "overrides"] as const;
+
+export type OverrideKind = (typeof OVERRIDE_KINDS)[number];
+
+export type Manifest = Readonly<Record<string, unknown>>;
+
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u;
+
+const MANIFEST_LABEL = "package.json";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Intentional below-floor overrides, grandfathered with the reason each is
+ * safe. A NEW below-floor pin must be fixed (raise the version to satisfy its
+ * dependents), NOT added here — this list is only for overrides that are
+ * deliberately, knowingly held below what some dependents declare.
+ */
+const ALLOWED_BELOW_FLOOR: ReadonlyMap<string, string> = new Map([
+  [
+    "@emnapi/core",
+    "Pinned to 1.9.1 (with @emnapi/runtime) to hold the @stll napi/emnapi " +
+      "WASM ABI at one version; some third-party wasm sidecars declare ^1.11 " +
+      "but run against 1.9.1 here. See the @stll napi architecture notes.",
+  ],
+  [
+    "@emnapi/runtime",
+    "Pinned to 1.9.1 (with @emnapi/core) for the @stll napi/emnapi WASM ABI.",
+  ],
+]);
+
+/**
+ * The minimum version that satisfies a range, for the caret/tilde/gte/exact
+ * shapes package.json deps overwhelmingly use. Returns null for anything that
+ * cannot be safely reduced to one floor (unions `||`, an explicit upper bound
+ * `<`, wildcards `*`/`x`, or a non-semver specifier), which callers then skip.
+ */
+export const rangeFloor = (range: string): string | null => {
+  const trimmed = range.trim();
+  if (trimmed === "" || /[|<*x:]/iu.test(trimmed)) {
+    return null;
+  }
+  const match = /^[\^~>=v\s]*(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/u.exec(
+    trimmed,
+  );
+  if (match === null) {
+    return null;
+  }
+  const candidate = match[1] ?? "";
+  // Guard against a mis-parse: the extracted version must actually satisfy the
+  // range it came from before it is treated as that range's floor.
+  return Bun.semver.satisfies(candidate, range) ? candidate : null;
+};
+
+/** A place in the graph that declares dependency ranges. */
+export type RangeSource = {
+  readonly declaredBy: string;
+  readonly manifest: Manifest;
+};
+
+/** A single declared range for one package. */
+export type RangeDeclaration = {
+  readonly declaredBy: string;
+  readonly range: string;
+};
+
+export type DeclaredRanges = ReadonlyMap<string, readonly RangeDeclaration[]>;
+
+export const collectDeclaredRanges = (
+  sources: readonly RangeSource[],
+): DeclaredRanges => {
+  const ranges = new Map<string, RangeDeclaration[]>();
+  for (const { declaredBy, manifest } of sources) {
+    for (const field of DEPENDENCY_FIELDS) {
+      const dependencies = manifest[field];
+      if (!isRecord(dependencies)) {
+        continue;
+      }
+      for (const [name, range] of Object.entries(dependencies)) {
+        if (typeof range !== "string") {
+          continue;
+        }
+        const existing = ranges.get(name);
+        if (existing) {
+          existing.push({ declaredBy, range });
+        } else {
+          ranges.set(name, [{ declaredBy, range }]);
+        }
+      }
+    }
+  }
+  return ranges;
+};
+
+/**
+ * Range declarations carried by a parsed bun.lock: every workspace manifest
+ * (`""` is the repo root) plus every resolved transitive package. A `packages`
+ * entry is `[specifier, registry, meta, integrity]` and the range-bearing
+ * fields live on `meta`.
+ */
+export const lockRangeSources = (parsedLock: unknown): RangeSource[] => {
+  if (!isRecord(parsedLock)) {
+    return [];
+  }
+  const sources: RangeSource[] = [];
+  const workspaces = parsedLock["workspaces"];
+  if (isRecord(workspaces)) {
+    for (const [directory, entry] of Object.entries(workspaces)) {
+      if (isRecord(entry)) {
+        sources.push({
+          declaredBy: `workspace ${directory === "" ? "<root>" : directory}`,
+          manifest: entry,
+        });
+      }
+    }
+  }
+  const packages = parsedLock["packages"];
+  if (isRecord(packages)) {
+    for (const [key, entry] of Object.entries(packages)) {
+      if (Array.isArray(entry) && isRecord(entry[2])) {
+        sources.push({ declaredBy: key, manifest: entry[2] });
+      }
+    }
+  }
+  return sources;
+};
+
+export type ResolutionGraph = {
+  readonly declared: DeclaredRanges;
+  readonly rootManifest: Manifest;
+};
+
+/**
+ * The one loading path both the guard and the fixer read: the root manifest's
+ * override maps plus every range bun.lock records for the graph.
+ *
+ * bun.lock is JSON-with-trailing-commas ("JSONC"-flavored), so a plain
+ * JSON.parse fails on it. Trailing commas only ever appear directly before a
+ * closing `}`/`]` and cannot occur inside bun.lock's string values, so
+ * stripping them is a safe, structure-preserving normalize (same approach as
+ * scripts/check-lockfile-workspace-versions.ts).
+ */
+export const loadResolutionGraph = async (
+  root: string,
+): Promise<ResolutionGraph> => {
+  const [manifestText, lockText] = await Promise.all([
+    Bun.file(path.join(root, "package.json")).text(),
+    Bun.file(path.join(root, "bun.lock")).text(),
+  ]);
+  const rootManifest: unknown = JSON.parse(manifestText);
+  const parsedLock: unknown = JSON.parse(
+    lockText.replace(/,(\s*[}\]])/gu, "$1"),
+  );
+  if (!isRecord(rootManifest)) {
+    throw new TypeError("package.json did not parse into an object");
+  }
+  if (!isRecord(parsedLock)) {
+    throw new TypeError("bun.lock did not parse into an object");
+  }
+  return {
+    declared: collectDeclaredRanges(lockRangeSources(parsedLock)),
+    rootManifest,
+  };
+};
+
+/** A declared range whose floor sits above the pinned version. */
+export type FloorRequirement = {
+  readonly declaredBy: string;
+  readonly floor: string;
+  readonly range: string;
+};
+
+/** A violation always has at least the requirement that set its floor. */
+export type FloorRequirements = readonly [
+  FloorRequirement,
+  ...FloorRequirement[],
+];
+
+export type ResolutionViolation = {
+  /** Highest floor demanded by any dependent: the version the pin must reach. */
+  readonly floor: string;
+  readonly kind: OverrideKind;
+  readonly packageName: string;
+  readonly pinned: string;
+  /** Every violated requirement, the one setting `floor` first. */
+  readonly requiredBy: FloorRequirements;
+};
+
+export type AnalyzeResolutionRangesOptions = {
+  readonly allowedBelowFloor?: ReadonlyMap<string, string>;
+  readonly declared: DeclaredRanges;
+  readonly rootManifest: Manifest;
+};
+
+export const analyzeResolutionRanges = ({
+  allowedBelowFloor = ALLOWED_BELOW_FLOOR,
+  declared,
+  rootManifest,
+}: AnalyzeResolutionRangesOptions): readonly ResolutionViolation[] => {
+  const violations: ResolutionViolation[] = [];
+  for (const kind of OVERRIDE_KINDS) {
+    const overrides = rootManifest[kind];
+    if (!isRecord(overrides)) {
+      continue;
+    }
+    for (const [packageName, pinned] of Object.entries(overrides)) {
+      if (allowedBelowFloor.has(packageName)) {
+        continue; // grandfathered intentional override
+      }
+      // Only an exact-version override can be compared to a range floor; a
+      // range or non-semver specifier (`workspace:`, `catalog:`, `npm:…`) is
+      // skipped.
+      if (typeof pinned !== "string" || !VERSION_PATTERN.test(pinned)) {
+        continue;
+      }
+      const requiredBy: FloorRequirement[] = [];
+      for (const { declaredBy, range } of declared.get(packageName) ?? []) {
+        const floor = rangeFloor(range);
+        if (floor !== null && Bun.semver.order(pinned, floor) < 0) {
+          requiredBy.push({ declaredBy, floor, range });
+        }
+      }
+      // Highest floor first, first-seen winning a tie, so the representative
+      // requirement is both the binding one and stable across runs.
+      const [binding, ...rest] = [...requiredBy].sort((left, right) =>
+        Bun.semver.order(right.floor, left.floor),
+      );
+      if (binding === undefined) {
+        continue;
+      }
+      violations.push({
+        floor: binding.floor,
+        kind,
+        packageName,
+        pinned,
+        requiredBy: [binding, ...rest],
+      });
+    }
+  }
+  return violations;
+};
+
+export type ResolutionRepair =
+  | {
+      readonly status: "raise";
+      readonly from: string;
+      readonly kind: OverrideKind;
+      readonly packageName: string;
+      readonly requiredBy: FloorRequirements;
+      readonly to: string;
+    }
+  | {
+      readonly status: "conflict";
+      readonly blockedBy: readonly RangeDeclaration[];
+      readonly kind: OverrideKind;
+      readonly packageName: string;
+      readonly pinned: string;
+      readonly target: string;
+    };
+
+export type PlanResolutionRepairsOptions = {
+  readonly declared: DeclaredRanges;
+  readonly violations: readonly ResolutionViolation[];
+};
+
+/**
+ * Turns violations into pin raises. The target is the highest floor any
+ * dependent demands; it is only accepted when it also satisfies every range
+ * that constrains the pin today — the violated ranges themselves (an exact
+ * `3.1.0` alongside a `^3.2.0` cannot both be met) and every range the current
+ * pin already satisfies (raising must not fall out of an upper-bounded window
+ * that works today). Otherwise no single version satisfies the dependents and
+ * the repair is a conflict a human has to resolve.
+ */
+export const planResolutionRepairs = ({
+  declared,
+  violations,
+}: PlanResolutionRepairsOptions): readonly ResolutionRepair[] =>
+  violations.map((violation) => {
+    const { floor, kind, packageName, pinned, requiredBy } = violation;
+    const violated = new Set(requiredBy.map(({ range }) => range));
+    const blockedBy = (declared.get(packageName) ?? []).filter(
+      ({ range }) =>
+        (violated.has(range) || Bun.semver.satisfies(pinned, range)) &&
+        !Bun.semver.satisfies(floor, range),
+    );
+    if (blockedBy.length > 0) {
+      return {
+        status: "conflict",
+        blockedBy,
+        kind,
+        packageName,
+        pinned,
+        target: floor,
+      };
+    }
+    return {
+      status: "raise",
+      from: pinned,
+      kind,
+      packageName,
+      requiredBy,
+      to: floor,
+    };
+  });
+
+export type OverridePin = {
+  readonly kind: OverrideKind;
+  readonly packageName: string;
+  readonly version: string;
+};
+
+/**
+ * Rewrites the pinned versions in a root manifest's override maps, changing
+ * nothing else in the file — key order, indentation and trailing bytes survive
+ * exactly, which is what lets the autofix boundary check compare texts.
+ */
+export const applyOverridePins = (
+  manifestText: string,
+  pins: readonly OverridePin[],
+): string => {
+  const rootStart = rootObjectStart(manifestText, MANIFEST_LABEL);
+  const replacements: JsonTextReplacement[] = pins.map(
+    ({ kind, packageName, version }) => {
+      const overridesStart = directPropertyValue({
+        label: MANIFEST_LABEL,
+        missingMessage: `package.json has no ${kind} object`,
+        objectStart: rootStart,
+        property: kind,
+        text: manifestText,
+      });
+      if (manifestText[overridesStart] !== "{") {
+        throw new TypeError(`package.json ${kind} must be an object`);
+      }
+      const pinStart = directPropertyValue({
+        label: MANIFEST_LABEL,
+        missingMessage: `package.json ${kind} has no entry for ${packageName}`,
+        objectStart: overridesStart,
+        property: packageName,
+        text: manifestText,
+      });
+      const token = stringTokenAt(manifestText, pinStart);
+      return {
+        end: token.end,
+        start: token.start,
+        value: JSON.stringify(version),
+      };
+    },
+  );
+  return applyReplacements(manifestText, replacements);
+};
+
+export type ManifestPinChange = {
+  readonly from: string;
+  readonly kind: OverrideKind;
+  readonly packageName: string;
+  readonly to: string;
+};
+
+export type ManifestChangeVerdict =
+  | { readonly status: "unchanged" }
+  | {
+      readonly status: "pins-raised";
+      readonly changes: readonly ManifestPinChange[];
+    }
+  | { readonly status: "rejected"; readonly reason: string };
+
+const parseManifest = (text: string): Manifest | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  return isRecord(parsed) ? parsed : null;
+};
+
+type OverrideChanges =
+  | { readonly status: "ok"; readonly changes: readonly ManifestPinChange[] }
+  | { readonly status: "rejected"; readonly reason: string };
+
+const overrideChanges = (
+  kind: OverrideKind,
+  before: Manifest,
+  after: Manifest,
+): OverrideChanges => {
+  const beforePins = before[kind];
+  const afterPins = after[kind];
+  if (!isRecord(beforePins) || !isRecord(afterPins)) {
+    return {
+      status: "rejected",
+      reason: `${kind} must be an object on both sides`,
+    };
+  }
+  const beforeKeys = Object.keys(beforePins);
+  if (!isDeepStrictEqual(beforeKeys, Object.keys(afterPins))) {
+    return {
+      status: "rejected",
+      reason: `${kind} keys were added, removed or reordered`,
+    };
+  }
+  const changes: ManifestPinChange[] = [];
+  for (const packageName of beforeKeys) {
+    const from = beforePins[packageName];
+    const to = afterPins[packageName];
+    if (from === to) {
+      continue;
+    }
+    if (typeof from !== "string" || typeof to !== "string") {
+      return {
+        status: "rejected",
+        reason: `${kind}.${packageName} is not a version string`,
+      };
+    }
+    if (!VERSION_PATTERN.test(from) || !VERSION_PATTERN.test(to)) {
+      return {
+        status: "rejected",
+        reason: `${kind}.${packageName} is not an exact version`,
+      };
+    }
+    if (Bun.semver.order(to, from) <= 0) {
+      return {
+        status: "rejected",
+        reason: `${kind}.${packageName} was not raised (${from} -> ${to})`,
+      };
+    }
+    changes.push({ from, kind, packageName, to });
+  }
+  return { status: "ok", changes };
+};
+
+/**
+ * The autofix boundary: the only manifest edit the workflow may push is an
+ * override pin raised to a dependent's floor. Reconstructing `after` by
+ * replaying exactly those pin values onto `before` proves that no other byte —
+ * key order, formatting, an unrelated field — moved.
+ */
+export const inspectManifestChange = (
+  before: string,
+  after: string,
+): ManifestChangeVerdict => {
+  if (before === after) {
+    return { status: "unchanged" };
+  }
+  const beforeManifest = parseManifest(before);
+  const afterManifest = parseManifest(after);
+  if (beforeManifest === null || afterManifest === null) {
+    return { status: "rejected", reason: "package.json is not a JSON object" };
+  }
+  const keys = [
+    ...new Set([...Object.keys(beforeManifest), ...Object.keys(afterManifest)]),
+  ];
+  const changedKeys = keys.filter(
+    (key) => !isDeepStrictEqual(beforeManifest[key], afterManifest[key]),
+  );
+  const overrideKinds: readonly string[] = OVERRIDE_KINDS;
+  const foreignKeys = changedKeys.filter((key) => !overrideKinds.includes(key));
+  if (foreignKeys.length > 0) {
+    return {
+      status: "rejected",
+      reason: `package.json changed outside resolutions: ${foreignKeys.join(", ")}`,
+    };
+  }
+
+  const changes: ManifestPinChange[] = [];
+  for (const kind of OVERRIDE_KINDS) {
+    if (!changedKeys.includes(kind)) {
+      continue;
+    }
+    const result = overrideChanges(kind, beforeManifest, afterManifest);
+    if (result.status === "rejected") {
+      return result;
+    }
+    changes.push(...result.changes);
+  }
+  if (changes.length === 0) {
+    return {
+      status: "rejected",
+      reason: "package.json text changed without changing any pin",
+    };
+  }
+  const replayed = applyOverridePins(
+    before,
+    changes.map(({ kind, packageName, to }) => ({
+      kind,
+      packageName,
+      version: to,
+    })),
+  );
+  if (replayed !== after) {
+    return {
+      status: "rejected",
+      reason: "package.json changed bytes outside the pinned versions",
+    };
+  }
+  return { status: "pins-raised", changes };
+};


### PR DESCRIPTION
A version bump can push a dependent's declared floor above a root `resolutions` pin, which bun applies anyway, so the resolution-range guard fails the Dependabot PR and a human has to hand-edit the pin. The graph analysis behind that guard is now a pure module, and a fixer built on it raises each offending pin to the lowest version every dependent accepts; the autofix job runs it after verifying its own sources against the base SHA, reinstalls with `--lockfile-only` so the lockfile follows, and re-runs the guard. The boundary is unchanged apart from root `package.json`: a dedicated check replays the pin changes onto the committed manifest and demands a byte-identical result, so nothing outside `resolutions` (or a lowered pin) can ride along. Floors that no single version satisfies are refused without a write and still fail the job.