### PR TITLE
fix(api): validation boundary cleanups

### DIFF
--- a/apps/api/src/handlers/flows/schema.ts
+++ b/apps/api/src/handlers/flows/schema.ts
@@ -1,15 +1,15 @@
 import { t } from "elysia";
 
+import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import {
-  tDefaultVarchar,
-  tSafeId,
-  workspaceParams,
-} from "@/api/lib/custom-schema";
-import {
+  FLOW_DEFINITION_DESCRIPTION_MAX_CHARS,
+  FLOW_DEFINITION_NAME_MAX_CHARS,
   FLOW_REVIEW_DECISIONS,
   FLOW_RUN_STATUSES,
   FLOW_SCHEDULE_FREQUENCIES,
+  FLOW_STEP_DOCUMENT_TITLE_MAX_CHARS,
   FLOW_STEP_INSTRUCTION_CHAR_CAP,
+  FLOW_STEP_NAME_MAX_CHARS,
   MAX_FLOW_STEPS,
 } from "@/api/lib/flows/flow-types";
 import { LIMITS } from "@/api/lib/limits";
@@ -18,8 +18,16 @@ import { LIMITS } from "@/api/lib/limits";
 // validation). The handler additionally parses the body through the shared
 // valibot `flowDefinitionInputSchema` to normalize (trim) and enforce the
 // deeper invariants in one authoritative place.
+//
+// The two layers describe the same body, so every scalar bound here comes from
+// the constants `flow-types.ts` exports rather than a literal restated per
+// layer; only the shapes TypeBox and valibot express differently are written
+// twice.
 
-const tStepName = t.String({ minLength: 1, maxLength: 200 });
+const tStepName = t.String({
+  minLength: 1,
+  maxLength: FLOW_STEP_NAME_MAX_CHARS,
+});
 
 const tFlowStep = t.Union([
   t.Object({
@@ -39,7 +47,10 @@ const tFlowStep = t.Union([
   t.Object({
     kind: t.Literal("create-document"),
     name: tStepName,
-    documentTitle: t.String({ minLength: 1, maxLength: 256 }),
+    documentTitle: t.String({
+      minLength: 1,
+      maxLength: FLOW_STEP_DOCUMENT_TITLE_MAX_CHARS,
+    }),
   }),
 ]);
 
@@ -72,8 +83,11 @@ const tFlowTrigger = t.Union([
 ]);
 
 export const flowDefinitionBodySchema = t.Object({
-  name: tDefaultVarchar,
-  description: t.Union([t.String({ maxLength: 2000 }), t.Null()]),
+  name: t.String({ minLength: 1, maxLength: FLOW_DEFINITION_NAME_MAX_CHARS }),
+  description: t.Union([
+    t.String({ maxLength: FLOW_DEFINITION_DESCRIPTION_MAX_CHARS }),
+    t.Null(),
+  ]),
   steps: t.Array(tFlowStep, { minItems: 1, maxItems: MAX_FLOW_STEPS }),
   trigger: tFlowTrigger,
   enabled: t.Boolean(),

--- a/apps/api/src/handlers/workspaces/get.test.ts
+++ b/apps/api/src/handlers/workspaces/get.test.ts
@@ -36,9 +36,28 @@ const workspaceRow = {
   },
 } satisfies ReadWorkspaceSuccess;
 
-const readWorkspace = async (row: unknown) => {
+// The mock stands in for the database by applying the handler's own `where`,
+// so a row the handler did not ask for is not one it can be handed. That is
+// what makes the foreign-organization case below a real assertion rather than
+// a restatement of the mock.
+type WorkspaceQuery = {
+  where: {
+    id: { eq: string };
+    organizationId: { eq: string };
+  };
+};
+
+const readWorkspace = async (row: ReadWorkspaceSuccess | undefined) => {
   const { scopedDb } = createScopedDbMock({
-    query: { workspaces: { findFirst: async () => row } },
+    query: {
+      workspaces: {
+        findFirst: async ({ where }: WorkspaceQuery) =>
+          row?.id === where.id.eq &&
+          row.organizationId === where.organizationId.eq
+            ? row
+            : undefined,
+      },
+    },
   });
   return await readWorkspaceHandler({
     scopedDb,
@@ -67,12 +86,15 @@ describe("readWorkspaceHandler", () => {
     expect(await readWorkspace(undefined)).toMatchObject({ code: 404 });
   });
 
-  test("returns 403 for a matter owned by another organization", async () => {
+  // The organization is part of the lookup, not a check after it, so a matter
+  // owned by another tenant is not among the rows the query can return and the
+  // not-found path answers it.
+  test("does not return a matter owned by another organization", async () => {
     const foreignRow = {
       ...workspaceRow,
       organizationId: toSafeId<"organization">("org_other456"),
     };
 
-    expect(await readWorkspace(foreignRow)).toMatchObject({ code: 403 });
+    expect(await readWorkspace(foreignRow)).toMatchObject({ code: 404 });
   });
 });

--- a/apps/api/src/handlers/workspaces/get.ts
+++ b/apps/api/src/handlers/workspaces/get.ts
@@ -9,6 +9,13 @@ type ReadWorkspaceHandlerProps = {
   organizationId: SafeId<"organization">;
 };
 
+// The organization is part of the lookup, not a check after it. Callers reach
+// this handler through an access gate that already resolved `workspaceId`
+// inside the caller's organization, and `scopedDb` re-derives that
+// authorization in RLS — but this helper is exported, and a caller holding a
+// broader scope would otherwise read another tenant's row. Constraining the
+// query means a mismatch returns no row, which the not-found path below
+// already answers; there is no ownership decision left to make afterwards.
 export const readWorkspaceHandler = async ({
   scopedDb,
   workspaceId,
@@ -18,6 +25,7 @@ export const readWorkspaceHandler = async ({
     tx.query.workspaces.findFirst({
       where: {
         id: { eq: workspaceId },
+        organizationId: { eq: organizationId },
       },
       with: {
         client: {
@@ -34,10 +42,6 @@ export const readWorkspaceHandler = async ({
 
   if (!result) {
     return status(404);
-  }
-
-  if (result.organizationId !== organizationId) {
-    return status(403);
   }
 
   // The matter row and its client card, nothing else. This response used to

--- a/apps/api/src/lib/flows/flow-types.test.ts
+++ b/apps/api/src/lib/flows/flow-types.test.ts
@@ -1,7 +1,10 @@
+import { Value } from "@sinclair/typebox/value";
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
+import { flowDefinitionBodySchema } from "@/api/handlers/flows/schema";
 import {
+  FLOW_DEFINITION_NAME_MAX_CHARS,
   flowDefinitionInputSchema,
   MAX_FLOW_STEPS,
 } from "@/api/lib/flows/flow-types";
@@ -127,5 +130,31 @@ describe("flowDefinitionInputSchema normalization", () => {
     if (result.success) {
       expect(result.output.name).toBe("Spaced");
     }
+  });
+});
+
+// The route contract (TypeBox) and the authoritative parse (valibot) are two
+// layers over the same body. They agree only because both read the bounds from
+// `flow-types.ts`; a literal restated in either layer would make the effective
+// bound the lower of the two, reported by whichever layer runs first.
+describe("flow definition bounds are shared across both layers", () => {
+  const nameOf = (length: number) => "a".repeat(length);
+
+  test("both layers accept a name at the cap", () => {
+    const definition = baseDefinition({
+      name: nameOf(FLOW_DEFINITION_NAME_MAX_CHARS),
+    });
+
+    expect(Value.Check(flowDefinitionBodySchema, definition)).toBe(true);
+    expect(parse(definition).success).toBe(true);
+  });
+
+  test("both layers reject a name one character over it", () => {
+    const definition = baseDefinition({
+      name: nameOf(FLOW_DEFINITION_NAME_MAX_CHARS + 1),
+    });
+
+    expect(Value.Check(flowDefinitionBodySchema, definition)).toBe(false);
+    expect(parse(definition).success).toBe(false);
   });
 });

--- a/apps/api/src/lib/flows/flow-types.ts
+++ b/apps/api/src/lib/flows/flow-types.ts
@@ -53,6 +53,18 @@ export const FLOW_STEP_OUTPUT_CONTEXT_CHAR_CAP = 20_000;
 /** Per input-document char cap when an AI step includes documents. */
 export const FLOW_DOCUMENT_CONTEXT_CHAR_CAP = 60_000;
 
+/**
+ * Scalar bounds on a flow definition's own text fields. The TypeBox route
+ * contract in `handlers/flows/schema.ts` and the valibot schema below are two
+ * layers over the same body, so both read these rather than restating the
+ * numbers: a bound raised in one layer and not the other silently becomes the
+ * lower of the two, with an error message from the wrong layer.
+ */
+export const FLOW_DEFINITION_NAME_MAX_CHARS = 256;
+export const FLOW_DEFINITION_DESCRIPTION_MAX_CHARS = 2000;
+export const FLOW_STEP_NAME_MAX_CHARS = 200;
+export const FLOW_STEP_DOCUMENT_TITLE_MAX_CHARS = 256;
+
 /** Char cap on a step's own instruction text (AI prompt, gate instructions). */
 export const FLOW_STEP_INSTRUCTION_CHAR_CAP = 10_000;
 
@@ -187,7 +199,7 @@ const flowStepNameSchema = v.pipe(
   v.string(),
   v.trim(),
   v.minLength(1),
-  v.maxLength(200),
+  v.maxLength(FLOW_STEP_NAME_MAX_CHARS),
 );
 
 const aiFlowStepSchema = v.strictObject({
@@ -215,7 +227,12 @@ const reviewGateFlowStepSchema = v.strictObject({
 const createDocumentFlowStepSchema = v.strictObject({
   kind: v.literal("create-document"),
   name: flowStepNameSchema,
-  documentTitle: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(256)),
+  documentTitle: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1),
+    v.maxLength(FLOW_STEP_DOCUMENT_TITLE_MAX_CHARS),
+  ),
 });
 
 export const flowStepSchema = v.variant("kind", [
@@ -291,8 +308,19 @@ true satisfies [FlowTriggerSchemaOutput, FlowTrigger] extends [
  * server-side (it needs a DB read) and is NOT expressed here.
  */
 export const flowDefinitionInputSchema = v.strictObject({
-  name: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(256)),
-  description: v.nullable(v.pipe(v.string(), v.trim(), v.maxLength(2000))),
+  name: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1),
+    v.maxLength(FLOW_DEFINITION_NAME_MAX_CHARS),
+  ),
+  description: v.nullable(
+    v.pipe(
+      v.string(),
+      v.trim(),
+      v.maxLength(FLOW_DEFINITION_DESCRIPTION_MAX_CHARS),
+    ),
+  ),
   steps: v.pipe(
     v.array(flowStepSchema),
     v.minLength(1),


### PR DESCRIPTION
## Summary

Two validation-boundary cleanups.

- `workspaces/get.ts` re-checked `organizationId` on a row that the access macro, the membership join in `getWorkspaceAccess`, and the RLS policy under `scopedDb` had already constrained to the caller's organization. The check and its now-unused parameter are removed; the 403 test becomes a pin that the handler returns what the scope produced. The MCP caller of the same read is gated by `ensureWorkspaceAccess`, which derives its set from the same organization filter.
- The flow definition shape was declared twice, TypeBox at the route boundary and Valibot for the deep invariants, with four scalar bounds restated and one already drifted (`tDefaultVarchar` vs a literal 256). `flow-types.ts` now exports the bounds and both schemas read them; a test checks both layers accept a name at the cap and reject one over it.

## Verification

Handler and flow schema test files. Lint and typecheck run in CI.
