### PR TITLE
fix(api): keep every cell of a CJEU table row

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
@@ -583,6 +583,55 @@ describe("parseEcjDecisionHtml", () => {
     ]);
   });
 
+  /**
+   * Rule 10 as an invariant rather than an example: a row shape the
+   * marker/content rules do not match is still walked for its text.
+   * The converter emits a numbered paragraph as a two-cell row, so the
+   * shape rules read cell 1 as the marker and cell 2 as its content —
+   * but a decision quoting a tariff or rate table carries a column per
+   * heading, description and rate, and a header row of `th`. Asserted
+   * across the row shapes rather than on one of them, because losing a
+   * cell is invisible downstream: the AST reads as complete.
+   */
+  test("keeps every cell of every row shape", () => {
+    const cellText = (row: number, cell: number) => `r${row}c${cell} content`;
+    const shapes = [1, 2, 3, 4, 5];
+    const rows = shapes
+      .map((cellCount, row) => {
+        const tag = row % 2 === 0 ? "td" : "th";
+        const cells = Array.from(
+          { length: cellCount },
+          (_, cell) => `<${tag}><p>${cellText(row, cell)}</p></${tag}>`,
+        ).join("");
+        return `<tr>${cells}</tr>`;
+      })
+      .join("");
+    const html = [
+      "<html><body><div class='coj-normal' lang='en'>",
+      "<p class='coj-sum-title-1'>JUDGMENT OF THE COURT</p>",
+      `<table><tbody>${rows}</tbody></table>`,
+      "</div></body></html>",
+    ].join("");
+
+    const { fulltext } = parseEcjDecisionHtml({
+      caseNumber: "C-1/00",
+      ecli: undefined,
+      court: "Court of Justice",
+      decisionDate: undefined,
+      decisionType: undefined,
+      sourceUrl: undefined,
+      celex: "62000CJ0001",
+      html,
+    });
+
+    const missing = shapes.flatMap((cellCount, row) =>
+      Array.from({ length: cellCount }, (_, cell) =>
+        cellText(row, cell),
+      ).filter((text) => !fulltext.includes(text)),
+    );
+    expect(missing).toEqual([]);
+  });
+
   test("reads the keyword chain in a non-Latin script", async () => {
     const html = await readFixture("62022CJ0128.el.html.gz");
     if (html === undefined) {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
@@ -939,8 +939,12 @@ const visitTable = (
     .children("tbody")
     .children("tr")
     .each((_, tr) => {
-      const cells = $(tr).children("td").toArray();
-      const [markerCell, contentCell] = cells;
+      // `th` counts as a cell. A decision quoting a tariff or rate
+      // table carries that table's column labels in a header row, and
+      // a row selected as `td` alone yields no cells at all — so the
+      // row would be dropped whole rather than shaped wrong.
+      const cells = $(tr).children("td, th").toArray();
+      const [markerCell, contentCell, ...extraCells] = cells;
       if (!markerCell) {
         return;
       }
@@ -954,19 +958,27 @@ const visitTable = (
         "number"
       ];
 
-      if (pointNumber !== undefined) {
+      if (pointNumber === undefined) {
+        // Unanchored markers ("–", "(22)", "1.") belong to the text: they
+        // number a quoted recital or an operative-part item.
+        visitCell($, builder, $(contentCell), {
+          marker: textOf($(markerCell)),
+        });
+      } else {
         builder.zone = builder.zone === "header" ? "body" : builder.zone;
         visitCell($, builder, $(contentCell), {
           number: Number.parseInt(pointNumber, 10),
         });
-        return;
       }
 
-      // Unanchored markers ("–", "(22)", "1.") belong to the text: they
-      // number a quoted recital or an operative-part item.
-      visitCell($, builder, $(contentCell), {
-        marker: textOf($(markerCell)),
-      });
+      // The marker/content pair is the converter's shape for a numbered
+      // paragraph, not a bound on the row: a quoted table has a column
+      // per tariff heading, description and rate, and the pair alone
+      // would silently keep the first two of them. Anything past the
+      // pair still contributes its text, in document order.
+      for (const cell of extraCells) {
+        visitCell($, builder, $(cell), undefined);
+      }
     });
 };
 


### PR DESCRIPTION
## Proposed change

`visitTable` in the CJEU parser reads every row as the converter's marker/content pair:

```ts
const cells = $(tr).children("td").toArray();
const [markerCell, contentCell] = cells;
```

Two consequences follow, and both lose text:

- **Cells past the second are never visited.** The pair is the converter's shape for a numbered paragraph (a marker cell holding `p.coj-count#pointN`, a content cell holding its text), not a bound on the row. A decision that quotes a tariff or rate table carries a column per heading, description and rate, so the parse keeps the first two and drops the remainder.
- **A `th` row is dropped whole.** Cells are selected as `children("td")`, so a row whose cells are `th` yields none, `markerCell` is `undefined`, and the row returns early. That is exactly the shape of a quoted table's column labels.

Both contradict the parser's own doc comment ("an element the vocabulary does not cover still contributes its text") and rule 10 of `handlers/case-law/CLAUDE.md`, which states that a table row the shape rules do not match is still walked for its content.

The loss is silent by construction: the AST stays well-formed and reads as complete, so nothing downstream, reader or retrieval, can tell a column is gone. `validateAndLog` catches it only once the dropped columns push a document past `MISSING_WORDS`/`CONTENT_LOSS`.

The fix counts `th` as a cell and walks the cells past the pair as content, in document order. Marker handling is untouched, so a two-cell row parses exactly as before.

The test encodes the invariant across row shapes (one to five cells, `td` and `th`) rather than as a single example, because a lost cell leaves output that still looks right. Reverting either half fails it: `th` rows vanish entirely, `td` rows lose everything past the second cell.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings. `tsc --noEmit -p apps/api` clean, oxlint clean on the touched files.
- [x] TESTING | `bun test` over `handlers/case-law/ingestion/parsers/` — 283 pass, 0 fail, including the Formex-oracle fixtures that assert the parse against the publisher's own structure in every language.
- [ ] DARK MODE SUPPORT | N/A, parser change with no UI surface.
- [ ] ISSUE LINKED | N/A.
- [ ] SCREENSHOT INCLUDED | N/A, no user-visible UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_013LiLGsaJJzXJPTLPHcCXja)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of EU court decision tables to retain text from all columns, including header cells.
  * Preserved table content in document order, including quoted tariff and rate tables.

* **Tests**
  * Added coverage for tables containing rows with one to five cells and mixed header and data cell types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->