### PR TITLE
feat(api): add a startup probe that opens once readiness has passed

### DIFF
--- a/apps/api/src/handlers/health/routes.test.ts
+++ b/apps/api/src/handlers/health/routes.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { createHealthRoute } from "@/api/handlers/health/routes";
+import type { ReadinessOutcome } from "@/api/lib/health/readiness";
+import { APP_COMMIT_SHA, APP_VERSION } from "@/api/lib/version";
 
 describe("health routes", () => {
   test("liveness and compatibility health do not touch dependencies", async () => {
@@ -55,5 +57,64 @@ describe("health routes", () => {
     const response = await route.handle(new Request("http://localhost/ready"));
     expect(response.status).toBe(503);
     expect(await response.text()).not.toContain("private dependency detail");
+  });
+});
+
+describe("startup probe", () => {
+  const startedRequest = () => new Request("http://localhost/started");
+
+  test("stays closed until readiness has passed once", async () => {
+    const route = createHealthRoute({
+      probeReadiness: async () => ({
+        status: "not-ready",
+        failed: ["database"],
+      }),
+    });
+
+    const response = await route.handle(startedRequest());
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ status: "starting" });
+  });
+
+  test("opens after one readiness success and reports build metadata", async () => {
+    const route = createHealthRoute({
+      probeReadiness: async () => ({ status: "ready" }),
+    });
+
+    const response = await route.handle(startedRequest());
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "started",
+      version: APP_VERSION,
+      commit: APP_COMMIT_SHA,
+    });
+  });
+
+  test("stays open after a later readiness failure", async () => {
+    let readiness: ReadinessOutcome = { status: "ready" };
+    const route = createHealthRoute({ probeReadiness: async () => readiness });
+
+    expect((await route.handle(startedRequest())).status).toBe(200);
+    readiness = { status: "not-ready", failed: ["redis"] };
+
+    const response = await route.handle(startedRequest());
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: "started" });
+  });
+
+  test("does not probe once started", async () => {
+    let readinessCalls = 0;
+    const route = createHealthRoute({
+      probeReadiness: async () => {
+        readinessCalls++;
+        return { status: "ready" };
+      },
+    });
+
+    await route.handle(startedRequest());
+    expect(readinessCalls).toBe(1);
+    await route.handle(startedRequest());
+    await route.handle(startedRequest());
+    expect(readinessCalls).toBe(1);
   });
 });

--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -11,6 +11,10 @@ import {
   probeApiReadiness,
   type ReadinessOutcome,
 } from "@/api/lib/health/readiness";
+import {
+  createStartupGate,
+  STARTUP_STATE,
+} from "@/api/lib/health/startup-gate";
 import { APP_COMMIT_SHA, APP_VERSION } from "@/api/lib/version";
 
 const BUILD_METADATA = {
@@ -58,7 +62,14 @@ export const createHealthRoute = ({
     async () => await readinessOutcome(probeReadiness),
     { ttlMs: PROBE_CACHE_TTL_MS },
   );
-  const readinessResponse = async () => await probeCache.run();
+  const startupGate = createStartupGate();
+  const readinessResponse = async () => {
+    const outcome = await probeCache.run();
+    if (outcome.ok) {
+      startupGate.markStarted();
+    }
+    return outcome;
+  };
   const livenessHandler = () => ({
     status: "ok" as const,
     ...BUILD_METADATA,
@@ -76,9 +87,22 @@ export const createHealthRoute = ({
     return { status: "ok" as const, ...BUILD_METADATA };
   };
 
+  const startedHandler = async ({ set }: Pick<Context, "set">) => {
+    if (startupGate.startup() === STARTUP_STATE.started) {
+      return { status: STARTUP_STATE.started, ...BUILD_METADATA };
+    }
+    const outcome = await readinessResponse();
+    if (!outcome.ok) {
+      set.status = 503;
+      return { status: STARTUP_STATE.starting, ...BUILD_METADATA };
+    }
+    return { status: STARTUP_STATE.started, ...BUILD_METADATA };
+  };
+
   return new Elysia()
     .get("/live", livenessHandler)
     .get("/ready", readinessHandler)
+    .get("/started", startedHandler)
     .get("/health", livenessHandler);
 };
 

--- a/apps/api/src/lib/health/startup-gate.ts
+++ b/apps/api/src/lib/health/startup-gate.ts
@@ -1,0 +1,30 @@
+/**
+ * Startup gate for deployment health checks: distinct from liveness (the
+ * process serves HTTP) and readiness (every dependency answers right now).
+ * It latches the first time readiness passes and never closes again, so a
+ * rollout can tell "this instance never came up" apart from "it came up and
+ * a dependency blipped later". One gate per health route instance, so tests
+ * get a fresh state without a module-level reset.
+ */
+
+export const STARTUP_STATE = {
+  starting: "starting",
+  started: "started",
+} as const;
+
+type StartupState = (typeof STARTUP_STATE)[keyof typeof STARTUP_STATE];
+
+type StartupGate = {
+  startup: () => StartupState;
+  markStarted: () => void;
+};
+
+export const createStartupGate = (): StartupGate => {
+  let startup: StartupState = STARTUP_STATE.starting;
+  return {
+    startup: () => startup,
+    markStarted: () => {
+      startup = STARTUP_STATE.started;
+    },
+  };
+};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -170,7 +170,7 @@ import { clearByokAdapterCache } from "@/api/lib/tanstack-ai-models";
 import { isUploadRateLimitedPath } from "@/api/lib/upload-rate-limit";
 import { initWorkflowWorkers } from "@/api/lib/workflow-queue";
 
-const HEALTH_PATHS = new Set(["/health", "/live", "/ready"]);
+const HEALTH_PATHS = new Set(["/health", "/live", "/ready", "/started"]);
 const DEFAULT_API_PORT = 3001;
 // Keep-alive idle timeout in seconds; see the `api.listen` call.
 const HTTP_IDLE_TIMEOUT_S = 75;

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -295,6 +295,10 @@ STELLA_API_HOST_PORT=8080 \
 - `/ready` checks Postgres, Redis/Valkey, object storage, authenticated
   Gotenberg health, and scheduled-job registration. It returns 503 if any
   required component is unavailable.
+- `/started` reports whether readiness has passed at least once since the
+  process started. It returns 503 until then and 200 afterwards for the life
+  of the process, so a rollout can tell a failed start apart from a later
+  dependency blip. Use it for a startup probe, never for readiness.
 - `/health` is a compatibility alias for `/live` and carries the same build
   metadata used by release verification. Do not use it as a readiness probe.
 


### PR DESCRIPTION
`GET /started` answers 503 with `status: "starting"` until the readiness probe set reports ready once, then 200 with `status: "started"` for the life of the process, so a startup check can tell a failed start apart from a later dependency blip. It reuses the readiness probe cache only while still starting and answers from memory once open; `/health` and `/ready` are unchanged.