### PR TITLE
feat(ui): band captions lead their columns and column titles stay in view

### DIFF
--- a/.changeset/kanban-band-caption-and-sticky-titles.md
+++ b/.changeset/kanban-band-caption-and-sticky-titles.md
@@ -1,0 +1,29 @@
+---
+"@stll/ui": minor
+---
+
+A kanban band caption now reads as the parent of the columns it groups: its
+line stands on the same row height as the column headers and sets the band's
+name a step heavier than a column title, instead of a shorter line with a
+smaller label that left a group looking subordinate to its own columns. Folded,
+the band's vertical caption keeps that weight.
+`KANBAN_BAND_CAPTION_ROW_HEIGHT` is now the chrome row height.
+
+A column title also stays readable while its column scrolls past: the swatch,
+the name and the count hold the visible inline edge of a board scrolled
+sideways until the column itself is gone, so the cards under it are never left
+unlabelled. The title travels only as far as the row's own controls, which stay
+at the end of the row, and takes no surface of its own, so the accent a caller
+washes a header cell with goes on painting under it.
+
+A card's pinned identity row takes a stacking layer, so the positioned controls
+a card carries lower in its own body no longer paint over the name of the card
+they belong to while it scrolls out. The shell's hover actions share that layer
+and still win on tree order; a caller anchoring its own always-visible overlay
+to the same corner now needs a layer of its own.
+
+`WorkspaceShell` pins its top bar at the new `SHELL_CHROME_LAYER_CLASS_NAME`
+(`z-30`), above the sticky chrome a view pins inside the shell's own scroller.
+A board's header sits at `z-20` and its lane rows at `z-10`; when the shell's
+content column rather than the board is the scroll container, the two used to
+tie on z-index and paint order decided which one covered the other.

--- a/packages/ui/src/components/workspace-shell.test.tsx
+++ b/packages/ui/src/components/workspace-shell.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
 
+import { SHELL_CHROME_LAYER_CLASS_NAME } from "../lib/overlay-layer";
 import { WorkspaceEndRail, WorkspaceShell } from "./workspace-shell";
 
 describe("WorkspaceShell", () => {
@@ -24,7 +25,14 @@ describe("WorkspaceShell", () => {
     );
     expect(markup).toContain("flex h-dvh min-h-0 w-full overflow-hidden");
     expect(markup).toContain('data-slot="workspace-shell-top-bar"');
-    expect(markup).toContain("sticky top-0 z-20 shrink-0");
+    // Above the sticky chrome a view pins inside the shell's own scroller: a
+    // board's header sits at z-20 and its lane rows at z-10, and when the
+    // shell's content column is the scroll container the two would otherwise
+    // tie and be settled by paint order.
+    expect(markup).toContain(
+      `sticky top-0 shrink-0 ${SHELL_CHROME_LAYER_CLASS_NAME}`,
+    );
+    expect(SHELL_CHROME_LAYER_CLASS_NAME).toBe("z-30");
     expect(markup).toContain('data-slot="workspace-shell-content"');
   });
 

--- a/packages/ui/src/components/workspace-shell.tsx
+++ b/packages/ui/src/components/workspace-shell.tsx
@@ -13,6 +13,7 @@ import {
   InspectorRailFooter,
   InspectorRailIconButton,
 } from "../inspector/chrome";
+import { SHELL_CHROME_LAYER_CLASS_NAME } from "../lib/overlay-layer";
 import { cn } from "../lib/utils";
 import { Sheet, SheetPopup, SheetTitle, SheetTrigger } from "./sheet";
 
@@ -114,7 +115,10 @@ export const WorkspaceShell = ({
         data-slot="workspace-shell-main"
       >
         <div
-          className="bg-background sticky top-0 z-20 shrink-0"
+          className={cn(
+            "bg-background sticky top-0 shrink-0",
+            SHELL_CHROME_LAYER_CLASS_NAME,
+          )}
           data-slot="workspace-shell-top-bar"
         >
           {topBar({ compactNavigationTrigger })}

--- a/packages/ui/src/kanban/board-chrome.playwright.spec.ts
+++ b/packages/ui/src/kanban/board-chrome.playwright.spec.ts
@@ -9,6 +9,9 @@ const TOLERANCE_PX = 1;
 /** `KANBAN_COLUMN_WIDTH_PX`, the unit this suite scrolls the board by. */
 const COLUMN_WIDTH_PX = 300;
 
+/** The header row's own inline padding (`px-3`), which the title starts at. */
+const COLUMN_TITLE_INSET_PX = 12;
+
 // A hovering pointer, which the suite's default device does not have: the
 // hover-revealed actions never appear without one, so every test below that
 // waits for them would sit there until it timed out.
@@ -67,6 +70,20 @@ const scrollInlineTo = async (board: Locator, left: number) => {
 
 const opacityOf = async (locator: Locator) =>
   await locator.evaluate((element) => getComputedStyle(element).opacity);
+
+const backgroundOf = async (locator: Locator) =>
+  await locator.evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  );
+
+/** Whether the element is what a pointer finds at the middle of its own box. */
+const coversItsOwnCentre = async (locator: Locator) =>
+  await locator.evaluate((element) => {
+    const { left, top, width, height } = element.getBoundingClientRect();
+    return element.contains(
+      document.elementFromPoint(left + width / 2, top + height / 2),
+    );
+  });
 
 test.describe("band caption on a board scrolled sideways", () => {
   test("holds the visible edge until the band it names is gone", async ({
@@ -232,5 +249,86 @@ test.describe("hover-revealed card actions on a touch device", () => {
     // board grows the dead corner back on all the others.
     expect(await opacityOf(other)).toBe("0");
     expect((await whatIsAtTheCorner(other)).insideActions).toBe(false);
+  });
+});
+
+test.describe("column title on a board scrolled sideways", () => {
+  test("holds the visible edge until its own column is gone", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const header = page.locator('[data-column-header="open"]');
+    const title = header.locator("[data-kanban-column-title]");
+
+    const contentLeft = await contentLeftOf(board);
+
+    // Unscrolled, the title leads its own column, inside the row's padding.
+    expect(
+      Math.abs(
+        (await leftOf(title)) - (await leftOf(header)) - COLUMN_TITLE_INSET_PX,
+      ),
+    ).toBeLessThanOrEqual(TOLERANCE_PX);
+
+    // Half a column past its start, with the rest of it still on screen.
+    await scrollInlineTo(board, COLUMN_WIDTH_PX * 0.5);
+
+    expect(await leftOf(header)).toBeLessThan(contentLeft);
+    expect(await rightOf(header)).toBeGreaterThan(contentLeft);
+    // The cards under it are still being read, so the name is still shown.
+    expect(Math.abs((await leftOf(title)) - contentLeft)).toBeLessThanOrEqual(
+      TOLERANCE_PX,
+    );
+
+    // Once the column itself is behind us, its title leaves with it rather
+    // than naming whatever column is under the edge now.
+    await scrollInlineTo(board, COLUMN_WIDTH_PX * 1.5);
+
+    expect(await rightOf(header)).toBeLessThan(contentLeft);
+    expect(await rightOf(title)).toBeLessThanOrEqual(contentLeft);
+  });
+
+  test("never covers the row's own controls, and lets the accent through", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const header = page.locator('[data-column-header="open"]');
+    const title = header.locator("[data-kanban-column-title]");
+    const actions = header.locator('[data-column-actions="open"]');
+
+    // The header cell carries the wash; the travelling title takes no surface
+    // of its own, so the accent goes on painting under it.
+    expect(await backgroundOf(header)).not.toBe("rgba(0, 0, 0, 0)");
+    expect(await backgroundOf(title)).toBe("rgba(0, 0, 0, 0)");
+    expect(await coversItsOwnCentre(title)).toBe(true);
+
+    // As far as the title can travel: it stops where the row's own controls
+    // begin rather than sliding over them.
+    await scrollInlineTo(board, COLUMN_WIDTH_PX * 0.9);
+
+    expect(await rightOf(title)).toBeLessThanOrEqual(await leftOf(actions));
+    expect(await coversItsOwnCentre(actions)).toBe(true);
+  });
+});
+
+test.describe("pinned chrome on a board scrolled sideways", () => {
+  test("keeps the band caption and the lane identity over what slides beneath", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const caption = page.locator("[data-kanban-band-caption]").first();
+    const identity = page.locator("[data-kanban-lane-identity]").first();
+
+    await scrollInlineTo(board, COLUMN_WIDTH_PX * 0.5);
+
+    // Both hold the visible edge while their own columns slide past, so both
+    // have to be what the reader actually finds there.
+    expect(await coversItsOwnCentre(caption)).toBe(true);
+    expect(await coversItsOwnCentre(identity)).toBe(true);
+
+    // And opaque: a serialized alpha channel would let the cells they hold
+    // back read through them.
+    const identityBackground = await backgroundOf(identity);
+    expect(identityBackground).not.toBe("rgba(0, 0, 0, 0)");
+    expect(identityBackground).not.toContain("/");
   });
 });

--- a/packages/ui/src/kanban/card-shell.test.tsx
+++ b/packages/ui/src/kanban/card-shell.test.tsx
@@ -41,7 +41,7 @@ describe("KanbanCardShell sticky header", () => {
     expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("body"));
   });
 
-  test("takes no stacking layer the actions overlay would have to outrank", () => {
+  test("takes the layer its own card's positioned controls have to share", () => {
     const markup = renderToStaticMarkup(
       <KanbanCardShell
         actions={<button type="button">More</button>}
@@ -51,11 +51,16 @@ describe("KanbanCardShell sticky header", () => {
       </KanbanCardShell>,
     );
 
-    // Callers anchor `actions` to the same corner with no layer of its own, so
-    // a layer here would paint the row over the trigger and swallow its clicks.
-    // Positioned already beats the card's flow content; tree order does the
-    // rest, and the row renders first.
-    expect(markup).not.toContain("z-[");
+    // Being positioned only beats the card's flow content: a control
+    // positioned later in the card's own body would paint over the row on
+    // tree order alone. An overlay that has to stay over the row shares the
+    // layer and wins on tree order, since the row renders first.
+    const row =
+      /<div class="(?<classes>[^"]*)" data-kanban-card-sticky-header=""/u
+        .exec(markup)
+        ?.groups?.["classes"]?.split(" ");
+
+    expect(row).toEqual(expect.arrayContaining(["sticky", "z-10"]));
     expect(markup.indexOf("ACME-1")).toBeLessThan(markup.indexOf("More"));
   });
 
@@ -197,8 +202,8 @@ describe("KanbanCardShell sticky header", () => {
       /<div[^>]*data-kanban-card-actions="hover"[^>]*>/u.exec(markup)?.[0] ??
       "";
 
-    // Positioned in the same corner as the row, and later in the tree, so
-    // only a layer of its own keeps the trigger clickable.
+    // Positioned in the same corner as the row, on the row's own layer, and
+    // later in the tree: that is what keeps the trigger clickable.
     expect(wrapper).toContain("absolute");
     expect(wrapper).toContain("end-1.5");
     expect(wrapper).toContain("z-10");

--- a/packages/ui/src/kanban/card-shell.tsx
+++ b/packages/ui/src/kanban/card-shell.tsx
@@ -173,22 +173,26 @@ const ACTIVE_CLASS = "ring-primary/30 ring-2";
  * gradient layer over the opaque page background instead, which is the card's
  * own surface at full opacity whatever the token turns out to be.
  *
- * No `z-index`: being positioned is already enough to paint over the card's
- * flow content, and taking a layer would put the row over the `actions`
- * overlay, which callers anchor to the same corner with no layer of its own.
- * Tree order settles the rest, and the row renders before `actions`.
+ * The row takes a layer of its own. Being positioned only beats the card's
+ * flow content: a card whose body carries positioned controls of its own (a
+ * band of selects at its foot, say) renders them after the row, and tree order
+ * alone paints them straight over the name of the card they belong to. An
+ * overlay meant to stay reachable over the row takes the same layer and wins
+ * on tree order, which is what the hover `actions` slot below does; a caller
+ * anchoring its own always-visible overlay to that corner does the same.
  */
 const STICKY_HEADER_CLASS =
-  "bg-background bg-[linear-gradient(var(--color-card),var(--color-card))] sticky mb-2 border-b pb-2";
+  "bg-background bg-[linear-gradient(var(--color-card),var(--color-card))] sticky z-10 mb-2 border-b pb-2";
 
 /**
  * Where the shell puts the actions it reveals on hover.
  *
  * The overlay takes a layer of its own here, unlike the always-visible slot:
  * it has to stay over the pinned identity row that leads the same corner, and
- * the row's own comment explains why the row cannot take one instead. An open
- * menu holds the actions on through its trigger's `aria-expanded`, or the
- * trigger would disappear from under the popup it just opened.
+ * the row now takes a layer too. Sharing it is enough, because the overlay is
+ * rendered after the row. An open menu holds the actions on through its
+ * trigger's `aria-expanded`, or the trigger would disappear from under the
+ * popup it just opened.
  *
  * The fade is decoration: a reader who asked for less motion still gets the
  * actions, they simply arrive at once.

--- a/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
+++ b/packages/ui/src/kanban/card-sticky-header.playwright.spec.ts
@@ -56,6 +56,15 @@ const expectRestingOnAction = async (header: Locator, actionBottom: number) => {
   );
 };
 
+/** Whether the element is what a pointer finds at the middle of its own box. */
+const coversItsOwnCentre = async (locator: Locator) =>
+  await locator.evaluate((element) => {
+    const { left, top, width, height } = element.getBoundingClientRect();
+    return element.contains(
+      document.elementFromPoint(left + width / 2, top + height / 2),
+    );
+  });
+
 /** How far the row was told to pin, out of `calc(var(...) + Npx)`. */
 const pinnedAboveOf = (offset: string) => {
   const match = /\+\s*(?<pixels>\d+(?:\.\d+)?)px/u.exec(offset);
@@ -151,17 +160,33 @@ test.describe("card sticky header", () => {
     await openFixture(page);
     const actions = page.locator('[data-card-actions="card-1"]');
 
-    // At rest the row leads the very corner the overlay is anchored to, so a
-    // stacking layer on the row would paint over the trigger and take its
-    // clicks.
-    const hit = await actions.evaluate((element) => {
-      const { left, top, width, height } = element.getBoundingClientRect();
-      return element.contains(
-        document.elementFromPoint(left + width / 2, top + height / 2),
-      );
-    });
+    // The row leads the very corner the overlay is anchored to. Both take the
+    // same layer, so the overlay stays reachable on tree order alone: it is
+    // rendered after the row.
+    expect(await coversItsOwnCentre(actions)).toBe(true);
+  });
 
-    expect(hit).toBe(true);
+  test("holds the row over the controls its own card carries below", async ({
+    page,
+  }) => {
+    const board = await openFixture(page);
+    const header = headerOf(page, "card-1");
+    const control = page.locator('[data-card-control="card-1"]');
+
+    // Far enough into the card for its row to be pinned, then far enough
+    // again for the control at the card's foot to reach that row.
+    await scrollTo(board, 300);
+    const travel = (await topOf(control)) - (await topOf(header));
+    await scrollTo(board, 300 + travel + 8);
+
+    // The two really are on top of each other, or the check below passes on
+    // a card that never overlapped its own row.
+    expect(await topOf(control)).toBeLessThan(await bottomOf(header));
+    expect(await bottomOf(control)).toBeGreaterThan(await topOf(header));
+    // And the row is what the reader sees there: a positioned control later
+    // in the card would otherwise paint straight over the name of the card
+    // it belongs to.
+    expect(await coversItsOwnCentre(header)).toBe(true);
   });
 
   test("keeps the row with its card while the card is the drag source", async ({

--- a/packages/ui/src/kanban/column-band-header.tsx
+++ b/packages/ui/src/kanban/column-band-header.tsx
@@ -4,7 +4,10 @@ import { ChevronDownIcon } from "lucide-react";
 
 import { DirectionalIcon } from "../components/directional-icon";
 import { cn } from "../lib/utils";
-import { KANBAN_BAND_CAPTION_ROW_HEIGHT } from "./layout-tokens";
+import {
+  KANBAN_BAND_CAPTION_ROW_HEIGHT,
+  KANBAN_CHROME_TOGGLE_COARSE_TARGET_CLASS,
+} from "./layout-tokens";
 
 /**
  * How a band toggle was activated. A pointer activation leaves the pointer
@@ -40,8 +43,11 @@ export type KanbanColumnBandHeaderProps = {
 
 /**
  * The band line above a run of columns: one `KANBAN_BAND_CAPTION_ROW_HEIGHT`
- * row of toggle, swatch, name, and count, so a band costs the board a
- * caption's height and nothing more.
+ * row of toggle, swatch, name, and count.
+ *
+ * The line carries the chrome row height and sets its name a step heavier than
+ * a column title, because the band names the columns under it: a smaller label
+ * on a shorter line read as subordinate to the very columns it groups.
  * Folded, only the toggle remains in this line; the band's name moves down
  * into the narrow column body, where the height is already there.
  */
@@ -68,7 +74,10 @@ export const KanbanColumnBandHeader = ({
     <button
       aria-expanded={!collapsed}
       aria-label={toggleLabel}
-      className="hover:bg-muted/60 text-muted-foreground hover:text-foreground flex size-6 shrink-0 items-center justify-center rounded-md transition-[background-color]"
+      className={cn(
+        "hover:bg-muted/60 text-muted-foreground hover:text-foreground flex size-7 shrink-0 items-center justify-center rounded-md transition-[background-color]",
+        KANBAN_CHROME_TOGGLE_COARSE_TARGET_CLASS,
+      )}
       // A keyboard activation reports no click count, so the board can tell a
       // fold that leaves the pointer over the new slot from one that does not.
       onClick={(event) =>
@@ -78,10 +87,7 @@ export const KanbanColumnBandHeader = ({
       type="button"
     >
       <DirectionalIcon
-        className={cn(
-          "size-3.5 transition-transform",
-          collapsed && "-rotate-90",
-        )}
+        className={cn("size-4 transition-transform", collapsed && "-rotate-90")}
         flip={collapsed}
         icon={ChevronDownIcon}
       />
@@ -89,10 +95,10 @@ export const KanbanColumnBandHeader = ({
     {compact ? null : (
       <>
         {swatch}
-        <span className="flex min-w-0 flex-1 items-baseline gap-1.5 truncate text-xs font-medium">
+        <span className="flex min-w-0 flex-1 items-baseline gap-1.5 truncate text-sm font-semibold">
           {title}
           {meta !== undefined && (
-            <span className="text-muted-foreground font-normal tabular-nums">
+            <span className="text-muted-foreground text-xs font-normal tabular-nums">
               {meta}
             </span>
           )}

--- a/packages/ui/src/kanban/column-header.test.tsx
+++ b/packages/ui/src/kanban/column-header.test.tsx
@@ -26,4 +26,43 @@ describe("KanbanColumnHeader", () => {
     expect(rootClass).not.toContain("py-2");
     expect(markup).toContain("truncate");
   });
+
+  test("pins the name to the visible edge without covering the row's end", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanColumnHeader
+        actions={<button type="button">menu</button>}
+        meta="7"
+        swatch={<span>dot</span>}
+        title="A very long column name"
+      />,
+    );
+    const titleGroup =
+      /<div[^>]*data-kanban-column-title=""[^>]*>/u.exec(markup)?.[0] ?? "";
+
+    // The swatch, the name and the count travel together, sized to their own
+    // content so they have room to travel at all.
+    expect(titleGroup).toContain("sticky");
+    expect(titleGroup).toContain("start-0");
+    expect(titleGroup).toContain("w-fit");
+    expect(titleGroup).toContain("max-w-full");
+    expect(titleGroup).toContain("z-10");
+    // Whatever surface the header row carries, rather than one of its own: a
+    // caller washes the header cell in the column's accent, and the name has
+    // to let that paint through.
+    expect(titleGroup).toContain("bg-inherit");
+    expect(titleGroup).not.toContain("bg-background");
+    // It travels inside a box that ends where the row's own controls begin,
+    // so a pinned name can never slide over the calculation or the menu.
+    const travelRegion =
+      /<div class="(?<classes>[^"]*)"><div[^>]*data-kanban-column-title=""/u
+        .exec(markup)
+        ?.groups?.["classes"]?.split(" ");
+
+    expect(travelRegion).toEqual(
+      expect.arrayContaining(["flex", "min-w-0", "flex-1"]),
+    );
+    expect(markup.indexOf("data-kanban-column-title")).toBeLessThan(
+      markup.indexOf("menu"),
+    );
+  });
 });

--- a/packages/ui/src/kanban/column-header.tsx
+++ b/packages/ui/src/kanban/column-header.tsx
@@ -45,13 +45,29 @@ export const KanbanColumnHeader = ({
       className,
     )}
   >
-    {swatch}
-    <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate">
-      {title}
-      {meta !== undefined && (
-        <span className="text-muted-foreground text-xs">{meta}</span>
-      )}
-    </span>
+    {/* How far the name may travel: up to where the row's own controls begin,
+     * so a name holding the visible edge of a board scrolled sideways never
+     * slides over the calculation or the column's menu. */}
+    <div className="flex min-w-0 flex-1">
+      {/* The name travels the width of its own column: a board scrolled
+       * sideways keeps it at the visible edge until the column it names is
+       * gone, rather than leaving the cards below it unlabelled. It has to
+       * size to its content to have any room to travel. `bg-inherit` repaints
+       * whatever surface the header row itself carries, and stays out of the
+       * way of the accent a caller washes the header cell around it with. */}
+      <div
+        className="sticky start-0 z-10 flex w-fit max-w-full items-center gap-2 bg-inherit"
+        data-kanban-column-title=""
+      >
+        {swatch}
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate">
+          {title}
+          {meta !== undefined && (
+            <span className="text-muted-foreground text-xs">{meta}</span>
+          )}
+        </span>
+      </div>
+    </div>
     {calculation}
     {dragHandle}
     {actions}

--- a/packages/ui/src/kanban/fixtures/board-chrome.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/board-chrome.fixture.tsx
@@ -88,11 +88,39 @@ const BoardChromeFixture = () => {
             ))}
           </div>
         )}
-        renderColumnHeader={({ column }) => (
-          <KanbanColumnHeader
-            title={column.type === "group" ? column.group.label : "Other"}
-          />
-        )}
+        renderColumnHeader={({ column }) => {
+          const value = column.type === "group" ? column.group.value : null;
+          const label = column.type === "group" ? column.group.label : "Other";
+          return (
+            // A header cell the way a host dresses one: the rounding and the
+            // accent wash sit on the container around the header row, so a
+            // title pinned inside that row has to let them paint through.
+            <div
+              className="w-full rounded-lg"
+              data-column-header={value ?? "other"}
+              style={
+                value === "open"
+                  ? {
+                      backgroundColor:
+                        "color-mix(in srgb, var(--option-blue) 50%, transparent)",
+                    }
+                  : undefined
+              }
+            >
+              <KanbanColumnHeader
+                actions={
+                  <button data-column-actions={value ?? "other"} type="button">
+                    More
+                  </button>
+                }
+                meta="1"
+                title={
+                  <span className="truncate text-sm font-medium">{label}</span>
+                }
+              />
+            </div>
+          );
+        }}
         renderLaneIdentity={({ group }) => (
           <span data-lane={group.value}>{group.label}</span>
         )}

--- a/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/card-sticky-header.fixture.tsx
@@ -106,7 +106,10 @@ const CardStickyHeaderFixture = () => {
                   // The overlay slot callers anchor to the same corner the
                   // identity row leads: it has to stay on top of the row.
                   actions={
-                    <div className="absolute end-1.5 top-1.5">
+                    // Anchored to the corner the pinned row leads, with a
+                    // layer of its own: the row takes one now, so an overlay
+                    // that wants to stay reachable has to take one too.
+                    <div className="absolute end-1.5 top-1.5 z-10">
                       <button data-card-actions={row.id} type="button">
                         More
                       </button>
@@ -125,6 +128,20 @@ const CardStickyHeaderFixture = () => {
                   <p className="text-muted-foreground text-xs">
                     A card far taller than the board it scrolls through.
                   </p>
+                  {/* A control low in the card's own body, the way a card
+                   * with a band of selects at its foot carries one:
+                   * positioned, and later in the tree than the pinned row,
+                   * so it passes over that row unless the row takes a
+                   * layer. */}
+                  <div className="absolute inset-x-3 top-[420px]">
+                    <button
+                      className="w-full rounded-md border px-2 py-1 text-xs"
+                      data-card-control={row.id}
+                      type="button"
+                    >
+                      Status
+                    </button>
+                  </div>
                   {row.id === "card-1" ? <FirstLayoutProbe /> : null}
                 </KanbanCardShell>
               </div>

--- a/packages/ui/src/kanban/layout-tokens.test.ts
+++ b/packages/ui/src/kanban/layout-tokens.test.ts
@@ -33,9 +33,11 @@ describe("kanban chrome row heights", () => {
     );
   });
 
-  test("keep a band's caption line shorter than the rows of chrome", () => {
-    expect(KANBAN_BAND_CAPTION_ROW_HEIGHT_PX).toBeLessThan(
-      KANBAN_CHROME_ROW_HEIGHT_PX,
-    );
+  // A band names the columns under it, so its caption sits on their row
+  // rather than on a shorter one of its own: a smaller caption read as a note
+  // about the header row instead of the group the columns belong to.
+  test("put a band's caption on the row its columns are on", () => {
+    expect(KANBAN_BAND_CAPTION_ROW_HEIGHT).toBe(KANBAN_CHROME_ROW_HEIGHT);
+    expect(KANBAN_BAND_CAPTION_ROW_HEIGHT_PX).toBe(KANBAN_CHROME_ROW_HEIGHT_PX);
   });
 });

--- a/packages/ui/src/kanban/layout-tokens.ts
+++ b/packages/ui/src/kanban/layout-tokens.ts
@@ -10,6 +10,15 @@
  */
 
 /**
+ * Where the board's chrome stacks: its header block at `z-20`, a lane's own
+ * row at `z-10` under it. Both stay below the shell's chrome
+ * (`SHELL_CHROME_LAYER_CLASS_NAME`), which pins a top bar around whatever the
+ * board is rendered in: when the shell's content column rather than the board
+ * is the scroll container, board and shell chrome are pinned in the same
+ * scroller, and equal z-indexes would leave paint order to decide.
+ */
+
+/**
  * The column header row and a lane's rows: a *fixed* height, tighter than the
  * inspector's 48px toolbar row, because a board shows three of these before
  * the first card and each one costs the cards their space. Fixed rather than
@@ -19,9 +28,26 @@ export const KANBAN_CHROME_ROW_HEIGHT = "h-9" as const;
 export const KANBAN_CHROME_ROW_HEIGHT_PX = 36 as const;
 
 /**
- * The band caption line, one step shorter again: a band names a run of
- * columns rather than holding controls of its own, so it reads as a label
- * over the header row rather than a second row of chrome.
+ * The band caption line, on the chrome row height like everything else: a band
+ * names the run of columns under it, so its caption reads as their parent. A
+ * shorter line with a smaller label read as a note *about* the header row, and
+ * left a group looking subordinate to its own columns.
+ *
+ * Still named for the caption, because that row is the one a caller composes
+ * against when it renders a band header of its own.
  */
-export const KANBAN_BAND_CAPTION_ROW_HEIGHT = "h-7" as const;
-export const KANBAN_BAND_CAPTION_ROW_HEIGHT_PX = 28 as const;
+export const KANBAN_BAND_CAPTION_ROW_HEIGHT = KANBAN_CHROME_ROW_HEIGHT;
+export const KANBAN_BAND_CAPTION_ROW_HEIGHT_PX = KANBAN_CHROME_ROW_HEIGHT_PX;
+
+/**
+ * A finger's 44px target on a control the chrome row keeps at its own height.
+ *
+ * The same pseudo-element the shared `Button` extends its own targets with:
+ * the visible control keeps the row's height, and only the touch surface
+ * grows. The surface is a fixed 44px centred on the control rather than an
+ * inset off its edges, so a 28px toggle and a 36px one both reach the same
+ * distance either way, and neither spills into the row underneath: an inset
+ * grows a short control downwards by whatever it is short by.
+ */
+export const KANBAN_CHROME_TOGGLE_COARSE_TARGET_CLASS =
+  "relative pointer-coarse:after:absolute pointer-coarse:after:inset-x-0 pointer-coarse:after:top-1/2 pointer-coarse:after:h-11 pointer-coarse:after:-translate-y-1/2";

--- a/packages/ui/src/kanban/sticky-lane.test.tsx
+++ b/packages/ui/src/kanban/sticky-lane.test.tsx
@@ -64,6 +64,9 @@ describe("KanbanCollapsedBandCaption", () => {
     expect(markup).toContain(">7<");
     expect(markup).toContain("[writing-mode:vertical-rl]");
     expect(markup).toContain('data-kanban-collapsed-band-caption=""');
+    // The weight the open caption sets a band's name in, kept through the
+    // fold so a narrow slot still reads as the name of a group of columns.
+    expect(markup).toContain("font-semibold");
   });
 
   test("sticks under the board's header without stretching in its slot", () => {

--- a/packages/ui/src/kanban/sticky-lane.tsx
+++ b/packages/ui/src/kanban/sticky-lane.tsx
@@ -101,7 +101,9 @@ export const KanbanCollapsedBandCaption = ({
     )}
     data-kanban-collapsed-band-caption=""
   >
-    <span className="max-h-40 truncate font-medium [writing-mode:vertical-rl]">
+    {/* The band's own name, at the weight the open caption sets it in: a
+        folded band still names the columns it stands for. */}
+    <span className="max-h-40 truncate font-semibold [writing-mode:vertical-rl]">
       {label}
     </span>
     <span className="tabular-nums">{meta}</span>

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -5,7 +5,10 @@ import { describe, expect, test } from "bun:test";
 import { KanbanColumnBandHeader } from "./column-band-header";
 import type { KanbanSchema } from "./grouping";
 import { resolveKanbanGrouping } from "./grouping";
-import { KANBAN_CHROME_ROW_HEIGHT } from "./layout-tokens";
+import {
+  KANBAN_BAND_CAPTION_ROW_HEIGHT,
+  KANBAN_CHROME_ROW_HEIGHT,
+} from "./layout-tokens";
 import { buildKanbanBoardMatrix } from "./matrix";
 import { KANBAN_STICKY_TOP_CLASS, KANBAN_STICKY_TOP_VAR } from "./sticky-lane";
 import { KanbanSubgroupBoard } from "./subgroup-board";
@@ -125,8 +128,15 @@ describe("KanbanSubgroupBoard", () => {
     // Opaque, or the cards it holds back read through it.
     expect(laneRow).toContain("bg-background");
     // The identity holds the visible inline edge, and has to size to its own
-    // content to have any room to travel there.
-    expect(markup).toContain("sticky start-0 flex w-fit");
+    // content to have any room to travel there. It is opaque and above the
+    // summaries under it, or they would read through it as it travels.
+    const identity =
+      /<div[^>]*data-kanban-lane-identity=""[^>]*>/u.exec(markup)?.[0] ?? "";
+
+    expect(identity).toContain("sticky start-0");
+    expect(identity).toContain("w-fit");
+    expect(identity).toContain("z-10");
+    expect(identity).toContain("bg-background");
     // The cells are told what the header *and* the lane row reach, or a
     // card's own pinned row would come to rest behind the lane's.
     expect(markup).toContain(`${KANBAN_STICKY_TOP_VAR}:72px`);
@@ -142,10 +152,12 @@ describe("KanbanSubgroupBoard", () => {
     expect(toggle).toContain(KANBAN_CHROME_ROW_HEIGHT);
     expect(toggle).toContain("relative");
     expect(toggle).toContain("pointer-coarse:after:absolute");
-    expect(toggle).toContain("pointer-coarse:after:min-h-11");
-    // Centred on the toggle: growing downwards alone would reach into the
-    // summaries row under it.
-    expect(toggle).toContain("pointer-coarse:after:-inset-y-1");
+    expect(toggle).toContain("pointer-coarse:after:h-11");
+    // Centred on the toggle, at a height of its own: an inset off the
+    // control's edges reaches into the summaries row under it by however
+    // much the control is short of 44px.
+    expect(toggle).toContain("pointer-coarse:after:top-1/2");
+    expect(toggle).toContain("pointer-coarse:after:-translate-y-1/2");
   });
 
   test("hands a lane's per-column cell to the caller's summary and action", () => {
@@ -365,12 +377,19 @@ describe("KanbanSubgroupBoard with column bands", () => {
       />,
     );
 
-    // The caption line is a fixed 28px row with a hairline, not a boxed panel.
+    // The caption line is a hairline over the columns, not a boxed panel, and
+    // it stands on the same row height as the columns it names.
     expect(open).toContain('data-slot="kanban-column-band-header"');
     expect(open).toMatch(
-      /class="[^"]*\bh-7\b[^"]*"[^>]*data-slot="kanban-column-band-header"/u,
+      new RegExp(
+        `class="[^"]*\\b${KANBAN_BAND_CAPTION_ROW_HEIGHT}\\b[^"]*"[^>]*data-slot="kanban-column-band-header"`,
+        "u",
+      ),
     );
     expect(open).not.toContain("rounded-lg border");
+    // The band's own name leads its columns: a step heavier than the column
+    // titles under it, not the smaller label it used to be.
+    expect(open).toContain("text-sm font-semibold");
     // Folded, the caption keeps only the toggle; the name sits vertically in
     // the default body slot with the count under it.
     const foldedHeader =

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -22,6 +22,7 @@ import type { KanbanColumnBand, KanbanGroup } from "./grouping";
 import {
   KANBAN_CHROME_ROW_HEIGHT,
   KANBAN_CHROME_ROW_HEIGHT_PX,
+  KANBAN_CHROME_TOGGLE_COARSE_TARGET_CLASS,
 } from "./layout-tokens";
 import type {
   KanbanBoardCell,
@@ -46,19 +47,6 @@ import type { KanbanStickyTopStyle } from "./sticky-lane";
  * to be.
  */
 const LANE_ROW_HEIGHT_PX = KANBAN_CHROME_ROW_HEIGHT_PX * 2;
-
-/**
- * A finger's 44px target on a toggle the chrome row keeps at 36px.
- *
- * The same pseudo-element the shared `Button` extends its own targets with:
- * the visible control keeps the row's height, and only the touch surface
- * grows. It grows evenly above and below rather than downwards, so the extra
- * reach stops well short of the controls a caller renders in the summaries
- * under it — those sit at the far end of their own column, not under the
- * lane's name.
- */
-const LANE_TOGGLE_COARSE_TARGET_CLASS =
-  "relative pointer-coarse:after:absolute pointer-coarse:after:inset-x-0 pointer-coarse:after:-inset-y-1 pointer-coarse:after:min-h-11";
 
 const groupValueKey = (value: string | null): string =>
   value === null ? "null" : `value:${value.length}:${value}`;
@@ -830,18 +818,23 @@ export const KanbanSubgroupBoard = <TRow,>({
                 )}
                 data-kanban-lane-row=""
               >
+                {/* Opaque and above the summaries under it: the identity
+                 * holds the visible inline edge while the row's own cells
+                 * slide past, and a transparent name would be read through
+                 * by whatever passes beneath it. */}
                 <div
                   className={cn(
-                    "sticky start-0 flex w-fit items-center",
+                    "bg-background sticky start-0 z-10 flex w-fit items-center",
                     KANBAN_CHROME_ROW_HEIGHT,
                   )}
+                  data-kanban-lane-identity=""
                 >
                   <button
                     aria-expanded={!collapsed}
                     className={cn(
                       "hover:bg-muted/60 flex items-center gap-2 rounded-lg px-2 text-start transition-[background-color]",
                       KANBAN_CHROME_ROW_HEIGHT,
-                      LANE_TOGGLE_COARSE_TARGET_CLASS,
+                      KANBAN_CHROME_TOGGLE_COARSE_TARGET_CLASS,
                     )}
                     onClick={() => setLaneCollapsed(group, count, !collapsed)}
                     type="button"

--- a/packages/ui/src/lib/overlay-layer.ts
+++ b/packages/ui/src/lib/overlay-layer.ts
@@ -9,6 +9,20 @@
 // composer painted on top of a dimmed template-check dialog.
 export const BOARD_DRAG_OVERLAY_Z_INDEX = 75;
 
+/**
+ * The shell's own sticky chrome: its top bar, and anything else the shell pins
+ * around a view.
+ *
+ * Not part of the ladder below, which is for portalled surfaces: this one
+ * stays in flow, so it only ever competes with the sticky chrome a view paints
+ * inside the shell's scroller. A kanban board pins its header at z-20 and a
+ * lane's row at z-10, and when the shell's content column (not the board) is
+ * the scroll container the two tie and paint order decides which one wins.
+ * Stated one step above that, and far below every portalled surface here,
+ * which must still cover the shell.
+ */
+export const SHELL_CHROME_LAYER_CLASS_NAME = "z-30";
+
 export const OVERLAY_LAYER_CLASS_NAMES = {
   /** Docked composer, suggestion chips, and other in-pane floating chrome. */
   chrome: "z-[80]",


### PR DESCRIPTION
- The band caption row is now `KANBAN_BAND_CAPTION_ROW_HEIGHT` = the chrome row height (`h-9`, 36px) with a `text-sm font-semibold` name, so a band reads as the parent of its columns instead of a smaller label under them; the folded vertical caption keeps that weight.
- A column's swatch, name and count are pinned to the visible inline edge (`data-kanban-column-title`, `sticky start-0 z-10 w-fit max-w-full bg-inherit`) and travel only as far as the row's own controls, which stay at the end of the row; the accent a caller washes a header cell with still paints under them.
- `WorkspaceShell` pins its top bar at the new `SHELL_CHROME_LAYER_CLASS_NAME` (`z-30`), above the board chrome (`z-20` header, `z-10` lane row) that shares the shell's scroller; the lane identity is now opaque and `z-10` over its own summaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kanban column titles now remain visible while horizontally scrolling.
  * Lane labels and band captions stay anchored during board scrolling.
  * Kanban band captions now match the height of column headers and lane rows.
  * Improved touch targets for Kanban controls.
* **Visual Improvements**
  * Band names use clearer, heavier typography, including collapsed captions.
  * Workspace top-bar layering now keeps it visible above board content.
* **Bug Fixes**
  * Resolved overlapping and obscured labels when scrolling Kanban boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->