### PR TITLE
fix(api): one owner for the provider error body behind a run error

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -100,6 +100,7 @@ import { getTemperatureForRole, resolveCaching } from "@/api/lib/ai-config";
 import {
   classifyAIError,
   isAnticipatedAIFailure,
+  providerErrorBody,
   providerStatusFields,
 } from "@/api/lib/ai-error";
 import type { AIErrorKind } from "@/api/lib/ai-error";
@@ -1384,32 +1385,6 @@ const errorFromRunErrorChunk = (
     Object.assign(error, { code });
   }
   return error;
-};
-
-// An adapter forwards the provider's structured error body as `rawEvent` only
-// when the SDK exception exposes one. An exception that carries the status as a
-// plain field and stringifies the response body into its message arrives with
-// neither `rawEvent` nor `code`, so the error rebuilt from the chunk holds no
-// status at all, and every failure from that provider (quota, billing, retired
-// model and outage alike) falls to `unknown`. Recover the body from the
-// message when the message is one. It is read for classification only and
-// never logged: a provider message can echo request content.
-const isErrorBodyRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-const providerErrorBody = (
-  message: string,
-): Record<string, unknown> | undefined => {
-  // `JSON.parse` skips leading whitespace, so the guard must too; otherwise a
-  // body an adapter passed through verbatim would be dropped over a newline.
-  if (!message.trimStart().startsWith("{")) {
-    return undefined;
-  }
-  const parsed = Result.try((): unknown => JSON.parse(message));
-  if (Result.isError(parsed)) {
-    return undefined;
-  }
-  return isErrorBodyRecord(parsed.value) ? parsed.value : undefined;
 };
 
 const providerDetailFromRunErrorChunk = (chunk: RunErrorChunk): unknown => {

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -1,4 +1,4 @@
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 
 /**
  * Stable, user-facing classification of AI provider errors.
@@ -133,6 +133,35 @@ const isProviderCredentialRejection = (error: unknown): boolean => {
 const isProviderError = (error: unknown): boolean =>
   isRecord(error) &&
   (providerStatusCode(error) !== null || isProviderCredentialRejection(error));
+
+/**
+ * The provider's structured error body, recovered from a stream error message.
+ *
+ * An adapter forwards that body as the run error's `rawEvent` only when the SDK
+ * exception exposes one. An exception that carries the status as a plain field
+ * and stringifies the response body into its message arrives with neither
+ * `rawEvent` nor `code`, so an error rebuilt from the event holds no status at
+ * all, and every failure from that provider (quota, billing, retired model and
+ * outage alike) falls to `unknown`. Recover the body from the message when the
+ * message is one, and hand it to the classifier as the failure's cause.
+ *
+ * Read for classification only and never logged: a provider message can echo
+ * request content.
+ */
+export const providerErrorBody = (
+  message: string,
+): Record<string, unknown> | undefined => {
+  // `JSON.parse` skips leading whitespace, so the guard must too; otherwise a
+  // body an adapter passed through verbatim would be dropped over a newline.
+  if (!message.trimStart().startsWith("{")) {
+    return undefined;
+  }
+  const parsed = Result.try((): unknown => JSON.parse(message));
+  if (Result.isError(parsed)) {
+    return undefined;
+  }
+  return isRecord(parsed.value) ? parsed.value : undefined;
+};
 
 const errorCause = (error: unknown): unknown => {
   if (!isRecord(error)) {

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -54,7 +54,7 @@ type ProviderRun =
       /** Cancels the caller's signal once the provider stream is exhausted. */
       abortAfter?: AbortController | undefined;
     }
-  | { type: "run-error"; code: string; message: string }
+  | { type: "run-error"; code?: string | undefined; message: string }
   | { type: "throw"; error: unknown }
   | { type: "abort-then-throw"; controller: AbortController }
   | { type: "object"; object: unknown; raw: string };
@@ -113,13 +113,19 @@ const abortRejectedRun = (controller: AbortController): ProviderRun => ({
   controller,
 });
 
+// An adapter reports `code` only when its SDK exception exposes a structured
+// body; leave it out to model the ones that stringify the body into the message.
 const runErrorRun = ({
   code,
   message,
 }: {
-  code: string;
+  code?: string | undefined;
   message: string;
-}): ProviderRun => ({ type: "run-error", code, message });
+}): ProviderRun => ({
+  type: "run-error",
+  ...(code === undefined ? {} : { code }),
+  message,
+});
 
 const objectRun = (
   object: unknown,
@@ -222,7 +228,7 @@ const providerAdapter: AnyTextAdapter = {
         } satisfies StreamChunk;
         yield {
           type: EventType.RUN_ERROR,
-          code: run.code,
+          ...(run.code === undefined ? {} : { code: run.code }),
           message: run.message,
           runId: PROVIDER_RUN_ID,
           threadId: PROVIDER_THREAD_ID,
@@ -1136,6 +1142,63 @@ describe("TanStack AI text generation", () => {
 
     expect(caught).toMatchObject({ code: "429", status: 502 });
     expect(classifyAIError(caught)).toBe("quota_exhausted");
+  });
+
+  // An adapter whose SDK exception stringifies the response body into the
+  // message reports the run error with no `code` and no `rawEvent`. The body is
+  // then the only evidence of what the provider answered, so the wrap has to
+  // keep it: without it quota, billing, retired model and outage all read as
+  // one unnamed transport failure.
+  test("classifies a run error whose only detail is the provider body", async () => {
+    queueRun(
+      runErrorRun({
+        message: JSON.stringify({
+          error: {
+            code: 429,
+            message: "Resource has been exhausted.",
+            status: "RESOURCE_EXHAUSTED",
+          },
+        }),
+      }),
+    );
+
+    const caught = await generateTextForTestModel({
+      caching: noCaching,
+      finishPolicy: "allow-incomplete",
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Say hello.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({ status: 502 });
+    expect(classifyAIError(caught)).toBe("quota_exhausted");
+  });
+
+  test("leaves a plain-text run error unclassified", async () => {
+    queueRun(runErrorRun({ message: "The model is currently overloaded." }));
+
+    const caught = await generateTextForTestModel({
+      caching: noCaching,
+      finishPolicy: "allow-incomplete",
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Say hello.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({ status: 502 });
+    expect(classifyAIError(caught)).toBe("unknown");
   });
 
   test("propagates provider run errors from streaming text", async () => {

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -26,6 +26,7 @@ import type {
   CachingDecision,
   OrgAIConfig,
 } from "@/api/lib/ai-config";
+import { providerErrorBody } from "@/api/lib/ai-error";
 import type { TanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
@@ -536,13 +537,20 @@ const throwIfTanStackRunError = (chunk: PublicStreamChunk): void => {
   throw tanStackRunError(chunk);
 };
 
-const tanStackRunError = (chunk: RunErrorEvent): HandlerError =>
-  new HandlerError({
+// The classifier reads a wrapped provider failure off the cause, so the body
+// has to survive the wrap. `rawEvent` carries it only for the adapters whose
+// SDK exception exposes one; `providerErrorBody` recovers it from the message
+// for the rest, which would otherwise reach the classifier with no status and
+// be named a transient transport outage.
+const tanStackRunError = (chunk: RunErrorEvent): HandlerError => {
+  const cause: unknown = chunk.rawEvent ?? providerErrorBody(chunk.message);
+  return new HandlerError({
     status: 502,
     message: chunk.message,
     ...(chunk.code ? { code: chunk.code } : {}),
-    ...(chunk.rawEvent === undefined ? {} : { cause: chunk.rawEvent }),
+    ...(cause === undefined ? {} : { cause }),
   });
+};
 
 const shouldRetryWithStandardServiceTier = ({
   error,


### PR DESCRIPTION
## Proposed change

`tanStackRunError` wraps a TanStack `RUN_ERROR` event in a 502 `HandlerError` and is
the only thing that carries the provider's own detail across that wrap: `code` from
the event's `code`, `cause` from its `rawEvent`. An adapter populates `rawEvent` only
when the SDK exception exposes a structured body. An exception that carries the
status as a plain field and stringifies the response body into its message arrives
with neither field set, so the wrap keeps nothing at all.

`classifyAIError` reads a wrapped provider failure off the cause and names it from
the provider's status (it deliberately will not read `status` off a `HandlerError`,
since that status is this service's own). With an empty wrap it has nothing to read
and answers `unknown`, so:

- quota, billing, rejected credentials, a retired model and an outage all collapse
  into one unnamed failure;
- `isAnticipatedAIFailure` grades each of them as a shape the service did not
  anticipate, rather than as the operational state of an upstream account;
- `aiHandlerError` falls through to the caller's fallback, so callers that classify
  against the cause (property preview, bounding-box generation) answer a generic 502
  where the provider's own status would have earned a 429 or 402 and the matching
  actionable copy.

`stream-chat.ts` already recovers that body by parsing the message, with a comment
naming exactly this adapter shape, but the helper is private to that file. Every
other AI call path — structured output, streaming text, and the batch generation
built on them — reaches the classifier through `tanStackRunError` instead. Two
readers of one event shape, and only one of them knows how to read it.

This gives the recovery one owner in `ai-error.ts`, next to the classifier it feeds:

- `tanStackRunError` falls back to the parsed body when `rawEvent` is absent;
- `stream-chat.ts` drops its private copy (and its duplicate of `isRecord`) for the
  shared one, leaving chat-path behaviour unchanged.

The body stays classification-only and is never logged: a provider message can echo
request content, and a non-`Error` cause contributes nothing to `errorFingerprint`
or to the cause-chain log attributes, both of which walk `Error` causes only. The
response body a caller receives is also unchanged — it carries `message` and `code`,
and `code` is still set from the event's own field alone.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
      `apps/api` typecheck and type-aware lint on the changed files are clean.
- [x] **TESTING** | `src/lib/tanstack-ai-generate.test.ts`, `src/lib/ai-error.test.ts`
      and `src/handlers/chat/stream-chat.test.ts` pass. Added two cases at the
      previously uncovered site: a run error whose only detail is the provider body
      classifies to its provider kind, and a plain-text one still stays `unknown`.
      The first fails on the old wrap. Rebased onto the fake-adapter harness that
      replaced the engine mock, so the queued run error carries no `code`.
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of AI provider errors when structured error details are included only in the error message.
  - Provider failures can now be classified more accurately, including identifying quota-related errors.
  - Plain-text error messages continue to receive an appropriate unknown classification when no structured details are available.

- **Tests**
  - Added coverage for quota-exhausted errors and unstructured provider error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
