### PR TITLE
fix(desktop): clipboard window keeps the previous app focused

### DIFF
--- a/apps/desktop/src-tauri/crates/macos-park/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/macos-park/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stella-desktop-macos"
 version = "0.0.1"
 edition = "2024"
-description = "Safe wrappers over the raw AppKit/WebKit calls behind clipboard window parking"
+description = "Safe wrappers over the raw AppKit/WebKit calls behind the clipboard window"
 license = "Apache-2.0"
 publish = false
 
@@ -20,6 +20,8 @@ tauri = "2"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = [
+  "NSApplication",
+  "NSPanel",
   "NSResponder",
   "NSWindow",
 ] }

--- a/apps/desktop/src-tauri/crates/macos-park/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/macos-park/src/lib.rs
@@ -1,12 +1,13 @@
-//! Safe wrappers over the raw AppKit/WebKit calls behind clipboard window
-//! parking. The desktop crate forbids `unsafe` code, so the pointer derefs
-//! and the private-selector call live here behind a minimal API that owns
-//! their soundness (pointers are obtained from live Tauri windows, and the
-//! main thread is verified before any AppKit call).
+//! Safe wrappers over the raw AppKit/WebKit calls behind the clipboard window:
+//! presenting it as a non-activating panel and parking it. The desktop crate
+//! forbids `unsafe` code, so the class swap, pointer derefs and the
+//! private-selector call live here behind a minimal API that owns their
+//! soundness (pointers are obtained from live Tauri windows, and the main
+//! thread is verified before any AppKit call).
 //!
 //! Everything is a no-op off macOS; the crate is empty there.
 
 #[cfg(target_os = "macos")]
 mod park;
 #[cfg(target_os = "macos")]
-pub use park::{disable_occlusion_detection, set_window_parked};
+pub use park::{disable_occlusion_detection, park_window, present_key_panel};

--- a/apps/desktop/src-tauri/crates/macos-park/src/park.rs
+++ b/apps/desktop/src-tauri/crates/macos-park/src/park.rs
@@ -1,27 +1,116 @@
-use objc2::MainThreadMarker;
-use objc2::runtime::AnyObject;
-use objc2::{msg_send, sel};
-use objc2_app_kit::NSWindow;
+use objc2::runtime::{AnyObject, NSObjectProtocol};
+use objc2::{ClassType, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+use objc2_app_kit::{NSApplication, NSPanel, NSWindow, NSWindowStyleMask};
 use tauri::{Runtime, WebviewWindow};
 
-/// Makes the window fully transparent and click-through (parked) or restores
-/// it. Returns false when the change could not be applied (not on the main
-/// thread, or no window handle); the caller then falls back to hiding.
-pub fn set_window_parked<R: Runtime>(window: &WebviewWindow<R>, parked: bool) -> bool {
-  if MainThreadMarker::new().is_none() {
-    return false;
+define_class!(
+  /// Class the clipboard window is re-classed to once it exists. A
+  /// non-activating panel takes key status without activating the app: the app
+  /// the user was working in stays frontmost, keeps its menu bar, and regains
+  /// its caret the moment the panel gives key status back.
+  // SAFETY: NSPanel has no subclassing requirements beyond NSWindow's, and the
+  // struct does not implement Drop.
+  #[unsafe(super(NSPanel))]
+  #[thread_kind = MainThreadOnly]
+  #[name = "StellaClipboardPanel"]
+  struct ClipboardPanel;
+
+  impl ClipboardPanel {
+    // Re-classing drops tao's override of these; without it a borderless
+    // window refuses key status.
+    #[unsafe(method(canBecomeKeyWindow))]
+    fn can_become_key_window(&self) -> bool {
+      true
+    }
+
+    #[unsafe(method(canBecomeMainWindow))]
+    fn can_become_main_window(&self) -> bool {
+      false
+    }
   }
-  let Ok(ns_window) = window.ns_window() else {
-    return false;
-  };
+);
+
+fn ns_window<R: Runtime>(
+  window: &WebviewWindow<R>,
+) -> Option<(MainThreadMarker, &NSWindow)> {
+  let main_thread = MainThreadMarker::new()?;
+  let ns_window = window.ns_window().ok()?;
   if ns_window.is_null() {
-    return false;
+    return None;
   }
   // SAFETY: `ns_window` returns a valid pointer to the live window's NSWindow
   // and the main thread was verified above.
-  let ns_window = unsafe { &*ns_window.cast::<NSWindow>() };
-  ns_window.setAlphaValue(if parked { 0.0 } else { 1.0 });
-  ns_window.setIgnoresMouseEvents(parked);
+  Some((main_thread, unsafe { &*ns_window.cast::<NSWindow>() }))
+}
+
+fn make_nonactivating_panel(ns_window: &NSWindow) {
+  let panel_class = ClipboardPanel::class();
+  if ns_window.class() == panel_class {
+    return;
+  }
+  // SAFETY: NSPanel adds no instance variables to NSWindow, so the window's
+  // existing allocation covers the new class. tao's `focusable` ivar becomes
+  // unreachable; its only reader is `set_focusable`, which nothing calls on
+  // this window.
+  unsafe { AnyObject::set_class(ns_window, panel_class) };
+  ns_window.setStyleMask(ns_window.styleMask() | NSWindowStyleMask::NonactivatingPanel);
+  // The mask alone does not update the window server's prevents-activation
+  // state on a window that already exists: keyboard use would stay
+  // non-activating, but a click inside the panel would activate the app and
+  // dismissal would then leave it frontmost. Private AppKit setter, hence the
+  // `respondsToSelector` guard; an AppKit without it keeps the click caveat.
+  let selector = sel!(_setPreventsActivation:);
+  if ns_window.respondsToSelector(selector) {
+    // SAFETY: the instance responds to the selector, which takes one BOOL.
+    unsafe {
+      let () = msg_send![ns_window, _setPreventsActivation: true];
+    }
+  }
+  // Panels hide when their app deactivates by default, which would defeat
+  // parking every time key status moves back to the previous app.
+  ns_window.setHidesOnDeactivate(false);
+}
+
+/// Shows the window as the key window without activating the app (so the app
+/// underneath stays frontmost), restoring it from a park first. Re-classes it
+/// into a non-activating panel on first use. Returns false when the change
+/// could not be applied (not on the main thread, or no window handle); the
+/// caller then falls back to an activating show.
+pub fn present_key_panel<R: Runtime>(window: &WebviewWindow<R>) -> bool {
+  let Some((main_thread, ns_window)) = ns_window(window) else {
+    return false;
+  };
+  make_nonactivating_panel(ns_window);
+  ns_window.setAlphaValue(1.0);
+  ns_window.setIgnoresMouseEvents(false);
+  // Cmd-H from an activating window (settings) hides the whole app, and
+  // ordering a window front does not clear that.
+  let app = NSApplication::sharedApplication(main_thread);
+  if app.isHidden() {
+    app.unhideWithoutActivation();
+  }
+  ns_window.makeKeyAndOrderFront(None);
+  true
+}
+
+/// Parks the window: fully transparent, click-through, and no longer key, so
+/// the app underneath gets its caret back. The window stays ordered in and
+/// WebKit keeps the page warm. Returns false when the change could not be
+/// applied (not on the main thread, or no window handle); the caller then
+/// falls back to hiding.
+pub fn park_window<R: Runtime>(window: &WebviewWindow<R>) -> bool {
+  let Some((_, ns_window)) = ns_window(window) else {
+    return false;
+  };
+  ns_window.setAlphaValue(0.0);
+  ns_window.setIgnoresMouseEvents(true);
+  // Ordering out is the only public way to give key status back. Ordering
+  // straight back in keeps the page on screen; WebKit coalesces the two into
+  // no visibility change.
+  if ns_window.isKeyWindow() {
+    ns_window.orderOut(None);
+    ns_window.orderFront(None);
+  }
   true
 }
 

--- a/apps/desktop/src-tauri/src/clipboard_window.rs
+++ b/apps/desktop/src-tauri/src/clipboard_window.rs
@@ -20,44 +20,25 @@ const CLIPBOARD_WINDOW_HEIGHT: f64 = 326.0;
 const CLIPBOARD_WINDOW_INSET: f64 = 18.0;
 const CLIPBOARD_WINDOW_RADIUS: f64 = 28.0;
 
-/// Whether the clipboard window is parked and which app held focus before the
-/// window last took it. Parking keeps the window on screen fully transparent
-/// and click-through instead of ordering it out: WebKit reclaims a hidden
-/// page's graphics caches within seconds and its compiled JS within minutes,
-/// which made the next open after an idle spell paint its content 200-600ms
-/// late. A parked page stays warm, so reopening paints immediately.
+/// Whether the clipboard window is parked. Parking keeps the window on screen
+/// fully transparent and click-through instead of ordering it out: WebKit
+/// reclaims a hidden page's graphics caches within seconds and its compiled JS
+/// within minutes, which made the next open after an idle spell paint its
+/// content 200-600ms late. A parked page stays warm, so reopening paints
+/// immediately.
 #[derive(Default)]
-pub struct ClipboardWindowPark(Mutex<ParkState>);
-
-#[derive(Default)]
-struct ParkState {
-  parked: bool,
-  #[cfg(target_os = "macos")]
-  previous_app_pid: Option<i32>,
-}
+pub struct ClipboardWindowPark(Mutex<bool>);
 
 impl ClipboardWindowPark {
   fn is_parked(&self) -> bool {
-    self.0.lock().map(|state| state.parked).unwrap_or(false)
+    self.0.lock().map(|parked| *parked).unwrap_or(false)
   }
 
   #[cfg(target_os = "macos")]
   fn set_parked(&self, parked: bool) {
     if let Ok(mut state) = self.0.lock() {
-      state.parked = parked;
+      *state = parked;
     }
-  }
-
-  #[cfg(target_os = "macos")]
-  fn remember_previous_app(&self, pid: i32) {
-    if let Ok(mut state) = self.0.lock() {
-      state.previous_app_pid = Some(pid);
-    }
-  }
-
-  #[cfg(target_os = "macos")]
-  fn previous_app_pid(&self) -> Option<i32> {
-    self.0.lock().ok().and_then(|state| state.previous_app_pid)
   }
 }
 
@@ -248,115 +229,78 @@ fn position_window(app: &AppHandle, window: &WebviewWindow) {
   let _ = window.set_position(LogicalPosition::new(x, y));
 }
 
+/// Runs `f` on the main thread and waits for its result; `default` when the
+/// event loop is gone or does not answer in time.
 #[cfg(target_os = "macos")]
-fn remember_previous_app(app: &AppHandle) {
-  use objc2::MainThreadMarker;
-  use objc2_app_kit::NSWorkspace;
-
-  if MainThreadMarker::new().is_none() {
-    let handle = app.clone();
-    let _ = app.run_on_main_thread(move || remember_previous_app(&handle));
-    return;
-  }
-  let Some(park) = app.try_state::<ClipboardWindowPark>() else {
-    return;
-  };
-  let Some(frontmost) = NSWorkspace::sharedWorkspace().frontmostApplication() else {
-    return;
-  };
-  let pid = frontmost.processIdentifier();
-  // Reopening while the window already holds focus keeps the earlier target.
-  if pid != std::process::id() as i32 {
-    park.remember_previous_app(pid);
-  }
-}
-
-#[cfg(target_os = "macos")]
-enum ParkFocusHandoff {
-  /// The window holds focus (Escape, copy): hand it back to the app that had
-  /// it before the window opened, or fall back to a real hide.
-  PreviousApp,
-  /// Focus already moved elsewhere (hide on blur): leave activation alone.
-  None,
-}
-
-/// Parks the window instead of hiding it. Returns false when parking is not
-/// possible (no main thread, no window handle, no app to hand focus to); the
-/// caller then falls back to ordering the window out.
-#[cfg(target_os = "macos")]
-fn park_window(window: &WebviewWindow, handoff: ParkFocusHandoff) -> bool {
+fn on_main_thread<T: Send + 'static>(
+  window: &WebviewWindow,
+  default: T,
+  f: impl FnOnce(&WebviewWindow) -> T + Send + 'static,
+) -> T {
   use objc2::MainThreadMarker;
 
   if MainThreadMarker::new().is_some() {
-    return park_window_on_main(window, handoff);
+    return f(window);
   }
   let (sender, receiver) = std::sync::mpsc::sync_channel(1);
   let cloned = window.clone();
   if window
     .app_handle()
     .run_on_main_thread(move || {
-      let _ = sender.send(park_window_on_main(&cloned, handoff));
+      let _ = sender.send(f(&cloned));
     })
     .is_err()
   {
-    return false;
+    return default;
   }
   receiver
     .recv_timeout(Duration::from_secs(1))
-    .unwrap_or(false)
+    .unwrap_or(default)
 }
 
-// `ActivateIgnoringOtherApps` is a no-op on macOS 14+ (activation from the
-// active app is already cooperative there) but required before it.
-#[allow(deprecated)]
+/// Shows the window as the key window without activating the app: the app the
+/// user was working in stays frontmost and gets its caret back on dismissal.
+/// Falls back to an activating show when the panel cannot be presented.
 #[cfg(target_os = "macos")]
-fn park_window_on_main(window: &WebviewWindow, handoff: ParkFocusHandoff) -> bool {
-  use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
-
-  let app = window.app_handle();
-  let Some(park) = app.try_state::<ClipboardWindowPark>() else {
-    return false;
-  };
-  if park.is_parked() {
-    return true;
+fn present(window: &WebviewWindow) -> tauri::Result<()> {
+  let presented = on_main_thread(window, false, |window| {
+    let presented = stella_desktop_macos::present_key_panel(window);
+    if presented
+      && let Some(park) = window.app_handle().try_state::<ClipboardWindowPark>()
+    {
+      park.set_parked(false);
+    }
+    presented
+  });
+  if presented {
+    return Ok(());
   }
-  if let ParkFocusHandoff::PreviousApp = handoff {
-    let activated = park
-      .previous_app_pid()
-      .and_then(NSRunningApplication::runningApplicationWithProcessIdentifier)
-      .is_some_and(|previous| {
-        previous.activateWithOptions(
-          NSApplicationActivationOptions::ActivateIgnoringOtherApps,
-        )
-      });
-    if !activated {
+  window.show().and_then(|()| window.set_focus())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn present(window: &WebviewWindow) -> tauri::Result<()> {
+  window.show().and_then(|()| window.set_focus())
+}
+
+/// Parks the window instead of hiding it. Returns false when parking is not
+/// possible (no main thread, no window handle); the caller then falls back to
+/// ordering the window out.
+#[cfg(target_os = "macos")]
+fn park(window: &WebviewWindow) -> bool {
+  on_main_thread(window, false, |window| {
+    let Some(park) = window.app_handle().try_state::<ClipboardWindowPark>() else {
+      return false;
+    };
+    if park.is_parked() {
+      return true;
+    }
+    if !stella_desktop_macos::park_window(window) {
       return false;
     }
-  }
-  if !stella_desktop_macos::set_window_parked(window, true) {
-    return false;
-  }
-  park.set_parked(true);
-  true
-}
-
-#[cfg(target_os = "macos")]
-fn unpark_window(window: &WebviewWindow) {
-  use objc2::MainThreadMarker;
-
-  if MainThreadMarker::new().is_none() {
-    let cloned = window.clone();
-    let _ = window
-      .app_handle()
-      .run_on_main_thread(move || unpark_window(&cloned));
-    return;
-  }
-  if !stella_desktop_macos::set_window_parked(window, false) {
-    return;
-  }
-  if let Some(park) = window.app_handle().try_state::<ClipboardWindowPark>() {
-    park.set_parked(false);
-  }
+    park.set_parked(true);
+    true
+  })
 }
 
 pub fn show(app: &AppHandle) {
@@ -371,17 +315,10 @@ pub fn show_on_launch(app: &AppHandle) {
 /// existing window is always a reopen.
 fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
   let requested = Instant::now();
-  #[cfg(target_os = "macos")]
-  {
-    let _ = app.show();
-    remember_previous_app(app);
-  }
 
   if let Some(window) = app.get_webview_window(CLIPBOARD_WINDOW_LABEL) {
     position_window(app, &window);
-    #[cfg(target_os = "macos")]
-    unpark_window(&window);
-    if window.show().and_then(|()| window.set_focus()).is_err() {
+    if present(&window).is_err() {
       capture_window_error(
         app,
         DesktopTelemetryOperation::ClipboardWindowOpen,
@@ -442,7 +379,7 @@ fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
     }
     let app = window.app_handle();
     position_window(app, &window);
-    if window.show().and_then(|()| window.set_focus()).is_err() {
+    if present(&window).is_err() {
       capture_window_error(
         app,
         DesktopTelemetryOperation::ClipboardWindowOpen,
@@ -479,7 +416,7 @@ fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
       let window_to_hide = window.clone();
       window.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Focused(false))
-          && hide_on_blur(&window_to_hide).is_err()
+          && hide(&window_to_hide).is_err()
         {
           capture_window_error(
             window_to_hide.app_handle(),
@@ -488,7 +425,6 @@ fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
           );
         }
       });
-      let _ = window.set_focus();
     }
     Err(error) => {
       tracing::error!(error = %error, "clipboard window could not be created");
@@ -521,21 +457,13 @@ pub fn toggle(app: &AppHandle) {
   show(app);
 }
 
-/// Dismissal while the window holds focus: park it and hand focus back to the
-/// previously focused app, or order it out when that is not possible.
+/// Parks the window, which also gives key status back to the app underneath,
+/// or orders it out when parking is not possible. Serves both an explicit
+/// dismissal (Escape, copy) and the hide on blur: whatever the user focused
+/// instead keeps it either way.
 pub fn hide(window: &WebviewWindow) -> Result<(), String> {
   #[cfg(target_os = "macos")]
-  if park_window(window, ParkFocusHandoff::PreviousApp) {
-    return Ok(());
-  }
-  order_out(window)
-}
-
-/// Hide after the window lost focus on its own: whatever the user focused
-/// keeps it, so parking must not re-activate the previously focused app.
-fn hide_on_blur(window: &WebviewWindow) -> Result<(), String> {
-  #[cfg(target_os = "macos")]
-  if park_window(window, ParkFocusHandoff::None) {
+  if park(window) {
     return Ok(());
   }
   order_out(window)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -141,9 +141,8 @@ pub fn run() {
         }
       }
 
-      // Paste uses the same default activation shortcut. Registration is
-      // intentionally non-fatal so users can open the timeline from the tray
-      // while another clipboard manager still owns the shortcut.
+      // Registration is intentionally non-fatal: the shortcut may already be
+      // taken, and the timeline stays reachable from the tray.
       {
         use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
         if let Err(error) = app.global_shortcut().on_shortcut(


### PR DESCRIPTION
## Summary

Opening the clipboard window activated the desktop process, so the app the user was working in lost focus, and reactivating it on dismissal did not reliably restore the caret.

The window is now presented as a non-activating panel: it takes key status without activating the app, so the previous app stays frontmost with its menu bar and gets its caret back as soon as the window parks.

- `crates/macos-park`: re-classes the Tauri window into an `NSPanel` subclass on first show (NSPanel adds no instance variables), adds the non-activating style mask, presents with `makeKeyAndOrderFront`. Parking also releases key status via a same-tick orderOut/orderFront, so the page stays on screen and warm.
- `clipboard_window.rs`: drops the previous-app PID tracking, the activation hand-back and the separate hide-on-blur path; one `hide` serves Escape, copy and blur.

Windows and Linux keep the activating show.
