### PR TITLE
fix(api): the replay waits for the source lease

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/replay-lease-wait.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay-lease-wait.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  acquireReplayLease,
+  REPLAY_LEASE_RETRY_PAUSE_MS,
+} from "@/api/handlers/case-law/ingestion/replay";
+
+// Stands in for the lease itself: the wait reads nothing from it.
+const LEASE = { source: "acquired" };
+
+// Refuses the first `refusals` attempts, the way an ingestion that takes the
+// lease per reconciliation unit refuses everyone until it reaches a gap.
+const refusingAcquire = (refusals: number) => {
+  let attempts = 0;
+  return {
+    acquire: async () => {
+      attempts += 1;
+      return await Promise.resolve(attempts > refusals ? LEASE : null);
+    },
+    attempts: () => attempts,
+  };
+};
+
+// Nothing sleeps: the budget is spent in recorded pauses, so a thirty-minute
+// wait costs the test nothing.
+const recordingSleep = () => {
+  const pauses: number[] = [];
+  return {
+    pauses,
+    sleep: async (ms: number) => {
+      pauses.push(ms);
+      await Promise.resolve();
+    },
+  };
+};
+
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+describe("waiting for a source's ingestion lease", () => {
+  test("takes a free lease without pausing", async () => {
+    const { acquire, attempts } = refusingAcquire(0);
+    const { pauses, sleep } = recordingSleep();
+    let announced = 0;
+
+    const acquisition = await acquireReplayLease({
+      acquire,
+      waitBudgetMs: THIRTY_MINUTES_MS,
+      onWaitStart: () => {
+        announced += 1;
+      },
+      sleep,
+    });
+
+    expect(acquisition).toEqual({
+      type: "acquired",
+      lease: LEASE,
+      waitedMs: 0,
+    });
+    expect(attempts()).toBe(1);
+    expect(pauses).toEqual([]);
+    expect(announced).toBe(0);
+  });
+
+  test("retries on a fixed pause until the holder releases", async () => {
+    const { acquire, attempts } = refusingAcquire(3);
+    const { pauses, sleep } = recordingSleep();
+    let announced = 0;
+
+    const acquisition = await acquireReplayLease({
+      acquire,
+      waitBudgetMs: THIRTY_MINUTES_MS,
+      onWaitStart: () => {
+        announced += 1;
+      },
+      sleep,
+    });
+
+    expect(acquisition).toEqual({
+      type: "acquired",
+      lease: LEASE,
+      waitedMs: 3 * REPLAY_LEASE_RETRY_PAUSE_MS,
+    });
+    expect(attempts()).toBe(4);
+    expect(pauses).toEqual([
+      REPLAY_LEASE_RETRY_PAUSE_MS,
+      REPLAY_LEASE_RETRY_PAUSE_MS,
+      REPLAY_LEASE_RETRY_PAUSE_MS,
+    ]);
+    // Said once, however long the wait runs.
+    expect(announced).toBe(1);
+  });
+
+  test("gives up once the budget is spent, and pauses no longer than it", async () => {
+    const { acquire, attempts } = refusingAcquire(Number.POSITIVE_INFINITY);
+    const { pauses, sleep } = recordingSleep();
+    const waitBudgetMs = 30_000;
+
+    const acquisition = await acquireReplayLease({
+      acquire,
+      waitBudgetMs,
+      sleep,
+    });
+
+    expect(acquisition).toEqual({
+      type: "unavailable",
+      waitedMs: waitBudgetMs,
+    });
+    expect(pauses.reduce((total, ms) => total + ms, 0)).toBe(waitBudgetMs);
+    // Every pause is preceded by an attempt, and the budget buys one more.
+    expect(attempts()).toBe(pauses.length + 1);
+  });
+
+  test("attempts once and reports the holder when the budget is zero", async () => {
+    const { acquire, attempts } = refusingAcquire(Number.POSITIVE_INFINITY);
+    const { pauses, sleep } = recordingSleep();
+    let announced = 0;
+
+    const acquisition = await acquireReplayLease({
+      acquire,
+      waitBudgetMs: 0,
+      onWaitStart: () => {
+        announced += 1;
+      },
+      sleep,
+    });
+
+    expect(acquisition).toEqual({ type: "unavailable", waitedMs: 0 });
+    expect(attempts()).toBe(1);
+    expect(pauses).toEqual([]);
+    expect(announced).toBe(0);
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/replay.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay.ts
@@ -824,6 +824,66 @@ const failureDetail = (error: unknown): string =>
     FAILURE_DETAIL_LIMIT,
   );
 
+/** Pause between lease attempts while a replay waits for the source. */
+export const REPLAY_LEASE_RETRY_PAUSE_MS = 5000;
+
+export type ReplayLeaseAcquisition<TLease> =
+  | { type: "acquired"; lease: TLease; waitedMs: number }
+  | { type: "unavailable"; waitedMs: number };
+
+// Generic over the lease because the wait reads nothing from it: an acquire
+// either produced one or did not.
+export type AcquireReplayLeaseOptions<TLease> = {
+  acquire: () => Promise<TLease | null>;
+  /** Paused time the acquire may be retried for; 0 attempts once. */
+  waitBudgetMs: number;
+  /** Called once, when the first attempt lost and the wait begins. */
+  onWaitStart?: () => void;
+  /** Test seam; a run sleeps. */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/**
+ * Take a source's ingestion lease, waiting out an ingestion that holds it.
+ *
+ * An ingestion takes the lease per reconciliation unit and releases it in
+ * between, so a single attempt made while the source is being crawled loses
+ * far more often than it wins. Retrying on a fixed pause claims one of the
+ * gaps instead; the budget bounds the wait so an unattended run still ends.
+ *
+ * The budget counts paused time alone: an attempt is one indexed update, and
+ * counting attempts too would make the number of tries depend on database
+ * latency.
+ */
+export const acquireReplayLease = async <TLease>({
+  acquire,
+  waitBudgetMs,
+  onWaitStart,
+  sleep = Bun.sleep,
+}: AcquireReplayLeaseOptions<TLease>): Promise<
+  ReplayLeaseAcquisition<TLease>
+> => {
+  const lease = await acquire();
+  if (lease !== null) {
+    return { type: "acquired", lease, waitedMs: 0 };
+  }
+  if (waitBudgetMs < REPLAY_LEASE_RETRY_PAUSE_MS) {
+    return { type: "unavailable", waitedMs: 0 };
+  }
+
+  onWaitStart?.();
+  let waitedMs = 0;
+  while (waitedMs + REPLAY_LEASE_RETRY_PAUSE_MS <= waitBudgetMs) {
+    await sleep(REPLAY_LEASE_RETRY_PAUSE_MS);
+    waitedMs += REPLAY_LEASE_RETRY_PAUSE_MS;
+    const retried = await acquire();
+    if (retried !== null) {
+      return { type: "acquired", lease: retried, waitedMs };
+    }
+  }
+  return { type: "unavailable", waitedMs };
+};
+
 export type ReplayCaseLawSourceOptions = {
   adapter: SourceAdapter;
   scopedDb: ScopedDb;

--- a/apps/api/src/scripts/replay-case-law-source.ts
+++ b/apps/api/src/scripts/replay-case-law-source.ts
@@ -38,6 +38,7 @@ import { caseLawSources } from "@/api/db/schema";
  */
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import {
+  acquireReplayLease,
   CASE_LAW_REPLAY_SCOPE,
   countReplayability,
   REPLAY_REJECTION_POLICY,
@@ -64,6 +65,8 @@ const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 const DEFAULT_LIMIT = 100;
 const DEFAULT_PAGE_SIZE = 25;
+const DEFAULT_LEASE_WAIT_MINUTES = 30;
+const MINUTE_MS = 60_000;
 /** A stored payload is one document; nothing here should take longer. */
 const STORED_RAW_READ_TIMEOUT_MS = 30_000;
 
@@ -82,7 +85,11 @@ const USAGE = `Usage: bun run src/scripts/replay-case-law-source.ts --adapter <k
   --celex <value>   Replay only the decision stored under this publisher id
                     (metadata.celex).
   --after <id>      Resume strictly after this decision id.
-  --page-size <n>   Rows read per query (default ${DEFAULT_PAGE_SIZE}).`;
+  --page-size <n>   Rows read per query (default ${DEFAULT_PAGE_SIZE}).
+  --lease-wait <minutes>
+                    How long an --apply run waits for the source's ingestion
+                    lease before giving up (default ${DEFAULT_LEASE_WAIT_MINUTES}).
+                    0 attempts once and exits if the lease is held.`;
 
 const flagValue = (name: string): string | undefined => {
   const index = process.argv.indexOf(`--${name}`);
@@ -115,6 +122,22 @@ const positiveInteger = (
   return parsed;
 };
 
+const nonNegativeInteger = (
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+): number => {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    console.error(`--${name} must be a non-negative integer, got: ${raw}`);
+    process.exit(1);
+  }
+  return parsed;
+};
+
 const adapterKey = flagValue("adapter");
 if (adapterKey === undefined || adapterKey.length === 0) {
   console.error(USAGE);
@@ -130,6 +153,11 @@ const pageSize = positiveInteger(
   flagValue("page-size"),
   DEFAULT_PAGE_SIZE,
   "page-size",
+);
+const leaseWaitMinutes = nonNegativeInteger(
+  flagValue("lease-wait"),
+  DEFAULT_LEASE_WAIT_MINUTES,
+  "lease-wait",
 );
 const celex = flagValue("celex");
 const court = flagValue("court");
@@ -234,19 +262,34 @@ const readStoredRaw: StoredRawReader = async (key) => {
 // A writing run takes the source's ingestion lease: it allocates observation
 // orders from the same counter a crawl does, and the two must not interleave.
 // A dry run writes nothing and takes nothing.
-const sourceLease = apply
-  ? await acquireCaseLawSourceIngestionLease({
-      scopedDb: ingestionDb,
-      sourceId: source.id,
+const acquisition = apply
+  ? await acquireReplayLease({
+      acquire: async () =>
+        await acquireCaseLawSourceIngestionLease({
+          scopedDb: ingestionDb,
+          sourceId: source.id,
+        }),
+      waitBudgetMs: leaseWaitMinutes * MINUTE_MS,
+      onWaitStart: () => {
+        console.log(
+          `lease held:          waiting up to ${leaseWaitMinutes} min for the running ingestion to release ${adapterKey}`,
+        );
+      },
     })
   : null;
 
-if (apply && sourceLease === null) {
+if (acquisition?.type === "unavailable") {
   console.error(
     `Source ${adapterKey} is being ingested right now (lease held). Retry later.`,
   );
   process.exit(1);
 }
+if (acquisition !== null && acquisition.waitedMs > 0) {
+  console.log(
+    `lease acquired:      after ${String(acquisition.waitedMs / 1000)} s of waiting`,
+  );
+}
+const sourceLease = acquisition?.lease ?? null;
 
 const replayed = await Result.tryPromise({
   try: async () =>

--- a/apps/api/src/scripts/replay-case-law-source.ts
+++ b/apps/api/src/scripts/replay-case-law-source.ts
@@ -106,33 +106,42 @@ const flagValue = (name: string): string | undefined => {
 
 const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
 
-const positiveInteger = (
-  raw: string | undefined,
-  fallback: number,
-  name: string,
-): number => {
-  if (raw === undefined) {
-    return fallback;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    console.error(`--${name} must be a positive integer, got: ${raw}`);
-    process.exit(1);
-  }
-  return parsed;
+/** Bounds a numeric flag accepts, with the wording its refusal uses. */
+const INTEGER_BOUND = {
+  POSITIVE: { minimum: 1, wording: "a positive integer" },
+  NON_NEGATIVE: { minimum: 0, wording: "a non-negative integer" },
+} as const;
+
+type IntegerBound = (typeof INTEGER_BOUND)[keyof typeof INTEGER_BOUND];
+
+type IntegerFlagOptions = {
+  bound: IntegerBound;
+  fallback: number;
+  name: string;
+  raw: string | undefined;
 };
 
-const nonNegativeInteger = (
-  raw: string | undefined,
-  fallback: number,
-  name: string,
-): number => {
+// The whole value has to be digits. `Number.parseInt` reads a prefix and
+// stops, so "30minutes" would pass as 30 minutes, "0.5" as 0 and "1e3" as 1:
+// every one of them a bound the operator did not ask for.
+const DECIMAL_DIGITS = /^\d+$/u;
+
+const integerFlag = ({
+  bound,
+  fallback,
+  name,
+  raw,
+}: IntegerFlagOptions): number => {
   if (raw === undefined) {
     return fallback;
   }
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isSafeInteger(parsed) || parsed < 0) {
-    console.error(`--${name} must be a non-negative integer, got: ${raw}`);
+  if (
+    !DECIMAL_DIGITS.test(raw) ||
+    !Number.isSafeInteger(parsed) ||
+    parsed < bound.minimum
+  ) {
+    console.error(`--${name} must be ${bound.wording}, got: ${raw}`);
     process.exit(1);
   }
   return parsed;
@@ -148,17 +157,24 @@ const apply = hasFlag("apply");
 const rejectionPolicy = hasFlag("withdraw-rejected")
   ? REPLAY_REJECTION_POLICY.WITHDRAW_NO_DOCUMENT
   : REPLAY_REJECTION_POLICY.REPORT;
-const limit = positiveInteger(flagValue("limit"), DEFAULT_LIMIT, "limit");
-const pageSize = positiveInteger(
-  flagValue("page-size"),
-  DEFAULT_PAGE_SIZE,
-  "page-size",
-);
-const leaseWaitMinutes = nonNegativeInteger(
-  flagValue("lease-wait"),
-  DEFAULT_LEASE_WAIT_MINUTES,
-  "lease-wait",
-);
+const limit = integerFlag({
+  bound: INTEGER_BOUND.POSITIVE,
+  fallback: DEFAULT_LIMIT,
+  name: "limit",
+  raw: flagValue("limit"),
+});
+const pageSize = integerFlag({
+  bound: INTEGER_BOUND.POSITIVE,
+  fallback: DEFAULT_PAGE_SIZE,
+  name: "page-size",
+  raw: flagValue("page-size"),
+});
+const leaseWaitMinutes = integerFlag({
+  bound: INTEGER_BOUND.NON_NEGATIVE,
+  fallback: DEFAULT_LEASE_WAIT_MINUTES,
+  name: "lease-wait",
+  raw: flagValue("lease-wait"),
+});
 const celex = flagValue("celex");
 const court = flagValue("court");
 if (celex?.length === 0) {


### PR DESCRIPTION
## What

`acquireReplayLease` retries the source ingestion lease on a fixed 5 s pause inside a paused-time budget; the script gains `--lease-wait <minutes>` (default 30, `0` keeps the single attempt) and logs when it starts waiting and when it acquires, with the time waited. The expired-budget path keeps the original error and exit code.

## Why

The standing ingestion holds the lease for one reconciliation unit at a time and releases between units, so a single attempt almost never wins against it and an operator run has to be relaunched by hand until it lands in a gap.

## Tests

`replay-lease-wait.test.ts`: free lease, three refusals then acquired, budget exhausted, `--lease-wait 0`; fake acquire and recorded sleeps, no real waiting. Replay db suite green.