### PR TITLE
chore(docker): bundle the case-law source replay into the API image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -105,6 +105,15 @@ RUN bun build \
     --target bun \
     --outfile /app/better-auth-sign-in-replay.js \
     apps/api/src/scripts/better-auth-sign-in-replay.ts
+# Case-law source replay: re-parses stored raw sources with the current
+# parsers and, when asked, withdraws a stored document that no longer parses.
+# It needs the API env (database, corpus bucket), so it runs inside the API
+# task like backfill.js:
+#   ["bun", "/app/replay-case-law-source.js", "--adapter", "eu-ecj"]
+RUN bun build \
+    --target bun \
+    --outfile /app/replay-case-law-source.js \
+    apps/api/src/scripts/replay-case-law-source.ts
 # Dedicated durable document-processing worker. Deploy the same image with
 # command override ["bun", "/app/document-processing-worker.js"]. OCR runs
 # in-image through the isolated local ONNX worker.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -225,6 +225,7 @@ COPY --chown=stella:stella --from=builder /app/better-auth-microsoft-identity-ma
 COPY --chown=stella:stella --from=builder /app/better-auth-17-backfill.js /app/better-auth-17-backfill.js
 COPY --chown=stella:stella --from=builder /app/database-census.js /app/database-census.js
 COPY --chown=stella:stella --from=builder /app/better-auth-sign-in-replay.js /app/better-auth-sign-in-replay.js
+COPY --chown=stella:stella --from=builder /app/replay-case-law-source.js /app/replay-case-law-source.js
 COPY --chown=stella:stella --from=builder /app/document-processing-worker.js /app/document-processing-worker.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
 # Bundled migration task entrypoint:

--- a/scripts/api-dockerfile-entrypoints.test.ts
+++ b/scripts/api-dockerfile-entrypoints.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+// Every operator entrypoint the builder stage bundles under /app must be
+// copied into the runner stage by the same name, or the documented command
+// override fails with module-not-found on the deployed image. The two lists
+// live sixty lines apart in the same file, so they are bound here rather than
+// by reading both on every change.
+const dockerfile = readFileSync(
+  nodePath.resolve(import.meta.dirname, "../apps/api/Dockerfile"),
+  "utf-8",
+);
+
+const stage = (name: string): string => {
+  const start = dockerfile.search(new RegExp(`^FROM .* AS ${name}$`, "mu"));
+  expect(start, name).toBeGreaterThan(-1);
+  const rest = dockerfile.slice(start + 1);
+  const next = rest.search(/^FROM /mu);
+  return next === -1 ? rest : rest.slice(0, next);
+};
+
+test("every bundled /app entrypoint reaches the runner stage", () => {
+  const built = [
+    ...stage("builder").matchAll(/--outfile \/app\/([\w.-]+\.js)/gu),
+  ]
+    .map((match) => match[1] ?? "")
+    .sort();
+  expect(built.length).toBeGreaterThan(0);
+  const copied = new Set(
+    [
+      ...stage("runner").matchAll(
+        /--from=builder \/app\/([\w.-]+\.js) \/app\/\1/gu,
+      ),
+    ].map((match) => match[1] ?? ""),
+  );
+  expect(built.filter((name) => !copied.has(name))).toEqual([]);
+});


### PR DESCRIPTION
## What

`/app/replay-case-law-source.js` is built into the API image next to the other operator entrypoints (`backfill.js`, `database-census.js`, …), so the replay runs inside the API task with the API env:

```
["bun", "/app/replay-case-law-source.js", "--adapter", "eu-ecj"]
```

## Why

The replay (#2975) re-parses stored raw sources with the current parsers and, with `--withdraw-rejected`, withdraws a stored document that no longer parses. It needs the database and the corpus bucket, which only the API task carries; without a bundle in the image it cannot be run in a deployed environment.