### PR TITLE
feat(api): index-job rows carry a reason apart from a failure

### DIFF
--- a/apps/api/drizzle/20260905200000_corpus_index_job_detail/migration.sql
+++ b/apps/api/drizzle/20260905200000_corpus_index_job_detail/migration.sql
@@ -1,0 +1,18 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- Why a succeeded index-job row was written, kept apart from the failure it
+-- is not. `error_message` is read as the failure of the row it sits on, so a
+-- withdrawal filing its reason there reads as an operation that failed. The
+-- reason moves to `detail`, and `error_message` keeps its one meaning.
+--
+-- Nullable with no default: existing rows are untouched and the table takes
+-- only a catalog change. Same width as `error_message` in both tables, so a
+-- reason is bounded the same way whichever column a reader came for.
+-- Rollback drops the column; nothing reads it before this deploys.
+ALTER TABLE "case_law_index_jobs"
+  ADD COLUMN IF NOT EXISTS "detail" varchar(2048);--> statement-breakpoint
+
+-- The trail is one shape across both families, so both tables move together.
+ALTER TABLE "legislation_index_jobs"
+  ADD COLUMN IF NOT EXISTS "detail" varchar(2048);

--- a/apps/api/drizzle/20260905200000_corpus_index_job_detail/migration.sql
+++ b/apps/api/drizzle/20260905200000_corpus_index_job_detail/migration.sql
@@ -1,5 +1,5 @@
 SET LOCAL lock_timeout = '1s';--> statement-breakpoint
-SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+SET LOCAL statement_timeout = '30s';--> statement-breakpoint
 
 -- Why a succeeded index-job row was written, kept apart from the failure it
 -- is not. `error_message` is read as the failure of the row it sits on, so a
@@ -15,4 +15,50 @@ ALTER TABLE "case_law_index_jobs"
 
 -- The trail is one shape across both families, so both tables move together.
 ALTER TABLE "legislation_index_jobs"
-  ADD COLUMN IF NOT EXISTS "detail" varchar(2048);
+  ADD COLUMN IF NOT EXISTS "detail" varchar(2048);--> statement-breakpoint
+
+-- Withdrawals recorded before this migration hold their reason in the failure
+-- column, so the rows written under the old writer are moved to the new one:
+-- without this the trail would mean two different things depending on when a
+-- row was written, and the constraint below could not stand.
+--
+-- Bounded by construction: only `withdraw` rows that carry a message are
+-- rewritten, an operation recorded by an operator action rather than by the
+-- indexing loop. The predicate has no index of its own, so the cost is one
+-- pass over each table, which is what the wider statement budget above is
+-- for. Idempotent: a second run matches nothing, because the column it reads
+-- is cleared by the same statement. Rollback is the mirrored update.
+UPDATE "case_law_index_jobs"
+  SET "detail" = "error_message", "error_message" = NULL
+  WHERE "operation" = 'withdraw'
+    AND "status" = 'succeeded'
+    AND "error_message" IS NOT NULL;--> statement-breakpoint
+
+UPDATE "legislation_index_jobs"
+  SET "detail" = "error_message", "error_message" = NULL
+  WHERE "operation" = 'withdraw'
+    AND "status" = 'succeeded'
+    AND "error_message" IS NOT NULL;--> statement-breakpoint
+
+-- The split the column exists for, enforced by the database rather than by
+-- every writer remembering it: a row that succeeded carries no failure. The
+-- reverse is deliberately not constrained — a failed row may record both what
+-- it was for and what went wrong.
+--
+-- NOT VALID: the statement above moved every row this could reject, so there
+-- is nothing to scan; the constraint still applies to every later INSERT and
+-- UPDATE, which is where the invariant has to hold. Rollback drops it.
+--
+-- This is the one place the change is not additive across a rollout: a writer
+-- from before it that still files a withdrawal's reason in `error_message` has
+-- its insert rejected. That path fails closed rather than writing a row the
+-- trail would misread — the audit row and the columns it describes share one
+-- transaction, so nothing half-written survives, and the withdrawal can be
+-- made again once the writer is replaced.
+ALTER TABLE "case_law_index_jobs"
+  ADD CONSTRAINT "case_law_index_jobs_succeeded_error_message"
+  CHECK ("status" <> 'succeeded' OR "error_message" IS NULL) NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "legislation_index_jobs"
+  ADD CONSTRAINT "legislation_index_jobs_succeeded_error_message"
+  CHECK ("status" <> 'succeeded' OR "error_message" IS NULL) NOT VALID;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -84,6 +84,7 @@ import { workspaces } from "./contacts";
 import {
   CORPUS_INDEX_JOB_OPERATION_SQL_VALUES,
   CORPUS_INDEX_JOB_STATUS_SQL_VALUES,
+  CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE,
 } from "./corpus-index-jobs";
 import type {
   CorpusIndexJobOperation,
@@ -2061,6 +2062,13 @@ export const caseLawIndexJobs = p.pgTable(
     p.check(
       "case_law_index_jobs_status_values",
       sql`${t.status} IN (${sql.join(CORPUS_INDEX_JOB_STATUS_SQL_VALUES, sql.raw(","))})`,
+    ),
+    // A row that succeeded carries no failure; its reason belongs in `detail`.
+    // The reverse is open on purpose: a failed row may record both what it was
+    // for and what went wrong.
+    p.check(
+      "case_law_index_jobs_succeeded_error_message",
+      sql`${t.status} <> ${CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE} OR ${t.errorMessage} IS NULL`,
     ),
     ...globalCaseLawPolicies(),
   ],

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -2038,6 +2038,13 @@ export const caseLawIndexJobs = p.pgTable(
     status: p.varchar({ length: 16 }).notNull().$type<CorpusIndexJobStatus>(),
     contentHash: p.varchar("content_hash", { length: 64 }),
     errorMessage: p.varchar("error_message", { length: 2048 }),
+    /**
+     * Why a succeeded operation was performed, in the caller's own words.
+     * Separate from `error_message`, which a reader takes as the failure of
+     * the row it sits on: a withdrawal's reason filed there reads as an
+     * operation that failed, which it did not.
+     */
+    detail: p.varchar("detail", { length: 2048 }),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
   },
   (t) => [

--- a/apps/api/src/db/schema/corpus-index-jobs.ts
+++ b/apps/api/src/db/schema/corpus-index-jobs.ts
@@ -46,7 +46,7 @@ export const CORPUS_INDEX_JOB_STATUS_SQL_VALUES = CORPUS_INDEX_JOB_STATUSES.map(
  * reason in `detail`; `error_message` is the failure of the row it sits on,
  * and both tables constrain the pair from this one declaration.
  */
-export const CORPUS_INDEX_JOB_SUCCEEDED_STATUS =
+const CORPUS_INDEX_JOB_SUCCEEDED_STATUS =
   "succeeded" as const satisfies CorpusIndexJobStatus;
 
 export const CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE = sql.raw(

--- a/apps/api/src/db/schema/corpus-index-jobs.ts
+++ b/apps/api/src/db/schema/corpus-index-jobs.ts
@@ -40,3 +40,15 @@ export const CORPUS_INDEX_JOB_OPERATION_SQL_VALUES =
 export const CORPUS_INDEX_JOB_STATUS_SQL_VALUES = CORPUS_INDEX_JOB_STATUSES.map(
   (status) => sql.raw(`'${status}'`),
 );
+
+/**
+ * The status of a row whose operation went through. Such a row carries its
+ * reason in `detail`; `error_message` is the failure of the row it sits on,
+ * and both tables constrain the pair from this one declaration.
+ */
+export const CORPUS_INDEX_JOB_SUCCEEDED_STATUS =
+  "succeeded" as const satisfies CorpusIndexJobStatus;
+
+export const CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE = sql.raw(
+  `'${CORPUS_INDEX_JOB_SUCCEEDED_STATUS}'`,
+);

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -267,6 +267,8 @@ export const legislationIndexJobs = p.pgTable(
     status: p.varchar({ length: 16 }).notNull().$type<CorpusIndexJobStatus>(),
     contentHash: p.varchar("content_hash", { length: 64 }),
     errorMessage: p.varchar("error_message", { length: 2048 }),
+    /** Why a succeeded operation was performed; see the case-law twin. */
+    detail: p.varchar("detail", { length: 2048 }),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
   },
   (t) => [

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -25,6 +25,7 @@ import type {
 import {
   CORPUS_INDEX_JOB_OPERATION_SQL_VALUES,
   CORPUS_INDEX_JOB_STATUS_SQL_VALUES,
+  CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE,
 } from "./corpus-index-jobs";
 import type {
   CorpusIndexJobOperation,
@@ -281,6 +282,12 @@ export const legislationIndexJobs = p.pgTable(
     p.check(
       "legislation_index_jobs_status_values",
       sql`${t.status} IN (${sql.join(CORPUS_INDEX_JOB_STATUS_SQL_VALUES, sql.raw(","))})`,
+    ),
+    // The case-law twin's invariant, on the same declaration: a succeeded row
+    // carries no failure.
+    p.check(
+      "legislation_index_jobs_succeeded_error_message",
+      sql`${t.status} <> ${CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE} OR ${t.errorMessage} IS NULL`,
     ),
     ...globalCaseLawPolicies(),
   ],

--- a/apps/api/src/handlers/case-law/ingestion/replay-apply.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay-apply.db.test.ts
@@ -619,6 +619,7 @@ test("the withdrawal takes the document and keeps the decision", async () => {
       operation: caseLawIndexJobs.operation,
       status: caseLawIndexJobs.status,
       contentHash: caseLawIndexJobs.contentHash,
+      detail: caseLawIndexJobs.detail,
       errorMessage: caseLawIndexJobs.errorMessage,
     })
     .from(caseLawIndexJobs)
@@ -626,7 +627,10 @@ test("the withdrawal takes the document and keeps the decision", async () => {
   expect(audited?.operation).toBe("withdraw");
   expect(audited?.status).toBe("succeeded");
   expect(audited?.contentHash).toBeNull();
-  expect(audited?.errorMessage).toContain("re-parse yielded no document");
+  // The reason is the detail of an operation that succeeded. The failure
+  // column stays clear: a reader takes anything in it as this row's failure.
+  expect(audited?.detail).toContain("re-parse yielded no document");
+  expect(audited?.errorMessage).toBeNull();
 
   // And it converges: the row holds no document to take, so a second run
   // reports the rejection and withdraws nothing.

--- a/apps/api/src/lib/legal-search/corpus-index-job-audit.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-job-audit.db.test.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  caseLawDecisions,
+  caseLawIndexJobs,
+  caseLawSources,
+  legislationDocuments,
+  legislationIndexJobs,
+  legislationSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { recordCorpusWithdrawalAuditEvent } from "@/api/lib/legal-search/corpus-index-job-audit";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const SOURCE_ID = toSafeId<"caseLawSource">(
+  "0198e331-e578-7000-8000-000000000201",
+);
+const DECISION_ID = toSafeId<"caseLawDecision">(
+  "0198e331-e578-7000-8000-000000000202",
+);
+const LEGISLATION_SOURCE_ID = toSafeId<"legislationSource">(
+  "0198e331-e578-7000-8000-000000000203",
+);
+const LEGISLATION_DOCUMENT_ID = toSafeId<"legislationDocument">(
+  "0198e331-e578-7000-8000-000000000204",
+);
+const GENERATION = "case_law_v5";
+
+// The driver reports a constraint violation as the cause of the failed query,
+// so the assertion reads the whole chain.
+const errorMessageChain = (error: unknown): string => {
+  const messages: string[] = [];
+  let current = error;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages.join(" | ");
+};
+
+const rejectionMessage = async (run: Promise<unknown>): Promise<string> =>
+  await run.then(
+    () => "no rejection",
+    (error: unknown) => errorMessageChain(error),
+  );
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+});
+
+beforeEach(async () => {
+  await db.delete(caseLawIndexJobs).where(sql`true`);
+  await db.delete(legislationIndexJobs).where(sql`true`);
+  await db.delete(caseLawDecisions).where(sql`true`);
+  await db.delete(legislationDocuments).where(sql`true`);
+  await db.delete(caseLawSources).where(sql`true`);
+  await db.delete(legislationSources).where(sql`true`);
+
+  await db.insert(caseLawSources).values({
+    id: SOURCE_ID,
+    adapterKey: "corpus-index-job-audit",
+    name: "Corpus index job audit",
+  });
+  await db.insert(caseLawDecisions).values({
+    id: DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "4 As 3/2008",
+    court: "Nejvyšší správní soud",
+    country: "CZE",
+    language: "cs",
+  });
+  await db.insert(legislationSources).values({
+    id: LEGISLATION_SOURCE_ID,
+    adapterKey: "corpus-index-job-audit",
+    name: "Corpus index job audit",
+  });
+  await db.insert(legislationDocuments).values({
+    id: LEGISLATION_DOCUMENT_ID,
+    sourceId: LEGISLATION_SOURCE_ID,
+    eli: "eli/cz/sb/2012/89",
+    title: "Občanský zákoník",
+    country: "CZE",
+    language: "cs",
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("a withdrawal files its reason as detail, not as a failure", async () => {
+  await db.transaction(
+    async (tx) =>
+      await recordCorpusWithdrawalAuditEvent(asTestRaw<Transaction>(tx), {
+        decisionId: DECISION_ID,
+        generation: GENERATION,
+        reason: "the stored payload re-parses to no document",
+      }),
+  );
+
+  const [audited] = await db
+    .select({
+      operation: caseLawIndexJobs.operation,
+      status: caseLawIndexJobs.status,
+      detail: caseLawIndexJobs.detail,
+      errorMessage: caseLawIndexJobs.errorMessage,
+    })
+    .from(caseLawIndexJobs)
+    .where(eq(caseLawIndexJobs.decisionId, DECISION_ID));
+  expect(audited).toEqual({
+    operation: "withdraw",
+    status: "succeeded",
+    detail: "the stored payload re-parses to no document",
+    errorMessage: null,
+  });
+});
+
+test("the database refuses a succeeded row that carries a failure", async () => {
+  expect(
+    await rejectionMessage(
+      db.insert(caseLawIndexJobs).values({
+        decisionId: DECISION_ID,
+        generation: GENERATION,
+        operation: "withdraw",
+        status: "succeeded",
+        errorMessage: "a reason filed where a failure belongs",
+      }),
+    ),
+  ).toContain(
+    'violates check constraint "case_law_index_jobs_succeeded_error_message"',
+  );
+
+  // A failed row is what the column is for, and it still records why.
+  await db.insert(caseLawIndexJobs).values({
+    decisionId: DECISION_ID,
+    generation: GENERATION,
+    operation: "index",
+    status: "failed",
+    errorMessage: "the index write did not land",
+  });
+  expect(
+    await db
+      .select({ errorMessage: caseLawIndexJobs.errorMessage })
+      .from(caseLawIndexJobs),
+  ).toEqual([{ errorMessage: "the index write did not land" }]);
+});
+
+test("legislation carries the same invariant", async () => {
+  expect(
+    await rejectionMessage(
+      db.insert(legislationIndexJobs).values({
+        documentId: LEGISLATION_DOCUMENT_ID,
+        generation: "legislation_v2",
+        operation: "withdraw",
+        status: "succeeded",
+        errorMessage: "a reason filed where a failure belongs",
+      }),
+    ),
+  ).toContain(
+    'violates check constraint "legislation_index_jobs_succeeded_error_message"',
+  );
+
+  await db.insert(legislationIndexJobs).values({
+    documentId: LEGISLATION_DOCUMENT_ID,
+    generation: "legislation_v2",
+    operation: "withdraw",
+    status: "succeeded",
+    detail: "the stored payload re-parses to no document",
+  });
+  expect(
+    await db
+      .select({
+        detail: legislationIndexJobs.detail,
+        errorMessage: legislationIndexJobs.errorMessage,
+      })
+      .from(legislationIndexJobs),
+  ).toEqual([
+    {
+      detail: "the stored payload re-parses to no document",
+      errorMessage: null,
+    },
+  ]);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-job-audit.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-job-audit.ts
@@ -44,6 +44,8 @@ export const recordCorpusWithdrawalAuditEvent = async (
     operation: "withdraw",
     status: "succeeded",
     contentHash: null,
-    errorMessage: reason.slice(0, REASON_LIMIT),
+    // `detail`, not `error_message`: the row succeeded, and a reason filed
+    // in the failure column reads as a failure that never happened.
+    detail: reason.slice(0, REASON_LIMIT),
   });
 };


### PR DESCRIPTION
## What

A nullable `detail` column (varchar 2048, additive migration) on `case_law_index_jobs` and `legislation_index_jobs`. The withdrawal audit writer records its reason there; `error_message` is left for failures.

## Why

A withdrawal row is `succeeded`, yet its reason lived in `error_message`, which reads as a failure that was not one. No product reader renders these rows; the only reader of the reason is the withdrawal test, updated here.

## Tests

replay-apply db test asserts `detail` carries the re-parse reason and `error_message` stays null; RLS coverage and grant tests, query-guard tests, migration coverage check.