### PR TITLE
fix(api): drop a workflow state command that timed out before it was sent

### DIFF
--- a/apps/api/src/lib/workflow/root-run-state-store.test.ts
+++ b/apps/api/src/lib/workflow/root-run-state-store.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import { createRootRunStateSend } from "@/api/lib/workflow/root-run-state-store";
+
+const COMMAND_TIMEOUT_MS = 20;
+// Long enough that the bound above is reached first, short enough to keep the
+// test quick.
+const LATE_CONNECT_MS = 200;
+
+/**
+ * The class this pins: run state is a lock and its bookkeeping, so a command
+ * that outlived the caller it was bounded for must not be applied. Bounding
+ * the wait alone does not do that — the connect keeps climbing after the
+ * rejection, and a `tryClaim` sent then would hold a workspace for a request
+ * that has already failed, a `clear` sent then would delete the state of
+ * whichever run claimed it next.
+ */
+describe("the root run-state command path", () => {
+  test("does not send a command whose connection arrived after the deadline", async () => {
+    const sent: string[] = [];
+    const send = createRootRunStateSend(async () => {
+      await Bun.sleep(LATE_CONNECT_MS);
+      return {
+        send: async (command: string) => {
+          sent.push(command);
+          return await Promise.resolve("OK");
+        },
+      };
+    }, COMMAND_TIMEOUT_MS);
+
+    const rejection: unknown = await send("DEL", ["key"]).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    // Past the connect, so the command has had its chance to be sent.
+    await Bun.sleep(LATE_CONNECT_MS);
+
+    expect(rejection).toMatchObject({ _tag: "TimeoutError" });
+    expect(sent).toEqual([]);
+  });
+
+  test("sends a command that reached a live connection inside the bound", async () => {
+    const sent: string[] = [];
+    const send = createRootRunStateSend(
+      async () =>
+        await Promise.resolve({
+          send: async (command: string) => {
+            sent.push(command);
+            return await Promise.resolve("OK");
+          },
+        }),
+    );
+
+    expect(await send("DEL", ["key"])).toBe("OK");
+    expect(sent).toEqual(["DEL"]);
+  });
+
+  test("the store's own client cannot queue commands while disconnected", async () => {
+    const source = await Bun.file(
+      new URL("root-run-state-store.ts", import.meta.url),
+    ).text();
+
+    // A queued command is one that outlives its caller, which is exactly what
+    // the bound above exists to prevent. The holder is what makes opting out
+    // safe: `ready()` awaits the connection, so no caller here can issue a
+    // command against a client that is still connecting.
+    expect(source).toContain("enableOfflineQueue: false");
+    expect(source.match(/createRedisClient\(/gu)).toHaveLength(1);
+  });
+});

--- a/apps/api/src/lib/workflow/root-run-state-store.ts
+++ b/apps/api/src/lib/workflow/root-run-state-store.ts
@@ -9,24 +9,53 @@ import { createWorkflowRunStateStore } from "@/api/lib/workflow/run-state-store"
 // process-wide instance every workflow path reaches for. Bind it to the
 // holder rather than to a client, so a connection that closes is replaced on
 // the next command instead of stranding the store on a dead socket.
-const rootRedis = createLazyRedisClient(() => createRedisClient());
+//
+// Run state is a lock and its bookkeeping, so a command that outlived its
+// caller must not be applied: a queued `tryClaim` would acquire a workspace
+// for a request that has already failed, and a queued `clear` would delete
+// the state of whichever run claimed it next. The queue is therefore off
+// here. The pre-connect rejection that opting out otherwise causes cannot
+// happen through this holder: `ready()` awaits the connection before any
+// caller is handed the client.
+const rootRedis = createLazyRedisClient(() =>
+  createRedisClient({ enableOfflineQueue: false }),
+);
 
-// The client reconnects for as long as an outage lasts and queues commands
-// while it does, so the bound is what stops a workflow step from waiting out
-// the whole outage inside one command. It covers the connect too: a caller
-// that arrives while the holder is still climbing its cold-start ladder gets
-// a failure it can retry rather than the ladder's full length.
+// The connect climbs a cold-start ladder longer than any one command should
+// wait behind, so the bound is what stops a workflow step from waiting out an
+// outage inside one command.
 const ROOT_COMMAND_TIMEOUT_MS = 2000;
 
-const sendRootCommand = async (
-  command: string,
-  args: string[],
-): Promise<unknown> =>
-  await withTimeout(
-    async (): Promise<unknown> =>
-      await (await rootRedis.ready()).send(command, args),
-    { label: "workflow run state command", timeoutMs: ROOT_COMMAND_TIMEOUT_MS },
-  );
+type RootRunStateRedis = {
+  send: (command: string, args: string[]) => Promise<unknown>;
+};
+
+/**
+ * The store's command path, bounded. Exported as its own seam so a test can
+ * drive a connection that arrives after the deadline; production has the one
+ * caller below.
+ */
+export const createRootRunStateSend =
+  (
+    ready: () => Promise<RootRunStateRedis>,
+    timeoutMs = ROOT_COMMAND_TIMEOUT_MS,
+  ) =>
+  async (command: string, args: string[]): Promise<unknown> =>
+    await withTimeout(
+      async (signal): Promise<unknown> => {
+        const client = await ready();
+        // The connect can outlast the deadline, and `withTimeout` has failed
+        // the caller by then. Sending here would apply a command whose caller
+        // was already told it had not run. A command that did reach a live
+        // connection is left to complete: it is the send, not the reply, that
+        // decides whether the run state moved.
+        signal.throwIfAborted();
+        return await client.send(command, args);
+      },
+      { label: "workflow run state command", timeoutMs },
+    );
+
+const sendRootCommand = createRootRunStateSend(rootRedis.ready);
 
 let rootWorkflowRunStateStore: ReturnType<
   typeof createWorkflowRunStateStore


### PR DESCRIPTION
The command bound rejects its caller and aborts the operation signal, but the workflow run-state command path ignored that signal, so a connection that arrived after the deadline still sent the command: a timed-out claim could take a lock for a request that had already failed, and a delayed clear could delete the state of whichever run claimed the workspace next. The store's own client now disables the offline queue, and the command path checks the abort between `ready()` and `send()`, so only a command that reached a live connection inside its bound is applied.
