### PR TITLE
fix(api): text generation reads the finish reason chat() moves into metadata

### DIFF
--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -1,3 +1,5 @@
+import { EventType } from "@tanstack/ai";
+import type { AnyTextAdapter, StreamChunk } from "@tanstack/ai";
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
@@ -10,7 +12,10 @@ import {
 } from "@stll/ai-catalog";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
+import type { CachingDecision } from "@/api/lib/ai-config";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { generateTanStackTextForRole } from "@/api/lib/tanstack-ai-generate";
+import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
 
 import {
   CANARY_TEXT_FINISH_POLICY,
@@ -47,12 +52,113 @@ describe("AI provider canary probe deadlines", () => {
   });
 });
 
+// The finish shapes a provider run can end in, as the probes' text calls see
+// them through the real chat runtime. `unfinished` is a stream that ends
+// without a `RUN_FINISHED` event at all.
+type ProbeFinish = "content_filter" | "length" | "stop" | "unfinished";
+
+const createProbeFinishAdapter = (finish: ProbeFinish): AnyTextAdapter => ({
+  kind: "text",
+  name: "probe-finish",
+  model: "probe-finish",
+  "~types": {
+    providerOptions: {},
+    inputModalities: ["text"],
+    messageMetadataByModality: {},
+    toolCapabilities: [],
+    toolCallMetadata: {},
+    systemPromptMetadata: undefined,
+  },
+  async *chatStream({ runId, threadId }) {
+    const resolvedRunId = runId ?? "run-1";
+    const resolvedThreadId = threadId ?? "thread-1";
+    const messageId = "provider-message-1";
+    yield {
+      type: EventType.RUN_STARTED,
+      runId: resolvedRunId,
+      threadId: resolvedThreadId,
+    } satisfies StreamChunk;
+    yield {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId,
+      role: "assistant",
+    } satisfies StreamChunk;
+    yield {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId,
+      delta: "OK",
+    } satisfies StreamChunk;
+    yield { type: EventType.TEXT_MESSAGE_END, messageId } satisfies StreamChunk;
+    if (finish === "unfinished") {
+      return;
+    }
+    yield {
+      type: EventType.RUN_FINISHED,
+      finishReason: finish,
+      runId: resolvedRunId,
+      threadId: resolvedThreadId,
+    } satisfies StreamChunk;
+  },
+  structuredOutput: () => {
+    throw new Error("Structured output is not part of this fixture");
+  },
+});
+
+const generateProbeTextFinishing = async (finish: ProbeFinish) => {
+  // SAFETY: the adapter is the only part of the resolved model the chat loop
+  // reads on this path; the rest is bookkeeping this test never routes through
+  // a provider.
+  const model = {
+    adapter: createProbeFinishAdapter(finish),
+    keySource: "instance",
+    modelId: "probe-finish",
+    modelOptions: {},
+    provider: "openai",
+  } as ResolvedTanStackTextModel;
+
+  return await generateTanStackTextForRole({
+    caching: {
+      enabled: false,
+      reason: "org-disabled",
+    } satisfies CachingDecision,
+    finishPolicy: CANARY_TEXT_FINISH_POLICY,
+    maxOutputTokens: 16,
+    organizationId: null,
+    orgAIConfig: null,
+    prompt: "Reply with exactly OK.",
+    resolveTextModel: () => model,
+    role: "chat",
+    serviceTier: "standard",
+    tenantWorkspaceIds: [],
+  });
+};
+
+const probeTextFailure = async (finish: ProbeFinish) =>
+  await generateProbeTextFinishing(finish).then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+
 describe("AI provider canary text finish policy", () => {
-  test("accepts a run that stopped at the probe's own output ceiling", () => {
-    // The probes size their ceiling for a one-line answer, so a model that
-    // spends the whole budget finishes on `length`. Rejecting that grades the
-    // canary's own budget as provider drift, on every provider at once.
-    expect(CANARY_TEXT_FINISH_POLICY).toBe("allow-incomplete");
+  // The probes size their ceiling for a one-line answer, so a model that
+  // spends the whole budget finishes on `length`. Rejecting that grades the
+  // canary's own budget as provider drift, on every provider at once.
+  test("accepts a run that stopped at the probe's own output ceiling", async () => {
+    expect(await generateProbeTextFinishing("length")).toBe("OK");
+    expect(await generateProbeTextFinishing("stop")).toBe("OK");
+  });
+
+  // Text still arrived in both cases, so `requireNonEmptyText` alone would
+  // pass them; the policy is what keeps a moderation or lifecycle regression
+  // from grading as a healthy provider.
+  test("rejects a moderated run that still returned text", async () => {
+    expect(await probeTextFailure("content_filter")).toBeInstanceOf(
+      HandlerError,
+    );
+  });
+
+  test("rejects a run that never reported a finish", async () => {
+    expect(await probeTextFailure("unfinished")).toBeInstanceOf(HandlerError);
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -13,6 +13,7 @@ import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-sc
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 import {
+  CANARY_TEXT_FINISH_POLICY,
   CanaryCredentialRejectedError,
   CanaryProviderRunError,
   CATALOG_SWEEP_BUDGET_MS,
@@ -43,6 +44,15 @@ describe("AI provider canary probe deadlines", () => {
     );
     expect(canaryCapabilityProbeTimeout("structured-output")).toBe(20_000);
     expect(canaryCapabilityProbeTimeout("unknown-probe")).toBeUndefined();
+  });
+});
+
+describe("AI provider canary text finish policy", () => {
+  test("accepts a run that stopped at the probe's own output ceiling", () => {
+    // The probes size their ceiling for a one-line answer, so a model that
+    // spends the whole budget finishes on `length`. Rejecting that grades the
+    // canary's own budget as provider drift, on every provider at once.
+    expect(CANARY_TEXT_FINISH_POLICY).toBe("allow-incomplete");
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -26,6 +26,7 @@ import {
   mergeGenerationOptions,
   resolveTanStackTextModel,
 } from "@/api/lib/tanstack-ai-generate";
+import type { TanStackTextFinishPolicy } from "@/api/lib/tanstack-ai-generate";
 import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
@@ -70,9 +71,10 @@ const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 // inside the ceiling the probe itself set. Those ceilings are sized for a
 // one-line answer, so a model that spends the whole budget reports a `length`
 // finish; grading that as a failure would report the canary's own budget as
-// provider drift. The probes' own assertions carry the contract instead:
-// non-empty text, and the exact token for the PDF role.
-export const CANARY_TEXT_FINISH_POLICY = "allow-incomplete" as const;
+// provider drift. A moderated, tool-bearing, or unfinished run stays a
+// failure: those are the provider regressions the probes exist to catch.
+export const CANARY_TEXT_FINISH_POLICY =
+  "allow-output-ceiling" satisfies TanStackTextFinishPolicy;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
 export const PDF_CANARY_TOKEN = "STELLA_PDF_CANARY_OK";
 const PDF_CANARY_FILENAME = "stella-provider-canary.pdf";

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -66,6 +66,13 @@ const CANARY_PROBE_RETRY_DELAY_MS = 5000;
 const CANARY_PROBE_RETRY_BACKOFF = 4;
 const PROVIDER_ERROR_MESSAGE_MAX_LENGTH = 16_384;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+// Every text probe asserts what the provider returned, not that it finished
+// inside the ceiling the probe itself set. Those ceilings are sized for a
+// one-line answer, so a model that spends the whole budget reports a `length`
+// finish; grading that as a failure would report the canary's own budget as
+// provider drift. The probes' own assertions carry the contract instead:
+// non-empty text, and the exact token for the PDF role.
+export const CANARY_TEXT_FINISH_POLICY = "allow-incomplete" as const;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
 export const PDF_CANARY_TOKEN = "STELLA_PDF_CANARY_OK";
 const PDF_CANARY_FILENAME = "stella-provider-canary.pdf";
@@ -1034,7 +1041,7 @@ const capabilityProbes = [
       const output = await generateTanStackTextForRole({
         abortSignal: signal,
         caching: CANARY_CACHING,
-        finishPolicy: "require-complete",
+        finishPolicy: CANARY_TEXT_FINISH_POLICY,
         maxOutputTokens: modelRoleMaxOutputTokens({
           modelId: DEFAULT_MODELS[provider][CAPABILITY_ROLE],
           role: CAPABILITY_ROLE,
@@ -1107,7 +1114,7 @@ const runModelRoleProbe = async ({
   const output = await generateTanStackTextForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    finishPolicy: "require-complete",
+    finishPolicy: CANARY_TEXT_FINISH_POLICY,
     maxOutputTokens: modelRoleMaxOutputTokens({
       modelId: selection.modelId,
       role,
@@ -1169,7 +1176,7 @@ const runWeeklyModelRoleProbe = async ({
   const output = await generateTanStackTextForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    finishPolicy: "require-complete",
+    finishPolicy: CANARY_TEXT_FINISH_POLICY,
     maxOutputTokens: modelRoleMaxOutputTokens({
       modelId: rotation.modelId,
       role,
@@ -1774,7 +1781,7 @@ const runCatalogModelProbe = async ({
   const output = await generateTanStackTextForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    finishPolicy: "require-complete",
+    finishPolicy: CANARY_TEXT_FINISH_POLICY,
     maxOutputTokens: modelRoleMaxOutputTokens({
       modelId,
       role: CATALOG_PROBE_ROLE,

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -26,7 +26,7 @@ const PROPERTY_FLAG = "--property";
 // `evals/` carries only its own colocated unit tests (e.g.
 // `evals/lib/model-turn.test.ts`), never the eval scripts themselves, which
 // call paid models and run on demand.
-const TEST_FILE_GLOB = "{src,evals}/**/*.test.{ts,tsx}";
+const TEST_FILE_GLOB = "{src,evals,scripts}/**/*.test.{ts,tsx}";
 // Non-test helper modules live here; some install a module mock at import.
 const TEST_HELPER_GLOB = "src/tests/**/*.ts";
 const MODULE_MOCK_PATTERN = /\bmock\.module\s*\(/u;

--- a/apps/api/src/lib/tanstack-ai-generate.canary.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.canary.test.ts
@@ -10,6 +10,7 @@ import {
   generateTanStackTextForRole,
   streamTanStackObjectForRole,
 } from "@/api/lib/tanstack-ai-generate";
+import type { TanStackTextFinishPolicy } from "@/api/lib/tanstack-ai-generate";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
 
 // Real `chat()` runtime, no module mocks. `generateTanStackTextForRole`
@@ -135,13 +136,11 @@ const outputCeilingModel = {
   provider: "anthropic",
 } as ResolvedTanStackTextModel;
 
-type FinishPolicy = "allow-incomplete" | "require-complete";
-
 const generateAtOutputCeiling = async ({
   finishPolicy,
   terminalEvents,
 }: {
-  finishPolicy: FinishPolicy;
+  finishPolicy: TanStackTextFinishPolicy;
   terminalEvents: string[];
 }) =>
   await generateTanStackTextForRole({
@@ -195,6 +194,35 @@ const generateWithCancellation = async (cancelAt: CancellationPoint) => {
   });
 };
 
+describe("TanStack completed-run canary", () => {
+  test("a run that finished on stop satisfies a complete-output caller", async () => {
+    const controller = new AbortController();
+    // SAFETY: the adapter is the only part of the resolved model the real chat
+    // loop reads on this path.
+    const model = {
+      adapter: createCancellingAdapter(controller, "after-finish"),
+      keySource: "instance",
+      modelId: "cancelling",
+      modelOptions: {},
+      provider: "openai",
+    } as ResolvedTanStackTextModel;
+
+    expect(
+      await generateTanStackTextForRole({
+        caching: noCaching,
+        finishPolicy: "require-complete",
+        organizationId: null,
+        orgAIConfig: null,
+        prompt: "Rewrite it.",
+        resolveTextModel: () => model,
+        role: "chat",
+        serviceTier: "standard",
+        tenantWorkspaceIds: [],
+      }),
+    ).toBe("half an answer");
+  });
+});
+
 describe("TanStack cancellation canary", () => {
   test("a run cancelled mid-stream rejects instead of returning its prefix", async () => {
     const caught = await generateWithCancellation("mid-stream").then(
@@ -219,6 +247,18 @@ describe("TanStack output-ceiling canary", () => {
     expect(
       await generateAtOutputCeiling({
         finishPolicy: "allow-incomplete",
+        terminalEvents,
+      }),
+    ).toBe("as far as it got");
+    expect(terminalEvents).toEqual(["finish:length"]);
+  });
+
+  test("returns the same partial text to an output-ceiling caller", async () => {
+    const terminalEvents: string[] = [];
+
+    expect(
+      await generateAtOutputCeiling({
+        finishPolicy: "allow-output-ceiling",
         terminalEvents,
       }),
     ).toBe("as far as it got");

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -8,6 +8,7 @@ import type {
   AnyTextAdapter,
   ModelMessage,
   RunErrorEvent,
+  RunFinishedEvent,
   StreamChunk,
   StructuredOutputPart,
   SystemPrompt,
@@ -108,8 +109,20 @@ type GenerateTanStackBaseOptions = {
 type TanStackTextForRoleOptions = GenerateTanStackBaseOptions &
   GenerateTanStackInputOptions;
 
+/**
+ * Which finish a caller accepts as an answer. `require-complete` rejects
+ * everything but `stop`. `allow-output-ceiling` also accepts `length`, the
+ * finish a run reports when it spends the whole `maxOutputTokens` budget, and
+ * still rejects a moderated (`content_filter`), tool-bearing, or unfinished
+ * run. `allow-incomplete` returns whatever text arrived.
+ */
+export type TanStackTextFinishPolicy =
+  | "allow-incomplete"
+  | "allow-output-ceiling"
+  | "require-complete";
+
 type GenerateTanStackTextForRoleOptions = TanStackTextForRoleOptions & {
-  finishPolicy: "allow-incomplete" | "require-complete";
+  finishPolicy: TanStackTextFinishPolicy;
 };
 
 type GenerateTanStackObjectForRoleOptions<TSchema extends v.GenericSchema> =
@@ -139,12 +152,19 @@ export type TanStackStructuredOutputEvent<TOutput> =
       type: "complete";
     };
 
-type TanStackTextFinishReason =
-  | "stop"
-  | "length"
-  | "content_filter"
-  | "tool_calls"
-  | null;
+type TanStackTextFinishReason = Exclude<
+  RunFinishedEvent["finishReason"],
+  undefined
+>;
+
+// `chat()` emits its public chunks in AG-UI spec shape, and `finishReason` is
+// not a spec key on `RUN_FINISHED`: the engine moves it into
+// `metadata.tanstack` before the chunk reaches a consumer. A chunk that never
+// went through the engine (a custom server, a fixture) still carries it at the
+// top level. Reading only the top level reports every finished run as
+// reason-less, which a complete-output caller then rejects.
+const runFinishReason = (chunk: RunFinishedEvent): TanStackTextFinishReason =>
+  chunk.finishReason ?? chunk.metadata?.tanstack?.finishReason ?? null;
 
 type ResolveTextModelOptions = Pick<
   GenerateTanStackBaseOptions,
@@ -172,6 +192,22 @@ const isAbortRejection = ({
   signal?.aborted === true &&
   (error === signal.reason ||
     (error instanceof Error && error.name === "AbortError"));
+
+const finishAccepted = (
+  finishPolicy: TanStackTextFinishPolicy,
+  finishReason: TanStackTextFinishReason,
+): boolean => {
+  switch (finishPolicy) {
+    case "allow-incomplete":
+      return true;
+    case "allow-output-ceiling":
+      return finishReason === "stop" || finishReason === "length";
+    case "require-complete":
+      return finishReason === "stop";
+    default:
+      return finishPolicy satisfies never;
+  }
+};
 
 export const generateTanStackTextForRole = async (
   options: GenerateTanStackTextForRoleOptions,
@@ -225,10 +261,7 @@ export const generateTanStackTextForRole = async (
     throw cancelledGenerationError();
   }
 
-  if (
-    options.finishPolicy === "require-complete" &&
-    state.finishReason !== "stop"
-  ) {
+  if (!finishAccepted(options.finishPolicy, state.finishReason)) {
     throw new HandlerError({
       status: 502,
       message: "AI generation did not complete",
@@ -400,7 +433,7 @@ const streamTanStackTextDeltas = async function* ({
       }),
     onChunk: (chunk) => {
       if (chunk.type === EventType.RUN_FINISHED) {
-        onFinishReason?.(chunk.finishReason ?? null);
+        onFinishReason?.(runFinishReason(chunk));
         return undefined;
       }
       if (

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -205,7 +205,8 @@ const finishAccepted = (
     case "require-complete":
       return finishReason === "stop";
     default:
-      return finishPolicy satisfies never;
+      finishPolicy satisfies never;
+      return panic(`Unhandled finish policy: ${String(finishPolicy)}`);
   }
 };
 


### PR DESCRIPTION
## Proposed change

The scheduled AI provider canary is red on every configured provider at once ([run 128](https://github.com/stella/stella/actions/runs/33941889747)): bedrock, openai, anthropic, openrouter and google each fail their four `role-*` probes, `prompt-caching`, and every `catalog:*` probe, all reporting `failed (provider error)`. The same probes were green on [run 127](https://github.com/stella/stella/actions/runs/33833331283) a day earlier. Five independent providers do not regress together, and the split says where to look: every probe that goes through `generateTanStackTextForRole` fails, while every `structured-role-*` probe passes.

`finishPolicy` became a required option on `generateTanStackTextForRole` in #2938, and the canary's four text call sites were filled in with `require-complete`. That policy rejects every finish but `stop`. The reader it relies on is the fault: `chat()` emits its public chunks in AG-UI spec shape, and `finishReason` is not a spec key on `RUN_FINISHED`, so the engine moves it into `metadata.tanstack` before the chunk reaches a consumer. `generateTanStackTextForRole` read only the top level, saw no reason on every finished run, and `require-complete` rejected it with a 502 `HandlerError`. `providerEvidence` drops a `HandlerError`'s status, so the canary reported `provider error` for its own reader. The unit tests around that helper replace `chat()` at the module boundary and yield fixtures with a top-level `finishReason`, which is why they stayed green.

This is not confined to the canary. The eight production callers #2938 moved onto `require-complete` (`generate-thread-title`, `suggest-thread-title`, `improve-prompt`, `properties/suggest-prompt`, `skills/resources/rewrite`, `time-entries/polish-narrative`, `flow-executor`, and compaction) have rejected every completed run since v0.8.17 shipped that change.

### Changes

- `generateTanStackTextForRole` reads the finish reason from `metadata.tanstack` when the top level carries none, and derives its reason type from the SDK's `RunFinishedEvent` so the two cannot drift.
- A third finish policy, `allow-output-ceiling`, accepts `stop` and `length` and still rejects a moderated (`content_filter`), tool-bearing, or unfinished run. The canary's text probes size `maxOutputTokens` for a one-line answer, so `length` is an outcome they must accept; the other finishes are the regressions the probes exist to catch. The four text call sites use it through one named constant.
- The API test runner globbed `{src,evals}` only, so the 29 test files under `apps/api/scripts/` (the four canary suites among them) never ran in `bun run test` or CI. The glob now includes `scripts/`; all 29 files pass through the runner.

### Verification

All three fixes are pinned through the real `chat()` runtime rather than a module mock, so a change to the SDK's chunk shape fails a test instead of the next scheduled run:

- a run that finishes on `stop` satisfies `require-complete` (failed before the reader fix, passes after)
- the Anthropic output-ceiling stream satisfies `allow-output-ceiling` and still fails `require-complete`
- the canary's policy accepts `stop` and `length`, and rejects `content_filter` and a stream with no finish event; mutating the constant to `require-complete` fails the first, mutating it to `allow-incomplete` fails the other two

Also run: `bun --filter @stll/api typecheck` (clean), `bun run lint:changed` (clean), `bunx oxfmt --check` on the touched files (clean), the API `tanstack-ai-generate` suites (32 pass) and every `apps/api/scripts` suite through the runner (432 pass, 0 fail).

Provider probes themselves need canary credentials and run on the schedule, so the restored path is verified against the runtime here and the two runs above rather than re-executed.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: API library and canary script, no UI surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-visible surface changes.
