### PR TITLE
fix(api): try a CJEU manifestation's items when negotiation is refused

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1137,22 +1137,39 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
     ]);
   });
 
-  test("stops the walk when a refusal is transient, not the address", async () => {
-    // 429 and 5xx say nothing about whether this address can serve the
-    // representation, so walking on would ask a publisher already refusing
-    // load for the same document three more times over.
-    const { fetches } = installStatusMock(429);
+  test.each(
+    [400, 401, 403, 408, 429, 500, 502, 503, 504].flatMap((status) =>
+      [0, 1, 2].map((ordinal) => ({ status, ordinal })),
+    ),
+  )(
+    "propagates HTTP $status at address $ordinal without further probing",
+    async ({ status, ordinal }) => {
+      const { fetches } = installItemOnlyMock(0);
+      const itemFetch = globalThis.fetch;
+      const failedUrl = `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}${ordinal === 0 ? "" : `/DOC_${ordinal}`}`;
+      globalThis.fetch = asFetchMock(
+        mock((input: string | URL | Request, init?: RequestInit) => {
+          if (requestUrl(input) === failedUrl) {
+            fetches.push({
+              url: failedUrl,
+              accept: new Headers(init?.headers).get("accept") ?? undefined,
+            });
+            return Promise.resolve(new Response("Unavailable", { status }));
+          }
+          return itemFetch(input, init);
+        }),
+      );
 
-    const outcome = await reconciliation.buildDecision({
-      celex: "62021CJ0128",
-      language: "EN",
-    });
-
-    expect(outcome).toEqual({ type: "detail-unavailable" });
-    expect(fetches).toEqual([
-      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}`,
-    ]);
-  });
+      await expect(
+        reconciliation.buildDecision({
+          celex: "62021CJ0128",
+          language: "EN",
+        }),
+      ).rejects.toThrow(`CJEU document request failed: ${status}`);
+      expect(fetches).toHaveLength(ordinal + 1);
+      expect(fetches.at(-1)?.url).toBe(failedUrl);
+    },
+  );
 
   test("keeps walking when a refusal means this address cannot serve it", async () => {
     // The counterpart to the test above: 404 is what the item walk exists for,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1160,12 +1160,16 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
         }),
       );
 
-      await expect(
+      const rejection = await rejectionOf(
         reconciliation.buildDecision({
           celex: "62021CJ0128",
           language: "EN",
         }),
-      ).rejects.toThrow(`CJEU document request failed: ${status}`);
+      );
+
+      expect(rejectionMessage(rejection)).toContain(
+        `CJEU document request failed: ${status}`,
+      );
       expect(fetches).toHaveLength(ordinal + 1);
       expect(fetches.at(-1)?.url).toBe(failedUrl);
     },

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1138,7 +1138,7 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
   });
 
   test.each(
-    [401, 403, 408, 429, 500, 502, 503, 504].flatMap((status) =>
+    [408, 429, 500, 502, 503, 504].flatMap((status) =>
       [0, 1, 2].map((ordinal) => ({ status, ordinal })),
     ),
   )(
@@ -1175,37 +1175,44 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
     },
   );
 
-  test("continues crawling other variants after a deterministic bad document request", async () => {
-    const { documentFetches } = installSparqlMock({
-      bindings: [enBinding, frBinding],
-      served: [FR_MANIFESTATION_ID],
-    });
-    const servedFetch = globalThis.fetch;
-    const rejectedUrl = `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}`;
-    globalThis.fetch = asFetchMock(
-      mock((input: string | URL | Request, init?: RequestInit) => {
-        if (requestUrl(input) === rejectedUrl) {
-          documentFetches.push(rejectedUrl);
-          return Promise.resolve(new Response("Bad request", { status: 400 }));
-        }
-        return servedFetch(input, init);
-      }),
-    );
+  // 401 and 403 pin the crawl exactly as 400 does, so the isolation has to
+  // key on retryability rather than on one status.
+  test.each([400, 401, 403])(
+    "continues crawling other variants after a deterministic HTTP %i document request",
+    async (rejectedStatus) => {
+      const { documentFetches } = installSparqlMock({
+        bindings: [enBinding, frBinding],
+        served: [FR_MANIFESTATION_ID],
+      });
+      const servedFetch = globalThis.fetch;
+      const rejectedUrl = `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}`;
+      globalThis.fetch = asFetchMock(
+        mock((input: string | URL | Request, init?: RequestInit) => {
+          if (requestUrl(input) === rejectedUrl) {
+            documentFetches.push(rejectedUrl);
+            return Promise.resolve(
+              new Response("Rejected", { status: rejectedStatus }),
+            );
+          }
+          return servedFetch(input, init);
+        }),
+      );
 
-    const outcome = await ecjAdapter.fetchPage("2024-01-18", {});
+      const outcome = await ecjAdapter.fetchPage("2024-01-18", {});
 
-    if (!Result.isOk(outcome)) {
-      throw new TypeError("Expected successful crawl page");
-    }
-    expect(outcome.value.decisions.map(({ language }) => language)).toEqual([
-      "fr",
-    ]);
-    expect(documentFetches).toEqual([
-      rejectedUrl,
-      `https://publications.europa.eu/resource/cellar/${FR_MANIFESTATION_ID}`,
-    ]);
-    expect(outcome.value.nextCursor).toBe("2024-01-19");
-  });
+      if (!Result.isOk(outcome)) {
+        throw new TypeError("Expected successful crawl page");
+      }
+      expect(outcome.value.decisions.map(({ language }) => language)).toEqual([
+        "fr",
+      ]);
+      expect(documentFetches).toEqual([
+        rejectedUrl,
+        `https://publications.europa.eu/resource/cellar/${FR_MANIFESTATION_ID}`,
+      ]);
+      expect(outcome.value.nextCursor).toBe("2024-01-19");
+    },
+  );
 
   test("keeps walking when a refusal means this address cannot serve it", async () => {
     // The counterpart to the test above: 404 is what the item walk exists for,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1034,6 +1034,29 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
     return { fetches };
   };
 
+  /** Answer every document address with one status, and record the requests. */
+  const installStatusMock = (status: number): { fetches: string[] } => {
+    const fetches: string[] = [];
+    globalThis.fetch = asFetchMock(
+      mock((input: string | URL | Request) => {
+        const url = requestUrl(input);
+        if (url.includes("sparql")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ results: { bindings: [enBinding] } }),
+              {
+                status: 200,
+              },
+            ),
+          );
+        }
+        fetches.push(url);
+        return Promise.resolve(new Response("", { status }));
+      }),
+    );
+    return { fetches };
+  };
+
   test("falls back to the manifestation's items when negotiation is refused", async () => {
     // Addressing the manifestation fixed the works whose XHTML sits at a later
     // ordinal, but it is not how Cellar stores all of them: for the rest the
@@ -1112,6 +1135,54 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
       `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_2`,
       `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_3`,
     ]);
+  });
+
+  test("stops the walk when a refusal is transient, not the address", async () => {
+    // 429 and 5xx say nothing about whether this address can serve the
+    // representation, so walking on would ask a publisher already refusing
+    // load for the same document three more times over.
+    const { fetches } = installStatusMock(429);
+
+    const outcome = await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    expect(outcome).toEqual({ type: "detail-unavailable" });
+    expect(fetches).toEqual([
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}`,
+    ]);
+  });
+
+  test("keeps walking when a refusal means this address cannot serve it", async () => {
+    // The counterpart to the test above: 404 is what the item walk exists for,
+    // so it must still spend the remaining addresses.
+    const { fetches } = installStatusMock(404);
+
+    await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    expect(fetches).toHaveLength(4);
+  });
+
+  test("records the address that served the document, not the one it is named by", async () => {
+    // An item-only manifestation answers 404 at its own URL, so persisting
+    // that as `documentUrl` would publish a link that does not resolve.
+    installItemOnlyMock(2);
+
+    const outcome = await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    if (outcome.type !== "built") {
+      throw new TypeError(`Expected built, got ${outcome.type}`);
+    }
+    expect(outcome.decision.documentUrl).toBe(
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_2`,
+    );
   });
 
   test("asks the content stream for XHTML", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -991,6 +991,129 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
     ]);
   });
 
+  /**
+   * Serve the manifestation only at one of its numbered items, the way Cellar
+   * stores a work whose manifestation resource does not content-negotiate:
+   * the manifestation URL answers 404 whatever is asked for, and the document
+   * is reachable only under it. Records every request so a test can state
+   * which addresses were tried, in order, and with what `Accept`.
+   */
+  const installItemOnlyMock = (
+    servedOrdinal: number,
+  ): { fetches: { url: string; accept: string | undefined }[] } => {
+    const fetches: { url: string; accept: string | undefined }[] = [];
+    globalThis.fetch = asFetchMock(
+      mock((input: string | URL | Request, init?: RequestInit) => {
+        const url = requestUrl(input);
+        if (url.includes("sparql")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ results: { bindings: [enBinding] } }),
+              { status: 200 },
+            ),
+          );
+        }
+        const accept = new Headers(init?.headers).get("accept") ?? undefined;
+        fetches.push({ url, accept });
+        if (!url.endsWith(`/DOC_${servedOrdinal}`)) {
+          return Promise.resolve(new Response("Not found", { status: 404 }));
+        }
+        // Cellar serves an older item as simplified HTML, and refuses any
+        // `Accept` naming a bare type it does not match.
+        if (accept !== undefined) {
+          return Promise.resolve(new Response("", { status: 406 }));
+        }
+        return Promise.resolve(
+          new Response(shortDocumentHtml, {
+            status: 200,
+            headers: { "Content-Type": "text/html;type=simplified" },
+          }),
+        );
+      }),
+    );
+    return { fetches };
+  };
+
+  test("falls back to the manifestation's items when negotiation is refused", async () => {
+    // Addressing the manifestation fixed the works whose XHTML sits at a later
+    // ordinal, but it is not how Cellar stores all of them: for the rest the
+    // manifestation URL answers 404 under negotiation while the document is
+    // served under it as an item. Neither addressing scheme covers the corpus,
+    // so a variant refused by one has to be tried against the other before it
+    // can be called unavailable.
+    const { fetches } = installItemOnlyMock(1);
+
+    const outcome = await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    if (outcome.type !== "built") {
+      throw new TypeError(`Expected built, got ${outcome.type}`);
+    }
+    expect(fetches.map(({ url }) => url)).toEqual([
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}`,
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_1`,
+    ]);
+  });
+
+  test("walks past an item ordinal the manifestation does not serve", async () => {
+    // The ordinal is no more fixed on this path than it was on the old one:
+    // stopping at `DOC_1` would reinstate the same defect one address along.
+    const { fetches } = installItemOnlyMock(2);
+
+    const outcome = await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    if (outcome.type !== "built") {
+      throw new TypeError(`Expected built, got ${outcome.type}`);
+    }
+    expect(fetches.at(-1)?.url).toBe(
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_2`,
+    );
+  });
+
+  test("asks an item for no media type in particular", async () => {
+    // The negotiated request names XHTML; an item request must not. Cellar
+    // serves these items as `text/html;type=simplified` and matches an
+    // `Accept` against that whole type, so naming a document type answers 406
+    // on precisely the documents this fallback exists to reach.
+    const { fetches } = installItemOnlyMock(1);
+
+    await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    // Strict: `toEqual` drops a trailing `undefined`, so it would hold just as
+    // well against a single negotiated request that never reached an item.
+    expect(fetches.map(({ accept }) => accept)).toStrictEqual([
+      "application/xhtml+xml",
+      undefined,
+    ]);
+  });
+
+  test("reports a variant unavailable only once every address has refused", async () => {
+    // The distinction the warning carries is only true if it is emitted after
+    // both addressing schemes have been tried, not after the first.
+    const { fetches } = installItemOnlyMock(0);
+
+    const outcome = await reconciliation.buildDecision({
+      celex: "62021CJ0128",
+      language: "EN",
+    });
+
+    expect(outcome).toEqual({ type: "detail-unavailable" });
+    expect(fetches.map(({ url }) => url)).toEqual([
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}`,
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_1`,
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_2`,
+      `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}/DOC_3`,
+    ]);
+  });
+
   test("asks the content stream for XHTML", async () => {
     // The item is chosen by content negotiation now that the URL no longer
     // names one, so the Accept header is what selects the document.

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1138,7 +1138,7 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
   });
 
   test.each(
-    [400, 401, 403, 408, 429, 500, 502, 503, 504].flatMap((status) =>
+    [401, 403, 408, 429, 500, 502, 503, 504].flatMap((status) =>
       [0, 1, 2].map((ordinal) => ({ status, ordinal })),
     ),
   )(
@@ -1174,6 +1174,38 @@ describe("euEcjAdapter.reconciliation.buildDecision", () => {
       expect(fetches.at(-1)?.url).toBe(failedUrl);
     },
   );
+
+  test("continues crawling other variants after a deterministic bad document request", async () => {
+    const { documentFetches } = installSparqlMock({
+      bindings: [enBinding, frBinding],
+      served: [FR_MANIFESTATION_ID],
+    });
+    const servedFetch = globalThis.fetch;
+    const rejectedUrl = `https://publications.europa.eu/resource/cellar/${EN_MANIFESTATION_ID}`;
+    globalThis.fetch = asFetchMock(
+      mock((input: string | URL | Request, init?: RequestInit) => {
+        if (requestUrl(input) === rejectedUrl) {
+          documentFetches.push(rejectedUrl);
+          return Promise.resolve(new Response("Bad request", { status: 400 }));
+        }
+        return servedFetch(input, init);
+      }),
+    );
+
+    const outcome = await ecjAdapter.fetchPage("2024-01-18", {});
+
+    if (!Result.isOk(outcome)) {
+      throw new TypeError("Expected successful crawl page");
+    }
+    expect(outcome.value.decisions.map(({ language }) => language)).toEqual([
+      "fr",
+    ]);
+    expect(documentFetches).toEqual([
+      rejectedUrl,
+      `https://publications.europa.eu/resource/cellar/${FR_MANIFESTATION_ID}`,
+    ]);
+    expect(outcome.value.nextCursor).toBe("2024-01-19");
+  });
 
   test("keeps walking when a refusal means this address cannot serve it", async () => {
     // The counterpart to the test above: 404 is what the item walk exists for,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -551,6 +551,35 @@ const XHTML_MEDIA_TYPE = "application/xhtml+xml";
 const DOCUMENT_MEDIA_TYPES = [XHTML_MEDIA_TYPE, "text/html"] as const;
 
 /**
+ * How many of a manifestation's items to try once negotiation has failed.
+ *
+ * Cellar addresses a manifestation two ways and neither covers the corpus on
+ * its own, so the document is looked for under both. Negotiating on the
+ * manifestation redirects to the right item for works Cellar stores that way;
+ * for the rest that URL answers 404 whatever is asked for, and the document is
+ * only reachable as a numbered item under it. The item ordinal is not fixed
+ * either — `DOC_1` is the manifestation's first item, not necessarily its
+ * document — so the items are tried in order rather than guessed at.
+ *
+ * Two is enough for every manifestation observed; the third is margin. The
+ * walk only runs when negotiation has already failed, so the modern corpus
+ * still costs one request.
+ */
+const MAX_MANIFESTATION_ITEMS = 3;
+
+/**
+ * Budget for acquiring one variant, across every address tried.
+ *
+ * Derived rather than chosen: the lookup makes at most one negotiated request
+ * plus one per item, each already bounded by `ADAPTER_TIMEOUT.REQUEST`. Bounding
+ * the whole lookup by a single request's budget instead would abort the walk
+ * partway and drop a document Cellar serves, which is the failure this fallback
+ * exists to prevent.
+ */
+const MANIFESTATION_LOOKUP_TIMEOUT =
+  ADAPTER_TIMEOUT.REQUEST * (MAX_MANIFESTATION_ITEMS + 1);
+
+/**
  * The media type a `Content-Type` names, without its parameters.
  *
  * Compared whole and case-insensitively rather than searched for. A parameter
@@ -565,6 +594,119 @@ const DOCUMENT_MEDIA_TYPES = [XHTML_MEDIA_TYPE, "text/html"] as const;
 const mediaTypeOf = (contentType: string): string =>
   (contentType.split(";").at(0) ?? "").trim().toLowerCase();
 
+type ManifestationRead =
+  | { type: "document"; html: string }
+  | { type: "unusable"; status: number };
+
+type ReadDocumentOptions = {
+  url: string;
+  /**
+   * `undefined` for an item URL, rather than the document types. Cellar serves
+   * an older item as `text/html;type=simplified` and matches an `Accept`
+   * against that whole type, so naming `text/html` answers 406 on exactly the
+   * documents the item walk exists to reach.
+   */
+  accept: string | undefined;
+  celex: string;
+  lang: EcjLanguage;
+  signal: AbortSignal;
+};
+
+/**
+ * Read one candidate address, yielding the document only when the response is
+ * one. An unusable answer is not reportable on its own: only the caller knows
+ * whether another address is left to try.
+ */
+const readDocumentResponse = async ({
+  url,
+  accept,
+  celex,
+  lang,
+  signal,
+}: ReadDocumentOptions): Promise<ManifestationRead> => {
+  const response = await fetchWithTimeout(url, {
+    signal,
+    timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+    headers: {
+      "User-Agent": INGESTION_USER_AGENT,
+      ...(accept === undefined ? {} : { Accept: accept }),
+    },
+  });
+
+  if (!response.ok) {
+    return { type: "unusable", status: response.status };
+  }
+
+  const mediaType = mediaTypeOf(response.headers.get("content-type") ?? "");
+  if (!DOCUMENT_MEDIA_TYPES.some((type) => type === mediaType)) {
+    logger.warn("case_law.ingestion.manifestation_not_a_document", {
+      adapterKey: ADAPTER_KEYS.EU_ECJ,
+      celex,
+      language: lang,
+      mediaType,
+      url,
+    });
+    return { type: "unusable", status: response.status };
+  }
+
+  const html = await response.text();
+  return html.length > MIN_DOCUMENT_LENGTH
+    ? { type: "document", html }
+    : { type: "unusable", status: response.status };
+};
+
+type ManifestationAddress = { url: string; accept: string | undefined };
+
+type ReadFirstServedOptions = {
+  addresses: ManifestationAddress[];
+  /** Refused statuses so far, in address order; appended to as they come. */
+  statuses: number[];
+  celex: string;
+  lang: EcjLanguage;
+  signal: AbortSignal;
+};
+
+/**
+ * Try each address in turn, yielding the first that serves a document.
+ *
+ * Recursive rather than a loop because the addresses must be tried in order
+ * and stopped at: awaiting them together would ask Cellar for every address
+ * of every variant, several times the requests for the fleet's most expensive
+ * source, to discard all but one answer.
+ */
+const readFirstServedAddress = async ({
+  addresses,
+  statuses,
+  celex,
+  lang,
+  signal,
+}: ReadFirstServedOptions): Promise<string | undefined> => {
+  const [address, ...rest] = addresses;
+  if (address === undefined) {
+    return undefined;
+  }
+
+  const read = await readDocumentResponse({
+    url: address.url,
+    accept: address.accept,
+    celex,
+    lang,
+    signal,
+  });
+  if (read.type === "document") {
+    return read.html;
+  }
+
+  statuses.push(read.status);
+  return readFirstServedAddress({
+    addresses: rest,
+    statuses,
+    celex,
+    lang,
+    signal,
+  });
+};
+
 const fetchManifestation = async ({
   contentUrl,
   celex,
@@ -572,44 +714,40 @@ const fetchManifestation = async ({
   signal,
 }: FetchManifestationOptions): Promise<string | undefined> => {
   try {
-    const response = await fetchWithTimeout(contentUrl, {
+    const statuses: number[] = [];
+    const html = await readFirstServedAddress({
+      addresses: [
+        { url: contentUrl, accept: XHTML_MEDIA_TYPE },
+        ...Array.from(
+          { length: MAX_MANIFESTATION_ITEMS },
+          (_unused, index): ManifestationAddress => ({
+            url: `${contentUrl}/DOC_${index + 1}`,
+            accept: undefined,
+          }),
+        ),
+      ],
+      statuses,
+      celex,
+      lang,
       signal,
-      timeoutMs: ADAPTER_TIMEOUT.REQUEST,
-      headers: {
-        "User-Agent": INGESTION_USER_AGENT,
-        Accept: XHTML_MEDIA_TYPE,
-      },
     });
-
-    if (!response.ok) {
-      // A variant the listing named and the content stream will not serve is
-      // reported unavailable, and the reconciliation loop retires it after
-      // its retry schedule. Saying so keeps a transport fault distinguishable
-      // from a translation the publisher never published.
-      logger.warn("case_law.ingestion.manifestation_unavailable", {
-        adapterKey: ADAPTER_KEYS.EU_ECJ,
-        celex,
-        language: lang,
-        httpStatus: response.status,
-        url: contentUrl,
-      });
-      return undefined;
+    if (html !== undefined) {
+      return html;
     }
 
-    const mediaType = mediaTypeOf(response.headers.get("content-type") ?? "");
-    if (!DOCUMENT_MEDIA_TYPES.some((type) => type === mediaType)) {
-      logger.warn("case_law.ingestion.manifestation_not_a_document", {
-        adapterKey: ADAPTER_KEYS.EU_ECJ,
-        celex,
-        language: lang,
-        mediaType,
-        url: contentUrl,
-      });
-      return undefined;
-    }
-
-    const html = await response.text();
-    return html.length > MIN_DOCUMENT_LENGTH ? html : undefined;
+    // A variant the listing named and no address on the content stream serves
+    // is reported unavailable, and the reconciliation loop retires it after
+    // its retry schedule. Saying so keeps a transport fault distinguishable
+    // from a translation the publisher never published; the statuses say which
+    // of the two addressing schemes refused it.
+    logger.warn("case_law.ingestion.manifestation_unavailable", {
+      adapterKey: ADAPTER_KEYS.EU_ECJ,
+      celex,
+      language: lang,
+      httpStatuses: statuses.join(","),
+      url: contentUrl,
+    });
+    return undefined;
   } catch (error) {
     // AbortErrors are expected (timeout, page cancellation)
     if (!(error instanceof DOMException)) {
@@ -1035,7 +1173,7 @@ export const buildDecision = async (
     lang,
     signal: AbortSignal.any([
       signal,
-      AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
+      AbortSignal.timeout(MANIFESTATION_LOOKUP_TIMEOUT),
     ]),
   });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -685,7 +685,7 @@ type ManifestationDocument = { html: string; url: string };
 type ManifestationLookup =
   | ({ type: "document" } & ManifestationDocument)
   | { type: "exhausted"; statuses: number[] }
-  | { type: "failed"; status: number; url: string };
+  | { type: "failed"; status: number };
 
 type ReadFirstServedOptions = {
   addresses: ManifestationAddress[];
@@ -727,7 +727,7 @@ const readFirstServedAddress = async ({
     return { type: "document", html: read.html, url: address.url };
   }
   if (read.type === "fetch-failed") {
-    return { type: "failed", status: read.status, url: address.url };
+    return { type: "failed", status: read.status };
   }
 
   statuses.push(read.status);
@@ -768,18 +768,14 @@ const fetchManifestation = async ({
       case "document":
         return { html: lookup.html, url: lookup.url };
       case "failed":
-        // The publisher could not answer for this variant, which says nothing
-        // about whether it holds it. Reported apart from the unavailable case
-        // so a throttle or an outage cannot be read as a translation that was
-        // never published.
-        logger.warn("case_law.ingestion.manifestation_fetch_failed", {
+        // Propagate to the caller's retry path instead of reporting missing
+        // content or probing another manifestation during a provider outage.
+        throw new AdapterFetchError({
+          message: `CJEU document request failed: ${lookup.status}`,
           adapterKey: ADAPTER_KEYS.EU_ECJ,
-          celex,
-          language: lang,
+          cursor: null,
           httpStatus: lookup.status,
-          url: lookup.url,
         });
-        return undefined;
       case "exhausted":
         // A variant the listing named and no address on the content stream
         // serves is reported unavailable, and the reconciliation loop retires
@@ -808,7 +804,7 @@ const fetchManifestation = async ({
         }),
       );
     }
-    return undefined;
+    throw error;
   }
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -755,83 +755,84 @@ const readFirstServedAddress = async ({
   });
 };
 
+type FetchManifestationResult = Result<
+  ManifestationDocument | undefined,
+  AdapterFetchError
+>;
+
 const fetchManifestation = async ({
   contentUrl,
   celex,
   lang,
   signal,
-}: FetchManifestationOptions): Promise<ManifestationDocument | undefined> => {
-  try {
-    const lookup = await readFirstServedAddress({
-      addresses: [
-        { url: contentUrl, accept: XHTML_MEDIA_TYPE },
-        ...Array.from(
-          { length: MAX_MANIFESTATION_ITEMS },
-          (_unused, index): ManifestationAddress => ({
-            url: `${contentUrl}/DOC_${index + 1}`,
-            accept: undefined,
-          }),
-        ),
-      ],
-      statuses: [],
-      celex,
-      lang,
-      signal,
-    });
-
-    switch (lookup.type) {
-      case "document":
-        return { html: lookup.html, url: lookup.url };
-      case "failed":
-        if (!isRetryableStatus(lookup.status)) {
-          // A deterministic bad document request must not pin the crawl's
-          // date cursor and prevent every later decision from being fetched.
-          logger.warn("case_law.ingestion.manifestation_rejected", {
-            adapterKey: ADAPTER_KEYS.EU_ECJ,
-            celex,
-            language: lang,
-            httpStatus: lookup.status,
-            url: contentUrl,
-          });
-          return undefined;
-        }
-        // Propagate to the caller's retry path instead of reporting missing
-        // content or probing another manifestation during a provider outage.
-        throw new AdapterFetchError({
+}: FetchManifestationOptions): Promise<FetchManifestationResult> => {
+  const fetched = await Result.tryPromise({
+    try: async () =>
+      await readFirstServedAddress({
+        addresses: [
+          { url: contentUrl, accept: XHTML_MEDIA_TYPE },
+          ...Array.from(
+            { length: MAX_MANIFESTATION_ITEMS },
+            (_unused, index): ManifestationAddress => ({
+              url: `${contentUrl}/DOC_${index + 1}`,
+              accept: undefined,
+            }),
+          ),
+        ],
+        statuses: [],
+        celex,
+        lang,
+        signal,
+      }),
+    catch: (cause) =>
+      new AdapterFetchError({
+        message: `CJEU manifestation fetch failed for ${celex}/${lang}`,
+        adapterKey: ADAPTER_KEYS.EU_ECJ,
+        cursor: null,
+        cause,
+      }),
+  });
+  if (Result.isError(fetched)) {
+    return fetched;
+  }
+  const lookup = fetched.value;
+  switch (lookup.type) {
+    case "document":
+      return Result.ok({ html: lookup.html, url: lookup.url });
+    case "failed":
+      if (!isRetryableStatus(lookup.status)) {
+        // A deterministic bad document request must not pin the crawl's
+        // date cursor and prevent every later decision from being fetched.
+        logger.warn("case_law.ingestion.manifestation_rejected", {
+          adapterKey: ADAPTER_KEYS.EU_ECJ,
+          celex,
+          language: lang,
+          httpStatus: lookup.status,
+          url: contentUrl,
+        });
+        return Result.ok(undefined);
+      }
+      return Result.err(
+        new AdapterFetchError({
           message: `CJEU document request failed: ${lookup.status}`,
           adapterKey: ADAPTER_KEYS.EU_ECJ,
           cursor: null,
           httpStatus: lookup.status,
-        });
-      case "exhausted":
-        // A variant the listing named and no address on the content stream
-        // serves is reported unavailable, and the reconciliation loop retires
-        // it after its retry schedule. The statuses say which of the two
-        // addressing schemes refused it.
-        logger.warn("case_law.ingestion.manifestation_unavailable", {
-          adapterKey: ADAPTER_KEYS.EU_ECJ,
-          celex,
-          language: lang,
-          httpStatuses: lookup.statuses.join(","),
-          url: contentUrl,
-        });
-        return undefined;
-      default: {
-        const exhaustive: never = lookup;
-        return exhaustive;
-      }
-    }
-  } catch (error) {
-    // AbortErrors are expected (timeout, page cancellation)
-    if (!(error instanceof DOMException)) {
-      captureError(
-        new TelemetryError({
-          message: `[eu-ecj] manifestation fetch failed for ${celex}/${lang}`,
-          cause: error,
         }),
       );
+    case "exhausted":
+      logger.warn("case_law.ingestion.manifestation_unavailable", {
+        adapterKey: ADAPTER_KEYS.EU_ECJ,
+        celex,
+        language: lang,
+        httpStatuses: lookup.statuses.join(","),
+        url: contentUrl,
+      });
+      return Result.ok(undefined);
+    default: {
+      const exhaustive: never = lookup;
+      return exhaustive;
     }
-    throw error;
   }
 };
 
@@ -1240,7 +1241,7 @@ export const buildDecision = async (
   // Fetch the language-specific XHTML stream from Cellar. The
   // human-facing EUR-Lex HTML endpoint is WAF-protected and may return
   // a challenge instead of document content to server-side callers.
-  const served = await fetchManifestation({
+  const manifestation = await fetchManifestation({
     contentUrl: documentUrl,
     celex,
     lang,
@@ -1250,6 +1251,15 @@ export const buildDecision = async (
     ]),
   });
 
+  if (Result.isError(manifestation)) {
+    const { error } = manifestation;
+    if (!(error.cause instanceof DOMException)) {
+      captureError(error);
+    }
+    // The adapter and fixture callers expose a rejecting promise contract.
+    throw error;
+  }
+  const served = manifestation.value;
   if (!served) {
     return undefined;
   }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -605,6 +605,7 @@ const mediaTypeOf = (contentType: string): string =>
  * conflation this adapter exists to avoid.
  */
 const ADDRESS_EXHAUSTED_STATUSES = [404, 406, 410, 415] as const;
+const INVALID_DOCUMENT_REQUEST_STATUS = 400;
 
 type ManifestationRead =
   | { type: "document"; html: string }
@@ -768,6 +769,18 @@ const fetchManifestation = async ({
       case "document":
         return { html: lookup.html, url: lookup.url };
       case "failed":
+        if (lookup.status === INVALID_DOCUMENT_REQUEST_STATUS) {
+          // A deterministic bad document request must not pin the crawl's
+          // date cursor and prevent every later decision from being fetched.
+          logger.warn("case_law.ingestion.manifestation_rejected", {
+            adapterKey: ADAPTER_KEYS.EU_ECJ,
+            celex,
+            language: lang,
+            httpStatus: lookup.status,
+            url: contentUrl,
+          });
+          return undefined;
+        }
         // Propagate to the caller's retry path instead of reporting missing
         // content or probing another manifestation during a provider outage.
         throw new AdapterFetchError({

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -594,9 +594,22 @@ const MANIFESTATION_LOOKUP_TIMEOUT =
 const mediaTypeOf = (contentType: string): string =>
   (contentType.split(";").at(0) ?? "").trim().toLowerCase();
 
+/**
+ * Statuses that say this address cannot serve this representation, and so are
+ * the only ones worth spending the next address on.
+ *
+ * Any other failure — throttling, a gateway error, a timeout — says nothing
+ * about the address. Walking on would ask a publisher already refusing load
+ * for the same document three more times, and would then report as
+ * permanently unserved a variant that was merely unreachable, which is the
+ * conflation this adapter exists to avoid.
+ */
+const ADDRESS_EXHAUSTED_STATUSES = [404, 406, 410, 415] as const;
+
 type ManifestationRead =
   | { type: "document"; html: string }
-  | { type: "unusable"; status: number };
+  | { type: "address-exhausted"; status: number }
+  | { type: "fetch-failed"; status: number };
 
 type ReadDocumentOptions = {
   url: string;
@@ -634,7 +647,11 @@ const readDocumentResponse = async ({
   });
 
   if (!response.ok) {
-    return { type: "unusable", status: response.status };
+    return ADDRESS_EXHAUSTED_STATUSES.some(
+      (status) => status === response.status,
+    )
+      ? { type: "address-exhausted", status: response.status }
+      : { type: "fetch-failed", status: response.status };
   }
 
   const mediaType = mediaTypeOf(response.headers.get("content-type") ?? "");
@@ -646,16 +663,29 @@ const readDocumentResponse = async ({
       mediaType,
       url,
     });
-    return { type: "unusable", status: response.status };
+    return { type: "address-exhausted", status: response.status };
   }
 
   const html = await response.text();
   return html.length > MIN_DOCUMENT_LENGTH
     ? { type: "document", html }
-    : { type: "unusable", status: response.status };
+    : { type: "address-exhausted", status: response.status };
 };
 
 type ManifestationAddress = { url: string; accept: string | undefined };
+
+/**
+ * The document and the address that actually served it, which is not always
+ * the one the manifestation is named by: an item-only manifestation answers
+ * 404 at its own URL, so persisting that as the decision's `documentUrl`
+ * would publish a dead link.
+ */
+type ManifestationDocument = { html: string; url: string };
+
+type ManifestationLookup =
+  | ({ type: "document" } & ManifestationDocument)
+  | { type: "exhausted"; statuses: number[] }
+  | { type: "failed"; status: number; url: string };
 
 type ReadFirstServedOptions = {
   addresses: ManifestationAddress[];
@@ -680,10 +710,10 @@ const readFirstServedAddress = async ({
   celex,
   lang,
   signal,
-}: ReadFirstServedOptions): Promise<string | undefined> => {
+}: ReadFirstServedOptions): Promise<ManifestationLookup> => {
   const [address, ...rest] = addresses;
   if (address === undefined) {
-    return undefined;
+    return { type: "exhausted", statuses };
   }
 
   const read = await readDocumentResponse({
@@ -694,7 +724,10 @@ const readFirstServedAddress = async ({
     signal,
   });
   if (read.type === "document") {
-    return read.html;
+    return { type: "document", html: read.html, url: address.url };
+  }
+  if (read.type === "fetch-failed") {
+    return { type: "failed", status: read.status, url: address.url };
   }
 
   statuses.push(read.status);
@@ -712,10 +745,9 @@ const fetchManifestation = async ({
   celex,
   lang,
   signal,
-}: FetchManifestationOptions): Promise<string | undefined> => {
+}: FetchManifestationOptions): Promise<ManifestationDocument | undefined> => {
   try {
-    const statuses: number[] = [];
-    const html = await readFirstServedAddress({
+    const lookup = await readFirstServedAddress({
       addresses: [
         { url: contentUrl, accept: XHTML_MEDIA_TYPE },
         ...Array.from(
@@ -726,28 +758,46 @@ const fetchManifestation = async ({
           }),
         ),
       ],
-      statuses,
+      statuses: [],
       celex,
       lang,
       signal,
     });
-    if (html !== undefined) {
-      return html;
-    }
 
-    // A variant the listing named and no address on the content stream serves
-    // is reported unavailable, and the reconciliation loop retires it after
-    // its retry schedule. Saying so keeps a transport fault distinguishable
-    // from a translation the publisher never published; the statuses say which
-    // of the two addressing schemes refused it.
-    logger.warn("case_law.ingestion.manifestation_unavailable", {
-      adapterKey: ADAPTER_KEYS.EU_ECJ,
-      celex,
-      language: lang,
-      httpStatuses: statuses.join(","),
-      url: contentUrl,
-    });
-    return undefined;
+    switch (lookup.type) {
+      case "document":
+        return { html: lookup.html, url: lookup.url };
+      case "failed":
+        // The publisher could not answer for this variant, which says nothing
+        // about whether it holds it. Reported apart from the unavailable case
+        // so a throttle or an outage cannot be read as a translation that was
+        // never published.
+        logger.warn("case_law.ingestion.manifestation_fetch_failed", {
+          adapterKey: ADAPTER_KEYS.EU_ECJ,
+          celex,
+          language: lang,
+          httpStatus: lookup.status,
+          url: lookup.url,
+        });
+        return undefined;
+      case "exhausted":
+        // A variant the listing named and no address on the content stream
+        // serves is reported unavailable, and the reconciliation loop retires
+        // it after its retry schedule. The statuses say which of the two
+        // addressing schemes refused it.
+        logger.warn("case_law.ingestion.manifestation_unavailable", {
+          adapterKey: ADAPTER_KEYS.EU_ECJ,
+          celex,
+          language: lang,
+          httpStatuses: lookup.statuses.join(","),
+          url: contentUrl,
+        });
+        return undefined;
+      default: {
+        const exhaustive: never = lookup;
+        return exhaustive;
+      }
+    }
   } catch (error) {
     // AbortErrors are expected (timeout, page cancellation)
     if (!(error instanceof DOMException)) {
@@ -1167,7 +1217,7 @@ export const buildDecision = async (
   // Fetch the language-specific XHTML stream from Cellar. The
   // human-facing EUR-Lex HTML endpoint is WAF-protected and may return
   // a challenge instead of document content to server-side callers.
-  const html = await fetchManifestation({
+  const served = await fetchManifestation({
     contentUrl: documentUrl,
     celex,
     lang,
@@ -1177,7 +1227,7 @@ export const buildDecision = async (
     ]),
   });
 
-  if (!html) {
+  if (!served) {
     return undefined;
   }
 
@@ -1189,8 +1239,10 @@ export const buildDecision = async (
     decisionType,
     language: ecjRowLanguage(lang),
     sourceUrl: eurLexSourceUrl(lang, celex),
-    documentUrl,
-    html,
+    // The address that answered, not the one the manifestation is named by:
+    // an item-only manifestation answers 404 at its own URL.
+    documentUrl: served.url,
+    html: served.html,
     metadata: {
       manifestationUri: binding.manifestation.value,
       languageUri: binding.language.value,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -605,7 +605,21 @@ const mediaTypeOf = (contentType: string): string =>
  * conflation this adapter exists to avoid.
  */
 const ADDRESS_EXHAUSTED_STATUSES = [404, 406, 410, 415] as const;
-const INVALID_DOCUMENT_REQUEST_STATUS = 400;
+
+/**
+ * Statuses worth holding the page's cursor for.
+ *
+ * A timeout, a throttle or a server fault is the publisher failing to answer,
+ * and the identical request can succeed later. Every other refusal is this
+ * request being rejected on its merits, and since `fetchPage` walks a day's
+ * variants with no per-variant catch, propagating one would hold the date
+ * cursor on that variant for good. 401 and 403 pin the crawl exactly as 400
+ * would, so the split is on retryability rather than on a single status.
+ */
+const RETRYABLE_STATUSES = [408, 429] as const;
+
+const isRetryableStatus = (status: number): boolean =>
+  status >= 500 || RETRYABLE_STATUSES.some((retryable) => retryable === status);
 
 type ManifestationRead =
   | { type: "document"; html: string }
@@ -769,7 +783,7 @@ const fetchManifestation = async ({
       case "document":
         return { html: lookup.html, url: lookup.url };
       case "failed":
-        if (lookup.status === INVALID_DOCUMENT_REQUEST_STATUS) {
+        if (!isRetryableStatus(lookup.status)) {
           // A deterministic bad document request must not pin the crawl's
           // date cursor and prevent every later decision from being fetched.
           logger.warn("case_law.ingestion.manifestation_rejected", {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -84,7 +84,7 @@
     "files": {}
   },
   "throw-outside-boundary": {
-    "count": 878,
+    "count": 879,
     "files": {
       "apps/api/src/handlers/case-law/corpus-index.ts": 12,
       "apps/api/src/handlers/case-law/decisions/latest.ts": 3,
@@ -95,7 +95,7 @@
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts": 4,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts": 9,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts": 11,
-      "apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts": 5,
+      "apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts": 6,
       "apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts": 4,
       "apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts": 5,
       "apps/api/src/handlers/case-law/ingestion/adapters/publisher-request-gate.ts": 2,
@@ -1122,21 +1122,8 @@
     }
   },
   "duplicate-token-blocks": {
-    "count": 129,
+    "count": 111,
     "files": {
-      ".oxlint-plugins/no-ambient-nondeterminism.ts": 1,
-      ".oxlint-plugins/no-auth-token-in-web-storage.ts": 1,
-      ".oxlint-plugins/no-native-s3-object-read.ts": 1,
-      ".oxlint-plugins/no-native-s3-object-write.ts": 1,
-      ".oxlint-plugins/no-object-url-leak.ts": 1,
-      ".oxlint-plugins/require-cn-for-classname-composition.ts": 2,
-      ".oxlint-plugins/require-custom-jsonb-column.ts": 2,
-      ".oxlint-plugins/require-query-signal.ts": 1,
-      ".oxlint-plugins/require-safe-window-open.ts": 2,
-      ".oxlint-plugins/require-stable-snapshot.ts": 1,
-      ".oxlint-plugins/require-stream-reader-disposal.ts": 2,
-      ".oxlint-plugins/require-timestamptz-column.ts": 2,
-      ".oxlint-plugins/require-use-shallow.ts": 1,
       "apps/api/scripts/seed-dev.ts": 2,
       "apps/api/scripts/seed-templates.ts": 2,
       "apps/api/src/db/schema.ts": 1,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -1122,8 +1122,21 @@
     }
   },
   "duplicate-token-blocks": {
-    "count": 111,
+    "count": 129,
     "files": {
+      ".oxlint-plugins/no-ambient-nondeterminism.ts": 1,
+      ".oxlint-plugins/no-auth-token-in-web-storage.ts": 1,
+      ".oxlint-plugins/no-native-s3-object-read.ts": 1,
+      ".oxlint-plugins/no-native-s3-object-write.ts": 1,
+      ".oxlint-plugins/no-object-url-leak.ts": 1,
+      ".oxlint-plugins/require-cn-for-classname-composition.ts": 2,
+      ".oxlint-plugins/require-custom-jsonb-column.ts": 2,
+      ".oxlint-plugins/require-query-signal.ts": 1,
+      ".oxlint-plugins/require-safe-window-open.ts": 2,
+      ".oxlint-plugins/require-stable-snapshot.ts": 1,
+      ".oxlint-plugins/require-stream-reader-disposal.ts": 2,
+      ".oxlint-plugins/require-timestamptz-column.ts": 2,
+      ".oxlint-plugins/require-use-shallow.ts": 1,
       "apps/api/scripts/seed-dev.ts": 2,
       "apps/api/scripts/seed-templates.ts": 2,
       "apps/api/src/db/schema.ts": 1,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -84,7 +84,7 @@
     "files": {}
   },
   "throw-outside-boundary": {
-    "count": 879,
+    "count": 878,
     "files": {
       "apps/api/src/handlers/case-law/corpus-index.ts": 12,
       "apps/api/src/handlers/case-law/decisions/latest.ts": 3,
@@ -95,7 +95,7 @@
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts": 4,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts": 9,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts": 11,
-      "apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts": 6,
+      "apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts": 5,
       "apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts": 4,
       "apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts": 5,
       "apps/api/src/handlers/case-law/ingestion/adapters/publisher-request-gate.ts": 2,


### PR DESCRIPTION
Some CJEU manifestations return 404 when requested with XHTML content negotiation, although a numbered item serves the document. Try the negotiated manifestation first, then `DOC_1` through `DOC_3` sequentially without an `Accept` header. Validate each response's media type and persist the URL that served the document.

Only address-specific refusal statuses (404, 406, 410, 415) advance the probe. Other permanent refusals end at the document so the date crawl can continue. Timeouts, throttling, and server failures propagate; internal manifestation handling uses typed `Result` values. The lookup timeout derives from the maximum number of requests. The three-item cap is a bounded heuristic based on observed manifestations, not an upstream guarantee.

The existing reconciliation census owns recovery for skipped variants: it re-lists year/month slices independently of the date cursor, compares CELEX/language identities against stored decisions, and durably parks missing variants. Recovery follows that persisted sweep and recheck schedule.

Regression coverage includes successful item URLs, retryable HTTP statuses at multiple probe positions, and page-level continuation after permanent refusals. Mutation checks verified the URL/error regressions against the earlier implementation and proved the permanent-refusal crawl test fails without its correction. All 71 adapter tests, focused type-aware lint, and the 65-metric ratchet check pass. Ratchet baselines are unchanged from main. Current-head CI is green, including code quality, type checks, database suites, builds, browser tests, and the required `ci-result`. All review threads are resolved.
