### PR TITLE
fix(api): queue broker commands until the connection is up

### DIFF
--- a/apps/api/src/lib/health/readiness.test.ts
+++ b/apps/api/src/lib/health/readiness.test.ts
@@ -1,13 +1,50 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 
-import {
+import type {
+  ReadinessDependency,
+  ReadinessProbes,
+} from "@/api/lib/health/readiness";
+
+/** The commands the fake server below has been asked to answer. */
+const receivedCommands: string[] = [];
+
+// A RESP3 server that answers the handshake and PING and nothing else. The
+// Redis probe only means something when a real Bun client runs it (see
+// `probeRedis`), and a real client needs a real socket to speak to.
+const fakeRedis = Bun.listen({
+  hostname: "127.0.0.1",
+  port: 0,
+  socket: {
+    data: (socket, data) => {
+      // Every command here is argument-free, so each bulk string in the frame
+      // is a command name.
+      for (const line of data.toString().split("\r\n")) {
+        if (line === "HELLO") {
+          receivedCommands.push(line);
+          socket.write("%1\r\n$6\r\nserver\r\n$4\r\nfake\r\n");
+        } else if (line === "PING") {
+          receivedCommands.push(line);
+          socket.write("+PONG\r\n");
+        }
+      }
+    },
+  },
+});
+
+// Read at import by the connection module the probe builds its client through.
+process.env["REDIS_URL"] = `redis://127.0.0.1:${fakeRedis.port}`;
+
+const {
   API_READINESS_DEPENDENCIES,
   READINESS_DEPENDENCY,
-  type ReadinessDependency,
-  type ReadinessProbes,
   probeObjectStorageReadiness,
+  probeRedis,
   runReadinessProbes,
-} from "@/api/lib/health/readiness";
+} = await import("@/api/lib/health/readiness");
+
+afterAll(() => {
+  fakeRedis.stop(true);
+});
 
 const successfulProbes = (calls: ReadinessDependency[]): ReadinessProbes => ({
   [READINESS_DEPENDENCY.database]: async () => {
@@ -25,6 +62,19 @@ const successfulProbes = (calls: ReadinessDependency[]): ReadinessProbes => ({
   [READINESS_DEPENDENCY.scheduledJobs]: async () => {
     calls.push(READINESS_DEPENDENCY.scheduledJobs);
   },
+});
+
+describe("the Redis readiness probe", () => {
+  test("sends its command on the connection it has just opened", async () => {
+    // The probe builds a client and sends PING at once, with no connect() in
+    // between: the command is issued while the socket and the RESP handshake
+    // are still in flight. That is the shape of every "create then send" call
+    // site, and a client that rejects such a command reports the dependency
+    // as unavailable for as long as the process runs.
+    await probeRedis(new AbortController().signal);
+
+    expect(receivedCommands).toContain("PING");
+  });
 });
 
 describe("API dependency readiness", () => {

--- a/apps/api/src/lib/health/readiness.ts
+++ b/apps/api/src/lib/health/readiness.ts
@@ -32,7 +32,13 @@ const S3_READINESS_CONTENT_TYPE = "application/octet-stream";
 const S3_READINESS_BYTES = new Uint8Array();
 let scheduledJobsReady = false;
 
-const probeRedis = async (signal: AbortSignal): Promise<void> => {
+/**
+ * Exported for the suite that drives it against a real Bun client: the probe
+ * sends its command on a client it has just built, so whether it passes is
+ * decided by the client's own behaviour before the connection is up, which no
+ * stand-in can stand in for.
+ */
+export const probeRedis = async (signal: AbortSignal): Promise<void> => {
   const client = createRedisClient();
   const close = () => {
     client.close();
@@ -40,17 +46,26 @@ const probeRedis = async (signal: AbortSignal): Promise<void> => {
   signal.addEventListener("abort", close, { once: true });
   const result = await Result.tryPromise({
     try: async (): Promise<unknown> => await client.send("PING", []),
-    catch: (cause) => cause,
+    // The connection failure is carried as the cause, so the Bun error code
+    // that says which failure it was survives the wrap.
+    catch: (cause) =>
+      new HealthCheckError({ message: "Redis PING failed", cause }),
   }).finally(() => {
     signal.removeEventListener("abort", close);
     client.close();
   });
-  if (Result.isError(result)) {
-    throw result.error;
+  if (Result.isOk(result) && result.value === "PONG") {
+    return;
   }
-  if (result.value !== "PONG") {
-    throw new HealthCheckError({ message: "Redis returned an invalid PING" });
-  }
+  // A probe reports its dependency through the promise it returns, so a
+  // failure is a rejection rather than an `Err` value: `runReadinessProbes`
+  // is the boundary that turns one into the failed-dependency list, the same
+  // shape `probeScheduledJobs` below reports through.
+  await Promise.reject(
+    Result.isError(result)
+      ? result.error
+      : new HealthCheckError({ message: "Redis returned an invalid PING" }),
+  );
 };
 
 type ObjectStorageReadinessProbe = {

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -69,18 +69,22 @@ describe("the reconnect policy", () => {
     expect(options.enableOfflineQueue).toBe(false);
   });
 
-  test("a reconnecting client does not buffer commands for the whole outage", () => {
-    // The two policies are a pair: an unbounded ladder plus Bun's default
-    // offline queue would buffer every command issued during an outage, so a
-    // caller blocks for its whole length instead of failing and retrying, and
-    // the backlog is replayed against a server that has since moved on.
-    expect(redisClientOptions(REDIS_URL).enableOfflineQueue).toBe(false);
-    // A caller whose framework owns buffering across a reconnect (the BullMQ
-    // adapter) can still opt back in; `maxRetries` above cannot.
+  test("a fresh client queues its first command until the connection is up", () => {
+    // A fresh client connects on its first command. Setting the option here
+    // at all would decide for every call site that such a command must be
+    // rejected outright, which is how a "create then send" caller (the
+    // readiness probe, the SSE subscriber) fails for the length of a
+    // handshake it never got to wait for. Leaving it unset keeps Bun's
+    // queue-until-connected default.
+    expect(redisClientOptions(REDIS_URL)).not.toHaveProperty(
+      "enableOfflineQueue",
+    );
+    // Fail-fast during an outage stays available to the call sites that pair
+    // it with a bounded command; `maxRetries` above cannot be overridden.
     expect(
-      redisClientOptions(REDIS_URL, { enableOfflineQueue: true })
+      redisClientOptions(REDIS_URL, { enableOfflineQueue: false })
         .enableOfflineQueue,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("assigning onclose reaches Bun's setter", () => {

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -47,16 +47,14 @@ export const redisClientOptions = (
   url: string,
   overrides?: RedisClientOverrides,
 ): RedisOptions => ({
-  // An unbounded reconnect ladder and an unbounded offline queue do not
-  // belong on the same client: a client that keeps reconnecting for the whole
-  // outage would also keep buffering every command issued during it, so
-  // callers block instead of failing and the backlog is replayed against a
-  // server that has since forgotten the state they were written for. Fail the
-  // command instead and let the caller decide — a periodic loop records the
-  // failure and retries on its next tick, a request path degrades. Every
-  // request-path client here already opts out explicitly; this makes that the
-  // default rather than something each new call site has to remember.
-  enableOfflineQueue: false,
+  // `enableOfflineQueue` is deliberately absent, so Bun's default (queue until
+  // the connection is up) applies. A fresh client connects on its first
+  // command, so disabling the queue here rejects that command outright — a
+  // "create then send" caller such as the readiness probe would fail for the
+  // length of the handshake it never got to wait for. A caller that wants
+  // fail-fast semantics during an outage says so explicitly and bounds its own
+  // commands, which is also what keeps the unbounded reconnect ladder above
+  // from turning a queue into an outage-long backlog.
   ...redisConnectionOptions(url),
   ...overrides,
   maxRetries: RECONNECT_ATTEMPT_LIMIT,
@@ -326,9 +324,10 @@ export const createBullMqConnection = (
   overrides?: RedisClientOverrides,
 ): ReturnType<typeof createBunRedisClient> => {
   // BullMQ's adapter owns command buffering across a reconnect (it schedules
-  // its own and replays what it holds), so the connection keeps the offline
-  // queue the factory otherwise defaults off. A queue that wants its enqueues
-  // to fail fast still says so through `overrides`.
+  // its own and replays what it holds), so the connection states the offline
+  // queue it needs rather than inheriting whatever the factory leaves unset. A
+  // queue that wants its enqueues to fail fast still says so through
+  // `overrides`.
   const raw = createRedisClient({ enableOfflineQueue: true, ...overrides });
   const connection = createBunRedisClient(raw, {
     // Railway's Redis proxy can trigger Bun's eager adapter read path before

--- a/apps/api/src/lib/redis-outage.test.ts
+++ b/apps/api/src/lib/redis-outage.test.ts
@@ -47,6 +47,8 @@ const { publishWorkspaceEvent, SSEBroadcastError } =
   await import("@/api/lib/sse-broadcast");
 const { broadcast } = await import("@/api/lib/sse");
 const { resourceUpdatedRealtimeEvent } = await import("@stll/api-contract");
+const { getRootWorkflowRunStateStore } =
+  await import("@/api/lib/workflow/root-run-state-store");
 const { brandPersistedWorkspaceId, brandPersistedEntityId } =
   await import("@/api/lib/safe-id-boundaries");
 
@@ -257,6 +259,19 @@ describe("rate limiting during a Valkey outage", () => {
       guards.claimDedup({ key: "digest-1", ttlMs: 60_000 }),
     );
     expect(claim.status === "ok" ? claim.value : null).toBe(true);
+  });
+});
+
+describe("workflow run state during a Valkey outage", () => {
+  test("a run-state command fails on its own bound rather than being held", async () => {
+    const result = await settle(
+      getRootWorkflowRunStateStore().clear(WORKSPACE_ID),
+    );
+
+    // The store's client keeps reconnecting and queues what it is given while
+    // it does, so the bound is the only thing between a workflow step and the
+    // length of the outage. Failing lets the step's own retry decide.
+    expect(result.status).toBe("error");
   });
 });
 

--- a/apps/api/src/lib/workflow/root-run-state-store.ts
+++ b/apps/api/src/lib/workflow/root-run-state-store.ts
@@ -2,6 +2,7 @@ import {
   createLazyRedisClient,
   createRedisClient,
 } from "@/api/lib/redis-client";
+import { withTimeout } from "@/api/lib/with-timeout";
 import { createWorkflowRunStateStore } from "@/api/lib/workflow/run-state-store";
 
 // The store binds one connection for its lifetime, and this one is the
@@ -10,13 +11,22 @@ import { createWorkflowRunStateStore } from "@/api/lib/workflow/run-state-store"
 // the next command instead of stranding the store on a dead socket.
 const rootRedis = createLazyRedisClient(() => createRedisClient());
 
+// The client reconnects for as long as an outage lasts and queues commands
+// while it does, so the bound is what stops a workflow step from waiting out
+// the whole outage inside one command. It covers the connect too: a caller
+// that arrives while the holder is still climbing its cold-start ladder gets
+// a failure it can retry rather than the ladder's full length.
+const ROOT_COMMAND_TIMEOUT_MS = 2000;
+
 const sendRootCommand = async (
   command: string,
   args: string[],
-): Promise<unknown> => {
-  const reply: unknown = await (await rootRedis.ready()).send(command, args);
-  return reply;
-};
+): Promise<unknown> =>
+  await withTimeout(
+    async (): Promise<unknown> =>
+      await (await rootRedis.ready()).send(command, args),
+    { label: "workflow run state command", timeoutMs: ROOT_COMMAND_TIMEOUT_MS },
+  );
 
 let rootWorkflowRunStateStore: ReturnType<
   typeof createWorkflowRunStateStore


### PR DESCRIPTION
A fresh broker client rejected any command issued before its connection was established. The factory no longer disables the offline queue by default; call sites that want fail-fast semantics still opt in explicitly, and the workflow run-state store bounds its commands instead.
