### PR TITLE
feat(ci): bot workflows commit through the GitHub API

### DIFF
--- a/.github/workflows/catalogue-upstream.yml
+++ b/.github/workflows/catalogue-upstream.yml
@@ -80,12 +80,12 @@ jobs:
           # green and only failing at a user's install click.
           bun run --filter @stll/catalogue check-pinned
 
-      - name: Open or update pull request
+      - name: Describe the bumps
         if: steps.check.outputs.update_count != '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
+        id: body
         run: |
           {
+            echo "pr-body<<EOF"
             echo "Automated bump of \`rev\` for github-sourced catalogue skills whose pinned upstream advanced on its default branch."
             echo
             echo "A maintainer must review each upstream diff before merging. The pinned commit SHA is what a \"recommended\" badge endorses, so open the linked compare view and confirm there are no unexpected or unsafe changes before accepting this PR."
@@ -93,23 +93,22 @@ jobs:
             echo "| Skill | Repo | Change |"
             echo "| --- | --- | --- |"
             jq -r '.updates[] | "| \(.slug) | \(.repo) | [\(.currentRev[0:7])...\(.latestRev[0:7])](\(.compareUrl)) |"' upstream.json
-          } > pr-body.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          gh auth setup-git
-          git switch -C catalogue/upstream-revs
-          git add packages/catalogue
-          git commit -m "chore: bump github-sourced catalogue skill revisions"
-          git push --force origin catalogue/upstream-revs
-
-          title="chore: bump github-sourced catalogue skill revisions"
-          number=$(gh pr list --head catalogue/upstream-revs --state open --json number --jq '.[0].number // empty')
-          if [ -n "$number" ]; then
-            gh pr edit "$number" --title "$title" --body-file pr-body.md
-          else
-            gh pr create --title "$title" --body-file pr-body.md --head catalogue/upstream-revs --base main
-          fi
+      # The commit is created through the API so GitHub signs it.
+      - name: Open or update pull request
+        if: steps.check.outputs.update_count != '0'
+        uses: stella/.github/.github/actions/signed-commit@d2be63db3536d391c8a38e35d786b15884b253f3
+        with:
+          token: ${{ github.token }}
+          mode: refresh-pr
+          branch: catalogue/upstream-revs
+          base: main
+          paths: packages/catalogue
+          commit-message: "chore: bump github-sourced catalogue skill revisions"
+          pr-title: "chore: bump github-sourced catalogue skill revisions"
+          pr-body: ${{ steps.body.outputs.pr-body }}
 
       - name: Surface upstream check failures
         if: steps.check.outputs.failure_count != '0'

--- a/.github/workflows/catalogue-upstream.yml
+++ b/.github/workflows/catalogue-upstream.yml
@@ -99,7 +99,7 @@ jobs:
       # The commit is created through the API so GitHub signs it.
       - name: Open or update pull request
         if: steps.check.outputs.update_count != '0'
-        uses: stella/.github/.github/actions/signed-commit@d2be63db3536d391c8a38e35d786b15884b253f3
+        uses: stella/.github/.github/actions/signed-commit@49138dbccd20714b3e8997c4346edc3efb5c29cd
         with:
           token: ${{ github.token }}
           mode: refresh-pr

--- a/.github/workflows/marketing-screenshots.yml
+++ b/.github/workflows/marketing-screenshots.yml
@@ -201,7 +201,7 @@ jobs:
       # belongs to a person, and a signed-commits rule would otherwise block
       # their pull request on this one commit.
       - name: Push regenerated baselines
-        uses: stella/.github/.github/actions/signed-commit@d2be63db3536d391c8a38e35d786b15884b253f3
+        uses: stella/.github/.github/actions/signed-commit@49138dbccd20714b3e8997c4346edc3efb5c29cd
         with:
           token: ${{ steps.app-token.outputs.token }}
           mode: append

--- a/.github/workflows/marketing-screenshots.yml
+++ b/.github/workflows/marketing-screenshots.yml
@@ -197,33 +197,17 @@ jobs:
             echo "The push below only reaches a branch of this repository. A pull request from a fork downloads that artifact and commits the PNGs itself."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # The commit is created through the API so GitHub signs it; the branch
+      # belongs to a person, and a signed-commits rule would otherwise block
+      # their pull request on this one commit.
       - name: Push regenerated baselines
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          BRANCH: ${{ inputs.ref || github.ref_name }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -euo pipefail
-
-          changed="$(git status --porcelain -- 'apps/landing/public/media/products/*.png')"
-          if [[ -z "$changed" ]]; then
-            echo "Baselines already match this branch; nothing to push." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          {
-            echo "### Regenerated marketing screenshots"
-            echo
-            echo "$changed" | cut -c4- | sed 's/^/- /'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          bot_id="$(gh api "users/${APP_SLUG}[bot]" --jq '.id')"
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
-
-          git add -- 'apps/landing/public/media/products/*.png'
-          git commit -m "chore(landing): regenerate marketing screenshots"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${BRANCH}"
+        uses: stella/.github/.github/actions/signed-commit@d2be63db3536d391c8a38e35d786b15884b253f3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          mode: append
+          branch: ${{ inputs.ref }}
+          paths: apps/landing/public/media/products/*.png
+          commit-message: "chore(landing): regenerate marketing screenshots"
 
       - name: Upload failure diagnostics
         if: failure()

--- a/.github/workflows/provenance-nightly.yml
+++ b/.github/workflows/provenance-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: stella/.github/.github/workflows/provenance-update.yml@d2be63db3536d391c8a38e35d786b15884b253f3
+    uses: stella/.github/.github/workflows/provenance-update.yml@49138dbccd20714b3e8997c4346edc3efb5c29cd
     secrets:
       app_id: ${{ secrets.PROVENANCE_APP_ID }}
       app_private_key: ${{ secrets.PROVENANCE_APP_PRIVATE_KEY }}

--- a/.github/workflows/provenance-nightly.yml
+++ b/.github/workflows/provenance-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: stella/.github/.github/workflows/provenance-update.yml@2703e4d3ed115089e593e4ca5cc749be4a5d8cee
+    uses: stella/.github/.github/workflows/provenance-update.yml@d2be63db3536d391c8a38e35d786b15884b253f3
     secrets:
       app_id: ${{ secrets.PROVENANCE_APP_ID }}
       app_private_key: ${{ secrets.PROVENANCE_APP_PRIVATE_KEY }}

--- a/.github/workflows/quarantine-prune.yml
+++ b/.github/workflows/quarantine-prune.yml
@@ -78,7 +78,7 @@ jobs:
       # proposal with one computed from current main.
       - name: Open or update the removal PR
         if: steps.prune.outputs.changed == 'true'
-        uses: stella/.github/.github/actions/signed-commit@d2be63db3536d391c8a38e35d786b15884b253f3
+        uses: stella/.github/.github/actions/signed-commit@49138dbccd20714b3e8997c4346edc3efb5c29cd
         with:
           token: ${{ steps.app-token.outputs.token }}
           mode: refresh-pr

--- a/.github/workflows/quarantine-prune.yml
+++ b/.github/workflows/quarantine-prune.yml
@@ -73,48 +73,27 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      # The commit is created through the API so GitHub signs it. The branch
+      # name is reserved for this job alone: re-running replaces its own
+      # proposal with one computed from current main.
       - name: Open or update the removal PR
         if: steps.prune.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        run: |
-          set -euo pipefail
+        uses: stella/.github/.github/actions/signed-commit@d2be63db3536d391c8a38e35d786b15884b253f3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          mode: refresh-pr
+          branch: ${{ env.PRUNE_BRANCH }}
+          base: main
+          paths: bunfig.toml
+          commit-message: |
+            chore(deps): remove expired quarantine excludes
 
-          bot_id="$(gh api "users/${APP_SLUG}[bot]" --jq '.id')"
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+            The release-age gate admits these packages on its own now, and an
+            entry left behind would let their next version skip it.
+          pr-title: "chore(deps): remove expired quarantine excludes"
+          pr-body: |
+            These temporary `minimumReleaseAgeExcludes` entries have passed their annotated expiry, so the release-age gate admits the packages without them.
 
-          git checkout -b "$PRUNE_BRANCH"
-          git add bunfig.toml
-          git commit -m "chore(deps): remove expired quarantine excludes
+            Leaving an expired entry in place is not neutral: it would let the next version of that package publish straight past the gate. Merging this restores that check.
 
-          The release-age gate admits these packages on its own now, and an
-          entry left behind would let their next version skip it."
-
-          # Force-with-lease is unsafe against a branch this job does not own,
-          # so the branch name is reserved for this job alone. Re-running
-          # replaces its own proposal with one computed from current main.
-          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --force "$remote" "HEAD:refs/heads/${PRUNE_BRANCH}"
-
-          if [[ -n "$(gh pr list --head "$PRUNE_BRANCH" --state open --json number --jq '.[0].number // ""')" ]]; then
-            echo "Updated the open removal PR." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          body_file="$RUNNER_TEMP/prune-pr-body.md"
-          # shellcheck disable=SC2016 # backticks are markdown, not substitution
-          printf '%s\n' \
-            'These temporary `minimumReleaseAgeExcludes` entries have passed their annotated expiry, so the release-age gate admits the packages without them.' \
-            '' \
-            'Leaving an expired entry in place is not neutral: it would let the next version of that package publish straight past the gate. Merging this restores that check.' \
-            '' \
-            'Opened automatically. The removal is what `bun scripts/check-stll-quarantine-excludes.ts --prune` produces.' \
-            > "$body_file"
-
-          gh pr create \
-            --base main \
-            --head "$PRUNE_BRANCH" \
-            --title "chore(deps): remove expired quarantine excludes" \
-            --body-file "$body_file" >> "$GITHUB_STEP_SUMMARY"
+            Opened automatically. The removal is what `bun scripts/check-stll-quarantine-excludes.ts --prune` produces.

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -516,9 +516,15 @@ describe("detect-e2e-changes", () => {
     expect(
       workflowStep(jobOf(marketingWorkflow, "check"), "Checkout"),
     ).not.toContain("ref:");
-    expect(workflowStep(update, "Push regenerated baselines")).toContain(
-      `BRANCH: ${githubExpression("inputs.ref || github.ref_name")}`,
+    // The push is an API commit appended to the named branch: GitHub signs
+    // it, so it cannot leave a person's pull request behind the
+    // signed-commits rule.
+    const push = workflowStep(update, "Push regenerated baselines");
+    expect(push).toContain(
+      "uses: stella/.github/.github/actions/signed-commit@",
     );
+    expect(push).toContain("mode: append");
+    expect(push).toContain(`branch: ${githubExpression("inputs.ref")}`);
 
     // Check-mode callers pass no ref and stay on their own triggering ref.
     expect(workflowJob("marketing-screenshots")).not.toContain("ref:");


### PR DESCRIPTION
## Summary

Bot workflows committed with the git CLI on the runner, so their commits were unsigned and cannot pass the branch rule that requires signed commits. Commits created through GitHub's API are signed by GitHub and attributed to the token's owner. This moves every updater in this repository onto the shared `signed-commit` action (stella/.github#103), which commits the working tree's changes under given pathspecs through `createCommitOnBranch`.

- `provenance-nightly.yml`: pins the shared provenance updater at the revision that commits through the API.
- `quarantine-prune.yml` and `catalogue-upstream.yml`: the branch-and-pull-request bookkeeping moves into the action's `refresh-pr` mode (rebuild the proposal from current main, keep one pull request open, close it when nothing is left to propose).
- `marketing-screenshots.yml`: the App's push onto a person's branch becomes an `append` commit, so that one commit cannot block their pull request.

The pin is the merged revision of stella/.github#103.

## Verification

- `actionlint` on the four workflows.
- The action itself is covered by its own tests and a live run against a scratch repository in stella/.github#103.
- Live check after merge: dispatch Provenance Nightly; the refreshed pull request must show verified commits.
