### PR TITLE
refactor(api): move the SSE module onto the result boundary

### DIFF
--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -120,11 +120,15 @@ const clearIntervalSpy = spyOn(globalThis, "clearInterval");
 const { broadcast, revokeWorkspaceSseAccess, startSse, stopSse, subscribe } =
   await import("@/api/lib/sse");
 
-// Let the fire-and-forget subscribe promise inside startSse settle.
-const flushMicrotasks = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+// Let the fire-and-forget subscribe promise inside startSse settle. A timer
+// turn drains the whole pending microtask queue, so this does not depend on
+// how many `await` points the module's attach path happens to have — counting
+// ticks silently under-drains the moment that chain grows. `Bun.sleep` is used
+// rather than `setTimeout` so the tests that stub the global timer still get a
+// real turn. The delay is 0, so a pending attach retry (200 ms at the shortest)
+// never fires inside it.
+const settlePendingWork = async (): Promise<void> => {
+  await Bun.sleep(0);
 };
 
 const workspaceId = toSafeId<"workspace">("ws_1");
@@ -217,7 +221,7 @@ describe("sse module import", () => {
       broadcastTestEvent(workspaceId, testEvent("before-start")),
     ).not.toThrow();
 
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 });
 
@@ -230,13 +234,13 @@ describe("startSse / stopSse lifecycle", () => {
 
     expect(setIntervalSpy).toHaveBeenCalledTimes(1);
 
-    await flushMicrotasks();
+    await settlePendingWork();
 
     expect(createdClients).toHaveLength(1);
     expect(createdClients[0]?.subscribe).toHaveBeenCalledTimes(1);
 
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("startSse is idempotent: repeated calls create only one timer and one subscriber", async () => {
@@ -249,12 +253,12 @@ describe("startSse / stopSse lifecycle", () => {
 
     expect(setIntervalSpy).toHaveBeenCalledTimes(1);
 
-    await flushMicrotasks();
+    await settlePendingWork();
 
     expect(createdClients).toHaveLength(1);
 
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("stopSse clears the interval and closes the subscriber", async () => {
@@ -262,7 +266,7 @@ describe("startSse / stopSse lifecycle", () => {
     createdClients.length = 0;
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const client = createdClients[0];
     expect(client).toBeDefined();
@@ -272,7 +276,7 @@ describe("startSse / stopSse lifecycle", () => {
     expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
     expect(client?.close).toHaveBeenCalledTimes(1);
 
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("stopSse is safe when startSse was never called", () => {
@@ -283,12 +287,12 @@ describe("startSse / stopSse lifecycle", () => {
     createdClients.length = 0;
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     stopSse();
     expect(() => stopSse()).not.toThrow();
 
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("a Redis connection failure during startSse is logged and does not throw", async () => {
@@ -297,14 +301,14 @@ describe("startSse / stopSse lifecycle", () => {
 
     expect(() => startTestSse()).not.toThrow();
 
-    await flushMicrotasks();
+    await settlePendingWork();
 
     // The client created for the failed connection attempt is still
     // closed, so a repeated failure does not leak a raw client handle.
     expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
 
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
     subscribeBehavior = "resolve";
   });
 
@@ -315,7 +319,7 @@ describe("startSse / stopSse lifecycle", () => {
     // stopSse runs before the mocked subscribe() promise has settled.
     stopSse();
 
-    await flushMicrotasks();
+    await settlePendingWork();
 
     expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
   });
@@ -329,7 +333,7 @@ describe("startSse / stopSse lifecycle", () => {
     // promise has not settled) when a new lifecycle starts.
     startTestSse();
 
-    await flushMicrotasks();
+    await settlePendingWork();
 
     expect(createdClients).toHaveLength(2);
     const [oldClient, newClient] = createdClients;
@@ -344,7 +348,7 @@ describe("startSse / stopSse lifecycle", () => {
     stopSse();
     expect(newClient?.close).toHaveBeenCalledTimes(1);
 
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 });
 
@@ -365,7 +369,7 @@ describe("subscribe: already-aborted signal", () => {
     // A subsequent broadcast must not resurrect or feed the dead stream:
     // nothing was registered, so there is nothing to enqueue into.
     broadcastTestEvent(workspaceId, testEvent("after-abort"));
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const second = await reader.read();
     expect(second.done).toBe(true);
@@ -378,7 +382,7 @@ describe("broadcast: local delivery without an attached subscriber", () => {
     // Local clients must still get it.
     startTestSse();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const controller = new AbortController();
     const stream = subscribeToWorkspace(controller.signal);
@@ -391,13 +395,13 @@ describe("broadcast: local delivery without an attached subscriber", () => {
     expect(text).toContain("local-only");
 
     controller.abort();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("preserves the resource carried by a semantic event", async () => {
     startTestSse();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const controller = new AbortController();
     const stream = subscribeToWorkspace(controller.signal);
@@ -415,7 +419,7 @@ describe("broadcast: local delivery without an attached subscriber", () => {
     expect(text).toContain(`"resource":{"type":"entity","id":"${entityId}"}`);
 
     controller.abort();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 });
 
@@ -434,7 +438,7 @@ describe("workspace access revocation", () => {
       },
     );
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const removedController = new AbortController();
     const retainedController = new AbortController();
@@ -458,14 +462,14 @@ describe("workspace access revocation", () => {
     retainedController.abort();
     startTestSse();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("closes only the removed member's streams before later events", async () => {
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const removedController = new AbortController();
     const retainedController = new AbortController();
@@ -490,13 +494,13 @@ describe("workspace access revocation", () => {
     removedController.abort();
     retainedController.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("a revocation from another API replica closes the local stream", async () => {
     createdClients.length = 0;
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const controller = new AbortController();
     const reader = subscribeToWorkspace(controller.signal).getReader();
@@ -513,7 +517,7 @@ describe("workspace access revocation", () => {
 
     controller.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 });
 
@@ -527,7 +531,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     subscribeBehavior = "resolve";
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const controller = new AbortController();
     const stream = subscribeToWorkspace(controller.signal);
@@ -545,7 +549,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
 
     controller.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("preserves event order while workspace authorization is pending", async () => {
@@ -570,14 +574,14 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
         publishWorkspace: publishWorkspaceEventMock,
       },
     );
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const controller = new AbortController();
     const reader = subscribeToWorkspace(controller.signal).getReader();
 
     broadcastTestEvent(workspaceId, testEvent("ordered-a"));
     broadcastTestEvent(workspaceId, testEvent("ordered-b"));
-    await flushMicrotasks();
+    await settlePendingWork();
     expect(authorizationCalls).toBe(1);
 
     firstAuthorization.resolve(undefined);
@@ -587,7 +591,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     controller.abort();
     startTestSse();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("a transient drop+reconnect re-subscribes via a fresh client and resumes exactly-once loopback delivery", async () => {
@@ -596,7 +600,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     subscribeBehavior = "resolve";
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
     const original = createdClients.at(-1);
     expect(original).toBeDefined();
 
@@ -614,7 +618,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     if (original) {
       simulateDeafReconnect(original);
     }
-    await flushMicrotasks();
+    await settlePendingWork();
 
     // The deaf client was closed and a distinct replacement subscribed.
     expect(original?.close).toHaveBeenCalledTimes(1);
@@ -634,7 +638,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
 
     controller.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("while the replacement subscriber has not yet attached, broadcasts fall back to inline delivery", async () => {
@@ -643,7 +647,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     subscribeBehavior = "resolve";
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
     const original = createdClients.at(-1);
     expect(original).toBeDefined();
 
@@ -658,7 +662,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     if (original) {
       simulateDeafReconnect(original);
     }
-    await flushMicrotasks();
+    await settlePendingWork();
 
     broadcastTestEvent(workspaceId, testEvent("deaf-window"));
     expect(decode((await reader.read()).value)).toContain("deaf-window");
@@ -667,7 +671,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     subscribeFailuresRemaining = 0;
     controller.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("an own event broadcast during the attach window is delivered exactly once (loopback copy dropped)", async () => {
@@ -676,7 +680,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     subscribeBehavior = "resolve";
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
     const original = createdClients.at(-1);
     expect(original).toBeDefined();
 
@@ -703,13 +707,13 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     // broadcasting a steady event that rides loopback only; reading it second
     // proves the windowed event was not delivered twice.
     expect(decode((await reader.read()).value)).toContain("own-in-window");
-    await flushMicrotasks();
+    await settlePendingWork();
     broadcastTestEvent(workspaceId, testEvent("after-window"));
     expect(decode((await reader.read()).value)).toContain("after-window");
 
     controller.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("a remote event received during the attach window is delivered via loopback", async () => {
@@ -718,7 +722,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     subscribeBehavior = "resolve";
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
     const original = createdClients.at(-1);
 
     const controller = new AbortController();
@@ -747,7 +751,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
 
     controller.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("a stale subscriber whose close() threw cannot deliver after a replacement attaches", async () => {
@@ -757,7 +761,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     closeFailuresRemaining = 0;
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
     const original = createdClients.at(-1);
     expect(original?.subscribedLive).toBe(true);
 
@@ -773,7 +777,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
         handler();
       }
     }
-    await flushMicrotasks();
+    await settlePendingWork();
 
     const replacement = createdClients.at(-1);
     expect(replacement).not.toBe(original);
@@ -799,7 +803,7 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     closeFailuresRemaining = 0;
     controller.abort();
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 });
 
@@ -810,7 +814,7 @@ describe("startSse: subscriber attach retry", () => {
     subscribeFailuresRemaining = 1;
 
     startTestSse();
-    await flushMicrotasks();
+    await settlePendingWork();
 
     // The first attempt created a client, failed, and closed it.
     expect(createdClients).toHaveLength(1);
@@ -818,7 +822,7 @@ describe("startSse: subscriber attach retry", () => {
 
     // Wait past the first backoff delay (200ms) so the retry can run.
     await Bun.sleep(300);
-    await flushMicrotasks();
+    await settlePendingWork();
 
     // A second client was created for the retry and stayed attached.
     expect(createdClients).toHaveLength(2);
@@ -830,7 +834,7 @@ describe("startSse: subscriber attach retry", () => {
     stopSse();
     expect(attached?.close).toHaveBeenCalledTimes(1);
 
-    await flushMicrotasks();
+    await settlePendingWork();
     subscribeFailuresRemaining = 0;
   });
 
@@ -883,7 +887,7 @@ describe("startSse: subscriber attach retry", () => {
     timeoutSpy.mockRestore();
     subscribeFailuresRemaining = 0;
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 
   test("a failed attach whose cleanup close() also throws still schedules the next attempt", async () => {
@@ -927,6 +931,6 @@ describe("startSse: subscriber attach retry", () => {
     subscribeFailuresRemaining = 0;
     closeFailuresRemaining = 0;
     stopSse();
-    await flushMicrotasks();
+    await settlePendingWork();
   });
 });

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -1,3 +1,5 @@
+import { Result } from "better-result";
+
 import type {
   DesktopEditSessionRealtimeEvent,
   OrganizationRealtimeEvent,
@@ -89,6 +91,44 @@ const formatSSE = (
 const formatKeepAlive = (): Uint8Array => encoder.encode(`:keep-alive\n\n`);
 
 /**
+ * Close one stream controller best-effort. `close()` throws for a controller
+ * that is already closed or errored, and every caller here is tearing that
+ * connection down anyway, so the failure carries no information.
+ */
+const closeControllerQuietly = (
+  controller: ReadableStreamDefaultController,
+): void =>
+  Result.try(() => {
+    controller.close();
+  }).unwrapOr(undefined);
+
+type StreamConnection = { controller: ReadableStreamDefaultController };
+
+type EnqueueOrDropOptions<TConnection extends StreamConnection> = {
+  chunk: Uint8Array;
+  connection: TConnection;
+  set: Set<TConnection>;
+};
+
+/**
+ * Push a chunk to one stream, dropping the connection when its controller is
+ * gone. `enqueue` fails for a closed or errored stream; that failure is this
+ * module's self-heal signal for a connection nothing reads any more.
+ */
+const enqueueOrDrop = <TConnection extends StreamConnection>({
+  chunk,
+  connection,
+  set,
+}: EnqueueOrDropOptions<TConnection>): void => {
+  const enqueued = Result.try(() => {
+    connection.controller.enqueue(chunk);
+  });
+  if (Result.isError(enqueued)) {
+    set.delete(connection);
+  }
+};
+
+/**
  * Register a new SSE connection for a workspace.
  * Returns a ReadableStream that stays open until the client disconnects.
  */
@@ -116,11 +156,7 @@ export const subscribe = ({
       // run). Treat it as an immediately-closed connection: close the
       // controller and never register.
       if (signal.aborted) {
-        try {
-          controller.close();
-        } catch {
-          // Already closed.
-        }
+        closeControllerQuietly(controller);
         return;
       }
 
@@ -138,11 +174,7 @@ export const subscribe = ({
         if (set.size === 0 && connections.get(workspaceId) === set) {
           connections.delete(workspaceId);
         }
-        try {
-          controller.close();
-        } catch {
-          // Already closed.
-        }
+        closeControllerQuietly(controller);
       };
 
       signal.addEventListener("abort", cleanup, { once: true });
@@ -174,11 +206,7 @@ export const subscribeUser = ({
       // runs, so the client may already be gone and an aborted signal never
       // fires a fresh "abort" event.
       if (signal.aborted) {
-        try {
-          controller.close();
-        } catch {
-          // Already closed.
-        }
+        closeControllerQuietly(controller);
         return;
       }
 
@@ -196,11 +224,7 @@ export const subscribeUser = ({
         if (set.size === 0 && userConnections.get(userId) === set) {
           userConnections.delete(userId);
         }
-        try {
-          controller.close();
-        } catch {
-          // Already closed.
-        }
+        closeControllerQuietly(controller);
       };
 
       signal.addEventListener("abort", cleanup, { once: true });
@@ -224,11 +248,7 @@ const closeLocalUserConnections = (
       continue;
     }
     set.delete(conn);
-    try {
-      conn.controller.close();
-    } catch {
-      // Already closed.
-    }
+    closeControllerQuietly(conn.controller);
   }
 
   if (set.size === 0 && userConnections.get(userId) === set) {
@@ -250,11 +270,7 @@ const closeLocalWorkspaceUserConnections = (
       continue;
     }
     set.delete(conn);
-    try {
-      conn.controller.close();
-    } catch {
-      // Already closed.
-    }
+    closeControllerQuietly(conn.controller);
   }
 
   if (set.size === 0 && connections.get(workspaceId) === set) {
@@ -269,11 +285,7 @@ const closeConnection = (
   conn: SSEConnection,
 ): void => {
   set.delete(conn);
-  try {
-    conn.controller.close();
-  } catch {
-    // Already closed.
-  }
+  closeControllerQuietly(conn.controller);
 };
 
 /** Reauthorize current access before pushing an event to local connections. */
@@ -300,10 +312,13 @@ const broadcastLocal = async (
   }
 
   const userIds = [...new Set(targets.map((connection) => connection.userId))];
-  let authorizedUserIds: ReadonlySet<SafeId<"user">>;
-  try {
-    authorizedUserIds = await authorizer({ userIds, workspaceId });
-  } catch (error: unknown) {
+  // The raw failure is what the log names, so it is carried through
+  // unwrapped; wrapping it would rename `error.type` in the sink.
+  const reauthorized = await Result.tryPromise({
+    try: async () => await authorizer({ userIds, workspaceId }),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(reauthorized)) {
     for (const conn of targets) {
       closeConnection(set, conn);
     }
@@ -311,10 +326,11 @@ const broadcastLocal = async (
       connections.delete(workspaceId);
     }
     logger.error("sse.workspace_reauthorization_failed", {
-      "error.type": errorTag(error),
+      "error.type": errorTag(reauthorized.error),
     });
     return;
   }
+  const authorizedUserIds = reauthorized.value;
 
   const chunk = formatSSE(event);
 
@@ -326,11 +342,7 @@ const broadcastLocal = async (
       closeConnection(set, conn);
       continue;
     }
-    try {
-      conn.controller.enqueue(chunk);
-    } catch {
-      set.delete(conn);
-    }
+    enqueueOrDrop({ chunk, connection: conn, set });
   }
 
   if (set.size === 0 && connections.get(workspaceId) === set) {
@@ -364,11 +376,7 @@ const broadcastLocalToUser = async (
   const closeTargets = () => {
     for (const conn of targets) {
       set.delete(conn);
-      try {
-        conn.controller.close();
-      } catch {
-        // Already closed.
-      }
+      closeControllerQuietly(conn.controller);
     }
     if (set.size === 0 && userConnections.get(userId) === set) {
       userConnections.delete(userId);
@@ -382,18 +390,19 @@ const broadcastLocalToUser = async (
     return;
   }
 
-  let authorized: boolean;
-  try {
-    authorized = await authorizer({ organizationId, userId });
-  } catch (error: unknown) {
+  const reauthorized = await Result.tryPromise({
+    try: async () => await authorizer({ organizationId, userId }),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(reauthorized)) {
     closeTargets();
     logger.error("sse.user_reauthorization_failed", {
-      "error.type": errorTag(error),
+      "error.type": errorTag(reauthorized.error),
     });
     return;
   }
 
-  if (!authorized) {
+  if (!reauthorized.value) {
     closeTargets();
     return;
   }
@@ -403,11 +412,7 @@ const broadcastLocalToUser = async (
     if (!set.has(conn)) {
       continue;
     }
-    try {
-      conn.controller.enqueue(chunk);
-    } catch {
-      set.delete(conn);
-    }
+    enqueueOrDrop({ chunk, connection: conn, set });
   }
 
   if (set.size === 0 && userConnections.get(userId) === set) {
@@ -424,11 +429,13 @@ const queueWorkspaceDelivery = (
 ): void => {
   const previous = workspaceDeliveryTails.get(workspaceId) ?? Promise.resolve();
   const current = previous.then(async () => {
-    try {
-      await operation();
-    } catch (error: unknown) {
+    const delivered = await Result.tryPromise({
+      try: async () => await operation(),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(delivered)) {
       logger.error("sse.workspace_delivery_failed", {
-        "error.type": errorTag(error),
+        "error.type": errorTag(delivered.error),
       });
     }
     return undefined;
@@ -455,11 +462,13 @@ const queueUserDelivery = (
 ): void => {
   const previous = userDeliveryTails.get(userId) ?? Promise.resolve();
   const current = previous.then(async () => {
-    try {
-      await operation();
-    } catch (error: unknown) {
+    const delivered = await Result.tryPromise({
+      try: async () => await operation(),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(delivered)) {
       logger.error("sse.user_delivery_failed", {
-        "error.type": errorTag(error),
+        "error.type": errorTag(delivered.error),
       });
     }
     return undefined;
@@ -491,11 +500,7 @@ const broadcastLocalToOrganization = (
       if (conn.organizationId !== organizationId) {
         continue;
       }
-      try {
-        conn.controller.enqueue(chunk);
-      } catch {
-        set.delete(conn);
-      }
+      enqueueOrDrop({ chunk, connection: conn, set });
     }
     if (set.size === 0 && connections.get(workspaceId) === set) {
       connections.delete(workspaceId);
@@ -525,70 +530,79 @@ const isOwnInlineDelivery = (payload: {
 }): boolean =>
   payload.deliveredInline === true && payload.originInstanceId === INSTANCE_ID;
 
+/**
+ * Route one already-received Redis payload. Parsing and ID branding both
+ * reject a malformed message by failing, so this runs under the
+ * `Result.try` in `handleMessage` rather than validating defensively here.
+ */
+const dispatchRedisMessage = (message: string): void => {
+  const parsed = parseRedisPayload(message);
+  if (!parsed) {
+    return;
+  }
+  if (parsed.scope === "user-access-revoked") {
+    const userId = brandPersistedUserId(parsed.id);
+    const organizationId = brandPersistedOrganizationId(parsed.organizationId);
+    queueUserDelivery(userId, () => {
+      closeLocalUserConnections(userId, organizationId);
+    });
+    return;
+  }
+  if (parsed.scope === "user") {
+    if (isOwnInlineDelivery(parsed)) {
+      return;
+    }
+    const userId = brandPersistedUserId(parsed.id);
+    const organizationId = brandPersistedOrganizationId(parsed.organizationId);
+    queueUserDelivery(userId, async () =>
+      broadcastLocalToUser(userId, organizationId, parsed.event),
+    );
+    return;
+  }
+  if (parsed.scope === "workspace-access-revoked") {
+    const workspaceId = brandPersistedWorkspaceId(parsed.id);
+    queueWorkspaceDelivery(workspaceId, () => {
+      closeLocalWorkspaceUserConnections(
+        workspaceId,
+        brandPersistedUserId(parsed.userId),
+      );
+    });
+    return;
+  }
+  if (parsed.scope === "workspace") {
+    if (isOwnInlineDelivery(parsed)) {
+      return;
+    }
+    const workspaceId = brandPersistedWorkspaceId(parsed.id);
+    queueWorkspaceDelivery(workspaceId, async () =>
+      broadcastLocal(workspaceId, parsed.event),
+    );
+  } else if (parsed.scope === "organization") {
+    if (isOwnInlineDelivery(parsed)) {
+      return;
+    }
+    broadcastLocalToOrganization(
+      brandPersistedOrganizationId(parsed.id),
+      parsed.event,
+    );
+  } else if (parsed.originInstanceId !== INSTANCE_ID) {
+    sessionDeliveryHandler?.(
+      brandPersistedDesktopEditSessionId(parsed.id),
+      parsed.event,
+    );
+  }
+};
+
 const handleMessage = (message: string): void => {
-  try {
-    const parsed = parseRedisPayload(message);
-    if (!parsed) {
-      return;
-    }
-    if (parsed.scope === "user-access-revoked") {
-      const userId = brandPersistedUserId(parsed.id);
-      const organizationId = brandPersistedOrganizationId(
-        parsed.organizationId,
-      );
-      queueUserDelivery(userId, () => {
-        closeLocalUserConnections(userId, organizationId);
-      });
-      return;
-    }
-    if (parsed.scope === "user") {
-      if (isOwnInlineDelivery(parsed)) {
-        return;
-      }
-      const userId = brandPersistedUserId(parsed.id);
-      const organizationId = brandPersistedOrganizationId(
-        parsed.organizationId,
-      );
-      queueUserDelivery(userId, async () =>
-        broadcastLocalToUser(userId, organizationId, parsed.event),
-      );
-      return;
-    }
-    if (parsed.scope === "workspace-access-revoked") {
-      const workspaceId = brandPersistedWorkspaceId(parsed.id);
-      queueWorkspaceDelivery(workspaceId, () => {
-        closeLocalWorkspaceUserConnections(
-          workspaceId,
-          brandPersistedUserId(parsed.userId),
-        );
-      });
-      return;
-    }
-    if (parsed.scope === "workspace") {
-      if (isOwnInlineDelivery(parsed)) {
-        return;
-      }
-      const workspaceId = brandPersistedWorkspaceId(parsed.id);
-      queueWorkspaceDelivery(workspaceId, async () =>
-        broadcastLocal(workspaceId, parsed.event),
-      );
-    } else if (parsed.scope === "organization") {
-      if (isOwnInlineDelivery(parsed)) {
-        return;
-      }
-      broadcastLocalToOrganization(
-        brandPersistedOrganizationId(parsed.id),
-        parsed.event,
-      );
-    } else if (parsed.originInstanceId !== INSTANCE_ID) {
-      sessionDeliveryHandler?.(
-        brandPersistedDesktopEditSessionId(parsed.id),
-        parsed.event,
-      );
-    }
-  } catch (error) {
+  const dispatched = Result.try({
+    try: () => {
+      dispatchRedisMessage(message);
+    },
+    catch: (cause) => cause,
+  });
+  if (Result.isError(dispatched)) {
     logger.warn("sse.invalid_redis_message", {
-      "error.type": errorTag(error),
+      "error.type": errorTag(dispatched.error),
       "payload.bytes": message.length,
     });
   }
@@ -792,11 +806,7 @@ const sendKeepAlive = () => {
 
   for (const [workspaceId, set] of connections) {
     for (const conn of set) {
-      try {
-        conn.controller.enqueue(chunk);
-      } catch {
-        set.delete(conn);
-      }
+      enqueueOrDrop({ chunk, connection: conn, set });
     }
     if (set.size === 0 && connections.get(workspaceId) === set) {
       connections.delete(workspaceId);
@@ -805,11 +815,7 @@ const sendKeepAlive = () => {
 
   for (const [userId, set] of userConnections) {
     for (const conn of set) {
-      try {
-        conn.controller.enqueue(chunk);
-      } catch {
-        set.delete(conn);
-      }
+      enqueueOrDrop({ chunk, connection: conn, set });
     }
     if (set.size === 0 && userConnections.get(userId) === set) {
       userConnections.delete(userId);
@@ -939,10 +945,16 @@ const SUBSCRIBER_ATTACH_STEADY_LOG_EVERY = 12;
  * would skip the retry scheduling and leave the instance permanently deaf.
  */
 const closeSubscriberQuietly = (client: SseRedisClient): void => {
-  try {
-    client.close();
-  } catch (error: unknown) {
-    logger.warn("sse.redis_close_failed", { "error.type": errorTag(error) });
+  const closed = Result.try({
+    try: () => {
+      client.close();
+    },
+    catch: (cause) => cause,
+  });
+  if (Result.isError(closed)) {
+    logger.warn("sse.redis_close_failed", {
+      "error.type": errorTag(closed.error),
+    });
   }
 };
 
@@ -962,63 +974,75 @@ const runAttachAttempt = async (
     return;
   }
 
-  // The client is constructed inside the try so a throwing constructor hits
-  // the fail-soft catch below instead of escaping as an unhandled rejection.
+  // The client is constructed inside the wrapper so a throwing constructor
+  // becomes a typed failure instead of escaping as an unhandled rejection.
+  // The candidate is tracked outside it because the failure path has to close
+  // whatever was already built.
   let subscriber: SseRedisClient | undefined;
-  try {
-    subscriber = lifecycle.createClient();
-    const attached = subscriber;
-    // Capture the generation this client is attaching under. The callback stays
-    // authorized to deliver only while the lifecycle's generation still matches;
-    // any later invalidation bumps it, structurally silencing a stale client
-    // even if its close() threw and left this callback live.
-    const attachGeneration = lifecycle.generation;
-    await attached.subscribe(REDIS_CHANNEL, (message) => {
-      if (
-        activeLifecycle === lifecycle &&
-        lifecycle.generation === attachGeneration
-      ) {
-        handleMessage(message);
-      }
-    });
-    if (activeLifecycle !== lifecycle) {
-      // stopSse (and possibly a subsequent startSse) ran while the connection
-      // was still being established; do not attach a stale subscriber to a
-      // lifecycle that is no longer the active one.
-      closeSubscriberQuietly(attached);
-      return;
-    }
-    lifecycle.subscriber = attached;
-    lifecycle.subscriptionLive = true;
-    // Bun auto-reconnects a dropped subscriber but does NOT re-issue SUBSCRIBE,
-    // and re-subscribing on the SAME client double-registers the callback (both
-    // verified against a mock RESP3 server), which would double-deliver every
-    // event locally. So on any reconnect, drop this now-deaf client and attach
-    // a fresh one, which subscribes exactly once on the new connection. Exactly-
-    // once local delivery holds because `subscriptionLive` is false for the
-    // whole deaf/reattach window, routing broadcasts to inline delivery until
-    // the replacement is subscribed. The initial connect fired before this
-    // handler was registered, so it runs only for genuine reconnects.
-    attached.onReconnect(() => {
-      if (activeLifecycle !== lifecycle || lifecycle.subscriber !== attached) {
+  // `connectionErrorFields` reports the failure's own code, errno and syscall,
+  // so the cause is carried through unwrapped rather than re-tagged.
+  const attempted = await Result.tryPromise({
+    try: async () => {
+      subscriber = lifecycle.createClient();
+      const attached = subscriber;
+      // Capture the generation this client is attaching under. The callback
+      // stays authorized to deliver only while the lifecycle's generation still
+      // matches; any later invalidation bumps it, structurally silencing a
+      // stale client even if its close() failed and left this callback live.
+      const attachGeneration = lifecycle.generation;
+      await attached.subscribe(REDIS_CHANNEL, (message) => {
+        if (
+          activeLifecycle === lifecycle &&
+          lifecycle.generation === attachGeneration
+        ) {
+          handleMessage(message);
+        }
+      });
+      if (activeLifecycle !== lifecycle) {
+        // stopSse (and possibly a subsequent startSse) ran while the connection
+        // was still being established; do not attach a stale subscriber to a
+        // lifecycle that is no longer the active one.
+        closeSubscriberQuietly(attached);
         return;
       }
-      lifecycle.subscriptionLive = false;
-      lifecycle.subscriber = null;
-      // Invalidate the deaf client's generation BEFORE closing it, so it stops
-      // delivering even if close() throws and leaves its callback live. The
-      // close itself is then only best-effort resource cleanup.
-      lifecycle.generation += 1;
-      closeSubscriberQuietly(attached);
-      logger.warn("sse.redis_subscriber_reconnected", {
-        channel: REDIS_CHANNEL,
+      lifecycle.subscriber = attached;
+      lifecycle.subscriptionLive = true;
+      // Bun auto-reconnects a dropped subscriber but does NOT re-issue
+      // SUBSCRIBE, and re-subscribing on the SAME client double-registers the
+      // callback (both verified against a mock RESP3 server), which would
+      // double-deliver every event locally. So on any reconnect, drop this
+      // now-deaf client and attach a fresh one, which subscribes exactly once
+      // on the new connection. Exactly-once local delivery holds because
+      // `subscriptionLive` is false for the whole deaf/reattach window, routing
+      // broadcasts to inline delivery until the replacement is subscribed. The
+      // initial connect fired before this handler was registered, so it runs
+      // only for genuine reconnects.
+      attached.onReconnect(() => {
+        if (
+          activeLifecycle !== lifecycle ||
+          lifecycle.subscriber !== attached
+        ) {
+          return;
+        }
+        lifecycle.subscriptionLive = false;
+        lifecycle.subscriber = null;
+        // Invalidate the deaf client's generation BEFORE closing it, so it
+        // stops delivering even if close() fails and leaves its callback live.
+        // The close itself is then only best-effort resource cleanup.
+        lifecycle.generation += 1;
+        closeSubscriberQuietly(attached);
+        logger.warn("sse.redis_subscriber_reconnected", {
+          channel: REDIS_CHANNEL,
+        });
+        launchAttachAttempt(lifecycle, 0);
       });
-      launchAttachAttempt(lifecycle, 0);
-    });
-    logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
-  } catch (error: unknown) {
+      logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
+    },
+    catch: (cause) => cause,
+  });
+  if (Result.isError(attempted)) {
     // Invalidate the failed candidate's generation BEFORE closing it, then
-    // close best-effort: a throwing close() must neither leave the candidate's
+    // close best-effort: a failing close() must neither leave the candidate's
     // callback able to deliver nor skip the retry scheduling below (which would
     // stop the instance retrying and leave it deaf until restart).
     if (subscriber) {
@@ -1030,6 +1054,7 @@ const runAttachAttempt = async (
       // attempt; abandon the retry chain quietly.
       return;
     }
+    const { error } = attempted;
     const rampDelay = SUBSCRIBER_ATTACH_RETRY_DELAYS_MS[attempt];
     const delayMs = rampDelay ?? SUBSCRIBER_ATTACH_STEADY_DELAY_MS;
     if (rampDelay !== undefined) {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -310,7 +310,7 @@
     }
   },
   "try-catch-outside-boundary": {
-    "count": 329,
+    "count": 310,
     "files": {
       "apps/api/src/handlers/ai-autocomplete/stream.ts": 1,
       "apps/api/src/handlers/api-keys/mint.ts": 1,
@@ -423,7 +423,6 @@
       "apps/api/src/lib/signals/scout.ts": 1,
       "apps/api/src/lib/skills/skill-package.ts": 8,
       "apps/api/src/lib/sse-broadcast.ts": 1,
-      "apps/api/src/lib/sse.ts": 19,
       "apps/api/src/lib/subprocess.ts": 2,
       "apps/api/src/lib/template-clause-links.ts": 1,
       "apps/api/src/lib/templates/suggest-template-fields.ts": 1,


### PR DESCRIPTION
Converts the 20 `try`/`catch` sites in `apps/api/src/lib/sse.ts` to `Result.try` / `Result.tryPromise`, so the module passes the `no-try-catch-outside-boundary` rule with zero findings; log events, error capture, retry backoff and attach/reattach semantics are unchanged, and each failure reaches its sink unwrapped because `errorTag` and `connectionErrorFields` report the failure's own class, code and errno.

The repeated controller-close and enqueue-or-drop blocks collapse into two helpers, the Redis message router moves into `dispatchRedisMessage`, and the test helper that drained a fixed three microtask ticks now takes a timer turn so it drains the queue whatever the module's await depth is.
