### PR TITLE
fix(ui): keep hidden card actions out of the touch path

### DIFF
--- a/.changeset/kanban-hover-actions-inert.md
+++ b/.changeset/kanban-hover-actions-inert.md
@@ -1,0 +1,10 @@
+---
+"@stll/ui": patch
+---
+
+A kanban card's hover-revealed actions no longer sit in the way while they are
+hidden. They took pointer events at rest and stayed visible on pointers that
+cannot hover, which left a small dead zone in the corner of every card: on a
+touch device a press there reached the actions instead of the card, so it never
+started the card's drag. Each pointer now has its own way to them — hover, tab,
+or, for a finger, opening the card, whose actions stay out while it is active.

--- a/packages/ui/src/kanban/board-chrome.playwright.spec.ts
+++ b/packages/ui/src/kanban/board-chrome.playwright.spec.ts
@@ -9,9 +9,9 @@ const TOLERANCE_PX = 1;
 /** `KANBAN_COLUMN_WIDTH_PX`, the unit this suite scrolls the board by. */
 const COLUMN_WIDTH_PX = 300;
 
-// A hovering pointer, which the suite's default device does not have: with a
-// coarse pointer the hover-revealed actions are shown at all times, and the
-// test asserting they appear would pass without ever revealing anything.
+// A hovering pointer, which the suite's default device does not have: the
+// hover-revealed actions never appear without one, so every test below that
+// waits for them would sit there until it timed out.
 test.use({
   viewport: { width: 1280, height: 800 },
   isMobile: false,
@@ -154,5 +154,83 @@ test.describe("hover-revealed card actions", () => {
     await expect.poll(async () => await opacityOf(hovered)).toBe("1");
 
     expect(await opacityOf(other)).toBe("0");
+  });
+});
+
+test.describe("hover-revealed card actions on a touch device", () => {
+  // A finger, which has no hover at all: the case the overlay used to show
+  // itself for, and the one where an overlay that answers a press costs the
+  // card the gesture.
+  test.use({ hasTouch: true, isMobile: true });
+
+  /**
+   * What a finger finds at the dead centre of the overlay's own box — the
+   * corner a card is pressed and dragged from, and the corner the actions
+   * appear in. Reported as both memberships, because the overlay sits inside
+   * the card: "inside the card" alone would be true either way.
+   */
+  const whatIsAtTheCorner = async (actions: Locator) =>
+    await actions.evaluate((element) => {
+      const { left, top, width, height } = element.getBoundingClientRect();
+      const found = document.elementFromPoint(
+        left + width / 2,
+        top + height / 2,
+      );
+      const body = element.closest("[data-card]");
+
+      return {
+        insideActions: element.contains(found),
+        insideCard: body?.contains(found) ?? false,
+      };
+    });
+
+  test("gives the corner to the card at rest and to the actions once it opens", async ({
+    page,
+  }) => {
+    await openFixture(page);
+    const card = page.locator('[data-card="open-1"]');
+    const actions = card.locator('[data-kanban-card-actions="hover"]');
+
+    // At rest the corner belongs to the card, so a press there is the card's
+    // to act on rather than the hidden overlay's to swallow.
+    const atRest = await whatIsAtTheCorner(actions);
+
+    expect(atRest.insideActions).toBe(false);
+    expect(atRest.insideCard).toBe(true);
+
+    // A tap on that same corner therefore reaches the card and opens it...
+    const box = await actions.boundingBox();
+
+    expect(box).not.toBeNull();
+    await page.touchscreen.tap(
+      (box?.x ?? 0) + (box?.width ?? 0) / 2,
+      (box?.y ?? 0) + (box?.height ?? 0) / 2,
+    );
+
+    // ...and the open card is a finger's way to the actions: it has no hover
+    // to reveal them with and no tab key to focus them by.
+    await expect.poll(async () => await opacityOf(actions)).toBe("1");
+
+    const opened = await whatIsAtTheCorner(actions);
+
+    expect(opened.insideActions).toBe(true);
+  });
+
+  test("leaves the cards a tap did not open alone", async ({ page }) => {
+    await openFixture(page);
+    const opened = page
+      .locator('[data-card="open-1"] [data-kanban-card-actions="hover"]')
+      .first();
+    const other = page
+      .locator('[data-card="blocked-1"] [data-kanban-card-actions="hover"]')
+      .first();
+
+    await page.locator('[data-card="open-1"]').tap();
+    await expect.poll(async () => await opacityOf(opened)).toBe("1");
+
+    // Every card carries this overlay; only the open one may show it, or the
+    // board grows the dead corner back on all the others.
+    expect(await opacityOf(other)).toBe("0");
+    expect((await whatIsAtTheCorner(other)).insideActions).toBe(false);
   });
 });

--- a/packages/ui/src/kanban/card-shell.test.tsx
+++ b/packages/ui/src/kanban/card-shell.test.tsx
@@ -88,7 +88,7 @@ describe("KanbanCardShell sticky header", () => {
     expect(markup).not.toContain("opacity-0");
   });
 
-  test("reveals hover actions on hover, focus, an open menu, and coarse pointers", () => {
+  test("reveals hover actions on hover, focus, and an open menu", () => {
     const markup = renderToStaticMarkup(
       <KanbanCardShell
         actions={<button type="button">More</button>}
@@ -105,15 +105,82 @@ describe("KanbanCardShell sticky header", () => {
     expect(wrapper).toContain("group-hover/card:opacity-100");
     // The hover group the wrapper answers to is on the shell's own wrapper.
     expect(markup).toContain("group/card");
-    // Focus keeps them reachable from the keyboard, an open menu keeps its
-    // own trigger from vanishing under the popup, and a pointer that cannot
-    // hover would otherwise never reveal them at all.
+    // Focus keeps them reachable from the keyboard, and an open menu keeps
+    // its own trigger from vanishing under the popup it just opened.
     expect(wrapper).toContain("focus-within:opacity-100");
     expect(wrapper).toContain("has-[[aria-expanded=true]]:opacity-100");
-    expect(wrapper).toContain("[@media(hover:none)]:opacity-100");
     // The fade is decoration; a reader who asked for less motion still gets
     // the actions, just without the transition.
     expect(wrapper).toContain("motion-reduce:transition-none");
+  });
+
+  test("keeps hidden hover actions out of the pointer's way", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell
+        actions={<button type="button">More</button>}
+        actionsVisibility="hover"
+      >
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+    const wrapper =
+      /<div[^>]*data-kanban-card-actions="hover"[^>]*>/u.exec(markup)?.[0] ??
+      "";
+    const classes = (/class="([^"]*)"/u.exec(wrapper)?.[1] ?? "").split(" ");
+
+    // Invisible is not out of the way: a transparent overlay is still the
+    // topmost hit, so at rest it must answer no pointer at all.
+    expect(classes).toContain("pointer-events-none");
+    // Every state that shows them hands them back, and nothing else does.
+    expect(classes).toContain("group-hover/card:pointer-events-auto");
+    expect(classes).toContain("focus-within:pointer-events-auto");
+    expect(classes).toContain("has-[[aria-expanded=true]]:pointer-events-auto");
+    expect(classes).toContain(
+      "group-data-[active=true]/card:pointer-events-auto",
+    );
+    // Shown on a pointer that cannot hover, they were a dead zone in the
+    // corner of every card: a long press there never reached the card, so it
+    // never started the card's drag.
+    expect(wrapper).not.toContain("hover:none");
+  });
+
+  test("reveals hover actions on the active card, the route a finger has", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell
+        actions={<button type="button">More</button>}
+        actionsVisibility="hover"
+        active
+      >
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+    const wrapper =
+      /<div[^>]*data-kanban-card-actions="hover"[^>]*>/u.exec(markup)?.[0] ??
+      "";
+
+    // A finger neither hovers nor tabs, so the card it opened is the one way
+    // in. The state is published on the group the overlay already answers.
+    expect(markup).toContain('class="group/card" data-active="true"');
+    expect(wrapper).toContain("group-data-[active=true]/card:opacity-100");
+    expect(wrapper).toContain(
+      "group-data-[active=true]/card:pointer-events-auto",
+    );
+  });
+
+  test("marks only an active card, so a resting card keeps its actions away", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCardShell
+        actions={<button type="button">More</button>}
+        actionsVisibility="hover"
+      >
+        <p>body</p>
+      </KanbanCardShell>,
+    );
+
+    // The flag is absent, not `data-active="false"`, so a resting card
+    // matches nothing: every card on a board carries this overlay, and the
+    // one the reader opened is meant to be the only one showing it.
+    expect(markup).not.toContain("data-active");
   });
 
   test("puts hover actions over the pinned identity row that leads the corner", () => {

--- a/packages/ui/src/kanban/card-shell.tsx
+++ b/packages/ui/src/kanban/card-shell.tsx
@@ -15,8 +15,18 @@ export type KanbanCardShellProps = {
    * bare icon buttons; `"always"` (the default) leaves a caller's own overlay
    * exactly where it put it.
    *
-   * A pointer that cannot hover would never reveal them, so a coarse pointer
-   * keeps them shown.
+   * While they are hidden they are also inert: they take no pointer events at
+   * all, so a touch anywhere over the card — including the corner they will
+   * appear in — reaches the card itself. A hidden overlay that still answered
+   * a press would sit as a small dead zone on every card, and a long press
+   * landing in it would never start the card's drag.
+   *
+   * Each pointer has its own way in. A pointer that hovers reveals them by
+   * hovering the card; the keyboard reveals them by tabbing into them, which
+   * being inert to a pointer never blocked. A finger has neither, so `active`
+   * is its route: the card a tap opened shows its actions for as long as it
+   * stays open. A board that never marks a card active leaves touch without
+   * one, and should keep `"always"`.
    */
   actionsVisibility?: "always" | "hover" | undefined;
   /**
@@ -95,7 +105,13 @@ export const KanbanCardShell = ({
 
   if (!onOpen) {
     return (
-      <div className="group/card" ref={dragRef}>
+      <div
+        className="group/card"
+        // Published on the group so the hover overlay can answer it: a finger
+        // never hovers, and an open card is how it reaches the same actions.
+        data-active={active ? "true" : undefined}
+        ref={dragRef}
+      >
         <div
           className={cn(CARD_CLASS, active && ACTIVE_CLASS, className)}
           ref={bodyRef}
@@ -107,7 +123,13 @@ export const KanbanCardShell = ({
   }
 
   return (
-    <div className="group/card" ref={dragRef}>
+    <div
+      className="group/card"
+      // Published on the group so the hover overlay can answer it: a finger
+      // never hovers, and an open card is how it reaches the same actions.
+      data-active={active ? "true" : undefined}
+      ref={dragRef}
+    >
       <div
         className={cn(
           CARD_CLASS,
@@ -170,6 +192,18 @@ const STICKY_HEADER_CLASS =
  *
  * The fade is decoration: a reader who asked for less motion still gets the
  * actions, they simply arrive at once.
+ *
+ * Every state that shows them also makes them answer a pointer again, and
+ * nothing else does: an invisible overlay that still took a press would leave
+ * a small dead zone in the corner of every card, and on a touch device that
+ * dead zone swallows the long press that starts the card's drag. Hiding alone
+ * would not have been enough — a transparent element is still the topmost hit.
+ * Focus is unaffected by `pointer-events`, so the keyboard path is untouched.
+ *
+ * The active card is what leaves a finger a way in, since it has neither
+ * hover nor tab: the card a tap opened keeps its actions out while it is
+ * open. It reads the state off the group rather than its own card box, so
+ * the pair stays in one class string.
  */
 const HOVER_ACTIONS_CLASS =
-  "absolute end-1.5 top-1.5 z-10 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/card:opacity-100 focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100";
+  "absolute end-1.5 top-1.5 z-10 flex items-center gap-0.5 opacity-0 pointer-events-none transition-opacity group-hover/card:pointer-events-auto group-hover/card:opacity-100 group-data-[active=true]/card:pointer-events-auto group-data-[active=true]/card:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 has-[[aria-expanded=true]]:pointer-events-auto has-[[aria-expanded=true]]:opacity-100 motion-reduce:transition-none";

--- a/packages/ui/src/kanban/fixtures/board-chrome.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/board-chrome.fixture.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 import { KanbanCardShell } from "../card-shell";
@@ -46,6 +46,10 @@ const matrix = buildKanbanBoardMatrix({
 });
 
 const BoardChromeFixture = () => {
+  // The card a tap opened, the way a host tracks the one whose detail is on
+  // screen. It is what gives a finger its way to the hover-revealed actions.
+  const [activeCardId, setActiveCardId] = useState<string | null>(null);
+
   useEffect(() => {
     document.documentElement.dataset["kanbanBoardChromeReady"] = "true";
     return () => {
@@ -73,6 +77,10 @@ const BoardChromeFixture = () => {
                     </button>
                   }
                   actionsVisibility="hover"
+                  active={activeCardId === row.id}
+                  onOpen={() => {
+                    setActiveCardId(row.id);
+                  }}
                 >
                   <span className="text-xs">{row.id}</span>
                 </KanbanCardShell>


### PR DESCRIPTION
- A card's hover-revealed actions are now inert while hidden
  (`pointer-events-none`, handed back by each state that shows them), and no
  longer force themselves visible on pointers that cannot hover. They were a
  24×24 dead zone in the corner of every card, and on touch a press there
  reached the actions instead of the card, so it never started the card's drag.
- Keyboard reach is unchanged — `pointer-events` does not affect focus, and
  `focus-within` still reveals them. Covered by a unit assertion and a
  touch-device Playwright case; both fail on the old class string.
