### PR TITLE
feat(desktop): error reports carry a redacted detail, and distinct failures report separately

### DIFF
--- a/apps/desktop/src-tauri/src/desktop_telemetry.rs
+++ b/apps/desktop/src-tauri/src/desktop_telemetry.rs
@@ -137,6 +137,131 @@ pub struct DesktopErrorReport {
   pub code: DesktopTelemetryErrorCode,
 }
 
+const MAX_ERROR_NAME_CHARS: usize = 64;
+const MAX_ERROR_MESSAGE_CHARS: usize = 200;
+const MAX_ERROR_FRAME_CHARS: usize = 160;
+/// Distinct error events kept per process before further reports are dropped.
+const MAX_REPORTED_ERRORS: usize = 200;
+
+/// What went wrong, without what the user was working on. The webview redacts
+/// before sending; this side is the trust boundary and redacts again, so a
+/// report can never carry clipboard text, search terms or document content
+/// even if the webview's copy of the rules drifts.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DesktopErrorDetail {
+  /// The thrown value's class (`TypeError`), or its type for non-errors.
+  pub error_name: String,
+  pub message: String,
+  /// `function@file:line:col` of the top frame; bundle file names only.
+  pub frame: Option<String>,
+}
+
+impl DesktopErrorDetail {
+  fn sanitized(self) -> Self {
+    Self {
+      error_name: bounded_identifier(&self.error_name, MAX_ERROR_NAME_CHARS)
+        .unwrap_or_else(|| "unknown".to_string()),
+      message: redact_error_message(&self.message),
+      frame: self.frame.as_deref().and_then(sanitized_frame),
+    }
+  }
+}
+
+/// Keeps a value made only of identifier characters; anything else is not a
+/// class name or a frame and is dropped rather than trimmed into one.
+fn bounded_identifier(value: &str, max_chars: usize) -> Option<String> {
+  let value = value.trim();
+  let valid = !value.is_empty()
+    && value.chars().count() <= max_chars
+    && value
+      .chars()
+      .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '$' | '.'));
+  valid.then(|| value.to_string())
+}
+
+fn sanitized_frame(frame: &str) -> Option<String> {
+  let frame = frame.trim();
+  let valid = !frame.is_empty()
+    && frame.chars().count() <= MAX_ERROR_FRAME_CHARS
+    && frame.chars().all(|c| {
+      c.is_ascii_alphanumeric()
+        || matches!(c, '_' | '$' | '.' | ':' | '@' | '-' | '<' | '>')
+    });
+  valid.then(|| frame.to_string())
+}
+
+/// Error messages quote the data they choked on (`Unexpected token 'x', "…" is
+/// not valid JSON`), so every quoted span becomes `"…"`, except single-quoted
+/// code identifiers such as `'item.sourceApp.name'`, which name code, not
+/// content. URLs and long unbroken tokens (blobs, base64) are dropped too.
+pub(crate) fn redact_error_message(message: &str) -> String {
+  let mut output = String::with_capacity(message.len());
+  let mut rest = message;
+  while let Some(start) = rest.find(['"', '\'', '`']) {
+    let quote = rest[start..].chars().next().unwrap_or('"');
+    output.push_str(&rest[..start]);
+    let after = &rest[start + quote.len_utf8()..];
+    let Some(end) = after.find(quote) else {
+      // An unterminated quote: everything after it is content.
+      output.push_str("\"…\"");
+      rest = "";
+      break;
+    };
+    let quoted = &after[..end];
+    let is_code_identifier = quote == '\''
+      && !quoted.is_empty()
+      && quoted
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '$' | '.' | '[' | ']'));
+    if is_code_identifier {
+      output.push('\'');
+      output.push_str(quoted);
+      output.push('\'');
+    } else {
+      output.push_str("\"…\"");
+    }
+    rest = &after[end + quote.len_utf8()..];
+  }
+  output.push_str(rest);
+  let collapsed = output
+    .split_whitespace()
+    .map(|token| {
+      if token.starts_with("http://") || token.starts_with("https://") {
+        "<url>"
+      } else if token.chars().count() > 48 {
+        "…"
+      } else {
+        token
+      }
+    })
+    .collect::<Vec<_>>()
+    .join(" ");
+  let mut bounded: String = collapsed.chars().take(MAX_ERROR_MESSAGE_CHARS).collect();
+  if bounded.chars().count() < collapsed.chars().count() {
+    bounded.push('…');
+  }
+  bounded
+}
+
+/// A webview error report: the allowlisted classification plus optional
+/// redacted detail.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DesktopFrontendErrorReport {
+  pub window: DesktopTelemetryWindow,
+  pub operation: DesktopTelemetryOperation,
+  pub code: DesktopTelemetryErrorCode,
+  #[serde(default)]
+  pub detail: Option<DesktopErrorDetail>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DesktopErrorEvent {
+  report: DesktopErrorReport,
+  detail: Option<DesktopErrorDetail>,
+}
+
 /// Startup phases measured on the clipboard path. Spans carry durations and
 /// counts only: never clipboard content, source-app identities, or search text.
 // The `Clipboard` prefix is the wire namespace shared with the frontend
@@ -237,15 +362,15 @@ pub struct DesktopFrontendTimingReport {
   pub duration_ms: u64,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum DesktopTelemetryEvent {
-  Error(DesktopErrorReport),
+  Error(DesktopErrorEvent),
   Timing(DesktopTimingReport),
 }
 
 #[derive(Clone)]
 pub struct DesktopTelemetry {
-  reported: Arc<Mutex<HashSet<DesktopErrorReport>>>,
+  reported: Arc<Mutex<HashSet<DesktopErrorEvent>>>,
   sender: Option<mpsc::Sender<DesktopTelemetryEvent>>,
 }
 
@@ -273,21 +398,46 @@ impl DesktopTelemetry {
   }
 
   pub fn capture(&self, report: DesktopErrorReport) {
-    let is_new = self
-      .reported
-      .lock()
-      .is_ok_and(|mut reported| reported.insert(report));
+    self.capture_event(DesktopErrorEvent {
+      report,
+      detail: None,
+    });
+  }
+
+  /// A webview report, with its detail redacted here regardless of what the
+  /// webview did.
+  pub fn capture_frontend(&self, report: DesktopFrontendErrorReport) {
+    self.capture_event(DesktopErrorEvent {
+      report: DesktopErrorReport {
+        window: report.window,
+        operation: report.operation,
+        code: report.code,
+      },
+      detail: report.detail.map(DesktopErrorDetail::sanitized),
+    });
+  }
+
+  fn capture_event(&self, event: DesktopErrorEvent) {
+    // Each distinct failure reports once per process; the cap stops a
+    // rejection loop with a changing message from flooding the sink.
+    let is_new = self.reported.lock().is_ok_and(|mut reported| {
+      reported.len() < MAX_REPORTED_ERRORS && reported.insert(event.clone())
+    });
     if !is_new {
       return;
     }
 
+    let detail = event.detail.as_ref();
     tracing::error!(
-      window = ?report.window,
-      operation = ?report.operation,
-      code = ?report.code,
+      window = ?event.report.window,
+      operation = ?event.report.operation,
+      code = ?event.report.code,
+      error_name = detail.map(|detail| detail.error_name.as_str()),
+      error_message = detail.map(|detail| detail.message.as_str()),
+      error_frame = detail.and_then(|detail| detail.frame.as_deref()),
       "desktop operation failed"
     );
-    self.enqueue(DesktopTelemetryEvent::Error(report));
+    self.enqueue(DesktopTelemetryEvent::Error(event));
   }
 
   pub fn capture_timing(&self, report: DesktopTimingReport) {
@@ -357,20 +507,31 @@ impl AnalyticsSinkConfig {
 
 fn analytics_error_payload(
   config: &AnalyticsSinkConfig,
-  report: DesktopErrorReport,
+  event: &DesktopErrorEvent,
 ) -> Value {
-  let window = report.window.as_str();
-  let operation = report.operation.as_str();
-  let code = report.code.as_str();
-  let fingerprint = format!("desktop:{window}:{operation}:{code}");
+  let window = event.report.window.as_str();
+  let operation = event.report.operation.as_str();
+  let code = event.report.code.as_str();
+  let detail = event.detail.as_ref();
+  // One issue per failure, not per classification: two different rejections
+  // under `runtime/unhandledRejection` must not collapse into one group.
+  let mut fingerprint = format!("desktop:{window}:{operation}:{code}");
+  if let Some(detail) = detail {
+    fingerprint.push(':');
+    fingerprint.push_str(&detail.error_name);
+    if let Some(frame) = &detail.frame {
+      fingerprint.push(':');
+      fingerprint.push_str(frame);
+    }
+  }
   json!({
     "api_key": config.key,
     "event": "$exception",
     "properties": {
       "$exception_fingerprint": fingerprint,
       "$exception_list": [{
-        "type": code,
-        "value": "",
+        "type": detail.map_or(code, |detail| detail.error_name.as_str()),
+        "value": detail.map_or("", |detail| detail.message.as_str()),
       }],
       "$exception_type": code,
       "$process_person_profile": false,
@@ -378,7 +539,10 @@ fn analytics_error_payload(
       "app_version": env!("CARGO_PKG_VERSION"),
       "desktop_window": window,
       "distinct_id": config.process_id,
+      "error_frame": detail.and_then(|detail| detail.frame.as_deref()),
+      "error_name": detail.map(|detail| detail.error_name.as_str()),
       "operation": operation,
+      "os": std::env::consts::OS,
       "service_name": "stella-desktop",
     }
   })
@@ -416,7 +580,7 @@ fn analytics_payload(
   event: DesktopTelemetryEvent,
 ) -> Value {
   match event {
-    DesktopTelemetryEvent::Error(report) => analytics_error_payload(config, report),
+    DesktopTelemetryEvent::Error(event) => analytics_error_payload(config, &event),
     DesktopTelemetryEvent::Timing(report) => analytics_timing_payload(config, report),
   }
 }
@@ -449,10 +613,10 @@ async fn run_observability_worker(
 
 #[tauri::command]
 pub fn desktop_report_error(
-  report: DesktopErrorReport,
+  report: DesktopFrontendErrorReport,
   telemetry: State<'_, DesktopTelemetry>,
 ) {
-  telemetry.capture(report);
+  telemetry.capture_frontend(report);
 }
 
 #[tauri::command]
@@ -528,18 +692,162 @@ mod tests {
     assert!(serde_json::from_value::<DesktopErrorReport>(value).is_err());
   }
 
+  fn event(detail: Option<DesktopErrorDetail>) -> DesktopErrorEvent {
+    DesktopErrorEvent {
+      report: report(),
+      detail,
+    }
+  }
+
   #[test]
   fn payload_contains_only_allowlisted_diagnostics() {
-    let payload = analytics_error_payload(&config(), report());
+    let payload = analytics_error_payload(&config(), &event(None));
     let properties = payload["properties"].as_object().unwrap();
 
     assert_eq!(payload["event"], "$exception");
     assert_eq!(properties["desktop_window"], "clipboard");
     assert_eq!(properties["operation"], "clipboardHistoryRead");
     assert_eq!(properties["$exception_type"], "invalidResponse");
+    assert_eq!(properties["$exception_list"][0]["type"], "invalidResponse");
     assert!(!properties.contains_key("clipboardText"));
     assert!(!properties.contains_key("message"));
     assert!(!properties.contains_key("stack"));
+  }
+
+  #[test]
+  fn detail_names_the_failure_and_splits_the_fingerprint() {
+    let detail = DesktopErrorDetail {
+      error_name: "TypeError".to_string(),
+      message: "undefined is not an object (evaluating 'item.sourceApp.name')"
+        .to_string(),
+      frame: Some("renderCard@index-3f2a.js:12:34".to_string()),
+    };
+
+    let payload = analytics_error_payload(&config(), &event(Some(detail)));
+    let properties = payload["properties"].as_object().unwrap();
+
+    assert_eq!(properties["$exception_list"][0]["type"], "TypeError");
+    assert_eq!(
+      properties["$exception_list"][0]["value"],
+      "undefined is not an object (evaluating 'item.sourceApp.name')"
+    );
+    assert_eq!(properties["error_name"], "TypeError");
+    assert_eq!(properties["error_frame"], "renderCard@index-3f2a.js:12:34");
+    assert_eq!(
+      properties["$exception_fingerprint"],
+      "desktop:clipboard:clipboardHistoryRead:invalidResponse:TypeError:renderCard@index-3f2a.js:12:34"
+    );
+    // Classification stays the type PostHog filters on.
+    assert_eq!(properties["$exception_type"], "invalidResponse");
+  }
+
+  #[test]
+  fn detail_and_frontend_reports_reject_unknown_fields() {
+    let detail = json!({
+      "errorName": "TypeError",
+      "message": "boom",
+      "frame": null,
+      "stack": "must never be accepted",
+    });
+    assert!(serde_json::from_value::<DesktopErrorDetail>(detail).is_err());
+
+    let report = json!({
+      "window": "clipboard",
+      "operation": "runtime",
+      "code": "unhandledRejection",
+      "detail": { "errorName": "TypeError", "message": "boom", "frame": null },
+      "plainText": "must never be accepted",
+    });
+    assert!(serde_json::from_value::<DesktopFrontendErrorReport>(report).is_err());
+  }
+
+  #[test]
+  fn redaction_keeps_the_shape_of_a_message_and_drops_its_content() {
+    assert_eq!(
+      redact_error_message(
+        r#"Unexpected token 'a', "Article 12 of the lease agreement" is not valid JSON"#
+      ),
+      r#"Unexpected token 'a', "…" is not valid JSON"#
+    );
+    assert_eq!(
+      redact_error_message(
+        "undefined is not an object (evaluating 'item.sourceApp.name')"
+      ),
+      "undefined is not an object (evaluating 'item.sourceApp.name')"
+    );
+    assert_eq!(
+      redact_error_message("Cannot read 'Jan Novák' from `notes`"),
+      r#"Cannot read "…" from "…""#
+    );
+    assert_eq!(
+      redact_error_message(
+        "Load failed https://example.org/contracts/42?token=abc now"
+      ),
+      "Load failed <url> now"
+    );
+    assert_eq!(
+      redact_error_message(&format!("blob {} rejected", "A".repeat(80))),
+      "blob … rejected"
+    );
+    assert_eq!(
+      redact_error_message("unterminated \"quote text"),
+      "unterminated \"…\""
+    );
+    let long = redact_error_message(&"word ".repeat(100));
+    assert_eq!(long.chars().count(), MAX_ERROR_MESSAGE_CHARS + 1);
+    assert!(long.ends_with('…'));
+  }
+
+  #[test]
+  fn sanitized_detail_rejects_names_and_frames_that_are_not_identifiers() {
+    let detail = DesktopErrorDetail {
+      error_name: "Type Error; DROP".to_string(),
+      message: "x".to_string(),
+      frame: Some("fn@index.js:1:2 \"quoted\"".to_string()),
+    }
+    .sanitized();
+
+    assert_eq!(detail.error_name, "unknown");
+    assert_eq!(detail.frame, None);
+    assert_eq!(
+      DesktopErrorDetail {
+        error_name: "string".to_string(),
+        message: "clipboard item no longer exists".to_string(),
+        frame: Some("@index-3f2a.js:9:1".to_string()),
+      }
+      .sanitized()
+      .frame
+      .as_deref(),
+      Some("@index-3f2a.js:9:1")
+    );
+  }
+
+  #[test]
+  fn distinct_details_report_separately_and_the_cap_holds() {
+    let telemetry = DesktopTelemetry {
+      reported: Arc::new(Mutex::new(HashSet::new())),
+      sender: None,
+    };
+    let detail = |message: &str| {
+      Some(DesktopErrorDetail {
+        error_name: "TypeError".to_string(),
+        message: message.to_string(),
+        frame: None,
+      })
+    };
+
+    telemetry.capture_event(event(detail("first")));
+    telemetry.capture_event(event(detail("second")));
+    telemetry.capture_event(event(detail("first")));
+    assert_eq!(telemetry.reported.lock().unwrap().len(), 2);
+
+    for index in 0..MAX_REPORTED_ERRORS {
+      telemetry.capture_event(event(detail(&format!("flood {index}"))));
+    }
+    assert_eq!(
+      telemetry.reported.lock().unwrap().len(),
+      MAX_REPORTED_ERRORS
+    );
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/desktop_telemetry.rs
+++ b/apps/desktop/src-tauri/src/desktop_telemetry.rs
@@ -159,13 +159,54 @@ pub struct DesktopErrorDetail {
 
 impl DesktopErrorDetail {
   fn sanitized(self) -> Self {
+    let error_name = bounded_identifier(&self.error_name, MAX_ERROR_NAME_CHARS)
+      .unwrap_or_else(|| "unknown".to_string());
+    // Only engine-written messages keep their text; everything else is a
+    // digest, computed here when the webview did not already send one.
+    let message = if ENGINE_ERROR_CLASSES.contains(&error_name.as_str()) {
+      redact_error_message(&self.message)
+    } else if is_message_digest(&self.message) {
+      self.message
+    } else {
+      message_digest(&self.message)
+    };
     Self {
-      error_name: bounded_identifier(&self.error_name, MAX_ERROR_NAME_CHARS)
-        .unwrap_or_else(|| "unknown".to_string()),
-      message: redact_error_message(&self.message),
+      error_name,
+      message,
       frame: self.frame.as_deref().and_then(sanitized_frame),
     }
   }
+}
+
+/// Error classes whose messages the engine writes: they describe code, not
+/// data, once quoted spans are redacted. Mirrors the webview allowlist.
+const ENGINE_ERROR_CLASSES: [&str; 7] = [
+  "TypeError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "URIError",
+  "EvalError",
+  "DOMException",
+];
+const MESSAGE_DIGEST_PREFIX: &str = "poly64:";
+
+/// A 64-bit polynomial rolling hash over the UTF-8 bytes (FNV's offset and
+/// prime, multiply-add), as 16 hex digits; the webview computes the same.
+fn message_digest(message: &str) -> String {
+  let mut hash: u64 = 14_695_981_039_346_656_037;
+  for byte in message.bytes() {
+    hash = hash
+      .wrapping_mul(1_099_511_628_211)
+      .wrapping_add(u64::from(byte));
+  }
+  format!("{MESSAGE_DIGEST_PREFIX}{hash:016x}")
+}
+
+fn is_message_digest(value: &str) -> bool {
+  value
+    .strip_prefix(MESSAGE_DIGEST_PREFIX)
+    .is_some_and(|hex| hex.len() == 16 && hex.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
 /// Keeps a value made only of identifier characters; anything else is not a
@@ -523,6 +564,10 @@ fn analytics_error_payload(
       fingerprint.push(':');
       fingerprint.push_str(frame);
     }
+    // Two string rejections share a class and have no frame; the message
+    // digest keeps them apart without carrying text.
+    fingerprint.push(':');
+    fingerprint.push_str(&message_digest(&detail.message));
   }
   json!({
     "api_key": config.key,
@@ -733,9 +778,13 @@ mod tests {
     );
     assert_eq!(properties["error_name"], "TypeError");
     assert_eq!(properties["error_frame"], "renderCard@index-3f2a.js:12:34");
+    let digest =
+      message_digest("undefined is not an object (evaluating 'item.sourceApp.name')");
     assert_eq!(
       properties["$exception_fingerprint"],
-      "desktop:clipboard:clipboardHistoryRead:invalidResponse:TypeError:renderCard@index-3f2a.js:12:34"
+      format!(
+        "desktop:clipboard:clipboardHistoryRead:invalidResponse:TypeError:renderCard@index-3f2a.js:12:34:{digest}"
+      )
     );
     // Classification stays the type PostHog filters on.
     assert_eq!(properties["$exception_type"], "invalidResponse");
@@ -809,16 +858,57 @@ mod tests {
 
     assert_eq!(detail.error_name, "unknown");
     assert_eq!(detail.frame, None);
+    let string_rejection = DesktopErrorDetail {
+      error_name: "string".to_string(),
+      message: "clipboard item no longer exists".to_string(),
+      frame: Some("@index-3f2a.js:9:1".to_string()),
+    }
+    .sanitized();
     assert_eq!(
+      string_rejection.frame.as_deref(),
+      Some("@index-3f2a.js:9:1")
+    );
+    // A message the engine did not write never survives as text.
+    assert_eq!(
+      string_rejection.message,
+      message_digest("clipboard item no longer exists")
+    );
+  }
+
+  #[test]
+  fn only_engine_error_messages_keep_their_text() {
+    // Same vector as the webview test, so both sides agree on the digest.
+    assert_eq!(message_digest("a"), "poly64:af63bd4c8601b840");
+    let sanitize = |error_name: &str, message: &str| {
       DesktopErrorDetail {
-        error_name: "string".to_string(),
-        message: "clipboard item no longer exists".to_string(),
-        frame: Some("@index-3f2a.js:9:1".to_string()),
+        error_name: error_name.to_string(),
+        message: message.to_string(),
+        frame: None,
       }
       .sanitized()
-      .frame
-      .as_deref(),
-      Some("@index-3f2a.js:9:1")
+      .message
+    };
+
+    assert_eq!(
+      sanitize("TypeError", "null is not an object (evaluating 'a.b')"),
+      "null is not an object (evaluating 'a.b')"
+    );
+    assert_eq!(
+      sanitize("Error", "Attorney client notes"),
+      message_digest("Attorney client notes")
+    );
+    assert_eq!(
+      sanitize("object.copy", "clipboard write failed"),
+      message_digest("clipboard write failed")
+    );
+    // A digest the webview already computed passes through unchanged.
+    assert_eq!(
+      sanitize("string", "poly64:af63bd4c8601b840"),
+      "poly64:af63bd4c8601b840"
+    );
+    assert_eq!(
+      sanitize("string", "poly64:not-a-digest"),
+      message_digest("poly64:not-a-digest")
     );
   }
 

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -87,6 +87,7 @@ import {
   DESKTOP_TELEMETRY_ERROR_CODES,
   DESKTOP_TELEMETRY_OPERATIONS,
   DESKTOP_TELEMETRY_WINDOWS,
+  describeError,
   reportDesktopError,
 } from "../telemetry/desktop-telemetry";
 import {
@@ -1095,9 +1096,10 @@ const ClipboardWelcomeDialog = ({ onClose }: ClipboardWelcomeDialogProps) => {
         });
         return undefined;
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         reportDesktopError({
           code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+          detail: describeError(error),
           operation: DESKTOP_TELEMETRY_OPERATIONS.autostartRead,
           window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
         });
@@ -1148,9 +1150,10 @@ const ClipboardWelcomeDialog = ({ onClose }: ClipboardWelcomeDialogProps) => {
         });
         return undefined;
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         reportDesktopError({
           code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+          detail: describeError(error),
           operation: DESKTOP_TELEMETRY_OPERATIONS.autostartUpdate,
           window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
         });
@@ -1337,12 +1340,13 @@ const ClipboardApp = () => {
           setError((current) => (current?.source === "read" ? null : current));
           return undefined;
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           if (disposed || requestId !== snapshotRequestIdRef.current) {
             return;
           }
           reportDesktopError({
             code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+            detail: describeError(error),
             operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardHistoryRead,
             window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
           });
@@ -1427,9 +1431,10 @@ const ClipboardApp = () => {
   });
 
   const requestHide = () => {
-    void invoke("clipboard_hide").catch(() => {
+    void invoke("clipboard_hide").catch((error: unknown) => {
       reportDesktopError({
         code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+        detail: describeError(error),
         operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardWindowHide,
         window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
       });
@@ -1526,9 +1531,10 @@ const ClipboardApp = () => {
           });
           return undefined;
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           reportDesktopError({
             code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+            detail: describeError(error),
             operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardHistoryUpdate,
             window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
           });
@@ -1568,9 +1574,10 @@ const ClipboardApp = () => {
 
   const openEditor = (id: string) => {
     setError((current) => (current?.source === "operation" ? null : current));
-    void invoke("clipboard_open_editor", { id }).catch(() => {
+    void invoke("clipboard_open_editor", { id }).catch((error: unknown) => {
       reportDesktopError({
         code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+        detail: describeError(error),
         operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardHistoryUpdate,
         window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
       });
@@ -2079,9 +2086,10 @@ const ClipboardApp = () => {
               href={STELLA_WEB_APP_URL}
               onClick={(event) => {
                 event.preventDefault();
-                void invoke("clipboard_open_stella").catch(() => {
+                void invoke("clipboard_open_stella").catch((error: unknown) => {
                   reportDesktopError({
                     code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+                    detail: describeError(error),
                     operation:
                       DESKTOP_TELEMETRY_OPERATIONS.clipboardExternalOpen,
                     window: DESKTOP_TELEMETRY_WINDOWS.clipboard,

--- a/apps/desktop/src/clipboard/ClipboardEditor.tsx
+++ b/apps/desktop/src/clipboard/ClipboardEditor.tsx
@@ -27,6 +27,7 @@ import {
   DESKTOP_TELEMETRY_ERROR_CODES,
   DESKTOP_TELEMETRY_OPERATIONS,
   DESKTOP_TELEMETRY_WINDOWS,
+  describeError,
   reportDesktopError,
 } from "../telemetry/desktop-telemetry";
 import { clipboardSourceLabel, clipboardSourceTitle } from "./clipboard-logic";
@@ -513,9 +514,10 @@ const ClipboardEditor = () => {
   const [state, setState] = useState<EditorState>({ type: "loading" });
   const loadError = t("errorReadHistory");
   const requestClose = () => {
-    closeEditor().catch(() => {
+    closeEditor().catch((error: unknown) => {
       reportDesktopError({
         code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+        detail: describeError(error),
         operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardEditorClose,
         window: DESKTOP_TELEMETRY_WINDOWS.clipboardEditor,
       });
@@ -573,12 +575,13 @@ const ClipboardEditor = () => {
           });
           return undefined;
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           if (disposed) {
             return;
           }
           reportDesktopError({
             code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+            detail: describeError(error),
             operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardEditorRead,
             window: DESKTOP_TELEMETRY_WINDOWS.clipboardEditor,
           });
@@ -629,9 +632,10 @@ const ClipboardEditor = () => {
         id: item.id,
       })
         .then(closeEditor)
-        .catch(() => {
+        .catch((error: unknown) => {
           reportDesktopError({
             code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+            detail: describeError(error),
             operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardEditorSave,
             window: DESKTOP_TELEMETRY_WINDOWS.clipboardEditor,
           });
@@ -671,9 +675,10 @@ const ClipboardEditor = () => {
       plainText,
     })
       .then(closeEditor)
-      .catch(() => {
+      .catch((error: unknown) => {
         reportDesktopError({
           code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+          detail: describeError(error),
           operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardEditorSave,
           window: DESKTOP_TELEMETRY_WINDOWS.clipboardEditor,
         });

--- a/apps/desktop/src/mainview/main.tsx
+++ b/apps/desktop/src/mainview/main.tsx
@@ -20,6 +20,7 @@ import { useSystemTheme } from "../shared/use-system-theme";
 import {
   DESKTOP_TELEMETRY_ERROR_CODES,
   DESKTOP_TELEMETRY_OPERATIONS,
+  describeError,
   desktopTelemetryWindowFromLabel,
   installDesktopErrorTelemetry,
   reportDesktopError,
@@ -119,23 +120,26 @@ const existingRoot: unknown = Reflect.get(rootElement, REACT_ROOT_KEY);
 const reactRoot = isReactRoot(existingRoot)
   ? existingRoot
   : createRoot(rootElement, {
-      onCaughtError: () => {
+      onCaughtError: (error) => {
         reportDesktopError({
           code: DESKTOP_TELEMETRY_ERROR_CODES.reactCaught,
+          detail: describeError(error),
           operation: DESKTOP_TELEMETRY_OPERATIONS.render,
           window: telemetryWindow,
         });
       },
-      onRecoverableError: () => {
+      onRecoverableError: (error) => {
         reportDesktopError({
           code: DESKTOP_TELEMETRY_ERROR_CODES.reactRecoverable,
+          detail: describeError(error),
           operation: DESKTOP_TELEMETRY_OPERATIONS.render,
           window: telemetryWindow,
         });
       },
-      onUncaughtError: () => {
+      onUncaughtError: (error) => {
         reportDesktopError({
           code: DESKTOP_TELEMETRY_ERROR_CODES.reactUncaught,
+          detail: describeError(error),
           operation: DESKTOP_TELEMETRY_OPERATIONS.render,
           window: telemetryWindow,
         });

--- a/apps/desktop/src/telemetry/desktop-telemetry.ts
+++ b/apps/desktop/src/telemetry/desktop-telemetry.ts
@@ -83,8 +83,21 @@ const MAX_TOKEN_CHARS = 48;
 /** Distinct failures reported per window before further reports are dropped. */
 const MAX_REPORTED_ERRORS = 50;
 
+// Character classes are tested one character at a time: the redaction and the
+// frame parser scan by hand so no pattern can backtrack on a hostile message.
+const isIdentifierChar = (char: string) => /[\w$.]/u.test(char);
+const isCodeIdentifierChar = (char: string) => /[\w$.[\]]/u.test(char);
+const isFrameFileChar = (char: string) => /[\w$.-]/u.test(char);
+const isFrameNameChar = (char: string) => /[\w$.<>]/u.test(char);
+const isDigit = (char: string) => char >= "0" && char <= "9";
+const QUOTES = new Set(['"', "'", "`"]);
+const BUNDLE_SUFFIXES = [".js:", ".mjs:", ".cjs:"];
+
+const everyChar = (value: string, predicate: (char: string) => boolean) =>
+  value.length > 0 && Array.from(value).every(predicate);
+
 const isIdentifier = (value: string, maxChars: number) =>
-  value.length > 0 && value.length <= maxChars && /^[\w$.]+$/u.test(value);
+  value.length <= maxChars && everyChar(value, isIdentifierChar);
 
 /**
  * Error messages quote the data they choked on, so every quoted span becomes
@@ -93,13 +106,28 @@ const isIdentifier = (value: string, maxChars: number) =>
  * native `redact_error_message`, which re-applies the same rules.
  */
 export const redactErrorMessage = (message: string) => {
-  const withoutQuotes = message.replace(
-    /(["'`])(.*?)\1|(["'`]).*$/gsu,
-    (_match, quote: string | undefined, quoted: string | undefined) =>
-      quote === "'" && quoted !== undefined && /^[\w$.[\]]+$/u.test(quoted)
+  let withoutQuotes = "";
+  let index = 0;
+  while (index < message.length) {
+    const char = message.charAt(index);
+    if (!QUOTES.has(char)) {
+      withoutQuotes += char;
+      index += 1;
+      continue;
+    }
+    const end = message.indexOf(char, index + 1);
+    if (end === -1) {
+      // An unterminated quote: everything after it is content.
+      withoutQuotes += '"…"';
+      break;
+    }
+    const quoted = message.slice(index + 1, end);
+    withoutQuotes +=
+      char === "'" && everyChar(quoted, isCodeIdentifierChar)
         ? `'${quoted}'`
-        : '"…"',
-  );
+        : '"…"';
+    index = end + 1;
+  }
   const collapsed = withoutQuotes
     .split(/\s+/u)
     .filter(Boolean)
@@ -115,19 +143,102 @@ export const redactErrorMessage = (message: string) => {
     : collapsed;
 };
 
-/** `function@file:line:col` for the first stack line that names a bundle file. */
+const digitsAt = (text: string, start: number) => {
+  let end = start;
+  while (end < text.length && isDigit(text.charAt(end))) {
+    end += 1;
+  }
+  return end > start ? { end, value: text.slice(start, end) } : null;
+};
+
+/** `function@file:line:col` when a stack line names a bundle file. */
+const frameFromStackLine = (line: string) => {
+  const suffixes = BUNDLE_SUFFIXES.map((suffix) => ({
+    at: line.indexOf(suffix),
+    suffix,
+  })).filter(({ at }) => at !== -1);
+  const marker = suffixes.sort((left, right) => left.at - right.at).at(0);
+  if (!marker) {
+    return null;
+  }
+  const row = digitsAt(line, marker.at + marker.suffix.length);
+  if (!row || line.charAt(row.end) !== ":") {
+    return null;
+  }
+  const column = digitsAt(line, row.end + 1);
+  if (!column) {
+    return null;
+  }
+  let fileStart = marker.at;
+  while (fileStart > 0 && isFrameFileChar(line.charAt(fileStart - 1))) {
+    fileStart -= 1;
+  }
+  const file = line.slice(fileStart, marker.at + marker.suffix.length - 1);
+  // The function name ends at the separator before the URL: `name@url`
+  // (WebKit) or `at name (url` (Chromium); the leading `at` is not a name.
+  const separator = Math.max(
+    line.lastIndexOf("@", marker.at),
+    line.lastIndexOf("(", marker.at),
+  );
+  let nameEnd = Math.max(separator, 0);
+  while (nameEnd > 0 && line.charAt(nameEnd - 1) === " ") {
+    nameEnd -= 1;
+  }
+  let nameStart = nameEnd;
+  while (nameStart > 0 && isFrameNameChar(line.charAt(nameStart - 1))) {
+    nameStart -= 1;
+  }
+  const name = line.slice(nameStart, nameEnd);
+  const fn = name === "at" ? "" : name;
+  return `${fn}@${file}:${row.value}:${column.value}`;
+};
+
+/**
+ * Error classes whose messages the engine writes: they describe code, not
+ * data, once quoted spans are redacted. Every other message (a plain `Error`,
+ * a string rejection, a command failure) is replaced by a digest, so it still
+ * separates failures without carrying text. Mirrors the native allowlist.
+ */
+const ENGINE_ERROR_CLASSES = new Set([
+  "TypeError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "URIError",
+  "EvalError",
+  "DOMException",
+]);
+
+// A 64-bit polynomial rolling hash over the UTF-8 bytes (FNV's offset and
+// prime, multiply-add instead of xor so no bitwise operators are needed).
+const DIGEST_SEED = 14_695_981_039_346_656_037n;
+const DIGEST_PRIME = 1_099_511_628_211n;
+const DIGEST_MODULUS = 18_446_744_073_709_551_616n;
+const textEncoder = new TextEncoder();
+
+/** 16 hex digits identifying a message without carrying it; the native side computes the same. */
+export const messageDigest = (message: string) => {
+  let hash = DIGEST_SEED;
+  for (const byte of textEncoder.encode(message)) {
+    hash = (hash * DIGEST_PRIME + BigInt(byte)) % DIGEST_MODULUS;
+  }
+  return `poly64:${hash.toString(16).padStart(16, "0")}`;
+};
+
+const reportableMessage = (errorName: string, message: string) =>
+  ENGINE_ERROR_CLASSES.has(errorName)
+    ? redactErrorMessage(message)
+    : messageDigest(message);
+
 const errorFrame = (stack: string | undefined) => {
   if (!stack) {
     return null;
   }
   for (const line of stack.split("\n")) {
-    const location = /([\w$.-]+\.[cm]?js):(\d+):(\d+)/u.exec(line);
-    if (!location) {
-      continue;
+    const frame = frameFromStackLine(line);
+    if (frame) {
+      return frame;
     }
-    const [, file, row, column] = location;
-    const fn = /^\s*(?:at\s+)?([\w$.<>]+)?\s*[@(]/u.exec(line)?.[1] ?? "";
-    return `${fn}@${file}:${row}:${column}`;
   }
   return null;
 };
@@ -138,20 +249,17 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 /** The redacted shape of a thrown or rejected value. */
 export const describeError = (value: unknown): DesktopErrorDetail => {
   if (value instanceof Error) {
+    const errorName = isIdentifier(value.name, MAX_ERROR_NAME_CHARS)
+      ? value.name
+      : "Error";
     return {
-      errorName: isIdentifier(value.name, MAX_ERROR_NAME_CHARS)
-        ? value.name
-        : "Error",
+      errorName,
       frame: errorFrame(value.stack),
-      message: redactErrorMessage(value.message),
+      message: reportableMessage(errorName, value.message),
     };
   }
   if (typeof value === "string") {
-    return {
-      errorName: "string",
-      frame: null,
-      message: redactErrorMessage(value),
-    };
+    return { errorName: "string", frame: null, message: messageDigest(value) };
   }
   if (isRecord(value)) {
     // Native command rejections are `{ kind, message }` records.
@@ -164,7 +272,7 @@ export const describeError = (value: unknown): DesktopErrorDetail => {
     return {
       errorName,
       frame: null,
-      message: typeof message === "string" ? redactErrorMessage(message) : "",
+      message: typeof message === "string" ? messageDigest(message) : "",
     };
   }
   return {
@@ -199,13 +307,15 @@ const reported = new Set<string>();
 
 export const reportDesktopError = (report: DesktopErrorReport) => {
   // Each distinct failure reports once per window; the detail keeps two
-  // different rejections under the same code apart.
+  // different rejections under the same code apart, string rejections by
+  // their digest.
   const key = [
     report.window,
     report.operation,
     report.code,
     report.detail?.errorName ?? "",
     report.detail?.frame ?? "",
+    report.detail?.message ?? "",
   ].join(":");
   if (reported.has(key) || reported.size >= MAX_REPORTED_ERRORS) {
     return;

--- a/apps/desktop/src/telemetry/desktop-telemetry.ts
+++ b/apps/desktop/src/telemetry/desktop-telemetry.ts
@@ -57,10 +57,121 @@ type DesktopTelemetryErrorCode =
 export type DesktopTelemetrySpan =
   (typeof DESKTOP_TELEMETRY_SPANS)[keyof typeof DESKTOP_TELEMETRY_SPANS];
 
+/**
+ * What went wrong, never what the user was working on. Messages are redacted
+ * here and again natively (the trust boundary), so clipboard text, search
+ * terms and document content cannot ride along in an error report.
+ */
+export type DesktopErrorDetail = {
+  /** The thrown value's class (`TypeError`), or its type for non-errors. */
+  errorName: string;
+  message: string;
+  /** `function@file:line:col` of the top frame; bundle file names only. */
+  frame: string | null;
+};
+
 export type DesktopErrorReport = {
   code: DesktopTelemetryErrorCode;
+  detail?: DesktopErrorDetail;
   operation: DesktopTelemetryOperation;
   window: DesktopTelemetryWindow;
+};
+
+const MAX_ERROR_NAME_CHARS = 64;
+const MAX_ERROR_MESSAGE_CHARS = 200;
+const MAX_TOKEN_CHARS = 48;
+/** Distinct failures reported per window before further reports are dropped. */
+const MAX_REPORTED_ERRORS = 50;
+
+const isIdentifier = (value: string, maxChars: number) =>
+  value.length > 0 && value.length <= maxChars && /^[\w$.]+$/u.test(value);
+
+/**
+ * Error messages quote the data they choked on, so every quoted span becomes
+ * `"…"`, except single-quoted code identifiers such as `'item.sourceApp.name'`.
+ * URLs and long unbroken tokens (blobs, base64) are dropped too. Mirrors the
+ * native `redact_error_message`, which re-applies the same rules.
+ */
+export const redactErrorMessage = (message: string) => {
+  const withoutQuotes = message.replace(
+    /(["'`])(.*?)\1|(["'`]).*$/gsu,
+    (_match, quote: string | undefined, quoted: string | undefined) =>
+      quote === "'" && quoted !== undefined && /^[\w$.[\]]+$/u.test(quoted)
+        ? `'${quoted}'`
+        : '"…"',
+  );
+  const collapsed = withoutQuotes
+    .split(/\s+/u)
+    .filter(Boolean)
+    .map((token) => {
+      if (token.startsWith("http://") || token.startsWith("https://")) {
+        return "<url>";
+      }
+      return token.length > MAX_TOKEN_CHARS ? "…" : token;
+    })
+    .join(" ");
+  return collapsed.length > MAX_ERROR_MESSAGE_CHARS
+    ? `${collapsed.slice(0, MAX_ERROR_MESSAGE_CHARS)}…`
+    : collapsed;
+};
+
+/** `function@file:line:col` for the first stack line that names a bundle file. */
+const errorFrame = (stack: string | undefined) => {
+  if (!stack) {
+    return null;
+  }
+  for (const line of stack.split("\n")) {
+    const location = /([\w$.-]+\.[cm]?js):(\d+):(\d+)/u.exec(line);
+    if (!location) {
+      continue;
+    }
+    const [, file, row, column] = location;
+    const fn = /^\s*(?:at\s+)?([\w$.<>]+)?\s*[@(]/u.exec(line)?.[1] ?? "";
+    return `${fn}@${file}:${row}:${column}`;
+  }
+  return null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/** The redacted shape of a thrown or rejected value. */
+export const describeError = (value: unknown): DesktopErrorDetail => {
+  if (value instanceof Error) {
+    return {
+      errorName: isIdentifier(value.name, MAX_ERROR_NAME_CHARS)
+        ? value.name
+        : "Error",
+      frame: errorFrame(value.stack),
+      message: redactErrorMessage(value.message),
+    };
+  }
+  if (typeof value === "string") {
+    return {
+      errorName: "string",
+      frame: null,
+      message: redactErrorMessage(value),
+    };
+  }
+  if (isRecord(value)) {
+    // Native command rejections are `{ kind, message }` records.
+    const kind = value["kind"] ?? value["code"];
+    const errorName =
+      typeof kind === "string" && isIdentifier(kind, MAX_ERROR_NAME_CHARS)
+        ? `object.${kind}`
+        : "object";
+    const message = value["message"];
+    return {
+      errorName,
+      frame: null,
+      message: typeof message === "string" ? redactErrorMessage(message) : "",
+    };
+  }
+  return {
+    errorName: value === null ? "null" : typeof value,
+    frame: null,
+    message: "",
+  };
 };
 
 export type DesktopTimingReport = {
@@ -87,29 +198,49 @@ export const reportDesktopTiming = ({
 const reported = new Set<string>();
 
 export const reportDesktopError = (report: DesktopErrorReport) => {
-  const key = `${report.window}:${report.operation}:${report.code}`;
-  if (reported.has(key)) {
+  // Each distinct failure reports once per window; the detail keeps two
+  // different rejections under the same code apart.
+  const key = [
+    report.window,
+    report.operation,
+    report.code,
+    report.detail?.errorName ?? "",
+    report.detail?.frame ?? "",
+  ].join(":");
+  if (reported.has(key) || reported.size >= MAX_REPORTED_ERRORS) {
     return;
   }
   reported.add(key);
-  // The native command accepts a deny-unknown-fields enum record. Never pass
-  // the caught value: messages, stacks, and clipboard data are not in schema.
+  // The native command accepts a deny-unknown-fields record. The caught value
+  // itself never crosses: only its redacted `describeError` shape does.
   void invoke("desktop_report_error", { report }).catch(() => undefined);
 };
 
 export const installDesktopErrorTelemetry = (
   desktopWindow: DesktopTelemetryWindow,
 ) => {
-  const onError = () => {
+  const onError = (event: ErrorEvent) => {
+    const detail: DesktopErrorDetail =
+      event.error === undefined
+        ? {
+            errorName: "ErrorEvent",
+            frame: event.filename
+              ? `@${event.filename.split("/").at(-1) ?? ""}:${event.lineno}:${event.colno}`
+              : null,
+            message: redactErrorMessage(event.message),
+          }
+        : describeError(event.error);
     reportDesktopError({
       code: DESKTOP_TELEMETRY_ERROR_CODES.unhandledError,
+      detail,
       operation: DESKTOP_TELEMETRY_OPERATIONS.runtime,
       window: desktopWindow,
     });
   };
-  const onUnhandledRejection = () => {
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => {
     reportDesktopError({
       code: DESKTOP_TELEMETRY_ERROR_CODES.unhandledRejection,
+      detail: describeError(event.reason),
       operation: DESKTOP_TELEMETRY_OPERATIONS.runtime,
       window: desktopWindow,
     });

--- a/apps/desktop/tests/desktop-telemetry.test.ts
+++ b/apps/desktop/tests/desktop-telemetry.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  describeError,
+  redactErrorMessage,
+} from "../src/telemetry/desktop-telemetry";
+
+describe("redactErrorMessage", () => {
+  test("drops quoted content but keeps single-quoted code identifiers", () => {
+    expect(
+      redactErrorMessage(
+        `Unexpected token 'a', "Article 12 of the lease agreement" is not valid JSON`,
+      ),
+    ).toBe(`Unexpected token 'a', "…" is not valid JSON`);
+    expect(
+      redactErrorMessage(
+        "undefined is not an object (evaluating 'item.sourceApp.name')",
+      ),
+    ).toBe("undefined is not an object (evaluating 'item.sourceApp.name')");
+    expect(redactErrorMessage("Cannot read 'Jan Novák' from `notes`")).toBe(
+      `Cannot read "…" from "…"`,
+    );
+    expect(redactErrorMessage('unterminated "quote text')).toBe(
+      'unterminated "…"',
+    );
+  });
+
+  test("drops urls and long tokens and bounds the length", () => {
+    expect(
+      redactErrorMessage(
+        "Load failed https://example.org/contracts/42?token=abc now",
+      ),
+    ).toBe("Load failed <url> now");
+    expect(redactErrorMessage(`blob ${"A".repeat(80)} rejected`)).toBe(
+      "blob … rejected",
+    );
+    const long = redactErrorMessage("word ".repeat(100));
+    expect(long.length).toBe(201);
+    expect(long.endsWith("…")).toBe(true);
+  });
+});
+
+describe("describeError", () => {
+  test("names the error class and the top bundle frame from a WebKit stack", () => {
+    const error = new TypeError(
+      "undefined is not an object (evaluating 'item.sourceApp.name')",
+    );
+    error.stack = [
+      "renderCard@tauri://localhost/assets/index-3f2a9c.js:12:34",
+      "@tauri://localhost/assets/index-3f2a9c.js:40:2",
+    ].join("\n");
+
+    expect(describeError(error)).toEqual({
+      errorName: "TypeError",
+      frame: "renderCard@index-3f2a9c.js:12:34",
+      message: "undefined is not an object (evaluating 'item.sourceApp.name')",
+    });
+  });
+
+  test("reads Chromium stack frames too", () => {
+    const error = new RangeError("Maximum call stack size exceeded");
+    error.stack = [
+      "RangeError: Maximum call stack size exceeded",
+      "    at grow (http://localhost:1420/assets/rail-9b1.js:7:19)",
+    ].join("\n");
+
+    expect(describeError(error).frame).toBe("grow@rail-9b1.js:7:19");
+  });
+
+  test("describes native command rejections without exposing content", () => {
+    expect(describeError("clipboard item no longer exists")).toEqual({
+      errorName: "string",
+      frame: null,
+      message: "clipboard item no longer exists",
+    });
+    expect(
+      describeError({
+        kind: "copy",
+        message: 'clipboard write failed for "Share purchase agreement"',
+      }),
+    ).toEqual({
+      errorName: "object.copy",
+      frame: null,
+      message: 'clipboard write failed for "…"',
+    });
+    expect(describeError(undefined)).toEqual({
+      errorName: "undefined",
+      frame: null,
+      message: "",
+    });
+    expect(describeError(null).errorName).toBe("null");
+  });
+
+  test("falls back to Error for names that are not identifiers", () => {
+    const error = new Error("boom");
+    error.name = "Not An Identifier";
+
+    expect(describeError(error).errorName).toBe("Error");
+  });
+});

--- a/apps/desktop/tests/desktop-telemetry.test.ts
+++ b/apps/desktop/tests/desktop-telemetry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   describeError,
+  messageDigest,
   redactErrorMessage,
 } from "../src/telemetry/desktop-telemetry";
 
@@ -67,12 +68,20 @@ describe("describeError", () => {
     expect(describeError(error).frame).toBe("grow@rail-9b1.js:7:19");
   });
 
-  test("describes native command rejections without exposing content", () => {
+  test("digests every message the engine did not write", () => {
+    // Same vector as the native test, so both sides agree on the digest.
+    expect(messageDigest("a")).toBe("poly64:af63bd4c8601b840");
     expect(describeError("clipboard item no longer exists")).toEqual({
       errorName: "string",
       frame: null,
-      message: "clipboard item no longer exists",
+      message: messageDigest("clipboard item no longer exists"),
     });
+    expect(describeError("Attorney client notes").message).not.toContain(
+      "Attorney",
+    );
+    expect(describeError(new Error("privileged draft text")).message).toBe(
+      messageDigest("privileged draft text"),
+    );
     expect(
       describeError({
         kind: "copy",
@@ -81,7 +90,9 @@ describe("describeError", () => {
     ).toEqual({
       errorName: "object.copy",
       frame: null,
-      message: 'clipboard write failed for "…"',
+      message: messageDigest(
+        'clipboard write failed for "Share purchase agreement"',
+      ),
     });
     expect(describeError(undefined)).toEqual({
       errorName: "undefined",


### PR DESCRIPTION
An unhandled rejection in a desktop window reported only `window`, `operation` and `code`, and both the webview (`reportDesktopError`) and the native side (`DesktopTelemetry::capture`) deduplicated on exactly that triple. One anonymous `$exception` per process was all that ever reached the sink, so a report could not say what failed or where.

**Detail, redacted twice.** `describeError` turns a thrown or rejected value into `{ errorName, message, frame }`: the error class (or the value's type; `object.<kind>` for native command rejections), a redacted message, and the top stack frame as `function@file:line:col` with bundle file names only. `redactErrorMessage` replaces every quoted span with `"…"` except single-quoted code identifiers (`'item.sourceApp.name'`), drops URLs and tokens over 48 chars, and bounds the text at 200 chars. The native `DesktopErrorDetail` is `deny_unknown_fields` and re-applies the same redaction plus identifier checks on the name and frame, so the webview's copy of the rules cannot leak content even if it drifts.

**Distinct failures, distinct issues.** The PostHog fingerprint appends the class and frame; `$exception_list` carries the class and redacted message; `error_name`, `error_frame` and `os` are added as properties. `$exception_type` stays the code so existing filters hold. Dedupe on both sides is keyed on the detail and capped (50 per window, 200 per process) so a rejection loop cannot flood the sink.

**Callers.** The runtime `error`/`unhandledrejection` handlers, the React root handlers, and every `invokeFailed` report in the clipboard rail and editor now pass the caught value through `describeError`. Native tracing gets the same fields.

Tests: Rust covers redaction, identifier validation, unknown-field rejection, the payload shape and fingerprint, and the dedupe cap; the desktop suite covers `describeError` against WebKit and Chromium stacks, native rejection shapes and the redaction rules.
