### PR TITLE
feat(desktop): keep table layout, alignment, rules and highlights in clipboard HTML

### DIFF
--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -2221,6 +2221,7 @@ const MAX_TABLE_SPAN: u32 = 20;
 /// Rules thicker than this are decoration, not a signature line.
 const MAX_RULE_WIDTH_PT: f32 = 6.0;
 const MAX_CELL_WIDTH_PT: f32 = 800.0;
+const HIGHLIGHT_BACKGROUND: &str = "var(--highlight, #fef08a)";
 
 fn sanitized_html(raw_html: &str) -> Option<String> {
   if raw_html.len() > MAX_ITEM_HTML_BYTES {
@@ -2326,13 +2327,13 @@ fn without_table_gaps(html: &str) -> String {
 /// Attribute values are re-emitted from parsed tokens, never passed through, so
 /// the webview only ever sees the vocabulary below.
 fn sanitized_attribute<'value>(
-  _element: &str,
+  element: &str,
   attribute: &str,
   value: &'value str,
 ) -> Option<Cow<'value, str>> {
   let value = value.trim();
   match attribute {
-    "style" => sanitized_style(value).map(Cow::Owned),
+    "style" => sanitized_style(element, value).map(Cow::Owned),
     "colspan" | "rowspan" => value
       .parse::<u32>()
       .ok()
@@ -2355,7 +2356,7 @@ fn sanitized_attribute<'value>(
 /// widths, rules, highlight) and drops typography, spacing and everything
 /// application-specific, so cards keep the app's type and theme. Colours are
 /// replaced by theme tokens rather than copied.
-fn sanitized_style(style: &str) -> Option<String> {
+fn sanitized_style(element: &str, style: &str) -> Option<String> {
   let mut declarations = Vec::new();
   for declaration in style.split(';') {
     let Some((property, value)) = declaration.split_once(':') else {
@@ -2373,19 +2374,20 @@ fn sanitized_style(style: &str) -> Option<String> {
         matches!(value.as_str(), "top" | "middle" | "bottom" | "baseline")
           .then(|| format!("vertical-align: {value}"))
       }
-      "white-space" => matches!(
-        value.as_str(),
-        "normal" | "nowrap" | "pre" | "pre-wrap" | "pre-line"
-      )
-      .then(|| format!("white-space: {value}")),
       "border-top" | "border-bottom" => {
         sanitized_rule(&value).map(|(width, line_style)| {
           format!("{property}: {width}pt {line_style} currentColor")
         })
       }
-      "width" => sanitized_width(&value).map(|width| format!("width: {width}")),
+      // Only cells keep a width: a table width would override the full-width
+      // layout and clip columns in the card.
+      "width" if matches!(element, "td" | "th") => {
+        sanitized_width(&value).map(|width| format!("width: {width}"))
+      }
+      // The theme token styles cards; the fallback keeps the highlight when
+      // the HTML is pasted into another application.
       "background" | "background-color" => {
-        is_plain_color(&value).then(|| "background: var(--highlight)".to_string())
+        is_plain_color(&value).then(|| format!("background: {HIGHLIGHT_BACKGROUND}"))
       }
       _ => None,
     };
@@ -3938,7 +3940,7 @@ mod tests {
       "{html}"
     );
     assert!(
-      html.contains(r#"<p align="right" style="text-align: right"><b><span style="background: var(--highlight)">Název strany A</span></b></p>"#),
+      html.contains(r#"<p align="right" style="text-align: right"><b><span style="background: var(--highlight, #fef08a)">Název strany A</span></b></p>"#),
       "{html}"
     );
     assert!(
@@ -3964,20 +3966,21 @@ mod tests {
   #[test]
   fn sanitizer_re_emits_styles_from_an_allow_list_only() {
     let html = sanitized_html(
-      r#"<table><tr><td colspan="9999" rowspan="abc" style="background:url(javascript:alert(1));text-align:RIGHT;position:fixed;width:120%;border-bottom:solid red 40pt;white-space:nowrap">x</td></tr></table>"#,
+      r#"<table style="width:800pt"><tr><td colspan="9999" rowspan="abc" style="background:url(javascript:alert(1));text-align:RIGHT;position:fixed;width:120%;border-bottom:solid red 40pt;white-space:nowrap">x</td></tr></table>"#,
     )
     .unwrap();
 
     assert_eq!(
       html,
-      r#"<table><tbody><tr><td style="text-align: right; border-bottom: 6pt solid currentColor; white-space: nowrap">x</td></tr></tbody></table>"#
+      r#"<table><tbody><tr><td style="text-align: right; border-bottom: 6pt solid currentColor">x</td></tr></tbody></table>"#
     );
-    assert_eq!(sanitized_style("color:red;font-family:Aptos"), None);
+    assert_eq!(sanitized_style("span", "color:red;font-family:Aptos"), None);
     assert_eq!(
-      sanitized_style("width:98.3pt;background:#FFFF00").as_deref(),
-      Some("width: 98.3pt; background: var(--highlight)")
+      sanitized_style("td", "width:98.3pt;background:#FFFF00").as_deref(),
+      Some("width: 98.3pt; background: var(--highlight, #fef08a)")
     );
-    assert_eq!(sanitized_style("border-bottom:none;width:-5pt"), None);
+    assert_eq!(sanitized_style("p", "width:98.3pt"), None);
+    assert_eq!(sanitized_style("td", "border-bottom:none;width:-5pt"), None);
     // Alignment alone is worth keeping as formatting.
     assert!(sanitized_html(r#"<p align="center">centred</p>"#).is_some());
     assert!(sanitized_html(r#"<p style="text-align:right">right</p>"#).is_some());

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -15,6 +15,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
+  borrow::Cow,
   collections::{BTreeSet, HashMap, HashSet},
   io::{Cursor, Write},
   net::IpAddr,
@@ -2215,6 +2216,12 @@ fn prune_items_preserving(
   items.len() != original_len
 }
 
+/// Largest `colspan`/`rowspan` kept; anything wider is layout abuse, not a clip.
+const MAX_TABLE_SPAN: u32 = 20;
+/// Rules thicker than this are decoration, not a signature line.
+const MAX_RULE_WIDTH_PT: f32 = 6.0;
+const MAX_CELL_WIDTH_PT: f32 = 800.0;
+
 fn sanitized_html(raw_html: &str) -> Option<String> {
   if raw_html.len() > MAX_ITEM_HTML_BYTES {
     return None;
@@ -2235,14 +2242,37 @@ fn sanitized_html(raw_html: &str) -> Option<String> {
     "span",
     "strike",
     "strong",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
     "u",
     "ul",
   ]);
+  let tag_attributes = HashMap::from([
+    (
+      "td",
+      HashSet::from(["align", "colspan", "rowspan", "valign"]),
+    ),
+    (
+      "th",
+      HashSet::from(["align", "colspan", "rowspan", "valign"]),
+    ),
+    ("tr", HashSet::from(["align", "valign"])),
+    ("p", HashSet::from(["align"])),
+    ("div", HashSet::from(["align"])),
+  ]);
   let html = HtmlSanitizer::new()
     .tags(allowed_tags)
+    .tag_attributes(tag_attributes)
+    .generic_attributes(HashSet::from(["style"]))
+    .attribute_filter(sanitized_attribute)
     .clean(&without_word_list_spacers(raw_html))
     .to_string();
-  let html = collapse_html_whitespace(&html);
+  let html = without_table_gaps(&collapse_html_whitespace(&html));
   let has_formatting = [
     "b",
     "blockquote",
@@ -2254,12 +2284,209 @@ fn sanitized_html(raw_html: &str) -> Option<String> {
     "pre",
     "s",
     "strong",
+    "table",
     "u",
     "ul",
   ]
   .iter()
-  .any(|tag| find_opening_tag(&html, tag).is_some());
+  .any(|tag| find_opening_tag(&html, tag).is_some())
+    || html.contains(" style=\"")
+    || html.contains(" align=\"");
   if has_formatting { Some(html) } else { None }
+}
+
+/// Source whitespace between table structure tags is never rendered; dropping
+/// it keeps the stored markup canonical.
+fn without_table_gaps(html: &str) -> String {
+  const TABLE_TAGS: [&str; 12] = [
+    "<table", "</table>", "<tbody", "</tbody>", "<thead", "</thead>", "<tfoot",
+    "</tfoot>", "<tr", "</tr>", "<td", "</td>",
+  ];
+  let mut output = String::with_capacity(html.len());
+  let mut rest = html;
+  while let Some(space) = rest.find(" <") {
+    let after_space = &rest[space + 1..];
+    let is_table_tag = TABLE_TAGS.iter().any(|tag| {
+      after_space.strip_prefix(tag).is_some_and(|following| {
+        tag.ends_with('>') || following.starts_with(['>', ' '])
+      })
+    }) || after_space.starts_with("<th")
+      && !after_space.starts_with("<thead")
+      || after_space.starts_with("</th>");
+    output.push_str(&rest[..space]);
+    if !is_table_tag {
+      output.push(' ');
+    }
+    rest = after_space;
+  }
+  output.push_str(rest);
+  output
+}
+
+/// Attribute values are re-emitted from parsed tokens, never passed through, so
+/// the webview only ever sees the vocabulary below.
+fn sanitized_attribute<'value>(
+  _element: &str,
+  attribute: &str,
+  value: &'value str,
+) -> Option<Cow<'value, str>> {
+  let value = value.trim();
+  match attribute {
+    "style" => sanitized_style(value).map(Cow::Owned),
+    "colspan" | "rowspan" => value
+      .parse::<u32>()
+      .ok()
+      .filter(|span| (2..=MAX_TABLE_SPAN).contains(span))
+      .map(|span| Cow::Owned(span.to_string())),
+    "align" => {
+      let value = value.to_ascii_lowercase();
+      matches!(value.as_str(), "left" | "right" | "center" | "justify")
+        .then_some(Cow::Owned(value))
+    }
+    "valign" => {
+      let value = value.to_ascii_lowercase();
+      matches!(value.as_str(), "top" | "middle" | "bottom").then_some(Cow::Owned(value))
+    }
+    _ => None,
+  }
+}
+
+/// Keeps the layout a copied block needs to stay legible (alignment, cell
+/// widths, rules, highlight) and drops typography, spacing and everything
+/// application-specific, so cards keep the app's type and theme. Colours are
+/// replaced by theme tokens rather than copied.
+fn sanitized_style(style: &str) -> Option<String> {
+  let mut declarations = Vec::new();
+  for declaration in style.split(';') {
+    let Some((property, value)) = declaration.split_once(':') else {
+      continue;
+    };
+    let property = property.trim().to_ascii_lowercase();
+    let value = value.trim().to_ascii_lowercase();
+    let kept = match property.as_str() {
+      "text-align" => matches!(
+        value.as_str(),
+        "left" | "right" | "center" | "justify" | "start" | "end"
+      )
+      .then(|| format!("text-align: {value}")),
+      "vertical-align" => {
+        matches!(value.as_str(), "top" | "middle" | "bottom" | "baseline")
+          .then(|| format!("vertical-align: {value}"))
+      }
+      "white-space" => matches!(
+        value.as_str(),
+        "normal" | "nowrap" | "pre" | "pre-wrap" | "pre-line"
+      )
+      .then(|| format!("white-space: {value}")),
+      "border-top" | "border-bottom" => {
+        sanitized_rule(&value).map(|(width, line_style)| {
+          format!("{property}: {width}pt {line_style} currentColor")
+        })
+      }
+      "width" => sanitized_width(&value).map(|width| format!("width: {width}")),
+      "background" | "background-color" => {
+        is_plain_color(&value).then(|| "background: var(--highlight)".to_string())
+      }
+      _ => None,
+    };
+    if let Some(kept) = kept {
+      declarations.push(kept);
+    }
+  }
+  (!declarations.is_empty()).then(|| declarations.join("; "))
+}
+
+/// A visible rule: its width in points (capped) and its line style.
+fn sanitized_rule(value: &str) -> Option<(String, &'static str)> {
+  let mut width = None;
+  let mut line_style = None;
+  for token in value.split_whitespace() {
+    match token {
+      "solid" => line_style = Some("solid"),
+      "double" => line_style = Some("double"),
+      "dotted" => line_style = Some("dotted"),
+      "dashed" => line_style = Some("dashed"),
+      _ => {
+        if let Some(points) = length_in_points(token) {
+          width = Some(points.min(MAX_RULE_WIDTH_PT));
+        }
+      }
+    }
+  }
+  let width = width.filter(|width| *width > 0.0)?;
+  Some((format_points(width), line_style?))
+}
+
+fn sanitized_width(value: &str) -> Option<String> {
+  if let Some(percent) = value.strip_suffix('%') {
+    let percent: f32 = percent.trim().parse().ok()?;
+    return (0.0..=100.0)
+      .contains(&percent)
+      .then(|| format!("{}%", format_points(percent)));
+  }
+  let points = length_in_points(value)?;
+  (points > 0.0).then(|| format!("{}pt", format_points(points.min(MAX_CELL_WIDTH_PT))))
+}
+
+/// CSS lengths as points. Negative lengths are Word's sub-point nudges and
+/// count as nothing.
+fn length_in_points(token: &str) -> Option<f32> {
+  let (number, factor) = if let Some(number) = token.strip_suffix("pt") {
+    (number, 1.0)
+  } else if let Some(number) = token.strip_suffix("px") {
+    (number, 0.75)
+  } else if let Some(number) = token.strip_suffix("cm") {
+    (number, 72.0 / 2.54)
+  } else if let Some(number) = token.strip_suffix("mm") {
+    (number, 7.2 / 2.54)
+  } else if let Some(number) = token.strip_suffix("in") {
+    (number, 72.0)
+  } else if let Some(number) = token.strip_suffix("em") {
+    (number, 12.0)
+  } else if token == "0" {
+    ("0", 1.0)
+  } else {
+    return None;
+  };
+  let number: f32 = number.trim().parse().ok()?;
+  number.is_finite().then(|| (number * factor).max(0.0))
+}
+
+fn format_points(value: f32) -> String {
+  let text = format!("{value:.2}");
+  text.trim_end_matches('0').trim_end_matches('.').to_string()
+}
+
+/// A colour literal a highlight can be mapped from: a name, `#hex` or an
+/// `rgb(...)` call. Anything else (`url(...)`, gradients, keywords) is not.
+fn is_plain_color(value: &str) -> bool {
+  if matches!(
+    value,
+    "" | "none"
+      | "transparent"
+      | "inherit"
+      | "initial"
+      | "unset"
+      | "white"
+      | "#fff"
+      | "#ffffff"
+  ) {
+    return false;
+  }
+  if let Some(hex) = value.strip_prefix('#') {
+    return matches!(hex.len(), 3 | 4 | 6 | 8)
+      && hex.chars().all(|c| c.is_ascii_hexdigit());
+  }
+  if let Some(arguments) = value
+    .strip_prefix("rgb(")
+    .or_else(|| value.strip_prefix("rgba("))
+    .and_then(|rest| rest.strip_suffix(')'))
+  {
+    return arguments
+      .chars()
+      .all(|c| c.is_ascii_digit() || matches!(c, ',' | '.' | '%' | ' ' | '/'));
+  }
+  value.chars().all(|c| c.is_ascii_alphabetic())
 }
 
 /// Word separates an auto-numbered list label from its paragraph with a span in
@@ -3670,6 +3897,90 @@ mod tests {
     let html = sanitized_html("<p>a\n\n  b</p>\n<pre>a\n  b</pre>\n").unwrap();
 
     assert_eq!(html, "<p>a b</p> <pre>a\n  b</pre>");
+  }
+
+  /// A Word signature block as Word puts it on the clipboard: a borderless
+  /// table, party headers spanning two cells with a highlight, a signature
+  /// rule drawn as a paragraph border, right-aligned names and values.
+  const WORD_SIGNATURE_TABLE_HTML: &str = concat!(
+    "<table border=0 cellspacing=0 cellpadding=0 style='border-collapse:collapse;",
+    "mso-table-layout-alt:fixed;mso-padding-alt:0cm 5.0pt 0cm 0cm'>\n",
+    " <tr>\n <td colspan=2 style='width:50.0%;padding:0cm 5.0pt 0cm 0cm'>\n",
+    " <p style='margin-bottom:30.0pt;text-align:justify;text-indent:-.05pt'>",
+    "<b><i><span style='font-size:10.0pt;mso-ascii-font-family:Aptos;",
+    "background:yellow;mso-highlight:yellow'>Strana A</span></i></b></p>\n",
+    " </td>\n <td colspan=2 style='width:50.0%'>\n <p><b><i>Strana B</i></b></p>\n",
+    " </td>\n </tr>\n <tr>\n <td colspan=2>\n",
+    " <div style='mso-element:para-border-div;border:none;",
+    "border-bottom:solid windowtext 1.5pt;padding:0cm 0cm 1.0pt 0cm'>\n",
+    " <p style='border:none;mso-border-bottom-alt:solid windowtext 1.5pt'>",
+    "<span style='font-size:10.0pt'>x</span></p>\n </div>\n",
+    " <p align=right style='margin:.05pt;text-align:right'><b>",
+    "<span style='background:yellow;mso-highlight:yellow'>Název strany A</span>",
+    "</b></p>\n </td>\n <td colspan=2><p>x</p></td>\n </tr>\n <tr>\n",
+    " <td width=94 valign=top style='width:15.0%'><p>Datum:</p></td>\n",
+    " <td style='width:35.0%'><p align=right style='text-align:right'>",
+    "05.09.2026</p></td>\n <td><p>Datum:</p></td><td><p>05.09.2026</p></td>\n",
+    " </tr>\n</table>",
+  );
+
+  #[test]
+  fn sanitizer_keeps_table_layout_rules_and_highlights_from_word() {
+    let html = sanitized_html(WORD_SIGNATURE_TABLE_HTML).unwrap();
+
+    assert!(
+      html.starts_with(r#"<table><tbody><tr><td colspan="2" style="width: 50%">"#),
+      "{html}"
+    );
+    assert!(html.contains("</td></tr><tr><td"), "{html}");
+    assert!(
+      html.contains(r#"<div style="border-bottom: 1.5pt solid currentColor">"#),
+      "{html}"
+    );
+    assert!(
+      html.contains(r#"<p align="right" style="text-align: right"><b><span style="background: var(--highlight)">Název strany A</span></b></p>"#),
+      "{html}"
+    );
+    assert!(
+      html.contains(r#"<td valign="top" style="width: 15%">"#),
+      "{html}"
+    );
+    for dropped in [
+      "mso-",
+      "Aptos",
+      "font-size",
+      "padding",
+      "margin",
+      "windowtext",
+      "yellow",
+      "border-collapse",
+      "cellspacing",
+      "width=\"94\"",
+    ] {
+      assert!(!html.contains(dropped), "{dropped} survived: {html}");
+    }
+  }
+
+  #[test]
+  fn sanitizer_re_emits_styles_from_an_allow_list_only() {
+    let html = sanitized_html(
+      r#"<table><tr><td colspan="9999" rowspan="abc" style="background:url(javascript:alert(1));text-align:RIGHT;position:fixed;width:120%;border-bottom:solid red 40pt;white-space:nowrap">x</td></tr></table>"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+      html,
+      r#"<table><tbody><tr><td style="text-align: right; border-bottom: 6pt solid currentColor; white-space: nowrap">x</td></tr></tbody></table>"#
+    );
+    assert_eq!(sanitized_style("color:red;font-family:Aptos"), None);
+    assert_eq!(
+      sanitized_style("width:98.3pt;background:#FFFF00").as_deref(),
+      Some("width: 98.3pt; background: var(--highlight)")
+    );
+    assert_eq!(sanitized_style("border-bottom:none;width:-5pt"), None);
+    // Alignment alone is worth keeping as formatting.
+    assert!(sanitized_html(r#"<p align="center">centred</p>"#).is_some());
+    assert!(sanitized_html(r#"<p style="text-align:right">right</p>"#).is_some());
   }
 
   #[test]

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -337,8 +337,8 @@ const ClipboardCard = ({
     "text-foreground line-clamp-[8] text-sm leading-5 text-pretty wrap-break-word",
     // HTML collapses its source whitespace; only plain text (and <pre>) keeps it.
     rendersHtml
-      ? "[&_blockquote]:border-s-2 [&_blockquote]:ps-3 [&_code]:font-mono [&_li]:ms-4 [&_ol]:list-decimal [&_pre]:whitespace-pre-wrap [&_strong]:font-semibold [&_ul]:list-disc"
-      : "whitespace-pre-wrap",
+      ? "clipboard-html [&_blockquote]:border-s-2 [&_blockquote]:ps-3 [&_code]:font-mono [&_li]:ms-4 [&_ol]:list-decimal [&_pre]:whitespace-pre-wrap [&_strong]:font-semibold [&_ul]:list-disc"
+      : "whitespace-pre-wrap tab-4",
   );
   let previewContent: ReactNode;
   if (item.type === "image") {

--- a/apps/desktop/src/clipboard/ClipboardEditor.tsx
+++ b/apps/desktop/src/clipboard/ClipboardEditor.tsx
@@ -88,6 +88,13 @@ const EDITOR_BLOCK_TAGS = new Set([
   "OL",
   "P",
   "PRE",
+  "TABLE",
+  "TBODY",
+  "TD",
+  "TFOOT",
+  "TH",
+  "THEAD",
+  "TR",
   "UL",
 ]);
 
@@ -471,7 +478,7 @@ const RichTextArea = memo(
         <div
           aria-label={label}
           autoFocus
-          className="clipboard-rich-editor bg-card ring-border focus:ring-ring min-h-0 flex-1 overflow-y-auto rounded-[22px] p-5 text-sm leading-6 ring-1 outline-none ring-inset focus:ring-2"
+          className="clipboard-rich-editor clipboard-html bg-card ring-border focus:ring-ring min-h-0 flex-1 overflow-y-auto rounded-[22px] p-5 text-sm leading-6 tab-4 ring-1 outline-none ring-inset focus:ring-2"
           contentEditable
           dir="auto"
           onInput={onInput}

--- a/apps/desktop/src/clipboard/ClipboardEditor.tsx
+++ b/apps/desktop/src/clipboard/ClipboardEditor.tsx
@@ -90,13 +90,14 @@ const EDITOR_BLOCK_TAGS = new Set([
   "PRE",
   "TABLE",
   "TBODY",
-  "TD",
   "TFOOT",
-  "TH",
   "THEAD",
   "TR",
   "UL",
 ]);
+
+/** Cells sit side by side: plain text separates them with a tab, rows with a newline. */
+const EDITOR_CELL_TAGS = new Set(["TD", "TH"]);
 
 const listItemsFromSelection = (fragment: DocumentFragment) => {
   const items: HTMLLIElement[] = [];
@@ -417,6 +418,27 @@ const editorPlainText = (editor: HTMLDivElement) => {
   };
   const isBlock = (node: Node) =>
     node instanceof HTMLElement && EDITOR_BLOCK_TAGS.has(node.tagName);
+  const isCell = (node: Node) =>
+    node instanceof HTMLElement && EDITOR_CELL_TAGS.has(node.tagName);
+  const appendSeparator = (child: Node, nextChild: Node | undefined) => {
+    if (!nextChild) {
+      return;
+    }
+    if (isCell(child) && isCell(nextChild)) {
+      parts.push("\t");
+      return;
+    }
+    if (isBlock(child) || isBlock(nextChild)) {
+      appendLineBreak();
+    }
+  };
+  const appendChildren = (node: Node) => {
+    const children = Array.from(node.childNodes);
+    for (const [index, child] of children.entries()) {
+      appendNode(child);
+      appendSeparator(child, children.at(index + 1));
+    }
+  };
   const appendNode = (node: Node) => {
     if (node instanceof Text) {
       parts.push(node.data);
@@ -429,24 +451,10 @@ const editorPlainText = (editor: HTMLDivElement) => {
       parts.push("\n");
       return;
     }
-    const children = Array.from(node.childNodes);
-    for (const [index, child] of children.entries()) {
-      appendNode(child);
-      const nextChild = children.at(index + 1);
-      if (nextChild && (isBlock(child) || isBlock(nextChild))) {
-        appendLineBreak();
-      }
-    }
+    appendChildren(node);
   };
 
-  const children = Array.from(editor.childNodes);
-  for (const [index, child] of children.entries()) {
-    appendNode(child);
-    const nextChild = children.at(index + 1);
-    if (nextChild && (isBlock(child) || isBlock(nextChild))) {
-      appendLineBreak();
-    }
-  }
+  appendChildren(editor);
   return parts.join("");
 };
 

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -248,6 +248,20 @@ body:has(.clipboard-editor-window) .font-sans {
   filter: drop-shadow(0 3px 6px rgb(0 0 0 / 0.36));
 }
 
+/* Sanitised clipboard HTML keeps only layout (tables, alignment, rules,
+ * highlights); typography and colours come from the surrounding surface. */
+.clipboard-html table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+.clipboard-html td,
+.clipboard-html th {
+  padding: 0 0.25em 0 0;
+  vertical-align: top;
+}
+
 .clipboard-search-input {
   color: var(--clipboard-search-text) !important;
   -webkit-text-fill-color: var(--clipboard-search-text) !important;

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -258,7 +258,7 @@ body:has(.clipboard-editor-window) .font-sans {
 
 .clipboard-html td,
 .clipboard-html th {
-  padding: 0 0.25em 0 0;
+  padding-inline-end: 0.25em;
   vertical-align: top;
 }
 


### PR DESCRIPTION
Formatted clips copied from Word (signature blocks, aligned label/value rows) rendered as stacked paragraphs in the clipboard card because the sanitizer dropped tables and every `style` attribute. Pasting was unaffected: Word reads back the stored RTF.

- `sanitized_html` allows `table`, `thead`, `tbody`, `tfoot`, `tr`, `td`, `th`; `colspan`/`rowspan` bounded to 2..20; `align`/`valign` from a fixed vocabulary.
- A `style` attribute is accepted on any allowed tag but is re-emitted from parsed tokens only: `text-align`, `vertical-align`, `white-space`, `width` (percent or capped points), `border-top`/`border-bottom` (capped width, line style, always `currentColor`), and any plain colour `background` mapped to `var(--highlight)`. Fonts, sizes, margins, padding, `mso-*` and everything else are dropped, so cards keep the app's typography and theme.
- Whitespace between table structure tags is removed so stored markup is canonical.
- Alignment alone now counts as formatting worth storing as HTML.
- Card and editor apply `.clipboard-html` table layout (full width, fixed, collapsed); plain text previews render tabs at four columns; the editor treats table tags as block boundaries.

Tests: a fixture shaped like Word's signature-table HTML asserts the kept structure and the dropped properties; a hostile fixture asserts `url(...)`, `position`, oversized spans and widths, and non-rule borders are refused.
