### PR TITLE
chore: sync shared agent skills

### DIFF
--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -74,7 +74,9 @@ and inspect the generated delta for drift; do not reread large mechanical
 copies.
 
 Check for accidental files, invalid states, authorization and disclosure
-boundaries, missing generated/i18n synchronization, migration compatibility,
+boundaries, missing generated/i18n synchronization, duplicated capabilities (an
+owner in `docs/module-ownership.md` or `packages/*` that the change bypasses),
+validation of data a boundary already validated, migration compatibility,
 performance, replay safety, and tests that cover real failure modes. Fix
 confirmed defects before publishing.
 

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -41,6 +41,10 @@ contracts without inventing files or symbols. Identify ownership boundaries,
 data contracts, invalid states, rollout risks, and generated artifacts
 explicitly.
 
+Before proposing a new helper, module, or schema, check
+`docs/module-ownership.md` and the existing packages for the capability. Name
+the owner the slice extends, or state why a second implementation is correct.
+
 ## 3. Create a Collision-Safe File
 
 Follow the repository's existing naming scheme when one exists and is safe for

--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -69,7 +69,9 @@ and inspect the generated delta for drift; do not reread large mechanical
 copies.
 
 Check for accidental files, invalid states, authorization and disclosure
-boundaries, missing generated/i18n synchronization, migration compatibility,
+boundaries, missing generated/i18n synchronization, duplicated capabilities (an
+owner in `docs/module-ownership.md` or `packages/*` that the change bypasses),
+validation of data a boundary already validated, migration compatibility,
 performance, replay safety, and tests that cover real failure modes. Fix
 confirmed defects before publishing.
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -36,6 +36,10 @@ contracts without inventing files or symbols. Identify ownership boundaries,
 data contracts, invalid states, rollout risks, and generated artifacts
 explicitly.
 
+Before proposing a new helper, module, or schema, check
+`docs/module-ownership.md` and the existing packages for the capability. Name
+the owner the slice extends, or state why a second implementation is correct.
+
 ## 3. Create a Collision-Safe File
 
 Follow the repository's existing naming scheme when one exists and is safe for


### PR DESCRIPTION
Bumps the shared skills submodule to its current main and regenerates the plan and open-pr skill copies. The two skills now carry a reuse check: name the module that already owns a capability, or say why a second implementation is correct.