### PR TITLE
fix(ci): allow screenshot updater artifact reads

### DIFF
--- a/.github/workflows/marketing-screenshots-update.yml
+++ b/.github/workflows/marketing-screenshots-update.yml
@@ -35,6 +35,8 @@ jobs:
     uses: ./.github/workflows/marketing-screenshots.yml
     permissions:
       contents: read
+      # The reusable check job's artifact-read permission must be declared even when update mode skips it.
+      actions: read
     with:
       mode: update
       ref: ${{ inputs.branch }}


### PR DESCRIPTION
## Summary

- Grant the screenshot updater the artifact-read permission required by its reusable check workflow.
- Keep the existing contents permission and secret boundary unchanged.

## Verification

- Local checks not run per request; CI is the validation source.