### PR TITLE
fix(desktop): every window opens on the screen the user is on, through one owner

### DIFF
--- a/apps/desktop/src-tauri/clippy.toml
+++ b/apps/desktop/src-tauri/clippy.toml
@@ -1,0 +1,30 @@
+# Screen selection has one owner: `window_placement`. The raw placement APIs
+# are banned everywhere else so a second "which screen" rule cannot appear;
+# the owner carries the only `allow`.
+disallowed-methods = [
+  { path = "tauri::webview::WebviewWindowBuilder::center", reason = "use window_placement::centered_on_target_screen" },
+  { path = "tauri::webview::WebviewWindow::center", reason = "position from window_placement::target_work_area" },
+  { path = "tauri::window::WindowBuilder::center", reason = "use window_placement::centered_on_target_screen" },
+  { path = "tauri::window::Window::center", reason = "position from window_placement::target_work_area" },
+  { path = "tauri::App::cursor_position", reason = "screen selection lives in window_placement" },
+  { path = "tauri::App::monitor_from_point", reason = "screen selection lives in window_placement" },
+  { path = "tauri::App::primary_monitor", reason = "screen selection lives in window_placement" },
+  { path = "tauri::App::available_monitors", reason = "screen selection lives in window_placement" },
+  { path = "tauri::AppHandle::cursor_position", reason = "screen selection lives in window_placement" },
+  { path = "tauri::AppHandle::monitor_from_point", reason = "screen selection lives in window_placement" },
+  { path = "tauri::AppHandle::primary_monitor", reason = "screen selection lives in window_placement" },
+  { path = "tauri::AppHandle::available_monitors", reason = "screen selection lives in window_placement" },
+  { path = "tauri::webview::Webview::cursor_position", reason = "screen selection lives in window_placement" },
+  { path = "tauri::webview::WebviewWindow::cursor_position", reason = "screen selection lives in window_placement" },
+  { path = "tauri::webview::WebviewWindow::monitor_from_point", reason = "screen selection lives in window_placement" },
+  { path = "tauri::webview::WebviewWindow::primary_monitor", reason = "screen selection lives in window_placement" },
+  { path = "tauri::webview::WebviewWindow::available_monitors", reason = "screen selection lives in window_placement" },
+  { path = "tauri::webview::WebviewWindow::current_monitor", reason = "screen selection lives in window_placement" },
+  { path = "tauri::window::Window::monitor_from_point", reason = "screen selection lives in window_placement" },
+  { path = "tauri::window::Window::primary_monitor", reason = "screen selection lives in window_placement" },
+  { path = "tauri::window::Window::available_monitors", reason = "screen selection lives in window_placement" },
+  { path = "tauri::window::Window::current_monitor", reason = "screen selection lives in window_placement" },
+  { path = "objc2_app_kit::NSScreen::screens", reason = "screen selection lives in window_placement" },
+  { path = "objc2_app_kit::NSScreen::mainScreen", reason = "screen selection lives in window_placement" },
+  { path = "objc2_app_kit::NSEvent::mouseLocation", reason = "screen selection lives in window_placement" },
+]

--- a/apps/desktop/src-tauri/src/clipboard_window.rs
+++ b/apps/desktop/src-tauri/src/clipboard_window.rs
@@ -13,12 +13,15 @@ use crate::desktop_telemetry::{
   DesktopTelemetryOperation, DesktopTelemetrySpan, DesktopTelemetryWindow,
   DesktopTimingReport,
 };
+use crate::window_placement::{self, WorkArea};
 
 const CLIPBOARD_WINDOW_LABEL: &str = "clipboard";
 const CLIPBOARD_EDITOR_WINDOW_LABEL: &str = "clipboard-editor";
 const CLIPBOARD_WINDOW_HEIGHT: f64 = 326.0;
 const CLIPBOARD_WINDOW_INSET: f64 = 18.0;
 const CLIPBOARD_WINDOW_RADIUS: f64 = 28.0;
+const CLIPBOARD_EDITOR_WIDTH: f64 = 700.0;
+const CLIPBOARD_EDITOR_HEIGHT: f64 = 520.0;
 
 /// Whether the clipboard window is parked. Parking keeps the window on screen
 /// fully transparent and click-through instead of ordering it out: WebKit
@@ -120,23 +123,20 @@ fn capture_window_error(
   }
 }
 
-/// Docked frame in Tauri logical coordinates (origin top-left of the primary
-/// screen, y down) from a Cocoa work area (origin bottom-left, y up).
-#[cfg(target_os = "macos")]
-fn docked_frame(primary_height: f64, work_area: DockedRect) -> DockedRect {
+/// The rail's frame docked to the bottom of a work area, inset on all sides
+/// and shortened when the area is too low for the full height.
+fn docked_frame(work_area: WorkArea) -> DockedRect {
   let width = (work_area.width - (CLIPBOARD_WINDOW_INSET * 2.0)).max(1.0);
   let available_height = (work_area.height - (CLIPBOARD_WINDOW_INSET * 2.0)).max(1.0);
   let height = CLIPBOARD_WINDOW_HEIGHT.min(available_height);
-  let bottom = work_area.y + CLIPBOARD_WINDOW_INSET;
   DockedRect {
     x: work_area.x + CLIPBOARD_WINDOW_INSET,
-    y: primary_height - (bottom + height),
+    y: work_area.y + work_area.height - height - CLIPBOARD_WINDOW_INSET,
     width,
     height,
   }
 }
 
-#[cfg(target_os = "macos")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct DockedRect {
   x: f64,
@@ -145,88 +145,15 @@ struct DockedRect {
   height: f64,
 }
 
-#[cfg(target_os = "macos")]
-impl From<objc2_foundation::NSRect> for DockedRect {
-  fn from(rect: objc2_foundation::NSRect) -> Self {
-    Self {
-      x: rect.origin.x,
-      y: rect.origin.y,
-      width: rect.size.width,
-      height: rect.size.height,
-    }
-  }
-}
-
-// AppKit is queried directly: tao's `cursor_position` returns primary-scaled
-// physical pixels while its `monitor_from_point` compares against display
-// bounds in points, so on mixed-DPI setups the lookup misses and falls back
-// to the primary display. Screen frames and the mouse location share one
-// coordinate space here, so containment is exact.
-#[cfg(target_os = "macos")]
-fn position_window(_app: &AppHandle, window: &WebviewWindow) {
-  use objc2::MainThreadMarker;
-  use objc2_app_kit::{NSEvent, NSScreen};
-
-  let Some(main_thread) = MainThreadMarker::new() else {
-    let handle = window.app_handle().clone();
-    let window = window.clone();
-    let _ = handle.run_on_main_thread(move || {
-      position_window(window.app_handle(), &window);
-    });
+/// Docks the rail to the bottom of the target screen. With no screen known the
+/// window keeps its last frame.
+fn position_window(app: &AppHandle, window: &WebviewWindow) {
+  let Some(work_area) = window_placement::target_work_area(app) else {
     return;
   };
-
-  let screens = NSScreen::screens(main_thread);
-  let Some(primary) = screens.iter().next() else {
-    let _ = window.center();
-    return;
-  };
-  let primary_height = primary.frame().size.height;
-  let cursor = NSEvent::mouseLocation();
-  let under_cursor = screens.iter().find(|screen| {
-    let frame = screen.frame();
-    cursor.x >= frame.origin.x
-      && cursor.x < frame.origin.x + frame.size.width
-      && cursor.y >= frame.origin.y
-      && cursor.y < frame.origin.y + frame.size.height
-  });
-  let focused = NSScreen::mainScreen(main_thread);
-  let screen = under_cursor.or(focused).unwrap_or(primary);
-
-  let frame = docked_frame(primary_height, screen.visibleFrame().into());
+  let frame = docked_frame(work_area);
   let _ = window.set_size(LogicalSize::new(frame.width, frame.height));
   let _ = window.set_position(LogicalPosition::new(frame.x, frame.y));
-}
-
-#[cfg(not(target_os = "macos"))]
-fn position_window(app: &AppHandle, window: &WebviewWindow) {
-  let monitor = app
-    .cursor_position()
-    .ok()
-    .and_then(|position| {
-      app
-        .monitor_from_point(position.x, position.y)
-        .ok()
-        .flatten()
-    })
-    .or_else(|| app.primary_monitor().ok().flatten());
-  let Some(monitor) = monitor else {
-    let _ = window.center();
-    return;
-  };
-
-  let scale_factor = monitor.scale_factor();
-  let work_area = monitor.work_area();
-  let work_position = work_area.position.to_logical::<f64>(scale_factor);
-  let work_size = work_area.size.to_logical::<f64>(scale_factor);
-  let available_width = (work_size.width - (CLIPBOARD_WINDOW_INSET * 2.0)).max(1.0);
-  let available_height = (work_size.height - (CLIPBOARD_WINDOW_INSET * 2.0)).max(1.0);
-  let height = CLIPBOARD_WINDOW_HEIGHT.min(available_height);
-  let x = work_position.x + CLIPBOARD_WINDOW_INSET;
-  let y = work_position.y + work_size.height - height - CLIPBOARD_WINDOW_INSET;
-
-  let _ = window.set_size(LogicalSize::new(available_width, height));
-  let _ = window.set_position(LogicalPosition::new(x, y));
 }
 
 /// Runs `f` on the main thread and waits for its result; `default` when the
@@ -237,25 +164,8 @@ fn on_main_thread<T: Send + 'static>(
   default: T,
   f: impl FnOnce(&WebviewWindow) -> T + Send + 'static,
 ) -> T {
-  use objc2::MainThreadMarker;
-
-  if MainThreadMarker::new().is_some() {
-    return f(window);
-  }
-  let (sender, receiver) = std::sync::mpsc::sync_channel(1);
   let cloned = window.clone();
-  if window
-    .app_handle()
-    .run_on_main_thread(move || {
-      let _ = sender.send(f(&cloned));
-    })
-    .is_err()
-  {
-    return default;
-  }
-  receiver
-    .recv_timeout(Duration::from_secs(1))
-    .unwrap_or(default)
+  window_placement::on_main_thread(window.app_handle(), default, move || f(&cloned))
 }
 
 /// Shows the window as the key window without activating the app: the app the
@@ -509,14 +419,18 @@ pub fn show_editor(app: &AppHandle) -> Result<(), String> {
     tauri::WebviewUrl::App("index.html".into()),
   )
   .title("Stella")
-  .inner_size(700.0, 520.0)
+  .inner_size(CLIPBOARD_EDITOR_WIDTH, CLIPBOARD_EDITOR_HEIGHT)
   .min_inner_size(560.0, 420.0)
   .always_on_top(true)
   .content_protected(content_protected)
   .resizable(true)
-  .center()
-  .visible(false)
-  .on_page_load(|window, payload| {
+  .visible(false);
+  let builder = window_placement::centered_on_target_screen(
+    app,
+    builder,
+    LogicalSize::new(CLIPBOARD_EDITOR_WIDTH, CLIPBOARD_EDITOR_HEIGHT),
+  );
+  let builder = builder.on_page_load(|window, payload| {
     if payload.event() != PageLoadEvent::Finished {
       return;
     }
@@ -544,23 +458,21 @@ pub fn show_editor(app: &AppHandle) -> Result<(), String> {
   })
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(test)]
 mod tests {
   use super::*;
 
   #[test]
   fn docks_to_the_bottom_of_a_secondary_screen_above_the_primary() {
     // External 2560x1440 display arranged above a 1728x1117 laptop screen,
-    // with a 25pt menu bar and no dock.
-    let frame = docked_frame(
-      1117.0,
-      DockedRect {
-        x: -416.0,
-        y: 1117.0,
-        width: 2560.0,
-        height: 1415.0,
-      },
-    );
+    // with a 25pt menu bar and no dock: its work area sits entirely above the
+    // primary origin in logical coordinates.
+    let frame = docked_frame(WorkArea {
+      x: -416.0,
+      y: -1415.0,
+      width: 2560.0,
+      height: 1415.0,
+    });
 
     assert_eq!(
       frame,
@@ -575,15 +487,13 @@ mod tests {
 
   #[test]
   fn docks_to_the_bottom_of_the_primary_screen_above_the_dock() {
-    let frame = docked_frame(
-      1117.0,
-      DockedRect {
-        x: 0.0,
-        y: 70.0,
-        width: 1728.0,
-        height: 1022.0,
-      },
-    );
+    // 1117pt screen, 25pt menu bar, 70pt dock.
+    let frame = docked_frame(WorkArea {
+      x: 0.0,
+      y: 25.0,
+      width: 1728.0,
+      height: 1022.0,
+    });
 
     assert_eq!(frame.x, 18.0);
     assert_eq!(frame.height, CLIPBOARD_WINDOW_HEIGHT);
@@ -592,15 +502,12 @@ mod tests {
 
   #[test]
   fn shrinks_on_a_short_work_area() {
-    let frame = docked_frame(
-      200.0,
-      DockedRect {
-        x: 0.0,
-        y: 0.0,
-        width: 400.0,
-        height: 200.0,
-      },
-    );
+    let frame = docked_frame(WorkArea {
+      x: 0.0,
+      y: 0.0,
+      width: 400.0,
+      height: 200.0,
+    });
 
     assert_eq!(frame.height, 200.0 - 36.0);
     assert_eq!(frame.y, 18.0);

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -272,8 +272,12 @@ async fn show_self_host_connect_dialog(
   )
   .title("Connect self-hosted Stella")
   .inner_size(420.0, 320.0)
-  .resizable(false)
-  .center();
+  .resizable(false);
+  let builder = crate::window_placement::centered_on_target_screen(
+    app_handle,
+    builder,
+    tauri::LogicalSize::new(420.0, 320.0),
+  );
 
   #[cfg(target_os = "macos")]
   let builder = builder

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod sse;
 mod tray;
 mod types;
 mod updater;
+mod window_placement;
 
 include!("command_manifest.rs");
 
@@ -428,8 +429,12 @@ fn ensure_main_window(handle: &tauri::AppHandle, tab: &str) {
   )
   .title("stella desktop")
   .inner_size(480.0, 460.0)
-  .resizable(false)
-  .center();
+  .resizable(false);
+  let builder = window_placement::centered_on_target_screen(
+    handle,
+    builder,
+    tauri::LogicalSize::new(480.0, 460.0),
+  );
 
   #[cfg(target_os = "macos")]
   let builder = builder

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -2488,7 +2488,7 @@ async fn show_takeover_dialog(
     urlencode(file_name),
   );
 
-  let window = tauri::WebviewWindowBuilder::new(
+  let builder = tauri::WebviewWindowBuilder::new(
     handle,
     "takeover-dialog",
     tauri::WebviewUrl::App(format!("takeover-dialog.html#{hash}").into()),
@@ -2496,8 +2496,12 @@ async fn show_takeover_dialog(
   .title("stella desktop")
   .inner_size(400.0, 260.0)
   .resizable(false)
-  .center()
-  .always_on_top(true)
+  .always_on_top(true);
+  let window = crate::window_placement::centered_on_target_screen(
+    handle,
+    builder,
+    tauri::LogicalSize::new(400.0, 260.0),
+  )
   .build();
 
   match window {

--- a/apps/desktop/src-tauri/src/window_placement.rs
+++ b/apps/desktop/src-tauri/src/window_placement.rs
@@ -146,7 +146,9 @@ pub fn target_work_area(app: &AppHandle) -> Option<WorkArea> {
     // The focused screen: the one holding the window the user is working in.
     .or_else(|| {
       app
-        .get_focused_window()
+        .webview_windows()
+        .into_values()
+        .find(|window| window.is_focused().unwrap_or(false))
         .and_then(|window| window.current_monitor().ok().flatten())
     })
     .or_else(|| app.primary_monitor().ok().flatten())?;

--- a/apps/desktop/src-tauri/src/window_placement.rs
+++ b/apps/desktop/src-tauri/src/window_placement.rs
@@ -1,0 +1,214 @@
+//! The one place that decides which screen a window opens on.
+//!
+//! Every window the app creates resolves its screen through
+//! [`target_work_area`]; the raw Tauri and AppKit screen APIs are disallowed
+//! everywhere else (`clippy.toml`), so a second rule cannot creep in. The rule:
+//! the screen under the cursor, else the focused screen, else the primary.
+
+use tauri::{
+  AppHandle, LogicalPosition, LogicalSize, Wry, webview::WebviewWindowBuilder,
+};
+
+/// A screen's work area in Tauri logical coordinates: origin at the top-left
+/// of the primary screen, y down, in points.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WorkArea {
+  pub x: f64,
+  pub y: f64,
+  pub width: f64,
+  pub height: f64,
+}
+
+/// Top-left corner that centres a window of `size` in `work_area`, pinned to
+/// the area's origin when the area is smaller than the window.
+pub fn centered_origin(
+  work_area: WorkArea,
+  size: LogicalSize<f64>,
+) -> LogicalPosition<f64> {
+  LogicalPosition::new(
+    work_area.x + ((work_area.width - size.width) / 2.0).max(0.0),
+    work_area.y + ((work_area.height - size.height) / 2.0).max(0.0),
+  )
+}
+
+/// Centres a window being built on the target screen. Tauri's own centring
+/// (primary screen) is the fallback only when no screen is known at all.
+pub fn centered_on_target_screen<'a>(
+  app: &AppHandle,
+  builder: WebviewWindowBuilder<'a, Wry, AppHandle>,
+  size: LogicalSize<f64>,
+) -> WebviewWindowBuilder<'a, Wry, AppHandle> {
+  match target_work_area(app) {
+    Some(work_area) => {
+      let origin = centered_origin(work_area, size);
+      builder.position(origin.x, origin.y)
+    }
+    #[allow(
+      clippy::disallowed_methods,
+      reason = "the fallback when no screen is known; every other caller goes through this owner"
+    )]
+    None => builder.center(),
+  }
+}
+
+/// Runs `f` on the main thread and waits for its result; `default` when the
+/// event loop is gone or does not answer in time.
+#[cfg(target_os = "macos")]
+pub(crate) fn on_main_thread<T: Send + 'static>(
+  app: &AppHandle,
+  default: T,
+  f: impl FnOnce() -> T + Send + 'static,
+) -> T {
+  use objc2::MainThreadMarker;
+
+  if MainThreadMarker::new().is_some() {
+    return f();
+  }
+  let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+  if app
+    .run_on_main_thread(move || {
+      let _ = sender.send(f());
+    })
+    .is_err()
+  {
+    return default;
+  }
+  receiver
+    .recv_timeout(std::time::Duration::from_secs(1))
+    .unwrap_or(default)
+}
+
+// AppKit is queried directly: tao's `cursor_position` returns primary-scaled
+// physical pixels while its `monitor_from_point` compares against display
+// bounds in points, so on mixed-DPI setups the lookup misses and falls back
+// to the primary display. Screen frames and the mouse location share one
+// coordinate space here, so containment is exact.
+#[cfg(target_os = "macos")]
+#[allow(
+  clippy::disallowed_methods,
+  reason = "this is the owner of screen selection; the ban keeps a second rule from appearing elsewhere"
+)]
+pub fn target_work_area(app: &AppHandle) -> Option<WorkArea> {
+  use objc2::MainThreadMarker;
+  use objc2_app_kit::{NSEvent, NSScreen};
+
+  on_main_thread(app, None, || {
+    let main_thread = MainThreadMarker::new()?;
+    let screens = NSScreen::screens(main_thread);
+    let primary = screens.iter().next()?;
+    let primary_height = primary.frame().size.height;
+    let cursor = NSEvent::mouseLocation();
+    let under_cursor = screens.iter().find(|screen| {
+      let frame = screen.frame();
+      cursor.x >= frame.origin.x
+        && cursor.x < frame.origin.x + frame.size.width
+        && cursor.y >= frame.origin.y
+        && cursor.y < frame.origin.y + frame.size.height
+    });
+    let focused = NSScreen::mainScreen(main_thread);
+    let screen = under_cursor.or(focused).unwrap_or(primary);
+    Some(logical_work_area(primary_height, screen.visibleFrame()))
+  })
+}
+
+/// Cocoa work area (origin bottom-left of the primary screen, y up) as a Tauri
+/// logical work area (origin top-left, y down).
+#[cfg(target_os = "macos")]
+pub(crate) fn logical_work_area(
+  primary_height: f64,
+  visible_frame: objc2_foundation::NSRect,
+) -> WorkArea {
+  WorkArea {
+    x: visible_frame.origin.x,
+    y: primary_height - (visible_frame.origin.y + visible_frame.size.height),
+    width: visible_frame.size.width,
+    height: visible_frame.size.height,
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+#[allow(
+  clippy::disallowed_methods,
+  reason = "this is the owner of screen selection; the ban keeps a second rule from appearing elsewhere"
+)]
+pub fn target_work_area(app: &AppHandle) -> Option<WorkArea> {
+  use tauri::Manager;
+
+  let monitor = app
+    .cursor_position()
+    .ok()
+    .and_then(|position| {
+      app
+        .monitor_from_point(position.x, position.y)
+        .ok()
+        .flatten()
+    })
+    .or_else(|| app.primary_monitor().ok().flatten())?;
+  let scale_factor = monitor.scale_factor();
+  let work_area = monitor.work_area();
+  let position = work_area.position.to_logical::<f64>(scale_factor);
+  let size = work_area.size.to_logical::<f64>(scale_factor);
+  Some(WorkArea {
+    x: position.x,
+    y: position.y,
+    width: size.width,
+    height: size.height,
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn centres_on_the_given_screen_not_the_primary() {
+    // Secondary 2560x1440 display left of the primary, 25pt menu bar.
+    let work_area = WorkArea {
+      x: -2560.0,
+      y: 25.0,
+      width: 2560.0,
+      height: 1415.0,
+    };
+
+    let origin = centered_origin(work_area, LogicalSize::new(700.0, 520.0));
+
+    assert_eq!(origin.x, -2560.0 + (2560.0 - 700.0) / 2.0);
+    assert_eq!(origin.y, 25.0 + (1415.0 - 520.0) / 2.0);
+  }
+
+  #[test]
+  fn pins_to_the_work_area_origin_when_the_window_does_not_fit() {
+    let work_area = WorkArea {
+      x: 100.0,
+      y: 40.0,
+      width: 600.0,
+      height: 400.0,
+    };
+
+    let origin = centered_origin(work_area, LogicalSize::new(700.0, 520.0));
+
+    assert_eq!((origin.x, origin.y), (100.0, 40.0));
+  }
+
+  #[cfg(target_os = "macos")]
+  #[test]
+  fn cocoa_work_areas_flip_into_top_left_logical_coordinates() {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    // External display above a 1117pt laptop screen, 25pt menu bar.
+    let area = logical_work_area(
+      1117.0,
+      NSRect::new(NSPoint::new(-416.0, 1117.0), NSSize::new(2560.0, 1415.0)),
+    );
+
+    assert_eq!(
+      area,
+      WorkArea {
+        x: -416.0,
+        y: -1415.0,
+        width: 2560.0,
+        height: 1415.0,
+      }
+    );
+  }
+}

--- a/apps/desktop/src-tauri/src/window_placement.rs
+++ b/apps/desktop/src-tauri/src/window_placement.rs
@@ -143,6 +143,12 @@ pub fn target_work_area(app: &AppHandle) -> Option<WorkArea> {
         .ok()
         .flatten()
     })
+    // The focused screen: the one holding the window the user is working in.
+    .or_else(|| {
+      app
+        .get_focused_window()
+        .and_then(|window| window.current_monitor().ok().flatten())
+    })
     .or_else(|| app.primary_monitor().ok().flatten())?;
   let scale_factor = monitor.scale_factor();
   let work_area = monitor.work_area();


### PR DESCRIPTION
The clipboard rail placed itself on the screen under the cursor, but the clip editor (and the main, self-host and takeover dialogs) called `WebviewWindowBuilder::center()`, which centres on the primary display. With two monitors the editor opened on the other screen.

- New `window_placement` module owns screen selection: screen under the cursor, else the focused screen, else the primary; returned as a work area in Tauri logical coordinates. macOS keeps the AppKit lookup (mixed-DPI correctness), other platforms use the Tauri monitor API. The Cocoa-to-logical flip moves here too.
- The rail docks into that work area with one cross-platform `docked_frame`; the two platform-specific `position_window` bodies collapse into one.
- The editor and the three dialogs centre on the same target through `centered_on_target_screen`.
- `clippy.toml` disallows `center()`, the monitor/cursor queries on `App`/`AppHandle`/`Window`/`WebviewWindow`/`Webview`, and the AppKit `NSScreen`/`NSEvent` lookups everywhere except the owner, so a second placement rule fails CI.

Tests cover the centring arithmetic, the Cocoa flip, and the docking frames in logical coordinates.
