### PR TITLE
chore(release): read the GitHub token from gh when no variable is set

### DIFF
--- a/scripts/prepare-maintenance-release.property.test.ts
+++ b/scripts/prepare-maintenance-release.property.test.ts
@@ -20,6 +20,7 @@ import {
   parseMaintenanceReleaseOptions,
   parseStableVersion,
   prepareMaintenanceReleaseFiles,
+  resolveGitHubToken,
   withFileRollback,
 } from "./prepare-maintenance-release";
 
@@ -83,6 +84,66 @@ afterEach(() => {
   for (const restore of restores.splice(0)) {
     restore();
   }
+});
+
+// The CLI is a spawned process in a release run; here it is a reader that
+// records whether it was asked at all.
+const cliToken = (token: string | null) => {
+  let asked = 0;
+  return {
+    asked: () => asked,
+    read: () => {
+      asked += 1;
+      return token;
+    },
+  };
+};
+
+describe("the token the GitHub reads are made with", () => {
+  test("prefers GH_TOKEN, and does not ask the CLI for one", () => {
+    const cli = cliToken("cli-token");
+
+    expect(
+      resolveGitHubToken(
+        { GH_TOKEN: "gh-token", GITHUB_TOKEN: "github-token" },
+        cli.read,
+      ),
+    ).toBe("gh-token");
+    expect(cli.asked()).toBe(0);
+  });
+
+  test("accepts GITHUB_TOKEN where GH_TOKEN is unset", () => {
+    const cli = cliToken("cli-token");
+
+    expect(resolveGitHubToken({ GITHUB_TOKEN: "github-token" }, cli.read)).toBe(
+      "github-token",
+    );
+    expect(cli.asked()).toBe(0);
+  });
+
+  // Without this the reads go out anonymous, and the anonymous rate limit
+  // answers a release preparation with HTTP 403.
+  test("falls back to the signed-in CLI when neither variable is set", () => {
+    const cli = cliToken("cli-token");
+
+    expect(resolveGitHubToken({}, cli.read)).toBe("cli-token");
+    expect(cli.asked()).toBe(1);
+  });
+
+  test("reads an empty variable as no token at all", () => {
+    expect(
+      resolveGitHubToken(
+        { GH_TOKEN: "", GITHUB_TOKEN: "" },
+        cliToken("cli-token").read,
+      ),
+    ).toBe("cli-token");
+  });
+
+  // A missing `gh`, or one that is signed out: the run continues
+  // unauthenticated rather than failing on the token.
+  test("stays unauthenticated when the CLI has no token to give", () => {
+    expect(resolveGitHubToken({}, cliToken(null).read)).toBeNull();
+  });
 });
 
 describe("maintenance release preparation", () => {

--- a/scripts/prepare-maintenance-release.property.test.ts
+++ b/scripts/prepare-maintenance-release.property.test.ts
@@ -86,64 +86,71 @@ afterEach(() => {
   }
 });
 
-// The CLI is a spawned process in a release run; here it is a reader that
-// records whether it was asked at all.
-const cliToken = (token: string | null) => {
-  let asked = 0;
+// The CLI is a spawned process in a release run; here it is a command runner
+// that records what it was asked to run, if anything.
+const cliToken = (stdout: string | null) => {
+  const commands: (readonly string[])[] = [];
   return {
-    asked: () => asked,
-    read: () => {
-      asked += 1;
-      return token;
+    commands,
+    run: (command: readonly string[]) => {
+      commands.push(command);
+      return stdout;
     },
   };
 };
 
 describe("the token the GitHub reads are made with", () => {
   test("prefers GH_TOKEN, and does not ask the CLI for one", () => {
-    const cli = cliToken("cli-token");
+    const cli = cliToken("cli-token\n");
 
     expect(
       resolveGitHubToken(
         { GH_TOKEN: "gh-token", GITHUB_TOKEN: "github-token" },
-        cli.read,
+        cli.run,
       ),
     ).toBe("gh-token");
-    expect(cli.asked()).toBe(0);
+    expect(cli.commands).toEqual([]);
   });
 
   test("accepts GITHUB_TOKEN where GH_TOKEN is unset", () => {
-    const cli = cliToken("cli-token");
+    const cli = cliToken("cli-token\n");
 
-    expect(resolveGitHubToken({ GITHUB_TOKEN: "github-token" }, cli.read)).toBe(
+    expect(resolveGitHubToken({ GITHUB_TOKEN: "github-token" }, cli.run)).toBe(
       "github-token",
     );
-    expect(cli.asked()).toBe(0);
+    expect(cli.commands).toEqual([]);
   });
 
   // Without this the reads go out anonymous, and the anonymous rate limit
   // answers a release preparation with HTTP 403.
   test("falls back to the signed-in CLI when neither variable is set", () => {
-    const cli = cliToken("cli-token");
+    const cli = cliToken("cli-token\n");
 
-    expect(resolveGitHubToken({}, cli.read)).toBe("cli-token");
-    expect(cli.asked()).toBe(1);
+    expect(resolveGitHubToken({}, cli.run)).toBe("cli-token");
+    // The reads go to github.com. A bare `gh auth token` would answer for
+    // the CLI's default host, which is an Enterprise instance under GH_HOST.
+    expect(cli.commands).toEqual([
+      ["gh", "auth", "token", "--hostname", "github.com"],
+    ]);
   });
 
   test("reads an empty variable as no token at all", () => {
     expect(
       resolveGitHubToken(
         { GH_TOKEN: "", GITHUB_TOKEN: "" },
-        cliToken("cli-token").read,
+        cliToken("cli-token\n").run,
       ),
     ).toBe("cli-token");
   });
 
-  // A missing `gh`, or one that is signed out: the run continues
-  // unauthenticated rather than failing on the token.
-  test("stays unauthenticated when the CLI has no token to give", () => {
-    expect(resolveGitHubToken({}, cliToken(null).read)).toBeNull();
-  });
+  // A missing `gh`, one signed out of github.com, or one that answers with
+  // nothing: the run continues unauthenticated rather than failing.
+  test.each([[null], [""], ["\n"]])(
+    "stays unauthenticated when the CLI answers %p",
+    (stdout) => {
+      expect(resolveGitHubToken({}, cliToken(stdout).run)).toBeNull();
+    },
+  );
 });
 
 describe("maintenance release preparation", () => {

--- a/scripts/prepare-maintenance-release.ts
+++ b/scripts/prepare-maintenance-release.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { Result } from "better-result";
 import { randomUUID } from "node:crypto";
 import {
   existsSync,
@@ -305,15 +306,58 @@ const assertCleanWorktree = () => {
   }
 };
 
+/** Asks the GitHub CLI for a token; the seam a test stands in for. */
+export type GhTokenReader = () => string | null;
+
+const nonEmptyToken = (value: string | undefined): string | null =>
+  value === undefined || value.length === 0 ? null : value;
+
+// `gh` may be absent, or present and signed out. Both mean the same thing
+// here: no token, and the reads below go out unauthenticated.
+const readCliToken: GhTokenReader = () => {
+  const spawned = Result.try(() =>
+    Bun.spawnSync(["gh", "auth", "token"], {
+      cwd: ROOT_DIR,
+      stderr: "pipe",
+      stdout: "pipe",
+    }),
+  );
+  if (Result.isError(spawned) || !spawned.value.success) {
+    return null;
+  }
+  return nonEmptyToken(spawned.value.stdout.toString().trim());
+};
+
+/**
+ * Token the GitHub reads are made with.
+ *
+ * The variables come first, since a workflow sets them. The signed-in CLI
+ * stands behind them so a local run is not left to the anonymous rate limit,
+ * which answers a release preparation with HTTP 403.
+ */
+export const resolveGitHubToken = (
+  env: Record<string, string | undefined>,
+  readGhToken: GhTokenReader = readCliToken,
+): string | null =>
+  nonEmptyToken(env["GH_TOKEN"]) ??
+  nonEmptyToken(env["GITHUB_TOKEN"]) ??
+  readGhToken();
+
+// Resolved once: one preparation makes a page of reads, and asking the CLI
+// per read would spawn it as many times.
+let resolvedToken: string | null | undefined;
+
 const requestGitHub = async (path: string): Promise<Response> => {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "stella-maintenance-release",
     "X-GitHub-Api-Version": "2022-11-28",
   };
-  const token = process.env["GH_TOKEN"] ?? process.env["GITHUB_TOKEN"];
-  if (token) {
-    headers["Authorization"] = `Bearer ${token}`;
+  if (resolvedToken === undefined) {
+    resolvedToken = resolveGitHubToken(process.env);
+  }
+  if (resolvedToken !== null) {
+    headers["Authorization"] = `Bearer ${resolvedToken}`;
   }
   return fetch(`${GITHUB_API_ROOT}${path}`, { headers });
 };

--- a/scripts/prepare-maintenance-release.ts
+++ b/scripts/prepare-maintenance-release.ts
@@ -306,26 +306,36 @@ const assertCleanWorktree = () => {
   }
 };
 
-/** Asks the GitHub CLI for a token; the seam a test stands in for. */
-export type GhTokenReader = () => string | null;
+/** Runs a command and returns its stdout; null when it does not run. */
+export type CommandOutput = (command: readonly string[]) => string | null;
 
-const nonEmptyToken = (value: string | undefined): string | null =>
-  value === undefined || value.length === 0 ? null : value;
+const nonEmptyToken = (value: string | null | undefined): string | null =>
+  value === undefined || value === null || value.length === 0 ? null : value;
 
-// `gh` may be absent, or present and signed out. Both mean the same thing
-// here: no token, and the reads below go out unauthenticated.
-const readCliToken: GhTokenReader = () => {
+// The reads go to github.com, so the token has to be that host's. A bare
+// `gh auth token` answers for the CLI's default host, which is an Enterprise
+// instance wherever the operator's GH_HOST points at one.
+const GH_TOKEN_COMMAND = [
+  "gh",
+  "auth",
+  "token",
+  "--hostname",
+  "github.com",
+] as const;
+
+// `gh` may be absent, or present and signed out of github.com. Both mean the
+// same thing here: no token, and the reads below go out unauthenticated.
+const spawnOutput: CommandOutput = (command) => {
   const spawned = Result.try(() =>
-    Bun.spawnSync(["gh", "auth", "token"], {
+    Bun.spawnSync([...command], {
       cwd: ROOT_DIR,
       stderr: "pipe",
       stdout: "pipe",
     }),
   );
-  if (Result.isError(spawned) || !spawned.value.success) {
-    return null;
-  }
-  return nonEmptyToken(spawned.value.stdout.toString().trim());
+  return Result.isError(spawned) || !spawned.value.success
+    ? null
+    : spawned.value.stdout.toString();
 };
 
 /**
@@ -337,11 +347,11 @@ const readCliToken: GhTokenReader = () => {
  */
 export const resolveGitHubToken = (
   env: Record<string, string | undefined>,
-  readGhToken: GhTokenReader = readCliToken,
+  runCommand: CommandOutput = spawnOutput,
 ): string | null =>
   nonEmptyToken(env["GH_TOKEN"]) ??
   nonEmptyToken(env["GITHUB_TOKEN"]) ??
-  readGhToken();
+  nonEmptyToken(runCommand(GH_TOKEN_COMMAND)?.trim());
 
 // Resolved once: one preparation makes a page of reads, and asking the CLI
 // per read would spawn it as many times.


### PR DESCRIPTION
## What

`resolveGitHubToken`: `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token` (a missing or failing `gh` leaves the run unauthenticated as before). Resolved once per run.

## Why

The release preparation reads GitHub Releases; unauthenticated reads hit the anonymous rate limit with HTTP 403 while the operator's `gh` session already holds a token.

## Tests

Five fallback-order tests with an injected reader in the script's property test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub authentication during maintenance release preparation.
  - Release requests now recognise configured GitHub tokens or an authenticated GitHub CLI session.
  - Empty, invalid, or unavailable credentials are handled safely, allowing unauthenticated processing where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->