### PR TITLE
fix(release): record an unpublished previous tag as never promoted

### DIFF
--- a/scripts/prepare-maintenance-release.property.test.ts
+++ b/scripts/prepare-maintenance-release.property.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import fc from "fast-check";
 import {
   existsSync,
@@ -14,6 +14,7 @@ import nodePath from "node:path";
 import { propertyConfig } from "@stll/property-testing";
 
 import {
+  fetchPublishedAt,
   MaintenanceReleaseError,
   nextPatchVersion,
   parseMaintenanceReleaseOptions,
@@ -23,10 +24,64 @@ import {
 } from "./prepare-maintenance-release";
 
 const roots: string[] = [];
+const restores: (() => void)[] = [];
+
+// Responses are consumed in request order: the release by tag, then, once that
+// answers 404, the tag ref and the pages of the release listing. An unexpected
+// extra request reads as HTTP 599 rather than reaching GitHub.
+const respondWith = (...responses: readonly Response[]) => {
+  const spy = spyOn(globalThis, "fetch");
+  for (const response of responses) {
+    spy.mockResolvedValueOnce(response);
+  }
+  spy.mockResolvedValue(new Response(null, { status: 599 }));
+  restores.push(() => {
+    spy.mockRestore();
+  });
+};
+
+const missing = () => new Response(null, { status: 404 });
+const tagRef = () => Response.json({ ref: "refs/tags/v1.2.3" });
+const draftRelease = { draft: true, published_at: null, tag_name: "v1.2.3" };
+
+const failureMessage = async (tag: string): Promise<string> => {
+  let publishedAt: string | null;
+  try {
+    publishedAt = await fetchPublishedAt(tag);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error(`Expected a failure; read ${String(publishedAt)}`);
+};
+
+const releaseFixture = (root: string, releaseDates: string) => {
+  mkdirSync(nodePath.join(root, "docs/changelog"), { recursive: true });
+  mkdirSync(nodePath.join(root, "apps/landing/src/data"), { recursive: true });
+  writeFileSync(nodePath.join(root, "VERSION"), "1.2.3\n");
+  writeFileSync(
+    nodePath.join(root, "docs/changelog/v1.2.3.md"),
+    "# Previous release\n",
+  );
+  writeFileSync(
+    nodePath.join(root, "apps/landing/src/data/changelog-release-dates.json"),
+    releaseDates,
+  );
+};
+
+const readReleaseDates = (root: string): unknown =>
+  JSON.parse(
+    readFileSync(
+      nodePath.join(root, "apps/landing/src/data/changelog-release-dates.json"),
+      "utf-8",
+    ),
+  );
 
 afterEach(() => {
   for (const root of roots.splice(0)) {
     rmSync(root, { force: true, recursive: true });
+  }
+  for (const restore of restores.splice(0)) {
+    restore();
   }
 });
 
@@ -123,6 +178,92 @@ describe("maintenance release preparation", () => {
       "v1.2.2": "2026-01-01T00:00:00Z",
       "v1.2.3": "2026-02-03T04:05:06Z",
     });
+  });
+
+  test("records a previous tag that was never promoted", () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), "stella-release-"));
+    roots.push(root);
+    releaseFixture(
+      root,
+      `${JSON.stringify({ "v1.2.2": "2026-01-01T00:00:00Z" }, null, 2)}\n`,
+    );
+
+    expect(
+      prepareMaintenanceReleaseFiles({ publishedAt: null, rootDir: root }),
+    ).toMatchObject({ previousTag: "v1.2.3", version: "1.2.4" });
+    expect(readReleaseDates(root)).toEqual({
+      "v1.2.2": "2026-01-01T00:00:00Z",
+      "v1.2.3": null,
+    });
+  });
+
+  test("keeps a previous tag already recorded as never promoted", () => {
+    const root = mkdtempSync(nodePath.join(tmpdir(), "stella-release-"));
+    roots.push(root);
+    releaseFixture(root, `${JSON.stringify({ "v1.2.3": null }, null, 2)}\n`);
+
+    prepareMaintenanceReleaseFiles({
+      publishedAt: "2026-02-03T04:05:06Z",
+      rootDir: root,
+    });
+    expect(readReleaseDates(root)).toEqual({ "v1.2.3": null });
+  });
+
+  test("reads the publication date of a published release", async () => {
+    respondWith(Response.json({ published_at: "2026-02-03T04:05:06Z" }));
+    expect(await fetchPublishedAt("v1.2.3")).toBe("2026-02-03T04:05:06Z");
+  });
+
+  test("reads a drafted release as never promoted", async () => {
+    respondWith(missing(), tagRef(), Response.json([draftRelease]));
+    expect(await fetchPublishedAt("v1.2.3")).toBeNull();
+  });
+
+  test("reads a release without a publication date as never promoted", async () => {
+    respondWith(Response.json({ published_at: null }));
+    expect(await fetchPublishedAt("v1.2.3")).toBeNull();
+  });
+
+  test("reads a release omitting the publication date as never promoted", async () => {
+    respondWith(Response.json({ tag_name: "v1.2.3" }));
+    expect(await fetchPublishedAt("v1.2.3")).toBeNull();
+  });
+
+  test("pages through the release listing to find the drafted release", async () => {
+    const filler = Array.from({ length: 100 }, (_unused, index) => ({
+      draft: false,
+      published_at: "2026-01-01T00:00:00Z",
+      tag_name: `v0.0.${String(index)}`,
+    }));
+    respondWith(
+      missing(),
+      tagRef(),
+      Response.json(filler),
+      Response.json([draftRelease]),
+    );
+    expect(await fetchPublishedAt("v1.2.3")).toBeNull();
+  });
+
+  test("fails when the previous tag has no release yet", async () => {
+    respondWith(missing(), tagRef(), Response.json([{ tag_name: "v1.2.2" }]));
+    expect(await failureMessage("v1.2.3")).toContain("has no GitHub release");
+  });
+
+  test("fails when the previous tag does not exist", async () => {
+    respondWith(missing(), missing());
+    expect(await failureMessage("v1.2.3")).toContain("does not exist");
+  });
+
+  test("fails on a GitHub error", async () => {
+    respondWith(new Response(null, { status: 500 }));
+    expect(await failureMessage("v1.2.3")).toContain("HTTP 500");
+  });
+
+  test("fails on an unreadable publication timestamp", async () => {
+    respondWith(Response.json({ published_at: "not a timestamp" }));
+    expect(await failureMessage("v1.2.3")).toContain(
+      "no valid published_at timestamp",
+    );
   });
 
   test("refuses to overwrite an already prepared release", () => {

--- a/scripts/prepare-maintenance-release.ts
+++ b/scripts/prepare-maintenance-release.ts
@@ -21,6 +21,9 @@ const REASON_FLAG = "--reason";
 // this standing attestation instead of stopping the release. Pass
 // CONFIRMATION_FLAG with REASON_FLAG to record a specific review instead.
 const DEFAULT_REVIEW_REASON = "Patch release, UX diff negligible";
+const GITHUB_API_ROOT = "https://api.github.com/repos/stella/stella";
+const RELEASE_PAGE_SIZE = 100;
+const RELEASE_PAGE_LIMIT = 20;
 const STABLE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/u;
 const MAINTENANCE_CHANGELOG =
   "# Maintenance release\n\nStella includes reliability and maintenance improvements.\n";
@@ -228,11 +231,11 @@ export const prepareMaintenanceReleaseFiles = ({
   rootDir,
   writeFile = atomicWriteFile,
 }: {
-  publishedAt: string;
+  publishedAt: string | null;
   rootDir: string;
   writeFile?: ReleaseFileWriter;
 }): PreparedMaintenanceRelease => {
-  if (Number.isNaN(Date.parse(publishedAt))) {
+  if (publishedAt !== null && Number.isNaN(Date.parse(publishedAt))) {
     throw new MaintenanceReleaseError(
       `Previous release has an invalid publication timestamp: ${publishedAt}`,
     );
@@ -302,7 +305,7 @@ const assertCleanWorktree = () => {
   }
 };
 
-const fetchPublishedAt = async (tag: string): Promise<string> => {
+const requestGitHub = async (path: string): Promise<Response> => {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "stella-maintenance-release",
@@ -312,26 +315,105 @@ const fetchPublishedAt = async (tag: string): Promise<string> => {
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
-  const response = await fetch(
-    `https://api.github.com/repos/stella/stella/releases/tags/${encodeURIComponent(tag)}`,
-    { headers },
-  );
-  if (!response.ok) {
+  return fetch(`${GITHUB_API_ROOT}${path}`, { headers });
+};
+
+const readPublishedAt = (tag: string, payload: unknown): string | null => {
+  if (!isRecord(payload)) {
     throw new MaintenanceReleaseError(
-      `Could not read ${tag} from GitHub Releases (HTTP ${String(response.status)})`,
+      `GitHub release ${tag} has no valid published_at timestamp`,
     );
   }
-  const payload: unknown = await response.json();
+  const publishedAt = payload["published_at"];
+  if (publishedAt === null || publishedAt === undefined) {
+    return null;
+  }
   if (
-    !isRecord(payload) ||
-    typeof payload["published_at"] !== "string" ||
-    Number.isNaN(Date.parse(payload["published_at"]))
+    typeof publishedAt !== "string" ||
+    Number.isNaN(Date.parse(publishedAt))
   ) {
     throw new MaintenanceReleaseError(
       `GitHub release ${tag} has no valid published_at timestamp`,
     );
   }
-  return payload["published_at"];
+  return publishedAt;
+};
+
+const assertTagExists = async (tag: string) => {
+  const response = await requestGitHub(
+    `/git/ref/tags/${encodeURIComponent(tag)}`,
+  );
+  if (response.status === 404) {
+    throw new MaintenanceReleaseError(
+      `Previous tag ${tag} does not exist; wait for the release workflow to build it`,
+    );
+  }
+  if (!response.ok) {
+    throw new MaintenanceReleaseError(
+      `Could not read tag ${tag} from GitHub (HTTP ${String(response.status)})`,
+    );
+  }
+};
+
+// The by-tag endpoint hides drafts, so its 404 is ambiguous. The full listing
+// includes drafts for an authenticated caller and separates the two cases: a
+// draft release is abandoned, no release object at all is unfinished.
+const findUnpromotedRelease = async (
+  tag: string,
+  page: number,
+): Promise<string | null> => {
+  if (page > RELEASE_PAGE_LIMIT) {
+    throw new MaintenanceReleaseError(
+      `Could not find ${tag} in the ${String(RELEASE_PAGE_LIMIT * RELEASE_PAGE_SIZE)} most recent GitHub Releases`,
+    );
+  }
+  const response = await requestGitHub(
+    `/releases?per_page=${String(RELEASE_PAGE_SIZE)}&page=${String(page)}`,
+  );
+  if (!response.ok) {
+    throw new MaintenanceReleaseError(
+      `Could not list GitHub Releases (HTTP ${String(response.status)})`,
+    );
+  }
+  const payload: unknown = await response.json();
+  if (!Array.isArray(payload)) {
+    throw new MaintenanceReleaseError(
+      "GitHub Releases returned an unexpected payload",
+    );
+  }
+  const entries: unknown[] = payload;
+  const release = entries.find(
+    (entry) => isRecord(entry) && entry["tag_name"] === tag,
+  );
+  if (isRecord(release)) {
+    return release["draft"] === true ? null : readPublishedAt(tag, release);
+  }
+  if (entries.length < RELEASE_PAGE_SIZE) {
+    throw new MaintenanceReleaseError(
+      `Previous tag ${tag} has no GitHub release yet; wait for the release workflow to publish one`,
+    );
+  }
+  return findUnpromotedRelease(tag, page + 1);
+};
+
+// `null` means the tag was built but never promoted: the release is a draft, or
+// it exists without a publication date. A tag whose release was never created
+// is unfinished rather than abandoned, and fails the cut instead: a `null`
+// written for it would never be replaced.
+export const fetchPublishedAt = async (tag: string): Promise<string | null> => {
+  const response = await requestGitHub(
+    `/releases/tags/${encodeURIComponent(tag)}`,
+  );
+  if (response.ok) {
+    return readPublishedAt(tag, await response.json());
+  }
+  if (response.status !== 404) {
+    throw new MaintenanceReleaseError(
+      `Could not read ${tag} from GitHub Releases (HTTP ${String(response.status)})`,
+    );
+  }
+  await assertTagExists(tag);
+  return findUnpromotedRelease(tag, 1);
 };
 
 const staleCaptureIds = (): string[] => [
@@ -406,7 +488,7 @@ const main = async () => {
       `maintenance-release: prepared ${prepared.version}`,
       `  VERSION`,
       `  ${prepared.changelogPath}`,
-      `  ${RELEASE_DATES_PATH} (${prepared.previousTag})`,
+      `  ${RELEASE_DATES_PATH} (${prepared.previousTag}${publishedAt === null ? ": never promoted" : ""})`,
       "Review the diff, commit it, and open the release PR.",
       "",
     ].join("\n"),


### PR DESCRIPTION
## Summary

- `fetchPublishedAt` returns `string | null`: a previous tag whose release is a draft (the by-tag endpoint answers 404) or carries no publication date was built and never promoted, so `changelog-release-dates.json` records it as `null` instead of the release preparation aborting; any other GitHub error or an unreadable timestamp still throws.
- Covers the fetch (published, draft, 404, error, unreadable timestamp) and extends the file-preparation tests for recording and preserving a `null`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maintenance releases now support tags that were built but never promoted.
  * Release preparation output identifies releases that were never promoted.
  * Release discovery now handles paginated release listings.

* **Bug Fixes**
  * Improved handling of missing tags, draft releases, unavailable releases, API errors, and invalid publication timestamps.
  * Release preparation now distinguishes between unpublished releases and releases that cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->