### PR TITLE
chore: re-pin ai-shared; a release-blocking defect is never deferred

### DIFF
--- a/.agents/skills/finish-pr/SKILL.md
+++ b/.agents/skills/finish-pr/SKILL.md
@@ -45,9 +45,10 @@ valid reviews, or bypass protections merely to make the PR green.
 Never request an automated review (`@coderabbitai review`, `@codex review`, or a
 timed re-request after a rate limit); reviews arrive on their own. Budget the loop:
 at most two review rounds after the first green head. When actionable findings keep
-arriving past that, keep the green head, triage the remaining findings yourself
-with a concrete accept or push-back, and land accepted fixes in one stacked
-follow-up PR instead of pushing to the converged head.
+arriving past that, keep the green head and triage the remaining findings yourself
+with a concrete accept or push-back. Open one stacked follow-up PR for the accepted
+fixes, then reply to each deferred finding with that PR's URL and resolve it: the
+named follow-up is the disposition, not a promise.
 
 ## 4. Stop at a Real Terminal State
 
@@ -55,7 +56,9 @@ The latest pushed head has converged only when:
 
 - required CI is green
 - automated reviewers are terminal, not pending
-- no actionable bot thread remains unresolved
+- no actionable automated finding remains in a review thread or a top-level
+  comment: each is implemented, already addressed, pushed back with evidence,
+  or deferred to a named follow-up PR
 - no unresolved human request for changes remains
 - no blocking review or merge conflict remains
 

--- a/.agents/skills/finish-pr/SKILL.md
+++ b/.agents/skills/finish-pr/SKILL.md
@@ -46,9 +46,15 @@ Never request an automated review (`@coderabbitai review`, `@codex review`, or a
 timed re-request after a rate limit); reviews arrive on their own. Budget the loop:
 at most two review rounds after the first green head. When actionable findings keep
 arriving past that, keep the green head and triage the remaining findings yourself
-with a concrete accept or push-back. Open one stacked follow-up PR for the accepted
-fixes, then reply to each deferred finding with that PR's URL and resolve it: the
-named follow-up is the disposition, not a promise.
+with a concrete accept, push-back, or defer. Open one stacked follow-up PR for the
+accepted fixes, then reply to each deferred finding with that PR's URL, and resolve
+the thread where the finding has one: the named follow-up is the disposition, not a
+promise. A deferred top-level comment stays open; the reply is its terminal state.
+
+The budget never defers a release-blocking defect. A finding that names a
+security, authorization, data-loss, or data-corruption defect, and survives
+verification, is fixed on this head however late it arrives: shipping a known
+defect to keep a round count is the outcome the budget exists to avoid.
 
 ## 4. Stop at a Real Terminal State
 
@@ -58,7 +64,8 @@ The latest pushed head has converged only when:
 - automated reviewers are terminal, not pending
 - no actionable automated finding remains in a review thread or a top-level
   comment: each is implemented, already addressed, pushed back with evidence,
-  or deferred to a named follow-up PR
+  or deferred to a named follow-up PR, and no verified release-blocking defect
+  was deferred
 - no unresolved human request for changes remains
 - no blocking review or merge conflict remains
 

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -11,13 +11,15 @@ work.
 ## 1. Resolve Scope and Isolation
 
 Inspect the branch, worktree, status, remotes, applicable repository
-instructions, and existing PR before changing history:
+instructions, and existing PR before changing history. Resolve the base
+repository first (step 3) and query it explicitly; in a fork checkout, `gh`
+defaults to the fork and would miss an upstream PR:
 
 ```bash
 git branch --show-current
 git status --short
-gh pr list --head "$(git branch --show-current)" --state all \
-  --json number,state,isDraft,headRefName,baseRefName,url
+gh pr list --repo "$BASE_REPO" --head "$(git branch --show-current)" \
+  --state all --json number,state,isDraft,headRefName,baseRefName,url
 ```
 
 An empty PR list means no PR exists. Authentication, network, or repository

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -19,12 +19,17 @@ defaults to the fork and would miss an upstream PR:
 git branch --show-current
 git status --short
 gh pr list --repo "$BASE_REPO" --head "$(git branch --show-current)" \
-  --state all --json number,state,isDraft,headRefName,baseRefName,url
+  --state all \
+  --json number,state,isDraft,headRefName,headRepositoryOwner,baseRefName,url
 ```
 
-An empty PR list means no PR exists. Authentication, network, or repository
-errors must remain visible and stop the workflow before history changes or
-publication.
+An empty PR list means no PR exists. `--head` filters by branch name alone, so
+in a fork workflow the list can hold another contributor's PR from a branch of
+the same name: treat a result as this checkout's PR only when its
+`headRepositoryOwner` is the owner your head remote pushes to.
+
+Authentication, network, or repository errors must remain visible and stop the
+workflow before history changes or publication.
 
 Never prepare a PR in a dirty shared checkout. If the checkout is on the
 default branch, detached, has unrelated changes, or spans repositories or

--- a/.agents/skills/rabbit-round/SKILL.md
+++ b/.agents/skills/rabbit-round/SKILL.md
@@ -36,6 +36,8 @@ comment:
 - **Already addressed**: current code or a pushed commit demonstrably resolves it.
 - **Push back**: incorrect, stale, speculative, or contrary to documented
   constraints.
+- **Defer**: accepted, but landing in a named follow-up PR because the enclosing
+  workflow's review budget is spent. Only with the follow-up PR's URL.
 
 Read the cited code and applicable instructions before deciding. Treat security,
 authorization, data loss, and compatibility claims as hypotheses to verify, not
@@ -62,13 +64,14 @@ finding. Keep responses short and factual:
 - implemented with an adjustment and why
 - already addressed, with the code or commit that proves it
 - not changing, with a concrete repository constraint or technical reason
+- deferred to a named follow-up PR, with its URL
 
 Follow repository attribution rules for GitHub comments. Do not claim a check
 passed unless it ran successfully on the reported head.
 
 After replying, resolve only review threads whose every participant is a
-confirmed allowed bot and that are implemented, already addressed, or answered
-with a supported pushback. Leave human, mixed-participant, and uncertain threads
+confirmed allowed bot and that are implemented, already addressed, answered
+with a supported pushback, or deferred to a named follow-up PR. Leave human, mixed-participant, and uncertain threads
 open. Top-level comments have no thread-resolution state; do not minimize bot
 summaries by default.
 

--- a/.agents/skills/rabbit-round/SKILL.md
+++ b/.agents/skills/rabbit-round/SKILL.md
@@ -37,7 +37,10 @@ comment:
 - **Push back**: incorrect, stale, speculative, or contrary to documented
   constraints.
 - **Defer**: accepted, but landing in a named follow-up PR because the enclosing
-  workflow's review budget is spent. Only with the follow-up PR's URL.
+  workflow's review budget is spent. Only with the follow-up PR's URL, and every
+  defer in one run names the same PR. Never for a verified release-blocking
+  defect (security, authorization, data loss, corruption): those are fixed on the
+  current head.
 
 Read the cited code and applicable instructions before deciding. Treat security,
 authorization, data loss, and compatibility claims as hypotheses to verify, not
@@ -70,10 +73,11 @@ Follow repository attribution rules for GitHub comments. Do not claim a check
 passed unless it ran successfully on the reported head.
 
 After replying, resolve only review threads whose every participant is a
-confirmed allowed bot and that are implemented, already addressed, answered
-with a supported pushback, or deferred to a named follow-up PR. Leave human, mixed-participant, and uncertain threads
-open. Top-level comments have no thread-resolution state; do not minimize bot
-summaries by default.
+confirmed allowed bot and that are implemented, already addressed, answered with
+a supported pushback, or deferred to a named follow-up PR. Leave human,
+mixed-participant, and uncertain threads open. Top-level comments have no
+thread-resolution state: a reply naming the follow-up PR is the whole disposition
+there. Do not minimize bot summaries by default.
 
 ## 5. Recheck the Current Head
 
@@ -81,7 +85,10 @@ Refresh the PR after the push and report one status:
 
 - `clean`: all current-head automated reviewers are terminal, required checks
   are green, and no actionable automated finding remains in a review thread or
-  top-level comment
+  top-level comment. A top-level finding answered with a defer reply carrying the
+  follow-up PR's URL is no longer actionable on later rounds, unless it names a
+  verified release-blocking defect: no defer makes one of those non-actionable,
+  and the status stays `needs_changes` until it is fixed on the current head
 - `pending_bots`: this round pushed the current head, or a current-head
   automated review or required check is still running
 - `needs_changes`: actionable automated feedback remains

--- a/.claude/skills/finish-pr/SKILL.md
+++ b/.claude/skills/finish-pr/SKILL.md
@@ -45,9 +45,10 @@ valid reviews, or bypass protections merely to make the PR green.
 Never request an automated review (`@coderabbitai review`, `@codex review`, or a
 timed re-request after a rate limit); reviews arrive on their own. Budget the loop:
 at most two review rounds after the first green head. When actionable findings keep
-arriving past that, keep the green head, triage the remaining findings yourself
-with a concrete accept or push-back, and land accepted fixes in one stacked
-follow-up PR instead of pushing to the converged head.
+arriving past that, keep the green head and triage the remaining findings yourself
+with a concrete accept or push-back. Open one stacked follow-up PR for the accepted
+fixes, then reply to each deferred finding with that PR's URL and resolve it: the
+named follow-up is the disposition, not a promise.
 
 ## 4. Stop at a Real Terminal State
 
@@ -55,7 +56,9 @@ The latest pushed head has converged only when:
 
 - required CI is green
 - automated reviewers are terminal, not pending
-- no actionable bot thread remains unresolved
+- no actionable automated finding remains in a review thread or a top-level
+  comment: each is implemented, already addressed, pushed back with evidence,
+  or deferred to a named follow-up PR
 - no unresolved human request for changes remains
 - no blocking review or merge conflict remains
 

--- a/.claude/skills/finish-pr/SKILL.md
+++ b/.claude/skills/finish-pr/SKILL.md
@@ -46,9 +46,15 @@ Never request an automated review (`@coderabbitai review`, `@codex review`, or a
 timed re-request after a rate limit); reviews arrive on their own. Budget the loop:
 at most two review rounds after the first green head. When actionable findings keep
 arriving past that, keep the green head and triage the remaining findings yourself
-with a concrete accept or push-back. Open one stacked follow-up PR for the accepted
-fixes, then reply to each deferred finding with that PR's URL and resolve it: the
-named follow-up is the disposition, not a promise.
+with a concrete accept, push-back, or defer. Open one stacked follow-up PR for the
+accepted fixes, then reply to each deferred finding with that PR's URL, and resolve
+the thread where the finding has one: the named follow-up is the disposition, not a
+promise. A deferred top-level comment stays open; the reply is its terminal state.
+
+The budget never defers a release-blocking defect. A finding that names a
+security, authorization, data-loss, or data-corruption defect, and survives
+verification, is fixed on this head however late it arrives: shipping a known
+defect to keep a round count is the outcome the budget exists to avoid.
 
 ## 4. Stop at a Real Terminal State
 
@@ -58,7 +64,8 @@ The latest pushed head has converged only when:
 - automated reviewers are terminal, not pending
 - no actionable automated finding remains in a review thread or a top-level
   comment: each is implemented, already addressed, pushed back with evidence,
-  or deferred to a named follow-up PR
+  or deferred to a named follow-up PR, and no verified release-blocking defect
+  was deferred
 - no unresolved human request for changes remains
 - no blocking review or merge conflict remains
 

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -11,13 +11,15 @@ work.
 ## 1. Resolve Scope and Isolation
 
 Inspect the branch, worktree, status, remotes, applicable repository
-instructions, and existing PR before changing history:
+instructions, and existing PR before changing history. Resolve the base
+repository first (step 3) and query it explicitly; in a fork checkout, `gh`
+defaults to the fork and would miss an upstream PR:
 
 ```bash
 git branch --show-current
 git status --short
-gh pr list --head "$(git branch --show-current)" --state all \
-  --json number,state,isDraft,headRefName,baseRefName,url
+gh pr list --repo "$BASE_REPO" --head "$(git branch --show-current)" \
+  --state all --json number,state,isDraft,headRefName,baseRefName,url
 ```
 
 An empty PR list means no PR exists. Authentication, network, or repository

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -19,12 +19,17 @@ defaults to the fork and would miss an upstream PR:
 git branch --show-current
 git status --short
 gh pr list --repo "$BASE_REPO" --head "$(git branch --show-current)" \
-  --state all --json number,state,isDraft,headRefName,baseRefName,url
+  --state all \
+  --json number,state,isDraft,headRefName,headRepositoryOwner,baseRefName,url
 ```
 
-An empty PR list means no PR exists. Authentication, network, or repository
-errors must remain visible and stop the workflow before history changes or
-publication.
+An empty PR list means no PR exists. `--head` filters by branch name alone, so
+in a fork workflow the list can hold another contributor's PR from a branch of
+the same name: treat a result as this checkout's PR only when its
+`headRepositoryOwner` is the owner your head remote pushes to.
+
+Authentication, network, or repository errors must remain visible and stop the
+workflow before history changes or publication.
 
 Never prepare a PR in a dirty shared checkout. If the checkout is on the
 default branch, detached, has unrelated changes, or spans repositories or

--- a/.claude/skills/rabbit-round/SKILL.md
+++ b/.claude/skills/rabbit-round/SKILL.md
@@ -36,6 +36,8 @@ comment:
 - **Already addressed**: current code or a pushed commit demonstrably resolves it.
 - **Push back**: incorrect, stale, speculative, or contrary to documented
   constraints.
+- **Defer**: accepted, but landing in a named follow-up PR because the enclosing
+  workflow's review budget is spent. Only with the follow-up PR's URL.
 
 Read the cited code and applicable instructions before deciding. Treat security,
 authorization, data loss, and compatibility claims as hypotheses to verify, not
@@ -62,13 +64,14 @@ finding. Keep responses short and factual:
 - implemented with an adjustment and why
 - already addressed, with the code or commit that proves it
 - not changing, with a concrete repository constraint or technical reason
+- deferred to a named follow-up PR, with its URL
 
 Follow repository attribution rules for GitHub comments. Do not claim a check
 passed unless it ran successfully on the reported head.
 
 After replying, resolve only review threads whose every participant is a
-confirmed allowed bot and that are implemented, already addressed, or answered
-with a supported pushback. Leave human, mixed-participant, and uncertain threads
+confirmed allowed bot and that are implemented, already addressed, answered
+with a supported pushback, or deferred to a named follow-up PR. Leave human, mixed-participant, and uncertain threads
 open. Top-level comments have no thread-resolution state; do not minimize bot
 summaries by default.
 

--- a/.claude/skills/rabbit-round/SKILL.md
+++ b/.claude/skills/rabbit-round/SKILL.md
@@ -37,7 +37,10 @@ comment:
 - **Push back**: incorrect, stale, speculative, or contrary to documented
   constraints.
 - **Defer**: accepted, but landing in a named follow-up PR because the enclosing
-  workflow's review budget is spent. Only with the follow-up PR's URL.
+  workflow's review budget is spent. Only with the follow-up PR's URL, and every
+  defer in one run names the same PR. Never for a verified release-blocking
+  defect (security, authorization, data loss, corruption): those are fixed on the
+  current head.
 
 Read the cited code and applicable instructions before deciding. Treat security,
 authorization, data loss, and compatibility claims as hypotheses to verify, not
@@ -70,10 +73,11 @@ Follow repository attribution rules for GitHub comments. Do not claim a check
 passed unless it ran successfully on the reported head.
 
 After replying, resolve only review threads whose every participant is a
-confirmed allowed bot and that are implemented, already addressed, answered
-with a supported pushback, or deferred to a named follow-up PR. Leave human, mixed-participant, and uncertain threads
-open. Top-level comments have no thread-resolution state; do not minimize bot
-summaries by default.
+confirmed allowed bot and that are implemented, already addressed, answered with
+a supported pushback, or deferred to a named follow-up PR. Leave human,
+mixed-participant, and uncertain threads open. Top-level comments have no
+thread-resolution state: a reply naming the follow-up PR is the whole disposition
+there. Do not minimize bot summaries by default.
 
 ## 5. Recheck the Current Head
 
@@ -81,7 +85,10 @@ Refresh the PR after the push and report one status:
 
 - `clean`: all current-head automated reviewers are terminal, required checks
   are green, and no actionable automated finding remains in a review thread or
-  top-level comment
+  top-level comment. A top-level finding answered with a defer reply carrying the
+  follow-up PR's URL is no longer actionable on later rounds, unless it names a
+  verified release-blocking defect: no defer makes one of those non-actionable,
+  and the status stays `needs_changes` until it is fixed on the current head
 - `pending_bots`: this round pushed the current head, or a current-head
   automated review or required check is still running
 - `needs_changes`: actionable automated feedback remains

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,10 @@ details unless they are already public in the repository.
   timed re-request after a rate limit). Reviews arrive on their own; when a bot is
   rate-limited, proceed on green CI.
 - This repository (including PRs, commits, comments) is public. Never include
-  marketing language, internal business context, pricing, competitive analysis, user
-  identities, conversation specifics, or security architecture beyond what the diff
-  shows. Write for the reviewing engineer.
+  marketing language, internal business context, pricing, competitive analysis,
+  product or end-user identities, conversation specifics, or security architecture
+  beyond what the diff shows. The requester attribution above is the one identity a
+  comment carries. Write for the reviewing engineer.
 
 ## Meta Preferences
 


### PR DESCRIPTION
Regenerates finish-pr, open-pr, rabbit-round and AGENTS.md from ai-shared 106eb249 (stella/ai-shared#46 and #48).

From #46: a Defer disposition for bot findings that land in a named follow-up PR, convergence that covers top-level bot comments, base-repository resolution before the existing-PR check, and the requester attribution named as the one identity a public comment carries.

From #48, closing the gaps review found in that deferral: a verified security, authorization, data-loss or data-corruption defect is never deferred, whatever the round, and neither the convergence list nor rabbit-round's `clean` status accepts a defer for one. `Defer` also joins the dispositions finish-pr names, every defer in a run points at the same follow-up PR, a top-level comment's defer reply is its terminal state because it has no resolution state, and the fork PR lookup selects `headRepositoryOwner` instead of trusting `--head`, which filters by branch name alone.

## Validation

- `bash .ai/shared/scripts/sync-ai-skills.sh --check .` is clean: the generated copies match the submodule.
