### PR TITLE
fix: prevent Elysia alias collisions in compiled API

### DIFF
--- a/apps/api/src/lib/elysia-bundle.artifact.test.ts
+++ b/apps/api/src/lib/elysia-bundle.artifact.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+test("compiled Elysia validates synchronous and asynchronous Standard Schema bodies", () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), "stella-elysia-artifact-"));
+  const entrypoint = path.join(testDir, "probe.ts");
+  const executable = path.join(testDir, "probe");
+
+  try {
+    writeFileSync(
+      entrypoint,
+      `import { Elysia } from ${JSON.stringify(Bun.resolveSync("elysia", import.meta.dir))};
+import * as v from ${JSON.stringify(Bun.resolveSync("valibot", import.meta.dir))};
+const app = new Elysia()
+  .post('/sync', ({ body }) => body, { body: v.object({ name: v.string() }) })
+  .post('/async', ({ body }) => body, { body: v.objectAsync({ name: v.pipeAsync(v.string(), v.checkAsync(async (value) => value.length > 0)) }) });
+const results = [];
+for (const route of ['/sync', '/async']) {
+  for (const body of [{ name: 'ok' }, { name: 42 }]) {
+    const response = await app.handle(new Request('http://localhost' + route, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+    }));
+    results.push({ route, status: response.status, body: response.ok ? await response.json() : null });
+  }
+}
+process.stdout.write(JSON.stringify(results));
+`,
+    );
+    const build = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "build",
+        "--compile",
+        "--no-compile-autoload-dotenv",
+        "--target",
+        "bun",
+        "--outfile",
+        executable,
+        entrypoint,
+      ],
+      env: { PATH: process.env["PATH"] ?? "", NODE_ENV: "production" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(build.exitCode, new TextDecoder().decode(build.stderr)).toBe(0);
+    const run = Bun.spawnSync({
+      cmd: [executable],
+      cwd: testDir,
+      env: { PATH: process.env["PATH"] ?? "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(run.exitCode, new TextDecoder().decode(run.stderr)).toBe(0);
+    const output: unknown = JSON.parse(new TextDecoder().decode(run.stdout));
+    expect(output).toEqual([
+      { route: "/sync", status: 200, body: { name: "ok" } },
+      { route: "/sync", status: 422, body: null },
+      { route: "/async", status: 200, body: { name: "ok" } },
+      { route: "/async", status: 422, body: null },
+    ]);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/apps/api/src/lib/elysia-bundle.artifact.test.ts
+++ b/apps/api/src/lib/elysia-bundle.artifact.test.ts
@@ -18,7 +18,7 @@ const app = new Elysia()
   .post('/async', ({ body }) => body, { body: v.objectAsync({ name: v.pipeAsync(v.string(), v.checkAsync(async (value) => value.length > 0)) }) });
 const results = [];
 for (const route of ['/sync', '/async']) {
-  for (const body of [{ name: 'ok' }, { name: 42 }]) {
+  for (const body of [{ name: 'ok' }, { name: 42 }, { name: '' }]) {
     const response = await app.handle(new Request('http://localhost' + route, {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
     }));
@@ -57,7 +57,9 @@ process.stdout.write(JSON.stringify(results));
     expect(output).toEqual([
       { route: "/sync", status: 200, body: { name: "ok" } },
       { route: "/sync", status: 422, body: null },
+      { route: "/sync", status: 200, body: { name: "" } },
       { route: "/async", status: 200, body: { name: "ok" } },
+      { route: "/async", status: 422, body: null },
       { route: "/async", status: 422, body: null },
     ]);
   } finally {

--- a/bun.lock
+++ b/bun.lock
@@ -990,6 +990,7 @@
     "drizzle-kit@1.0.0-rc.4": "patches/drizzle-kit@1.0.0-rc.4.patch",
     "@astrojs/mdx@7.0.7": "patches/@astrojs__mdx@7.0.7.patch",
     "better-call@1.4.0": "patches/better-call@1.4.0.patch",
+    "elysia@1.4.29": "patches/elysia@1.4.29.patch",
   },
   "overrides": {
     "@atlaskit/pragmatic-drag-and-drop": "3.1.0",

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -18,6 +18,9 @@ STELLA_API_ENV_FILE="deploy/selfhost/.env"
 # [internal] Optional. Stella ocr pdf font path.
 # STELLA_OCR_PDF_FONT_PATH=""
 
+# [internal] Optional. Stella yara rules dir.
+# STELLA_YARA_RULES_DIR=""
+
 # [secret] Optional. Local-development-only read-only Postgres URL for the
 # shared public-law corpus. Unset uses DATABASE_URL.
 # PUBLIC_LAW_DATABASE_URL=""

--- a/package.json
+++ b/package.json
@@ -241,7 +241,8 @@
     "eslint-plugin-drizzle@0.2.3": "patches/eslint-plugin-drizzle@0.2.3.patch",
     "drizzle-kit@1.0.0-rc.4": "patches/drizzle-kit@1.0.0-rc.4.patch",
     "better-call@1.4.0": "patches/better-call@1.4.0.patch",
-    "@better-auth/oauth-provider@1.7.1": "patches/@better-auth%2Foauth-provider@1.7.1.patch"
+    "@better-auth/oauth-provider@1.7.1": "patches/@better-auth%2Foauth-provider@1.7.1.patch",
+    "elysia@1.4.29": "patches/elysia@1.4.29.patch"
   },
   "trustedDependencies": [
     "lefthook"

--- a/patches/elysia@1.4.29.patch
+++ b/patches/elysia@1.4.29.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/schema.js b/dist/schema.js
+index 9c4f1e82dcbb5094f6735bdab8ee38c42effd378..f67664910a3d897e7ed80382867ebfb9ef923db9 100644
+--- a/dist/schema.js
++++ b/dist/schema.js
+@@ -298,7 +298,6 @@ const isOptional = (schema) => schema ? schema?.[import_typebox.Kind] === "Impor
+         newValue = (0, import_utils.mergeDeep)(newValue, values[i]);
+       return { value: newValue };
+     };
+-    var Check = Check2, runCheckers = runCheckers2, mergeValues = mergeValues2;
+     const typeboxSubValidator = (schema2) => {
+       let mirror;
+       if (normalize === !0 || normalize === "exactMirror")
+diff --git a/dist/schema.mjs b/dist/schema.mjs
+index fa5bbe9ee1d3919fc222311b44de0a7f6b1dc37a..bb7e6fc323317dfb3dd0fa82b09d6412915fd688 100644
+--- a/dist/schema.mjs
++++ b/dist/schema.mjs
+@@ -280,7 +280,6 @@ const isOptional = (schema) => schema ? schema?.[Kind] === "Import" && schema.Re
+         newValue = mergeDeep(newValue, values[i]);
+       return { value: newValue };
+     };
+-    var Check = Check2, runCheckers = runCheckers2, mergeValues = mergeValues2;
+     const typeboxSubValidator = (schema2) => {
+       let mirror;
+       if (normalize === !0 || normalize === "exactMirror")


### PR DESCRIPTION
Remove unused function-scoped aliases from Elysia’s published ESM and CommonJS schema modules through a pinned dependency patch. Bun can rename these aliases into conflicting block-scoped declarations, causing the compiled API to fail before startup.

Add a compiled Elysia/Valibot regression covering synchronous and asynchronous validation: valid bodies return 200 and invalid bodies return 422. The same test fails with the unpatched dependency at the Check2 declaration.

Both linux/arm64 and linux/amd64 final API images pass a full local release rehearsal: fresh migrations, corrupt-history rejection and restoration, API liveness and scheduler startup, bundled entrypoint probes, and runtime assets. Repository-wide lint and typechecking pass. Regenerate the self-host environment example for the existing YARA runtime setting.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved confidence in request-body validation for compiled deployments, covering synchronous and asynchronous validation scenarios.

- **Configuration**
  - Added optional self-hosting configuration entries for specifying the Stella YARA rules directory.

- **Maintenance**
  - Streamlined bundled output by removing unused build artefacts without changing runtime behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->