### PR TITLE
fix(api): thread titles accept an output-ceiling finish

### DIFF
--- a/apps/api/src/handlers/chat/generate-thread-title.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.ts
@@ -7,6 +7,7 @@ import { aiTitlingMayReplace } from "@/api/handlers/chat/thread-title";
 import {
   buildThreadTitlePrompt,
   cleanGeneratedTitle,
+  TITLE_FINISH_POLICY,
   TITLE_MAX_OUTPUT_TOKENS,
 } from "@/api/handlers/chat/thread-title-prompt";
 import type { ChatMessage } from "@/api/handlers/chat/types";
@@ -65,7 +66,7 @@ export const generateThreadTitle = async ({
   try {
     const text = await generateTanStackTextForRole({
       abortSignal: AbortSignal.timeout(TITLE_GENERATION_TIMEOUT_MS),
-      finishPolicy: "require-complete",
+      finishPolicy: TITLE_FINISH_POLICY,
       maxOutputTokens: TITLE_MAX_OUTPUT_TOKENS,
       role: "fast",
       serviceTier: "batch",

--- a/apps/api/src/handlers/chat/suggest-thread-title.ts
+++ b/apps/api/src/handlers/chat/suggest-thread-title.ts
@@ -10,6 +10,7 @@ import { loadRecapMessageWindow } from "@/api/handlers/chat/thread-recap-window"
 import {
   buildThreadTitlePrompt,
   cleanGeneratedTitle,
+  TITLE_FINISH_POLICY,
   TITLE_MAX_OUTPUT_TOKENS,
 } from "@/api/handlers/chat/thread-title-prompt";
 import { resolveCaching } from "@/api/lib/ai-config";
@@ -180,7 +181,7 @@ export const createSuggestThreadTitle = ({
                 role: "fast",
                 scopeKey: threadId,
               }),
-              finishPolicy: "require-complete",
+              finishPolicy: TITLE_FINISH_POLICY,
               maxOutputTokens: TITLE_MAX_OUTPUT_TOKENS,
               organizationId: session.activeOrganizationId,
               orgAIConfig,

--- a/apps/api/src/handlers/chat/thread-title-prompt.ts
+++ b/apps/api/src/handlers/chat/thread-title-prompt.ts
@@ -1,8 +1,18 @@
 import type { ChatMessage } from "@/api/handlers/chat/types";
+import type { TanStackTextFinishPolicy } from "@/api/lib/tanstack-ai-generate";
 
 export const TITLE_MAX_LENGTH = 60;
 export const TITLE_CONTEXT_MAX_LENGTH = 500;
 export const TITLE_MAX_OUTPUT_TOKENS = 32;
+
+// A title is a label, not content: `cleanGeneratedTitle` bounds it to
+// TITLE_MAX_LENGTH anyway, and the 32-token ceiling above is what a verbose
+// model spends before the run reports a `length` finish. A title cut at that
+// ceiling still names the thread, so grading it as a failure would turn a
+// wordy model into a 502 and leave the thread on its placeholder. A moderated,
+// tool-bearing, or unfinished run stays a failure.
+export const TITLE_FINISH_POLICY =
+  "allow-output-ceiling" satisfies TanStackTextFinishPolicy;
 
 export type TitleContextMessage = Pick<ChatMessage, "parts" | "role">;
 


### PR DESCRIPTION
## Proposed change

`generateTanStackTextForRole` takes a required `finishPolicy`. `require-complete`
accepts only a `stop` finish; `allow-output-ceiling` also accepts `length`, the
finish a run reports when it spends its whole `maxOutputTokens` budget, and still
rejects moderated (`content_filter`), tool-bearing, and unfinished runs. The two
titling paths were moved to `require-complete` in #2938, but that policy rejected
every run until v0.8.21, so this is the first release where they actually run under
it. With `TITLE_MAX_OUTPUT_TOKENS` at 32, a wordy model hits the ceiling and reports
`length`: `POST /threads/:threadId/title/suggest` then answers 502, and the
fire-and-forget generator on thread creation leaves the thread on its placeholder.

A title is a label, not content that replaces something. `cleanGeneratedTitle`
already trims wrappers and bounds the result to `TITLE_MAX_LENGTH`, and a title cut
at the token ceiling still names the thread, so both handlers now use
`TITLE_FINISH_POLICY` (`allow-output-ceiling`), defined next to the token ceiling it
depends on in the shared `thread-title-prompt` module. The other six
`require-complete` callers keep the strict policy because a truncated output there is
silently wrong, not merely short: `improve-prompt` (the rewrite replaces the user's
text), `properties/suggest-prompt` (the suggestion is used verbatim as a prompt),
`skills/resources/rewrite` (replaces resource content), `time-entries/polish-narrative`
(replaces the narrative), `flows/flow-executor` (step output feeds later steps), and
chat compaction (a durable checkpoint, guarded by the
`require-complete-compaction-generation` lint rule).

## Verification

- `bun --filter @stll/api typecheck` — pass
- `bun run lint:changed` (type-aware, 3 files) — pass
- `bunx oxfmt --check` on the three touched files — pass
- `bun run test -- src/handlers/chat` from `apps/api` — 953 pass, 0 fail; the four
  title-related files (`generate-thread-title.integration`,
  `suggest-thread-title.integration`, `thread-title-prompt`, `thread-title`)
  account for 75 of them

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: API handler policy, no UI surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-visible surface changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic thread title generation so valid titles are retained when the model reaches its output limit.
  - Continued rejecting incomplete, moderated, or tool-related generation results to maintain title quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->