### PR TITLE
fix(api): report a settled document processing attempt once

### DIFF
--- a/apps/api/src/lib/document-processing-failure-fields.ts
+++ b/apps/api/src/lib/document-processing-failure-fields.ts
@@ -4,7 +4,7 @@ import {
 } from "@/api/lib/errors/utils";
 
 /**
- * Log fields for a document-processing run that failed for good.
+ * Safe log fields for a failed document-processing attempt.
  *
  * `errorTag` alone names the class, and every extraction failure shares one
  * class, so the tag cannot tell a parser rejection from a timeout, a crash,

--- a/apps/api/src/lib/document-processing-queue-attempt.ts
+++ b/apps/api/src/lib/document-processing-queue-attempt.ts
@@ -54,15 +54,15 @@ export const settleDocumentProcessingAttemptError = async ({
 }: {
   error: unknown;
   lifecycleSignal: AbortSignal;
-  markFailed: () => Promise<void>;
+  markFailed: () => Promise<"settled" | "unsettled">;
   returnToQueue: () => Promise<void>;
-}): Promise<"failed" | "interrupted"> => {
+}): Promise<"failed" | "interrupted" | "unsettled"> => {
   if (isLifecycleInterruptionError({ error, lifecycleSignal })) {
     await returnToQueue();
     return "interrupted";
   }
-  await markFailed();
-  return "failed";
+  const failureSettlement = await markFailed();
+  return failureSettlement === "settled" ? "failed" : "unsettled";
 };
 
 /**

--- a/apps/api/src/lib/document-processing-queue-attempt.ts
+++ b/apps/api/src/lib/document-processing-queue-attempt.ts
@@ -1,9 +1,12 @@
+import { TaggedError } from "better-result";
+
 import type { documentProcessingRuns } from "@/api/db/schema";
 import {
   AUTOMATIC_OCR_MAX_ATTEMPTS,
   SEARCHABLE_PDF_FAILURE_CODE,
   SEARCH_INDEX_FAILURE_CODE,
 } from "@/api/lib/document-processing-queue-policy";
+import { isTransientRedisConnectionError } from "@/api/lib/redis-error-classification";
 
 const AUTOMATIC_OCR_RETRY_BASE_DELAY_MS = 30_000;
 const AUTOMATIC_OCR_RETRY_MAX_DELAY_MS = 30 * 60 * 1000;
@@ -60,6 +63,47 @@ export const settleDocumentProcessingAttemptError = async ({
   }
   await markFailed();
   return "failed";
+};
+
+/**
+ * Wraps a failure the run-level path has already recorded.
+ *
+ * `markRunFailed` logs every attempt at the severity its outcome earns: WARN
+ * while the durable retry model still has attempts left, ERROR with a capture
+ * once at the terminal transition. The run then rethrows so BullMQ records the
+ * job as failed, which hands the same error to the job-level handler. Without
+ * a marker that handler cannot tell a settled attempt from machinery that
+ * failed before any run was claimed, so it reports every attempt of a run that
+ * is retrying by design.
+ */
+export class DocumentProcessingRunSettledError extends TaggedError(
+  "DocumentProcessingRunSettledError",
+)<{
+  cause: unknown;
+  message: string;
+}> {}
+
+export const DOCUMENT_PROCESSING_FAILURE_REPORT = {
+  /** The run-level path already logged this attempt at its own severity. */
+  ALREADY_REPORTED: "already-reported",
+  /** Failed outside a claimed run, so this handler is its only reporter. */
+  MACHINERY: "machinery",
+  /** An expected Valkey transient that the job's own retry heals. */
+  TRANSIENT_CONNECTION: "transient-connection",
+} as const;
+
+/**
+ * A settled failure may wrap a connection error the run already reported, so
+ * the settled marker has to be read before the transient classification.
+ */
+export const documentProcessingFailureReport = (error: unknown) => {
+  if (error instanceof DocumentProcessingRunSettledError) {
+    return DOCUMENT_PROCESSING_FAILURE_REPORT.ALREADY_REPORTED;
+  }
+  if (isTransientRedisConnectionError(error)) {
+    return DOCUMENT_PROCESSING_FAILURE_REPORT.TRANSIENT_CONNECTION;
+  }
+  return DOCUMENT_PROCESSING_FAILURE_REPORT.MACHINERY;
 };
 
 export const automaticOcrRetryDelayMs = (attemptCount: number): number =>

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -24,6 +24,9 @@ import {
 } from "@/api/lib/document-processing-queue";
 import {
   automaticOcrRetryDelayMs,
+  DOCUMENT_PROCESSING_FAILURE_REPORT,
+  documentProcessingFailureReport,
+  DocumentProcessingRunSettledError,
   isRetryableAutomaticOcrFailure,
   isRetryableOcrDerivativeFailure,
   isRetryableSearchIndexFailure,
@@ -1085,7 +1088,50 @@ describe("worker interruption lifecycle", () => {
 
   test("threads shutdown cancellation into OCR and still fails BullMQ delivery", () => {
     expect(queueSource).toContain("signal: lifecycleSignal");
-    expect(queueSource).toContain("throw processingResult.error");
+    expect(queueSource).toContain(
+      "throw new DocumentProcessingRunSettledError",
+    );
+    expect(queueSource).toContain("cause: processingResult.error");
+  });
+
+  test("leaves a settled attempt to the run-level path that already reported it", () => {
+    expect(
+      documentProcessingFailureReport(
+        new DocumentProcessingRunSettledError({
+          cause: new Error("parser exited nonzero"),
+          message: "parser exited nonzero",
+        }),
+      ),
+    ).toBe(DOCUMENT_PROCESSING_FAILURE_REPORT.ALREADY_REPORTED);
+  });
+
+  test("keeps a settled attempt settled even when it wraps a transient drop", () => {
+    const dropped = new Error("Connection is closed");
+    Object.assign(dropped, { code: "ERR_REDIS_CONNECTION_CLOSED" });
+
+    expect(
+      documentProcessingFailureReport(
+        new DocumentProcessingRunSettledError({
+          cause: dropped,
+          message: dropped.message,
+        }),
+      ),
+    ).toBe(DOCUMENT_PROCESSING_FAILURE_REPORT.ALREADY_REPORTED);
+  });
+
+  test("reports a transient drop reaching the job unsettled as a disruption", () => {
+    const dropped = new Error("Connection is closed");
+    Object.assign(dropped, { code: "ERR_REDIS_CONNECTION_CLOSED" });
+
+    expect(documentProcessingFailureReport(dropped)).toBe(
+      DOCUMENT_PROCESSING_FAILURE_REPORT.TRANSIENT_CONNECTION,
+    );
+  });
+
+  test("reports a failure that never reached a claimed run as machinery", () => {
+    expect(documentProcessingFailureReport(new Error("claim failed"))).toBe(
+      DOCUMENT_PROCESSING_FAILURE_REPORT.MACHINERY,
+    );
   });
 
   test("uses one compare-and-set transition to restore the claimed attempt", () => {

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -1018,6 +1018,7 @@ describe("worker interruption lifecycle", () => {
       lifecycleSignal: lifecycle.signal,
       markFailed: async () => {
         calls.push("failed");
+        return "settled";
       },
       returnToQueue: async () => {
         calls.push("queued");
@@ -1036,6 +1037,7 @@ describe("worker interruption lifecycle", () => {
       lifecycleSignal: new AbortController().signal,
       markFailed: async () => {
         calls.push("failed");
+        return "settled";
       },
       returnToQueue: async () => {
         calls.push("queued");
@@ -1056,6 +1058,7 @@ describe("worker interruption lifecycle", () => {
       lifecycleSignal: lifecycle.signal,
       markFailed: async () => {
         calls.push("failed");
+        return "settled";
       },
       returnToQueue: async () => {
         calls.push("queued");
@@ -1076,6 +1079,7 @@ describe("worker interruption lifecycle", () => {
       lifecycleSignal: lifecycle.signal,
       markFailed: async () => {
         calls.push("failed");
+        return "settled";
       },
       returnToQueue: async () => {
         calls.push("queued");
@@ -1086,12 +1090,28 @@ describe("worker interruption lifecycle", () => {
     expect(calls).toEqual(["queued"]);
   });
 
+  test("leaves a lost claim available to the job-level reporter", async () => {
+    const outcome = await settleDocumentProcessingAttemptError({
+      error: new Error("processing failed after claim loss"),
+      lifecycleSignal: new AbortController().signal,
+      markFailed: async () => "unsettled",
+      returnToQueue: async () => undefined,
+    });
+
+    expect(outcome).toBe("unsettled");
+  });
+
   test("threads shutdown cancellation into OCR and still fails BullMQ delivery", () => {
     expect(queueSource).toContain("signal: lifecycleSignal");
     expect(queueSource).toContain(
       "throw new DocumentProcessingRunSettledError",
     );
     expect(queueSource).toContain("cause: processingResult.error");
+    expect(queueSource).toContain('if (settlement === "unsettled")');
+    expect(queueSource).toContain("throw processingResult.error");
+    expect(queueSource).toContain(
+      'logger.warn("document_processing.attempt_failed", {\n      ...documentProcessingFailureFields(error)',
+    );
   });
 
   test("leaves a settled attempt to the run-level path that already reported it", () => {

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -1068,20 +1068,22 @@ export const processDocumentProcessingRun = async (
   heartbeat.stop();
 
   if (Result.isError(processingResult)) {
-    await settleDocumentProcessingAttemptError({
+    const settlement = await settleDocumentProcessingAttemptError({
       error: processingResult.error,
       lifecycleSignal,
-      markFailed: async () => {
-        await markRunFailed({
+      markFailed: async () =>
+        markRunFailed({
           claimToken,
           error: processingResult.error,
           run,
-        });
-      },
+        }),
       returnToQueue: async () => {
         await returnInterruptedRunToQueue({ claimToken, run });
       },
     });
+    if (settlement === "unsettled") {
+      throw processingResult.error;
+    }
     // Rethrown so BullMQ records the job as failed. The settle above has
     // already reported this attempt, so it goes back wrapped: the job-level
     // handler reports only what reaches it unsettled.
@@ -1118,7 +1120,7 @@ const markRunFailed = async ({
   claimToken: string;
   error: unknown;
   run: typeof documentProcessingRuns.$inferSelect;
-}): Promise<void> => {
+}): Promise<"settled" | "unsettled"> => {
   const failureCode = errorCode(error);
   const outcome = await rootDb.transaction(
     async (tx): Promise<MarkRunFailedOutcome | null> => {
@@ -1179,7 +1181,7 @@ const markRunFailed = async ({
     },
   );
   if (outcome === null) {
-    return;
+    return "unsettled";
   }
   // One exception per run, at its terminal transition. An attempt whose
   // failure schedules a retry is expected churn of the durable retry model
@@ -1187,12 +1189,12 @@ const markRunFailed = async ({
   // defect up to AUTOMATIC_OCR_MAX_ATTEMPTS times.
   if (outcome.retryScheduled) {
     logger.warn("document_processing.attempt_failed", {
-      "error.type": errorTag(error),
+      ...documentProcessingFailureFields(error),
       attempt: String(outcome.attemptCount),
       errorCode: failureCode,
       runId: run.id,
     });
-    return;
+    return "settled";
   }
   captureError(error, { runId: run.id });
   logger.error("document_processing.run_failed", {
@@ -1200,6 +1202,7 @@ const markRunFailed = async ({
     errorCode: failureCode,
     runId: run.id,
   });
+  return "settled";
 };
 
 const returnInterruptedRunToQueue = async ({

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -59,6 +59,9 @@ import { documentProcessingFailureFields } from "@/api/lib/document-processing-f
 import { DocumentOcrError } from "@/api/lib/document-processing-ocr-result";
 import {
   automaticOcrRetryDelayMs,
+  DOCUMENT_PROCESSING_FAILURE_REPORT,
+  documentProcessingFailureReport,
+  DocumentProcessingRunSettledError,
   isRetryableAutomaticOcrFailure,
   isRetryableOcrDerivativeFailure,
   isRetryableSearchIndexFailure,
@@ -1079,7 +1082,16 @@ export const processDocumentProcessingRun = async (
         await returnInterruptedRunToQueue({ claimToken, run });
       },
     });
-    throw processingResult.error;
+    // Rethrown so BullMQ records the job as failed. The settle above has
+    // already reported this attempt, so it goes back wrapped: the job-level
+    // handler reports only what reaches it unsettled.
+    throw new DocumentProcessingRunSettledError({
+      cause: processingResult.error,
+      message:
+        processingResult.error instanceof Error
+          ? processingResult.error.message
+          : "Document processing run failed",
+    });
   }
 };
 
@@ -1184,7 +1196,7 @@ const markRunFailed = async ({
   }
   captureError(error, { runId: run.id });
   logger.error("document_processing.run_failed", {
-    "error.type": errorTag(error),
+    ...documentProcessingFailureFields(error),
     errorCode: failureCode,
     runId: run.id,
   });
@@ -2569,20 +2581,29 @@ const handleDocumentProcessingFailure = ({
   job: { data: DocumentProcessingJobData } | undefined;
 }): void => {
   // No capture here: run-scoped failures capture once at their terminal
-  // transition in `markRunFailed`, and a dropped Redis socket on the claim
-  // path heals on the job's own retry. Machinery failures stay visible
-  // through the ERROR log.
-  if (isTransientRedisConnectionError(error)) {
-    logger.warn("document_processing.job_disrupted", {
-      "error.type": errorTag(error),
-      runId: job?.data.runId ?? "",
-    });
-    return;
+  // transition in `markRunFailed`, which is also where they are logged, so a
+  // settled attempt is left alone. A dropped Redis socket on the claim path
+  // heals on the job's own retry. Only machinery that failed before a run was
+  // claimed has no other reporter, so only it stays on the ERROR log.
+  const report = documentProcessingFailureReport(error);
+  switch (report) {
+    case DOCUMENT_PROCESSING_FAILURE_REPORT.ALREADY_REPORTED:
+      return;
+    case DOCUMENT_PROCESSING_FAILURE_REPORT.TRANSIENT_CONNECTION:
+      logger.warn("document_processing.job_disrupted", {
+        "error.type": errorTag(error),
+        runId: job?.data.runId ?? "",
+      });
+      return;
+    case DOCUMENT_PROCESSING_FAILURE_REPORT.MACHINERY:
+      logger.error("document_processing.failed", {
+        ...documentProcessingFailureFields(error),
+        runId: job?.data.runId ?? "",
+      });
+      return;
+    default:
+      report satisfies never;
   }
-  logger.error("document_processing.failed", {
-    ...documentProcessingFailureFields(error),
-    runId: job?.data.runId ?? "",
-  });
 };
 
 const RECONCILIATION_PHASE = {


### PR DESCRIPTION
## Proposed change

`processDocumentProcessingRun` rethrows a failure that `settleDocumentProcessingAttemptError` has already recorded, so BullMQ marks the job failed. That same error then reaches `handleDocumentProcessingFailure`, which has no way to tell it apart from machinery that failed before a run was ever claimed, so it logs `document_processing.failed` at ERROR.

`markRunFailed` has already logged that attempt, and deliberately not at ERROR: while the durable retry model still has attempts left it emits `document_processing.attempt_failed` at WARN, and its comment says why ("capturing every attempt reported the same defect up to `AUTOMATIC_OCR_MAX_ATTEMPTS` times"). The job-level ERROR undoes that. A run retrying by design reports an ERROR on every attempt, so a run that exhausts its attempts emits `AUTOMATIC_OCR_MAX_ATTEMPTS` of them and then the terminal `document_processing.run_failed` as well.

Changes:

- `DocumentProcessingRunSettledError` wraps the rethrow, so "the run-level path has already reported this" is carried in the type instead of guessed at the job boundary. It keeps the original error as its `cause` and reuses its message, so what BullMQ records for the job is unchanged.
- `documentProcessingFailureReport` names the three outcomes the job-level handler actually has (already reported, transient connection, machinery) as one union, read with an exhaustive `switch`. Sniffing for the known run-scoped error classes instead would silently regress the moment another one appears; a marker plus an exhaustive read cannot. The settled marker is read before the transient classification, since a settled attempt may wrap a connection error the run already reported.
- The extraction detail (`error.code`, mime type, size, and the exit code or termination reason) only ever rode on the per-attempt `document_processing.failed` line, so dropping that line alone would lose it. `documentProcessingFailureFields` moves onto the terminal `document_processing.run_failed`, which is what its own docstring describes: a run that failed for good. A terminal failure keeps every field it had, on one line, beside the `captureError` that already pairs the same two helpers.

Net effect on a run that fails every attempt: `AUTOMATIC_OCR_MAX_ATTEMPTS` WARNs and one ERROR, rather than `AUTOMATIC_OCR_MAX_ATTEMPTS` ERRORs and one more.

Adjacent and deliberately unchanged: `errorCode()` maps anything that is neither a `DocumentProcessingJobError` nor a `DocumentOcrError` to `"processing_failed"`, which is a member of `RETRYABLE_AUTOMATIC_OCR_FAILURE_CODES`. An extraction failure that cannot succeed on a retry therefore still consumes the full attempt budget. Whether a deterministic parser rejection should be retried at all is a policy question rather than a logging one, so it is left for a separate change.

## Checklist

- [x] **BUILD ASSURANCE** | `bun --filter @stll/api typecheck` and `bun --filter @stll/api lint` both exit 0, and `bun run format` is clean. The workspace-wide `bun run verify` does not complete on my machine: the type-aware oxlint step alone reaches ~10 GB RSS with `tsgolint` alongside it, so it needs CI to confirm.
- [x] **TESTING** | `apps/api/src/lib/document-processing-queue.test.ts` passes (68 tests). Four cases cover the disposition union: a settled attempt, a settled attempt wrapping a transient connection drop, an unsettled transient drop, and an unsettled machinery failure. The existing source assertion on the rethrow is updated to the wrapped throw.
- [ ] **DARK MODE SUPPORT** | Not applicable, no UI in this change.
- [ ] **ISSUE LINKED** | No issue.
- [ ] **SCREENSHOT INCLUDED** | Not applicable, no UI in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fh6kFHLCHBQHiXLT4jGHwb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fh6kFHLCHBQHiXLT4jGHwb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document-processing failure handling and reporting.
  * Prevented duplicate error logging for processing attempts that have already been settled.
  * Added clearer handling for temporary connection failures and unexpected processing errors.
  * Ensured failed processing jobs are correctly recorded by the queue after an attempt is settled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->