### PR TITLE
fix(api): the CJEU lookup switch panics on an impossible state

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -830,8 +830,8 @@ const fetchManifestation = async ({
       });
       return Result.ok(undefined);
     default: {
-      const exhaustive: never = lookup;
-      return exhaustive;
+      lookup satisfies never;
+      return panic(`Unhandled lookup: ${String(lookup)}`);
     }
   }
 };


### PR DESCRIPTION
A `never` binding merged after the exhaustiveness rule landed, so main fails the rule on `eu-ecj.ts` for any PR that lints it. The site now asserts with `satisfies never` and panics, as every other exhaustive switch does. Adapter tests pass. A merge-bar change in #2970 makes a rule-changing PR require currency with its base so this merge-order hole cannot recur.