### PR TITLE
fix(api): bound corpus projection bootstrap pages by their page size

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
-import { sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
@@ -282,7 +282,7 @@ test("bootstrap locks source policy before canonical rows for every family", asy
   assertSourceBeforeDocument("legislation_sources", "legislation_documents");
 });
 
-test("cursor pages seek both canonical and projection primary keys", async () => {
+test("a cursor page is an id-range seek, never an anti-join over the corpus", async () => {
   const statements: string[] = [];
   const loggedDb = drizzle({
     client,
@@ -317,23 +317,212 @@ test("cursor pages seek both canonical and projection primary keys", async () =>
       ),
   );
 
-  const assertCursorBound = (
+  const assertPagedByIdRange = (
     canonicalTable: string,
-    canonicalId: string,
+    sourceTable: string,
   ): void => {
-    const queries = statements.filter(
-      (query) =>
-        query.includes(`from "${canonicalTable}"`) &&
-        query.includes('left join "corpus_index_projection_states"'),
+    const cursorPages = statements.filter((query) =>
+      query.includes(`for share of "${sourceTable}"`),
     );
-    expect(queries).toHaveLength(2);
-    for (const query of queries) {
-      expect(query).toContain(`"${canonicalTable}"."${canonicalId}" > $`);
-      expect(query).toContain(
-        '"corpus_index_projection_states"."entity_id" > $',
-      );
-    }
+    expect(cursorPages).toHaveLength(1);
+    const cursorPage = cursorPages.at(0);
+    expect(cursorPage).toContain(`"${canonicalTable}"."id" > $`);
+    // The page must not pay for rows outside its id range, so the desired
+    // state anti-join belongs to the rows it seeds, not to its paging.
+    expect(cursorPage).not.toContain(
+      'left join "corpus_index_projection_states"',
+    );
+
+    const seedingReads = statements.filter((query) =>
+      query.includes(`for update of "${canonicalTable}"`),
+    );
+    expect(seedingReads).toHaveLength(1);
+    const seedingRead = seedingReads.at(0);
+    expect(seedingRead).toContain('left join "corpus_index_projection_states"');
+    expect(seedingRead).toContain(`"${canonicalTable}"."id" in (`);
   };
-  assertCursorBound("case_law_decisions", "id");
-  assertCursorBound("legislation_documents", "id");
+  assertPagedByIdRange("case_law_decisions", "case_law_sources");
+  assertPagedByIdRange("legislation_documents", "legislation_sources");
+});
+
+test("a page's work is bounded by its limit, not by how many rows are already seeded", async () => {
+  const THIRD_DECISION_ID = toSafeId<"caseLawDecision">(
+    "0198e331-e578-7000-8000-000000000107",
+  );
+  const FOURTH_DECISION_ID = toSafeId<"caseLawDecision">(
+    "0198e331-e578-7000-8000-000000000108",
+  );
+  const FIFTH_DECISION_ID = toSafeId<"caseLawDecision">(
+    "0198e331-e578-7000-8000-000000000109",
+  );
+  await db.insert(caseLawDecisions).values(
+    [THIRD_DECISION_ID, FOURTH_DECISION_ID, FIFTH_DECISION_ID].map(
+      (id, index) => ({
+        id,
+        sourceId: CASE_LAW_SOURCE_ID,
+        caseNumber: `6 As ${index + 5}/2010`,
+        court: "Nejvyšší správní soud",
+        country: "CZE",
+        language: "cs",
+        contentHash: String(index).repeat(64),
+      }),
+    ),
+  );
+
+  const seedAll = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "case_law", generation: "case_law_v5", limit: 5 },
+      ),
+  );
+  expect(seedAll).toMatchObject({ status: "advanced", seededCount: 5 });
+  await db
+    .delete(corpusIndexProjectionStates)
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, "case_law"),
+        eq(corpusIndexProjectionStates.generation, "case_law_v5"),
+        inArray(corpusIndexProjectionStates.entityId, [
+          SECOND_CASE_LAW_DECISION_ID,
+          THIRD_DECISION_ID,
+        ]),
+      ),
+    );
+
+  const firstPage = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "case_law", generation: "case_law_v5", limit: 2 },
+      ),
+  );
+  // The page covers the first two ids and seeds only the gap among them; it
+  // does not skip ahead to the next unseeded row.
+  expect(firstPage).toMatchObject({
+    status: "advanced",
+    claimedCount: 1,
+    seededCount: 1,
+    entityIds: [SECOND_CASE_LAW_DECISION_ID],
+    nextAfterEntityId: SECOND_CASE_LAW_DECISION_ID,
+  });
+
+  const secondPage = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          limit: 2,
+          afterEntityId: SECOND_CASE_LAW_DECISION_ID,
+        },
+      ),
+  );
+  expect(secondPage).toMatchObject({
+    status: "advanced",
+    claimedCount: 1,
+    seededCount: 1,
+    entityIds: [THIRD_DECISION_ID],
+    nextAfterEntityId: FOURTH_DECISION_ID,
+  });
+
+  const seededPage = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          limit: 2,
+          afterEntityId: FOURTH_DECISION_ID,
+        },
+      ),
+  );
+  expect(seededPage).toMatchObject({
+    status: "advanced",
+    claimedCount: 0,
+    seededCount: 0,
+    entityIds: [],
+    nextAfterEntityId: FIFTH_DECISION_ID,
+  });
+
+  const rangeComplete = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          limit: 2,
+          afterEntityId: FIFTH_DECISION_ID,
+        },
+      ),
+  );
+  expect(rangeComplete).toMatchObject({ status: "range_complete" });
+
+  const complete = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "case_law", generation: "case_law_v5", limit: 2 },
+      ),
+  );
+  expect(complete).toMatchObject({ status: "complete" });
+
+  expect(
+    await db
+      .select({ entityId: corpusIndexProjectionStates.entityId })
+      .from(corpusIndexProjectionStates),
+  ).toHaveLength(5);
+});
+
+test("a legislation page with nothing to seed advances instead of stalling", async () => {
+  const seedFirst = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "legislation", generation: "legislation_v2", limit: 1 },
+      ),
+  );
+  expect(seedFirst).toMatchObject({
+    status: "advanced",
+    seededCount: 1,
+    nextAfterEntityId: LEGISLATION_DOCUMENT_ID,
+  });
+
+  const seededPage = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "legislation", generation: "legislation_v2", limit: 1 },
+      ),
+  );
+  expect(seededPage).toMatchObject({
+    status: "advanced",
+    claimedCount: 0,
+    seededCount: 0,
+    entityIds: [],
+    nextAfterEntityId: LEGISLATION_DOCUMENT_ID,
+  });
+
+  const gapPage = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "legislation",
+          generation: "legislation_v2",
+          limit: 1,
+          afterEntityId: LEGISLATION_DOCUMENT_ID,
+        },
+      ),
+  );
+  expect(gapPage).toMatchObject({
+    status: "advanced",
+    claimedCount: 1,
+    seededCount: 1,
+    entityIds: [SECOND_LEGISLATION_DOCUMENT_ID],
+    nextAfterEntityId: SECOND_LEGISLATION_DOCUMENT_ID,
+  });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
@@ -192,20 +192,24 @@ test("bulk bootstrap advances a keyset cursor and reaches a fixed point", async 
     entityIds: [],
   });
 
-  const complete = await db.transaction(
+  // Replaying the sweep from the head of the corpus claims nothing and still
+  // advances: a page sees only its own id range, so concluding that the
+  // generation is seeded belongs to the caller driving the sweep.
+  const replay = await db.transaction(
     async (tx) =>
       await bootstrapCorpusProjectionDesiredStateBatchTx(
         asTestRaw<Transaction>(tx),
         { family: "case_law", generation: "case_law_v5", limit: 1 },
       ),
   );
-  expect(complete).toEqual({
-    status: "complete",
+  expect(replay).toEqual({
+    status: "advanced",
     family: "case_law",
     generation: "case_law_v5",
     claimedCount: 0,
     seededCount: 0,
     entityIds: [],
+    nextAfterEntityId: CASE_LAW_DECISION_ID,
   });
 
   expect(
@@ -459,22 +463,35 @@ test("a page's work is bounded by its limit, not by how many rows are already se
         },
       ),
   );
+  // The sweep ends at the end of the id range; the pages above cost two ids
+  // each, whichever of those ids already carried a desired state.
   expect(rangeComplete).toMatchObject({ status: "range_complete" });
-
-  const complete = await db.transaction(
-    async (tx) =>
-      await bootstrapCorpusProjectionDesiredStateBatchTx(
-        asTestRaw<Transaction>(tx),
-        { family: "case_law", generation: "case_law_v5", limit: 2 },
-      ),
-  );
-  expect(complete).toMatchObject({ status: "complete" });
 
   expect(
     await db
       .select({ entityId: corpusIndexProjectionStates.entityId })
       .from(corpusIndexProjectionStates),
   ).toHaveLength(5);
+});
+
+test("a null-cursor page reports complete only when the corpus holds no rows", async () => {
+  await db.delete(caseLawDecisions).where(sql`true`);
+
+  const result = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "case_law", generation: "case_law_v5", limit: 2 },
+      ),
+  );
+  expect(result).toEqual({
+    status: "complete",
+    family: "case_law",
+    generation: "case_law_v5",
+    claimedCount: 0,
+    seededCount: 0,
+    entityIds: [],
+  });
 });
 
 test("a legislation page with nothing to seed advances instead of stalling", async () => {
@@ -525,4 +542,18 @@ test("a legislation page with nothing to seed advances instead of stalling", asy
     entityIds: [SECOND_LEGISLATION_DOCUMENT_ID],
     nextAfterEntityId: SECOND_LEGISLATION_DOCUMENT_ID,
   });
+
+  const rangeComplete = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "legislation",
+          generation: "legislation_v2",
+          limit: 1,
+          afterEntityId: SECOND_LEGISLATION_DOCUMENT_ID,
+        },
+      ),
+  );
+  expect(rangeComplete).toMatchObject({ status: "range_complete" });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -163,6 +163,34 @@ const setZeroLegislationProjectionEpochs = async (
     );
 };
 
+type SeededEntityIdQuery = {
+  family: CorpusIndexProjectionSubject["family"];
+  generation: string;
+  entityIds: string[];
+};
+
+/**
+ * Which of the page's canonical ids already carry a desired state. The read is
+ * a primary-key lookup bounded by the page, so it never widens with the number
+ * of rows seeded so far.
+ */
+const selectSeededEntityIds = async (
+  tx: Transaction,
+  { family, generation, entityIds }: SeededEntityIdQuery,
+): Promise<ReadonlySet<string>> => {
+  const rows = await tx
+    .select({ entityId: corpusIndexProjectionStates.entityId })
+    .from(corpusIndexProjectionStates)
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, family),
+        eq(corpusIndexProjectionStates.generation, generation),
+        inArray(corpusIndexProjectionStates.entityId, entityIds),
+      ),
+    );
+  return new Set(rows.map(({ entityId }) => entityId));
+};
+
 const hasUnseededCaseLawRows = async (
   tx: Transaction,
   generation: string,
@@ -209,19 +237,10 @@ const bootstrapCaseLaw = async (
   limit: number,
   afterEntityId: SafeId<"caseLawDecision"> | undefined,
 ): Promise<CorpusIndexProjectionBootstrapResult> => {
-  const conditions = [
-    isNull(corpusIndexProjectionStates.entityId),
-    ...(afterEntityId === undefined
-      ? []
-      : [gt(caseLawDecisions.id, afterEntityId)]),
-  ];
   const projectionConditions = [
     eq(corpusIndexProjectionStates.family, "case_law"),
     eq(corpusIndexProjectionStates.generation, generation),
     eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
-    ...(afterEntityId === undefined
-      ? []
-      : [gt(corpusIndexProjectionStates.entityId, afterEntityId)]),
   ];
   const candidates = await tx
     .select({
@@ -231,8 +250,11 @@ const bootstrapCaseLaw = async (
     })
     .from(caseLawDecisions)
     .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
-    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
-    .where(and(...conditions))
+    .where(
+      afterEntityId === undefined
+        ? undefined
+        : gt(caseLawDecisions.id, afterEntityId),
+    )
     .orderBy(asc(caseLawDecisions.id))
     .limit(limit)
     // Canonical mutations lock source policy before the decision. Bootstrap
@@ -250,41 +272,82 @@ const bootstrapCaseLaw = async (
   }
 
   const candidateIds = candidates.map(({ documentId }) => documentId);
-  const lockedRows = await tx
-    .select({
-      documentId: caseLawDecisions.id,
-      sourceId: caseLawDecisions.sourceId,
-      jurisdiction: caseLawDecisions.country,
-      language: caseLawDecisions.language,
-      documentType: caseLawDecisions.decisionType,
-      contentHash: caseLawDecisions.contentHash,
-      redactedAt: caseLawDecisions.redactedAt,
-      caseNumber: caseLawDecisions.caseNumber,
-      court: caseLawDecisions.court,
-      decisionDate: caseLawDecisions.decisionDate,
-      ecli: caseLawDecisions.ecli,
-      metadata: caseLawDecisions.metadata,
-      projectionEpoch: caseLawDecisions.projectionEpoch,
-    })
-    .from(caseLawDecisions)
-    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
-    .where(and(...conditions, inArray(caseLawDecisions.id, candidateIds)))
-    .orderBy(asc(caseLawDecisions.id))
-    .limit(limit)
-    .for("update", { of: caseLawDecisions, skipLocked: true });
+  const seededEntityIds = await selectSeededEntityIds(tx, {
+    family: "case_law",
+    generation,
+    entityIds: candidateIds,
+  });
+  const unseededIds = candidateIds.filter(
+    (candidateId) => !seededEntityIds.has(candidateId),
+  );
+  const lockedRows: BootstrapCaseLawRow[] =
+    unseededIds.length === 0
+      ? []
+      : await tx
+          .select({
+            documentId: caseLawDecisions.id,
+            sourceId: caseLawDecisions.sourceId,
+            jurisdiction: caseLawDecisions.country,
+            language: caseLawDecisions.language,
+            documentType: caseLawDecisions.decisionType,
+            contentHash: caseLawDecisions.contentHash,
+            redactedAt: caseLawDecisions.redactedAt,
+            caseNumber: caseLawDecisions.caseNumber,
+            court: caseLawDecisions.court,
+            decisionDate: caseLawDecisions.decisionDate,
+            ecli: caseLawDecisions.ecli,
+            metadata: caseLawDecisions.metadata,
+            projectionEpoch: caseLawDecisions.projectionEpoch,
+          })
+          .from(caseLawDecisions)
+          .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
+          .where(
+            and(
+              isNull(corpusIndexProjectionStates.entityId),
+              inArray(caseLawDecisions.id, unseededIds),
+            ),
+          )
+          .orderBy(asc(caseLawDecisions.id))
+          .limit(limit)
+          .for("update", { of: caseLawDecisions, skipLocked: true });
   const lockedById = new Map(lockedRows.map((row) => [row.documentId, row]));
-  // Advance only across the contiguous prefix actually locked. Skipping past
-  // an earlier busy row would make a keyset cursor strand it indefinitely.
+  // Advance only across the contiguous prefix this batch accounts for: a row
+  // that already has a desired state needs nothing, a locked row is ours, and
+  // the first row another worker holds ends the page, because skipping past it
+  // would make a keyset cursor strand it indefinitely.
   const rows: BootstrapCaseLawRow[] = [];
+  let pageEndEntityId: SafeId<"caseLawDecision"> | undefined;
   for (const candidate of candidates) {
-    const row = lockedById.get(candidate.documentId);
-    if (row === undefined) {
-      break;
+    if (!seededEntityIds.has(candidate.documentId)) {
+      const row = lockedById.get(candidate.documentId);
+      if (row === undefined) {
+        break;
+      }
+      rows.push(row);
     }
-    rows.push(row);
+    pageEndEntityId = candidate.documentId;
+  }
+  if (pageEndEntityId === undefined) {
+    return emptyBootstrapResult("busy", "case_law", generation);
   }
   if (rows.length === 0) {
-    return emptyBootstrapResult("busy", "case_law", generation);
+    // Only a page starting at the head of the corpus can conclude anything
+    // about rows outside its own id range.
+    if (
+      afterEntityId === undefined &&
+      !(await hasUnseededCaseLawRows(tx, generation))
+    ) {
+      return emptyBootstrapResult("complete", "case_law", generation);
+    }
+    return {
+      status: "advanced",
+      family: "case_law",
+      generation,
+      claimedCount: 0,
+      seededCount: 0,
+      entityIds: [],
+      nextAfterEntityId: pageEndEntityId,
+    };
   }
 
   const entityIds = rows.map(({ documentId }) => documentId);
@@ -386,10 +449,6 @@ const bootstrapCaseLaw = async (
       `Corpus projection bootstrap inserted ${inserted.length} of ${rows.length} case-law states`,
     );
   }
-  const lastEntityId = rows.at(-1)?.documentId;
-  if (lastEntityId === undefined) {
-    return panic("Corpus projection bootstrap claimed no case-law row");
-  }
   return {
     status: "advanced",
     family: "case_law",
@@ -397,7 +456,7 @@ const bootstrapCaseLaw = async (
     claimedCount: rows.length,
     seededCount: inserted.length,
     entityIds,
-    nextAfterEntityId: lastEntityId,
+    nextAfterEntityId: pageEndEntityId,
   };
 };
 
@@ -407,19 +466,10 @@ const bootstrapLegislation = async (
   limit: number,
   afterEntityId: SafeId<"legislationDocument"> | undefined,
 ): Promise<CorpusIndexProjectionBootstrapResult> => {
-  const conditions = [
-    isNull(corpusIndexProjectionStates.entityId),
-    ...(afterEntityId === undefined
-      ? []
-      : [gt(legislationDocuments.id, afterEntityId)]),
-  ];
   const projectionConditions = [
     eq(corpusIndexProjectionStates.family, "legislation"),
     eq(corpusIndexProjectionStates.generation, generation),
     eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
-    ...(afterEntityId === undefined
-      ? []
-      : [gt(corpusIndexProjectionStates.entityId, afterEntityId)]),
   ];
   const candidates = await tx
     .select({
@@ -432,8 +482,11 @@ const bootstrapLegislation = async (
       legislationSources,
       eq(legislationSources.id, legislationDocuments.sourceId),
     )
-    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
-    .where(and(...conditions))
+    .where(
+      afterEntityId === undefined
+        ? undefined
+        : gt(legislationDocuments.id, afterEntityId),
+    )
     .orderBy(asc(legislationDocuments.id))
     .limit(limit)
     .for("share", { of: legislationSources });
@@ -449,40 +502,78 @@ const bootstrapLegislation = async (
   }
 
   const candidateIds = candidates.map(({ documentId }) => documentId);
-  const lockedRows = await tx
-    .select({
-      documentId: legislationDocuments.id,
-      sourceId: legislationDocuments.sourceId,
-      jurisdiction: legislationDocuments.country,
-      language: legislationDocuments.language,
-      documentType: legislationDocuments.documentType,
-      contentHash: legislationDocuments.contentHash,
-      title: legislationDocuments.title,
-      status: legislationDocuments.status,
-      effectiveDate: legislationDocuments.effectiveDate,
-      versionValidFrom: legislationDocuments.versionValidFrom,
-      versionValidTo: legislationDocuments.versionValidTo,
-      eli: legislationDocuments.eli,
-      projectionEpoch: legislationDocuments.projectionEpoch,
-    })
-    .from(legislationDocuments)
-    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
-    .where(and(...conditions, inArray(legislationDocuments.id, candidateIds)))
-    .orderBy(asc(legislationDocuments.id))
-    .limit(limit)
-    .for("update", { of: legislationDocuments, skipLocked: true });
+  const seededEntityIds = await selectSeededEntityIds(tx, {
+    family: "legislation",
+    generation,
+    entityIds: candidateIds,
+  });
+  const unseededIds = candidateIds.filter(
+    (candidateId) => !seededEntityIds.has(candidateId),
+  );
+  const lockedRows: BootstrapLegislationRow[] =
+    unseededIds.length === 0
+      ? []
+      : await tx
+          .select({
+            documentId: legislationDocuments.id,
+            sourceId: legislationDocuments.sourceId,
+            jurisdiction: legislationDocuments.country,
+            language: legislationDocuments.language,
+            documentType: legislationDocuments.documentType,
+            contentHash: legislationDocuments.contentHash,
+            title: legislationDocuments.title,
+            status: legislationDocuments.status,
+            effectiveDate: legislationDocuments.effectiveDate,
+            versionValidFrom: legislationDocuments.versionValidFrom,
+            versionValidTo: legislationDocuments.versionValidTo,
+            eli: legislationDocuments.eli,
+            projectionEpoch: legislationDocuments.projectionEpoch,
+          })
+          .from(legislationDocuments)
+          .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
+          .where(
+            and(
+              isNull(corpusIndexProjectionStates.entityId),
+              inArray(legislationDocuments.id, unseededIds),
+            ),
+          )
+          .orderBy(asc(legislationDocuments.id))
+          .limit(limit)
+          .for("update", { of: legislationDocuments, skipLocked: true });
   const lockedById = new Map(lockedRows.map((row) => [row.documentId, row]));
-  // See the case-law path: the cursor may cross only a fully claimed prefix.
+  // See the case-law path: the cursor may cross only the prefix this batch
+  // accounts for, seeded or claimed.
   const rows: BootstrapLegislationRow[] = [];
+  let pageEndEntityId: SafeId<"legislationDocument"> | undefined;
   for (const candidate of candidates) {
-    const row = lockedById.get(candidate.documentId);
-    if (row === undefined) {
-      break;
+    if (!seededEntityIds.has(candidate.documentId)) {
+      const row = lockedById.get(candidate.documentId);
+      if (row === undefined) {
+        break;
+      }
+      rows.push(row);
     }
-    rows.push(row);
+    pageEndEntityId = candidate.documentId;
+  }
+  if (pageEndEntityId === undefined) {
+    return emptyBootstrapResult("busy", "legislation", generation);
   }
   if (rows.length === 0) {
-    return emptyBootstrapResult("busy", "legislation", generation);
+    if (
+      afterEntityId === undefined &&
+      !(await hasUnseededLegislationRows(tx, generation))
+    ) {
+      return emptyBootstrapResult("complete", "legislation", generation);
+    }
+    return {
+      status: "advanced",
+      family: "legislation",
+      generation,
+      claimedCount: 0,
+      seededCount: 0,
+      entityIds: [],
+      nextAfterEntityId: pageEndEntityId,
+    };
   }
 
   const entityIds = rows.map(({ documentId }) => documentId);
@@ -538,10 +629,6 @@ const bootstrapLegislation = async (
       `Corpus projection bootstrap inserted ${inserted.length} of ${rows.length} legislation states`,
     );
   }
-  const lastEntityId = rows.at(-1)?.documentId;
-  if (lastEntityId === undefined) {
-    return panic("Corpus projection bootstrap claimed no legislation row");
-  }
   return {
     status: "advanced",
     family: "legislation",
@@ -549,16 +636,19 @@ const bootstrapLegislation = async (
     claimedCount: rows.length,
     seededCount: inserted.length,
     entityIds,
-    nextAfterEntityId: lastEntityId,
+    nextAfterEntityId: pageEndEntityId,
   };
 };
 
 /**
- * Seed one active final generation in a bounded, replay-safe batch. The query
- * uses a keyset cursor so a large seeded prefix is not rescanned on every
- * batch. Rows skipped because another worker owns them remain eligible for a
- * later null-cursor sweep; callers reset the cursor after range_complete.
- * A busy result never advances the cursor.
+ * Seed one active final generation in a bounded, replay-safe batch. A page is
+ * the next `limit` canonical ids after the keyset cursor, and only the ids in
+ * that page that still lack a desired state are locked and seeded, so a page
+ * costs its limit however much of the corpus is already seeded. The cursor
+ * crosses the whole page even when it seeds nothing. Rows skipped because
+ * another worker owns them remain eligible for a later null-cursor sweep;
+ * callers reset the cursor after range_complete. A busy result never advances
+ * the cursor.
  */
 export const bootstrapCorpusProjectionDesiredStateBatchTx = async (
   tx: Transaction,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -191,46 +191,6 @@ const selectSeededEntityIds = async (
   return new Set(rows.map(({ entityId }) => entityId));
 };
 
-const hasUnseededCaseLawRows = async (
-  tx: Transaction,
-  generation: string,
-): Promise<boolean> => {
-  const rows = await tx
-    .select({ documentId: caseLawDecisions.id })
-    .from(caseLawDecisions)
-    .leftJoin(
-      corpusIndexProjectionStates,
-      and(
-        eq(corpusIndexProjectionStates.family, "case_law"),
-        eq(corpusIndexProjectionStates.generation, generation),
-        eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
-      ),
-    )
-    .where(isNull(corpusIndexProjectionStates.entityId))
-    .limit(1);
-  return rows.length > 0;
-};
-
-const hasUnseededLegislationRows = async (
-  tx: Transaction,
-  generation: string,
-): Promise<boolean> => {
-  const rows = await tx
-    .select({ documentId: legislationDocuments.id })
-    .from(legislationDocuments)
-    .leftJoin(
-      corpusIndexProjectionStates,
-      and(
-        eq(corpusIndexProjectionStates.family, "legislation"),
-        eq(corpusIndexProjectionStates.generation, generation),
-        eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
-      ),
-    )
-    .where(isNull(corpusIndexProjectionStates.entityId))
-    .limit(1);
-  return rows.length > 0;
-};
-
 const bootstrapCaseLaw = async (
   tx: Transaction,
   generation: string,
@@ -261,11 +221,10 @@ const bootstrapCaseLaw = async (
     // uses the same order; a short policy update may delay this bounded claim.
     .for("share", { of: caseLawSources });
   if (candidates.length === 0) {
-    if (afterEntityId !== undefined) {
-      return emptyBootstrapResult("range_complete", "case_law", generation);
-    }
+    // The id range is exhausted. Whether the generation is fully seeded is a
+    // question about every page of a sweep, so the caller owns it.
     return emptyBootstrapResult(
-      (await hasUnseededCaseLawRows(tx, generation)) ? "busy" : "complete",
+      afterEntityId === undefined ? "complete" : "range_complete",
       "case_law",
       generation,
     );
@@ -331,14 +290,6 @@ const bootstrapCaseLaw = async (
     return emptyBootstrapResult("busy", "case_law", generation);
   }
   if (rows.length === 0) {
-    // Only a page starting at the head of the corpus can conclude anything
-    // about rows outside its own id range.
-    if (
-      afterEntityId === undefined &&
-      !(await hasUnseededCaseLawRows(tx, generation))
-    ) {
-      return emptyBootstrapResult("complete", "case_law", generation);
-    }
     return {
       status: "advanced",
       family: "case_law",
@@ -491,11 +442,10 @@ const bootstrapLegislation = async (
     .limit(limit)
     .for("share", { of: legislationSources });
   if (candidates.length === 0) {
-    if (afterEntityId !== undefined) {
-      return emptyBootstrapResult("range_complete", "legislation", generation);
-    }
+    // The id range is exhausted. Whether the generation is fully seeded is a
+    // question about every page of a sweep, so the caller owns it.
     return emptyBootstrapResult(
-      (await hasUnseededLegislationRows(tx, generation)) ? "busy" : "complete",
+      afterEntityId === undefined ? "complete" : "range_complete",
       "legislation",
       generation,
     );
@@ -559,12 +509,6 @@ const bootstrapLegislation = async (
     return emptyBootstrapResult("busy", "legislation", generation);
   }
   if (rows.length === 0) {
-    if (
-      afterEntityId === undefined &&
-      !(await hasUnseededLegislationRows(tx, generation))
-    ) {
-      return emptyBootstrapResult("complete", "legislation", generation);
-    }
     return {
       status: "advanced",
       family: "legislation",
@@ -649,6 +593,11 @@ const bootstrapLegislation = async (
  * another worker owns them remain eligible for a later null-cursor sweep;
  * callers reset the cursor after range_complete. A busy result never advances
  * the cursor.
+ *
+ * Every page reads only its own id range, so no page can tell that a
+ * generation is fully seeded; complete means the corpus holds no rows at all.
+ * A caller concludes a generation is seeded from a whole sweep that claimed
+ * nothing and met no busy page.
  */
 export const bootstrapCorpusProjectionDesiredStateBatchTx = async (
   tx: Transaction,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -13,6 +13,7 @@ import {
   legislationSources,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
+import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
 import { deriveCorpusIndexProjectionDescriptor } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
 import {
   buildCorpusIndexProjectionDesiredStateValues,
@@ -95,38 +96,6 @@ const validateBootstrapLimit = (limit: number): number => {
   return limit;
 };
 
-type BootstrapCaseLawRow = {
-  documentId: SafeId<"caseLawDecision">;
-  sourceId: SafeId<"caseLawSource">;
-  jurisdiction: string;
-  language: string;
-  documentType: string | null;
-  contentHash: string | null;
-  redactedAt: Date | null;
-  caseNumber: string;
-  court: string;
-  decisionDate: string | null;
-  ecli: string | null;
-  metadata: Record<string, unknown> | null;
-  projectionEpoch: bigint;
-};
-
-type BootstrapLegislationRow = {
-  documentId: SafeId<"legislationDocument">;
-  sourceId: SafeId<"legislationSource">;
-  jurisdiction: string;
-  language: string;
-  documentType: string | null;
-  contentHash: string | null;
-  title: string;
-  status: string;
-  effectiveDate: string | null;
-  versionValidFrom: string | null;
-  versionValidTo: string | null;
-  eli: string;
-  projectionEpoch: bigint;
-};
-
 const setZeroCaseLawProjectionEpochs = async (
   tx: Transaction,
   entityIds: readonly SafeId<"caseLawDecision">[],
@@ -191,91 +160,102 @@ const selectSeededEntityIds = async (
   return new Set(rows.map(({ entityId }) => entityId));
 };
 
-const bootstrapCaseLaw = async (
-  tx: Transaction,
-  generation: string,
-  limit: number,
-  afterEntityId: SafeId<"caseLawDecision"> | undefined,
-): Promise<CorpusIndexProjectionBootstrapResult> => {
-  const projectionConditions = [
-    eq(corpusIndexProjectionStates.family, "case_law"),
-    eq(corpusIndexProjectionStates.generation, generation),
-    eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
-  ];
-  const candidates = await tx
-    .select({
-      documentId: caseLawDecisions.id,
-      sourceId: caseLawDecisions.sourceId,
-      sourceDescriptor: caseLawSources.descriptor,
-    })
-    .from(caseLawDecisions)
-    .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
-    .where(
-      afterEntityId === undefined
-        ? undefined
-        : gt(caseLawDecisions.id, afterEntityId),
-    )
-    .orderBy(asc(caseLawDecisions.id))
-    .limit(limit)
-    // Canonical mutations lock source policy before the decision. Bootstrap
-    // uses the same order; a short policy update may delay this bounded claim.
-    .for("share", { of: caseLawSources });
+type CorpusBootstrapCandidate<TEntityId extends string> = {
+  documentId: TEntityId;
+  sourceId: string;
+  sourceDescriptor: Parameters<typeof isRedistributable>[0];
+};
+
+/** One page's rows to insert; a family builds them with or without a query. */
+type CorpusBootstrapDesiredState =
+  (typeof corpusIndexProjectionStates.$inferInsert)[];
+
+type CorpusBootstrapRow<TEntityId extends string> = {
+  documentId: TEntityId;
+  sourceId: string;
+};
+
+/** What a page did, before it is dressed in its family's branded envelope. */
+type CorpusBootstrapPage<TEntityId extends string> =
+  | { status: "complete" | "range_complete" | "busy" }
+  | {
+      status: "advanced";
+      claimedCount: number;
+      seededCount: number;
+      entityIds: TEntityId[];
+      nextAfterEntityId: TEntityId;
+    };
+
+type CorpusBootstrapPageOptions<
+  TEntityId extends string,
+  TRow extends CorpusBootstrapRow<TEntityId>,
+> = {
+  tx: Transaction;
+  family: CorpusIndexProjectionSubject["family"];
+  generation: string;
+  afterEntityId: TEntityId | undefined;
+  /** The page: the next `limit` canonical ids after the cursor, seeded or not. */
+  selectCandidates: () => Promise<CorpusBootstrapCandidate<TEntityId>[]>;
+  lockUnseededRows: (unseededIds: TEntityId[]) => Promise<TRow[]>;
+  claimProjectionEpochs: (entityIds: TEntityId[]) => Promise<void>;
+  buildDesiredStateValues: (input: {
+    rows: TRow[];
+    entityIds: TEntityId[];
+    manifest: CorpusIndexManifest;
+    descriptorOf: (
+      sourceId: string,
+    ) => CorpusBootstrapCandidate<TEntityId>["sourceDescriptor"];
+  }) => CorpusBootstrapDesiredState | Promise<CorpusBootstrapDesiredState>;
+};
+
+/**
+ * The page sequence both families share: read an id range, find which of its
+ * ids still need a desired state, lock those, and seed the prefix the batch
+ * can account for. Every read is bounded by the page, so the cost of a page
+ * does not grow with the number of rows already seeded.
+ */
+const runCorpusBootstrapPage = async <
+  TEntityId extends string,
+  TRow extends CorpusBootstrapRow<TEntityId>,
+>({
+  tx,
+  family,
+  generation,
+  afterEntityId,
+  selectCandidates,
+  lockUnseededRows,
+  claimProjectionEpochs,
+  buildDesiredStateValues,
+}: CorpusBootstrapPageOptions<TEntityId, TRow>): Promise<
+  CorpusBootstrapPage<TEntityId>
+> => {
+  const candidates = await selectCandidates();
   if (candidates.length === 0) {
     // The id range is exhausted. Whether the generation is fully seeded is a
     // question about every page of a sweep, so the caller owns it.
-    return emptyBootstrapResult(
-      afterEntityId === undefined ? "complete" : "range_complete",
-      "case_law",
-      generation,
-    );
+    return {
+      status: afterEntityId === undefined ? "complete" : "range_complete",
+    };
   }
 
   const candidateIds = candidates.map(({ documentId }) => documentId);
   const seededEntityIds = await selectSeededEntityIds(tx, {
-    family: "case_law",
+    family,
     generation,
     entityIds: candidateIds,
   });
   const unseededIds = candidateIds.filter(
     (candidateId) => !seededEntityIds.has(candidateId),
   );
-  const lockedRows: BootstrapCaseLawRow[] =
-    unseededIds.length === 0
-      ? []
-      : await tx
-          .select({
-            documentId: caseLawDecisions.id,
-            sourceId: caseLawDecisions.sourceId,
-            jurisdiction: caseLawDecisions.country,
-            language: caseLawDecisions.language,
-            documentType: caseLawDecisions.decisionType,
-            contentHash: caseLawDecisions.contentHash,
-            redactedAt: caseLawDecisions.redactedAt,
-            caseNumber: caseLawDecisions.caseNumber,
-            court: caseLawDecisions.court,
-            decisionDate: caseLawDecisions.decisionDate,
-            ecli: caseLawDecisions.ecli,
-            metadata: caseLawDecisions.metadata,
-            projectionEpoch: caseLawDecisions.projectionEpoch,
-          })
-          .from(caseLawDecisions)
-          .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
-          .where(
-            and(
-              isNull(corpusIndexProjectionStates.entityId),
-              inArray(caseLawDecisions.id, unseededIds),
-            ),
-          )
-          .orderBy(asc(caseLawDecisions.id))
-          .limit(limit)
-          .for("update", { of: caseLawDecisions, skipLocked: true });
+  const lockedRows: TRow[] =
+    unseededIds.length === 0 ? [] : await lockUnseededRows(unseededIds);
   const lockedById = new Map(lockedRows.map((row) => [row.documentId, row]));
   // Advance only across the contiguous prefix this batch accounts for: a row
   // that already has a desired state needs nothing, a locked row is ours, and
   // the first row another worker holds ends the page, because skipping past it
   // would make a keyset cursor strand it indefinitely.
-  const rows: BootstrapCaseLawRow[] = [];
-  let pageEndEntityId: SafeId<"caseLawDecision"> | undefined;
+  const rows: TRow[] = [];
+  let pageEndEntityId: TEntityId | undefined;
   for (const candidate of candidates) {
     if (!seededEntityIds.has(candidate.documentId)) {
       const row = lockedById.get(candidate.documentId);
@@ -287,13 +267,11 @@ const bootstrapCaseLaw = async (
     pageEndEntityId = candidate.documentId;
   }
   if (pageEndEntityId === undefined) {
-    return emptyBootstrapResult("busy", "case_law", generation);
+    return { status: "busy" };
   }
   if (rows.length === 0) {
     return {
       status: "advanced",
-      family: "case_law",
-      generation,
       claimedCount: 0,
       seededCount: 0,
       entityIds: [],
@@ -308,102 +286,39 @@ const bootstrapCaseLaw = async (
       sourceDescriptor,
     ]),
   );
-
-  const identifiers = await tx
-    .select({
-      decisionId: caseLawDecisionIdentifiers.decisionId,
-      type: caseLawDecisionIdentifiers.type,
-      value: caseLawDecisionIdentifiers.value,
-    })
-    .from(caseLawDecisionIdentifiers)
-    .where(inArray(caseLawDecisionIdentifiers.decisionId, entityIds))
-    .orderBy(
-      asc(caseLawDecisionIdentifiers.decisionId),
-      asc(caseLawDecisionIdentifiers.type),
-      asc(caseLawDecisionIdentifiers.value),
-    )
-    .limit(entityIds.length * DECISION_IDENTIFIER_MAX_COUNT + 1)
-    .for("share");
-  if (identifiers.length > entityIds.length * DECISION_IDENTIFIER_MAX_COUNT) {
-    return panic(
-      `Corpus projection bootstrap identifier count exceeds ${DECISION_IDENTIFIER_MAX_COUNT} per decision`,
-    );
-  }
-  const identifiersByDecision = new Map<
-    string,
-    { type: string; value: string }[]
-  >(entityIds.map((entityId) => [entityId, []]));
-  for (const identifier of identifiers) {
-    const values = identifiersByDecision.get(identifier.decisionId);
-    if (values === undefined) {
-      return panic(
-        `Corpus projection bootstrap loaded an identifier for unclaimed decision ${identifier.decisionId}`,
-      );
-    }
-    if (values.length >= DECISION_IDENTIFIER_MAX_COUNT) {
-      return panic(
-        `Corpus projection bootstrap decision exceeds ${DECISION_IDENTIFIER_MAX_COUNT} identifiers: ${identifier.decisionId}`,
-      );
-    }
-    values.push({ type: identifier.type, value: identifier.value });
-  }
-
   // Recheck the generation after claiming canonical rows. Retirement waits on
   // this mutation fence, and a changed status rolls back the bounded claim.
   const manifest = await lockActiveCorpusProjectionManifestForMutation(
     tx,
-    "case_law",
+    family,
     generation,
   );
-  await setZeroCaseLawProjectionEpochs(tx, entityIds);
+  await claimProjectionEpochs(entityIds);
 
-  const values = rows.map((row: BootstrapCaseLawRow) =>
-    buildCorpusIndexProjectionDesiredStateValues({
-      subject: { family: "case_law", entityId: row.documentId },
-      generation,
-      epoch: row.projectionEpoch === 0n ? 1n : row.projectionEpoch,
-      descriptor: deriveCorpusIndexProjectionDescriptor(manifest, {
-        family: "case_law",
-        documentId: row.documentId,
-        sourceId: row.sourceId,
-        jurisdiction: row.jurisdiction,
-        language: row.language,
-        documentType: row.documentType,
-        contentHash: row.contentHash,
-        redistributionEligible: isRedistributable(
-          descriptors.has(row.sourceId)
-            ? (descriptors.get(row.sourceId) ?? null)
-            : panic(
-                `Corpus projection bootstrap lost source descriptor for case-law source ${row.sourceId}`,
-              ),
-        ),
-        redacted: row.redactedAt !== null,
-        caseNumber: row.caseNumber,
-        identifiers:
-          identifiersByDecision.get(row.documentId) ??
-          panic(
-            `Corpus projection bootstrap lost identifier state for decision ${row.documentId}`,
+  const values = await buildDesiredStateValues({
+    rows,
+    entityIds,
+    manifest,
+    // A source with no descriptor is a policy the corpus allows; a source the
+    // page never read is a bug in the candidate query.
+    descriptorOf: (sourceId) =>
+      descriptors.has(sourceId)
+        ? descriptors.get(sourceId)
+        : panic(
+            `Corpus projection bootstrap lost source descriptor for ${family} source ${sourceId}`,
           ),
-        court: row.court,
-        decisionDate: row.decisionDate,
-        ecli: row.ecli,
-        metadata: row.metadata,
-      }),
-    }),
-  );
+  });
   const inserted = await tx
     .insert(corpusIndexProjectionStates)
     .values(values)
     .returning({ entityId: corpusIndexProjectionStates.entityId });
   if (inserted.length !== rows.length) {
     return panic(
-      `Corpus projection bootstrap inserted ${inserted.length} of ${rows.length} case-law states`,
+      `Corpus projection bootstrap inserted ${inserted.length} of ${rows.length} ${family} states`,
     );
   }
   return {
     status: "advanced",
-    family: "case_law",
-    generation,
     claimedCount: rows.length,
     seededCount: inserted.length,
     entityIds,
@@ -411,177 +326,248 @@ const bootstrapCaseLaw = async (
   };
 };
 
+const bootstrapCaseLaw = async (
+  tx: Transaction,
+  generation: string,
+  limit: number,
+  afterEntityId: SafeId<"caseLawDecision"> | undefined,
+): Promise<CorpusBootstrapPage<SafeId<"caseLawDecision">>> => {
+  const projectionConditions = [
+    eq(corpusIndexProjectionStates.family, "case_law"),
+    eq(corpusIndexProjectionStates.generation, generation),
+    eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
+  ];
+  return await runCorpusBootstrapPage({
+    tx,
+    family: "case_law",
+    generation,
+    afterEntityId,
+    selectCandidates: async () =>
+      await tx
+        .select({
+          documentId: caseLawDecisions.id,
+          sourceId: caseLawDecisions.sourceId,
+          sourceDescriptor: caseLawSources.descriptor,
+        })
+        .from(caseLawDecisions)
+        .innerJoin(
+          caseLawSources,
+          eq(caseLawSources.id, caseLawDecisions.sourceId),
+        )
+        .where(
+          afterEntityId === undefined
+            ? undefined
+            : gt(caseLawDecisions.id, afterEntityId),
+        )
+        .orderBy(asc(caseLawDecisions.id))
+        .limit(limit)
+        // Canonical mutations lock source policy before the decision. Bootstrap
+        // uses the same order; a short policy update may delay this bounded claim.
+        .for("share", { of: caseLawSources }),
+    lockUnseededRows: async (unseededIds) =>
+      await tx
+        .select({
+          documentId: caseLawDecisions.id,
+          sourceId: caseLawDecisions.sourceId,
+          jurisdiction: caseLawDecisions.country,
+          language: caseLawDecisions.language,
+          documentType: caseLawDecisions.decisionType,
+          contentHash: caseLawDecisions.contentHash,
+          redactedAt: caseLawDecisions.redactedAt,
+          caseNumber: caseLawDecisions.caseNumber,
+          court: caseLawDecisions.court,
+          decisionDate: caseLawDecisions.decisionDate,
+          ecli: caseLawDecisions.ecli,
+          metadata: caseLawDecisions.metadata,
+          projectionEpoch: caseLawDecisions.projectionEpoch,
+        })
+        .from(caseLawDecisions)
+        .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
+        .where(
+          and(
+            isNull(corpusIndexProjectionStates.entityId),
+            inArray(caseLawDecisions.id, unseededIds),
+          ),
+        )
+        .orderBy(asc(caseLawDecisions.id))
+        .limit(limit)
+        .for("update", { of: caseLawDecisions, skipLocked: true }),
+    claimProjectionEpochs: async (entityIds) =>
+      await setZeroCaseLawProjectionEpochs(tx, entityIds),
+    buildDesiredStateValues: async ({
+      rows,
+      entityIds,
+      manifest,
+      descriptorOf,
+    }) => {
+      const identifiers = await tx
+        .select({
+          decisionId: caseLawDecisionIdentifiers.decisionId,
+          type: caseLawDecisionIdentifiers.type,
+          value: caseLawDecisionIdentifiers.value,
+        })
+        .from(caseLawDecisionIdentifiers)
+        .where(inArray(caseLawDecisionIdentifiers.decisionId, entityIds))
+        .orderBy(
+          asc(caseLawDecisionIdentifiers.decisionId),
+          asc(caseLawDecisionIdentifiers.type),
+          asc(caseLawDecisionIdentifiers.value),
+        )
+        .limit(entityIds.length * DECISION_IDENTIFIER_MAX_COUNT + 1)
+        .for("share");
+      if (
+        identifiers.length >
+        entityIds.length * DECISION_IDENTIFIER_MAX_COUNT
+      ) {
+        return panic(
+          `Corpus projection bootstrap identifier count exceeds ${DECISION_IDENTIFIER_MAX_COUNT} per decision`,
+        );
+      }
+      const identifiersByDecision = new Map<
+        string,
+        { type: string; value: string }[]
+      >(entityIds.map((entityId) => [entityId, []]));
+      for (const identifier of identifiers) {
+        const values = identifiersByDecision.get(identifier.decisionId);
+        if (values === undefined) {
+          return panic(
+            `Corpus projection bootstrap loaded an identifier for unclaimed decision ${identifier.decisionId}`,
+          );
+        }
+        if (values.length >= DECISION_IDENTIFIER_MAX_COUNT) {
+          return panic(
+            `Corpus projection bootstrap decision exceeds ${DECISION_IDENTIFIER_MAX_COUNT} identifiers: ${identifier.decisionId}`,
+          );
+        }
+        values.push({ type: identifier.type, value: identifier.value });
+      }
+      return rows.map((row) =>
+        buildCorpusIndexProjectionDesiredStateValues({
+          subject: { family: "case_law", entityId: row.documentId },
+          generation,
+          epoch: row.projectionEpoch === 0n ? 1n : row.projectionEpoch,
+          descriptor: deriveCorpusIndexProjectionDescriptor(manifest, {
+            family: "case_law",
+            documentId: row.documentId,
+            sourceId: row.sourceId,
+            jurisdiction: row.jurisdiction,
+            language: row.language,
+            documentType: row.documentType,
+            contentHash: row.contentHash,
+            redistributionEligible: isRedistributable(
+              descriptorOf(row.sourceId),
+            ),
+            redacted: row.redactedAt !== null,
+            caseNumber: row.caseNumber,
+            identifiers:
+              identifiersByDecision.get(row.documentId) ??
+              panic(
+                `Corpus projection bootstrap lost identifier state for decision ${row.documentId}`,
+              ),
+            court: row.court,
+            decisionDate: row.decisionDate,
+            ecli: row.ecli,
+            metadata: row.metadata,
+          }),
+        }),
+      );
+    },
+  });
+};
+
 const bootstrapLegislation = async (
   tx: Transaction,
   generation: string,
   limit: number,
   afterEntityId: SafeId<"legislationDocument"> | undefined,
-): Promise<CorpusIndexProjectionBootstrapResult> => {
+): Promise<CorpusBootstrapPage<SafeId<"legislationDocument">>> => {
   const projectionConditions = [
     eq(corpusIndexProjectionStates.family, "legislation"),
     eq(corpusIndexProjectionStates.generation, generation),
     eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
   ];
-  const candidates = await tx
-    .select({
-      documentId: legislationDocuments.id,
-      sourceId: legislationDocuments.sourceId,
-      sourceDescriptor: legislationSources.descriptor,
-    })
-    .from(legislationDocuments)
-    .innerJoin(
-      legislationSources,
-      eq(legislationSources.id, legislationDocuments.sourceId),
-    )
-    .where(
-      afterEntityId === undefined
-        ? undefined
-        : gt(legislationDocuments.id, afterEntityId),
-    )
-    .orderBy(asc(legislationDocuments.id))
-    .limit(limit)
-    .for("share", { of: legislationSources });
-  if (candidates.length === 0) {
-    // The id range is exhausted. Whether the generation is fully seeded is a
-    // question about every page of a sweep, so the caller owns it.
-    return emptyBootstrapResult(
-      afterEntityId === undefined ? "complete" : "range_complete",
-      "legislation",
-      generation,
-    );
-  }
-
-  const candidateIds = candidates.map(({ documentId }) => documentId);
-  const seededEntityIds = await selectSeededEntityIds(tx, {
-    family: "legislation",
-    generation,
-    entityIds: candidateIds,
-  });
-  const unseededIds = candidateIds.filter(
-    (candidateId) => !seededEntityIds.has(candidateId),
-  );
-  const lockedRows: BootstrapLegislationRow[] =
-    unseededIds.length === 0
-      ? []
-      : await tx
-          .select({
-            documentId: legislationDocuments.id,
-            sourceId: legislationDocuments.sourceId,
-            jurisdiction: legislationDocuments.country,
-            language: legislationDocuments.language,
-            documentType: legislationDocuments.documentType,
-            contentHash: legislationDocuments.contentHash,
-            title: legislationDocuments.title,
-            status: legislationDocuments.status,
-            effectiveDate: legislationDocuments.effectiveDate,
-            versionValidFrom: legislationDocuments.versionValidFrom,
-            versionValidTo: legislationDocuments.versionValidTo,
-            eli: legislationDocuments.eli,
-            projectionEpoch: legislationDocuments.projectionEpoch,
-          })
-          .from(legislationDocuments)
-          .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
-          .where(
-            and(
-              isNull(corpusIndexProjectionStates.entityId),
-              inArray(legislationDocuments.id, unseededIds),
-            ),
-          )
-          .orderBy(asc(legislationDocuments.id))
-          .limit(limit)
-          .for("update", { of: legislationDocuments, skipLocked: true });
-  const lockedById = new Map(lockedRows.map((row) => [row.documentId, row]));
-  // See the case-law path: the cursor may cross only the prefix this batch
-  // accounts for, seeded or claimed.
-  const rows: BootstrapLegislationRow[] = [];
-  let pageEndEntityId: SafeId<"legislationDocument"> | undefined;
-  for (const candidate of candidates) {
-    if (!seededEntityIds.has(candidate.documentId)) {
-      const row = lockedById.get(candidate.documentId);
-      if (row === undefined) {
-        break;
-      }
-      rows.push(row);
-    }
-    pageEndEntityId = candidate.documentId;
-  }
-  if (pageEndEntityId === undefined) {
-    return emptyBootstrapResult("busy", "legislation", generation);
-  }
-  if (rows.length === 0) {
-    return {
-      status: "advanced",
-      family: "legislation",
-      generation,
-      claimedCount: 0,
-      seededCount: 0,
-      entityIds: [],
-      nextAfterEntityId: pageEndEntityId,
-    };
-  }
-
-  const entityIds = rows.map(({ documentId }) => documentId);
-  const descriptors = new Map(
-    candidates.map(({ sourceId, sourceDescriptor }) => [
-      sourceId,
-      sourceDescriptor,
-    ]),
-  );
-
-  const manifest = await lockActiveCorpusProjectionManifestForMutation(
+  return await runCorpusBootstrapPage({
     tx,
-    "legislation",
-    generation,
-  );
-  await setZeroLegislationProjectionEpochs(tx, entityIds);
-
-  const values = rows.map((row: BootstrapLegislationRow) =>
-    buildCorpusIndexProjectionDesiredStateValues({
-      subject: { family: "legislation", entityId: row.documentId },
-      generation,
-      epoch: row.projectionEpoch === 0n ? 1n : row.projectionEpoch,
-      descriptor: deriveCorpusIndexProjectionDescriptor(manifest, {
-        family: "legislation",
-        documentId: row.documentId,
-        sourceId: row.sourceId,
-        jurisdiction: row.jurisdiction,
-        language: row.language,
-        documentType: row.documentType,
-        contentHash: row.contentHash,
-        redistributionEligible: isRedistributable(
-          descriptors.has(row.sourceId)
-            ? (descriptors.get(row.sourceId) ?? null)
-            : panic(
-                `Corpus projection bootstrap lost source descriptor for legislation source ${row.sourceId}`,
-              ),
-        ),
-        title: row.title,
-        status: row.status,
-        effectiveDate: row.effectiveDate,
-        versionValidFrom: row.versionValidFrom,
-        versionValidTo: row.versionValidTo,
-        eli: row.eli,
-      }),
-    }),
-  );
-  const inserted = await tx
-    .insert(corpusIndexProjectionStates)
-    .values(values)
-    .returning({ entityId: corpusIndexProjectionStates.entityId });
-  if (inserted.length !== rows.length) {
-    return panic(
-      `Corpus projection bootstrap inserted ${inserted.length} of ${rows.length} legislation states`,
-    );
-  }
-  return {
-    status: "advanced",
     family: "legislation",
     generation,
-    claimedCount: rows.length,
-    seededCount: inserted.length,
-    entityIds,
-    nextAfterEntityId: pageEndEntityId,
-  };
+    afterEntityId,
+    selectCandidates: async () =>
+      await tx
+        .select({
+          documentId: legislationDocuments.id,
+          sourceId: legislationDocuments.sourceId,
+          sourceDescriptor: legislationSources.descriptor,
+        })
+        .from(legislationDocuments)
+        .innerJoin(
+          legislationSources,
+          eq(legislationSources.id, legislationDocuments.sourceId),
+        )
+        .where(
+          afterEntityId === undefined
+            ? undefined
+            : gt(legislationDocuments.id, afterEntityId),
+        )
+        .orderBy(asc(legislationDocuments.id))
+        .limit(limit)
+        .for("share", { of: legislationSources }),
+    lockUnseededRows: async (unseededIds) =>
+      await tx
+        .select({
+          documentId: legislationDocuments.id,
+          sourceId: legislationDocuments.sourceId,
+          jurisdiction: legislationDocuments.country,
+          language: legislationDocuments.language,
+          documentType: legislationDocuments.documentType,
+          contentHash: legislationDocuments.contentHash,
+          title: legislationDocuments.title,
+          status: legislationDocuments.status,
+          effectiveDate: legislationDocuments.effectiveDate,
+          versionValidFrom: legislationDocuments.versionValidFrom,
+          versionValidTo: legislationDocuments.versionValidTo,
+          eli: legislationDocuments.eli,
+          projectionEpoch: legislationDocuments.projectionEpoch,
+        })
+        .from(legislationDocuments)
+        .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
+        .where(
+          and(
+            isNull(corpusIndexProjectionStates.entityId),
+            inArray(legislationDocuments.id, unseededIds),
+          ),
+        )
+        .orderBy(asc(legislationDocuments.id))
+        .limit(limit)
+        .for("update", { of: legislationDocuments, skipLocked: true }),
+    claimProjectionEpochs: async (entityIds) =>
+      await setZeroLegislationProjectionEpochs(tx, entityIds),
+    buildDesiredStateValues: ({ rows, manifest, descriptorOf }) =>
+      rows.map((row) =>
+        buildCorpusIndexProjectionDesiredStateValues({
+          subject: { family: "legislation", entityId: row.documentId },
+          generation,
+          epoch: row.projectionEpoch === 0n ? 1n : row.projectionEpoch,
+          descriptor: deriveCorpusIndexProjectionDescriptor(manifest, {
+            family: "legislation",
+            documentId: row.documentId,
+            sourceId: row.sourceId,
+            jurisdiction: row.jurisdiction,
+            language: row.language,
+            documentType: row.documentType,
+            contentHash: row.contentHash,
+            redistributionEligible: isRedistributable(
+              descriptorOf(row.sourceId),
+            ),
+            title: row.title,
+            status: row.status,
+            effectiveDate: row.effectiveDate,
+            versionValidFrom: row.versionValidFrom,
+            versionValidTo: row.versionValidTo,
+            eli: row.eli,
+          }),
+        }),
+      ),
+  });
 };
 
 /**
@@ -604,21 +590,48 @@ export const bootstrapCorpusProjectionDesiredStateBatchTx = async (
   options: CorpusIndexProjectionBootstrapOptions,
 ): Promise<CorpusIndexProjectionBootstrapResult> => {
   const limit = validateBootstrapLimit(options.limit);
+  const { generation } = options;
   switch (options.family) {
-    case "case_law":
-      return await bootstrapCaseLaw(
+    case "case_law": {
+      const page = await bootstrapCaseLaw(
         tx,
-        options.generation,
+        generation,
         limit,
         options.afterEntityId,
       );
-    case "legislation":
-      return await bootstrapLegislation(
+      if (page.status !== "advanced") {
+        return emptyBootstrapResult(page.status, "case_law", generation);
+      }
+      return {
+        status: "advanced",
+        family: "case_law",
+        generation,
+        claimedCount: page.claimedCount,
+        seededCount: page.seededCount,
+        entityIds: page.entityIds,
+        nextAfterEntityId: page.nextAfterEntityId,
+      };
+    }
+    case "legislation": {
+      const page = await bootstrapLegislation(
         tx,
-        options.generation,
+        generation,
         limit,
         options.afterEntityId,
       );
+      if (page.status !== "advanced") {
+        return emptyBootstrapResult(page.status, "legislation", generation);
+      }
+      return {
+        status: "advanced",
+        family: "legislation",
+        generation,
+        claimedCount: page.claimedCount,
+        seededCount: page.seededCount,
+        entityIds: page.entityIds,
+        nextAfterEntityId: page.nextAfterEntityId,
+      };
+    }
     default:
       options satisfies never;
       return panic(`Unhandled options: ${String(options)}`);


### PR DESCRIPTION
## What

A bootstrap page now walks the next `limit` ids after the cursor (a keyset range scan on the primary key), looks up which of them already carry a desired-state row, and locks and seeds only the gaps. The cursor advances by a full page even when nothing was seeded. A head-of-corpus page with nothing to seed consults the existing EXISTS probe and reports `complete` when nothing is left. Same shape for case law and legislation.

## Why

The page query selected the next `limit` rows that had no desired-state row. When almost every row is already seeded (the second pass over a corpus starts from a null cursor after `range_complete`), one page had to anti-join nearly the whole table to find its rows, exceeded any transaction deadline, and since the cursor only advances on success the same page was retried forever. A page's work must be bounded by its size, not by the table.

## Tests

pglite: a page's work is bounded by its limit, not by how many rows are already seeded (advances exactly `limit` ids, seeds only the gap in range, then `range_complete`, then `complete`); a legislation page with nothing to seed advances instead of stalling; the query-shape guard now asserts the cursor page carries no anti-join and the seeding read is restricted to the page's ids.