### PR TITLE
fix(web): drop two unused exports that predate the dead-export budget

### DIFF
--- a/apps/web/src/components/pdf/page-organizer.logic.ts
+++ b/apps/web/src/components/pdf/page-organizer.logic.ts
@@ -28,7 +28,7 @@ export type PageOrganizerUI = {
   anchorPageId: string | null;
 };
 
-export type PageOrganizerHistory = {
+type PageOrganizerHistory = {
   initial: PageOrganizerPlan;
   past: readonly PageOrganizerPlan[];
   present: PageOrganizerPlan;

--- a/apps/web/src/lib/pdf/page-editor/page-editor-protocol.ts
+++ b/apps/web/src/lib/pdf/page-editor/page-editor-protocol.ts
@@ -1,4 +1,4 @@
-export type PageRotation = 0 | 90 | 180 | 270;
+type PageRotation = 0 | 90 | 180 | 270;
 
 export type NormalizedCrop = {
   x: number;


### PR DESCRIPTION
## Summary

The dead-export budget fails on main: #2419 merged between the budget's baseline seed and #2943's merge and added two exports nothing imports (`PageOrganizerHistory` in `page-organizer.logic.ts`, and the protocol module's own `PageRotation` in `page-editor-protocol.ts`). Both lose their `export`; the baseline is untouched.

## Verification

`bun scripts/knip-exports-ratchet.ts --check` and the three page-editor/organizer test files.
