### PR TITLE
fix(db): move the index-job detail backfill out of the migration

### DIFF
--- a/apps/api/drizzle/20260905200000_corpus_index_job_detail/migration.sql
+++ b/apps/api/drizzle/20260905200000_corpus_index_job_detail/migration.sql
@@ -1,5 +1,5 @@
 SET LOCAL lock_timeout = '1s';--> statement-breakpoint
-SET LOCAL statement_timeout = '30s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
 
 -- Why a succeeded index-job row was written, kept apart from the failure it
 -- is not. `error_message` is read as the failure of the row it sits on, so a
@@ -17,37 +17,17 @@ ALTER TABLE "case_law_index_jobs"
 ALTER TABLE "legislation_index_jobs"
   ADD COLUMN IF NOT EXISTS "detail" varchar(2048);--> statement-breakpoint
 
--- Withdrawals recorded before this migration hold their reason in the failure
--- column, so the rows written under the old writer are moved to the new one:
--- without this the trail would mean two different things depending on when a
--- row was written, and the constraint below could not stand.
---
--- Bounded by construction: only `withdraw` rows that carry a message are
--- rewritten, an operation recorded by an operator action rather than by the
--- indexing loop. The predicate has no index of its own, so the cost is one
--- pass over each table, which is what the wider statement budget above is
--- for. Idempotent: a second run matches nothing, because the column it reads
--- is cleared by the same statement. Rollback is the mirrored update.
-UPDATE "case_law_index_jobs"
-  SET "detail" = "error_message", "error_message" = NULL
-  WHERE "operation" = 'withdraw'
-    AND "status" = 'succeeded'
-    AND "error_message" IS NOT NULL;--> statement-breakpoint
-
-UPDATE "legislation_index_jobs"
-  SET "detail" = "error_message", "error_message" = NULL
-  WHERE "operation" = 'withdraw'
-    AND "status" = 'succeeded'
-    AND "error_message" IS NOT NULL;--> statement-breakpoint
-
 -- The split the column exists for, enforced by the database rather than by
 -- every writer remembering it: a row that succeeded carries no failure. The
 -- reverse is deliberately not constrained — a failed row may record both what
 -- it was for and what went wrong.
 --
--- NOT VALID: the statement above moved every row this could reject, so there
--- is nothing to scan; the constraint still applies to every later INSERT and
--- UPDATE, which is where the invariant has to hold. Rollback drops it.
+-- NOT VALID: rows written before the column existed keep a withdrawal's reason
+-- in `error_message`, and neither table has an index that could find them
+-- inside a migration's budget. Nothing is scanned here; the constraint applies
+-- to every later INSERT and UPDATE, which is where the invariant has to hold,
+-- and the `corpusIndex.backfillJobDetail` scheduler task moves the old rows in
+-- bounded pages. Rollback drops the constraint.
 --
 -- This is the one place the change is not additive across a rollout: a writer
 -- from before it that still files a withdrawal's reason in `error_message` has

--- a/apps/api/src/db/high-volume-tables.ts
+++ b/apps/api/src/db/high-volume-tables.ts
@@ -21,9 +21,13 @@ export const HIGH_VOLUME_TABLES = [
   "case_law_citations",
   "case_law_decision_identifiers",
   "case_law_decisions",
+  // One append-only audit row per document per index operation, so the trail
+  // grows with the corpus and with every rebuild of it.
+  "case_law_index_jobs",
   "case_law_provision_citations",
   "case_law_search_document_preview_passages",
   "case_law_search_documents",
   "corpus_index_projection_intents",
   "corpus_index_projection_states",
+  "legislation_index_jobs",
 ] as const;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -6,6 +6,7 @@ export * from "./schema/templates";
 export * from "./schema/billing";
 export * from "./schema/workspace-admin";
 export * from "./schema/clauses";
+export * from "./schema/corpus-index-jobs";
 export * from "./schema/case-law";
 export * from "./schema/legislation";
 export * from "./schema/corpus-index-generations";

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -84,6 +84,7 @@ import { workspaces } from "./contacts";
 import {
   CORPUS_INDEX_JOB_OPERATION_SQL_VALUES,
   CORPUS_INDEX_JOB_STATUS_SQL_VALUES,
+  CORPUS_INDEX_JOB_SUCCEEDED_CHECKS,
   CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE,
 } from "./corpus-index-jobs";
 import type {
@@ -2067,7 +2068,7 @@ export const caseLawIndexJobs = p.pgTable(
     // The reverse is open on purpose: a failed row may record both what it was
     // for and what went wrong.
     p.check(
-      "case_law_index_jobs_succeeded_error_message",
+      CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.case_law_index_jobs,
       sql`${t.status} <> ${CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE} OR ${t.errorMessage} IS NULL`,
     ),
     ...globalCaseLawPolicies(),

--- a/apps/api/src/db/schema/corpus-index-jobs.ts
+++ b/apps/api/src/db/schema/corpus-index-jobs.ts
@@ -52,3 +52,14 @@ const CORPUS_INDEX_JOB_SUCCEEDED_STATUS =
 export const CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE = sql.raw(
   `'${CORPUS_INDEX_JOB_SUCCEEDED_STATUS}'`,
 );
+
+/**
+ * The check each trail carries, by the table that carries it. Named here
+ * because more than the table has to know it: the migration added it NOT
+ * VALID, and the repair that moves the historical rows validates it by name
+ * once none is left.
+ */
+export const CORPUS_INDEX_JOB_SUCCEEDED_CHECKS = {
+  case_law_index_jobs: "case_law_index_jobs_succeeded_error_message",
+  legislation_index_jobs: "legislation_index_jobs_succeeded_error_message",
+} as const;

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -25,6 +25,7 @@ import type {
 import {
   CORPUS_INDEX_JOB_OPERATION_SQL_VALUES,
   CORPUS_INDEX_JOB_STATUS_SQL_VALUES,
+  CORPUS_INDEX_JOB_SUCCEEDED_CHECKS,
   CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE,
 } from "./corpus-index-jobs";
 import type {
@@ -286,7 +287,7 @@ export const legislationIndexJobs = p.pgTable(
     // The case-law twin's invariant, on the same declaration: a succeeded row
     // carries no failure.
     p.check(
-      "legislation_index_jobs_succeeded_error_message",
+      CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.legislation_index_jobs,
       sql`${t.status} <> ${CORPUS_INDEX_JOB_SUCCEEDED_SQL_VALUE} OR ${t.errorMessage} IS NULL`,
     ),
     ...globalCaseLawPolicies(),

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -326,6 +326,21 @@ const rewrittenMigrationHistories = {
     ],
     requiredIndexes: [],
   },
+  // The first file moved every withdrawal's reason into the new column with
+  // one UPDATE per index-job table, and neither table has an index for that
+  // predicate: the scan exceeded the statement budget and took the whole
+  // migration down with it. The current file keeps only DDL and leaves the
+  // rows to the `corpusIndex.backfillJobDetail` scheduler task, which walks
+  // the primary key in bounded pages. The schema effect is the same either
+  // way, and the task finds nothing to do where the first file ran.
+  "20260905200000_corpus_index_job_detail": {
+    currentHash:
+      "fe62e3944fef31f98fd578e7521dcfbed6a35e6c9cc40bfdf1da5ca0dabb3788",
+    priorHashes: [
+      "66eb1a83964f86bedcebcbf9cd8dd01f436c5142a16d427c944540947471d76a",
+    ],
+    requiredIndexes: [],
+  },
 } as const satisfies Readonly<Record<string, RewrittenMigrationHistory>>;
 
 export const REWRITTEN_MIGRATION_HISTORIES: Readonly<

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -186,6 +186,8 @@ export const PG_ERROR = {
   DEADLOCK_DETECTED: "40P01",
   /** A statement gave up waiting for a lock it asked for with `lock_timeout`. */
   LOCK_NOT_AVAILABLE: "55P03",
+  /** A statement was cancelled: `statement_timeout` expired, or an operator said so. */
+  QUERY_CANCELED: "57014",
   FOREIGN_KEY_VIOLATION: "23503",
   SERIALIZATION_FAILURE: "40001",
   UNIQUE_VIOLATION: "23505",

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -184,6 +184,8 @@ export const isTransientPgConnectionError = (error: unknown): boolean =>
 
 export const PG_ERROR = {
   DEADLOCK_DETECTED: "40P01",
+  /** A statement gave up waiting for a lock it asked for with `lock_timeout`. */
+  LOCK_NOT_AVAILABLE: "55P03",
   FOREIGN_KEY_VIOLATION: "23503",
   SERIALIZATION_FAILURE: "40001",
   UNIQUE_VIOLATION: "23505",

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -17,6 +17,7 @@ import { RECONCILE_BUFFER_INTENTS_TASK } from "@/api/lib/scheduler/tasks/buffer-
 import { RECONCILE_CASE_LAW_CORPUS_UPLOAD_INTENTS_TASK } from "@/api/lib/scheduler/tasks/case-law-corpus-upload-cleanup";
 import { BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK } from "@/api/lib/scheduler/tasks/case-law-redaction-tombstone-backfill";
 import { CHAT_THREAD_COMPACTOR_TASK } from "@/api/lib/scheduler/tasks/chat-thread-compactor";
+import { BACKFILL_CORPUS_INDEX_JOB_DETAIL_TASK } from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
 import { EXPIRE_DESKTOP_EDIT_SESSIONS_TASK } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
 import { RECOVER_DOCUMENT_DEADLINE_SCOUTS_TASK } from "@/api/lib/scheduler/tasks/document-deadline-scout-recovery";
 import { DISPATCH_DOCUMENT_OCR_TASK } from "@/api/lib/scheduler/tasks/document-processing-ocr";
@@ -194,6 +195,14 @@ export const DECLARED_SCHEDULER_JOBS = [
     mode: "oneShot",
     schedule: { type: "interval", everyMs: 60 * 1000 },
     task: BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK,
+  },
+  {
+    description:
+      "Move withdrawal reasons from the index-job failure column to detail",
+    id: "corpusIndex.backfillJobDetail.v1",
+    mode: "oneShot",
+    schedule: { type: "interval", everyMs: 60 * 1000 },
+    task: BACKFILL_CORPUS_INDEX_JOB_DETAIL_TASK,
   },
   {
     description: "Periodically repair governed work rows for legacy tasks",

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -20,6 +20,10 @@ import {
   compactChatThreads,
 } from "@/api/lib/scheduler/tasks/chat-thread-compactor";
 import {
+  BACKFILL_CORPUS_INDEX_JOB_DETAIL_TASK,
+  backfillCorpusIndexJobDetail,
+} from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
+import {
   EXPIRE_DESKTOP_EDIT_SESSIONS_TASK,
   expireDesktopEditSessions,
 } from "@/api/lib/scheduler/tasks/desktop-edit-session-expiry";
@@ -109,6 +113,7 @@ const SCHEDULER_TASKS = {
   [FLOW_RUN_TASK]: runScheduledFlow,
   [BACKFILL_CASE_LAW_REDACTION_TOMBSTONES_TASK]:
     backfillCaseLawRedactionTombstones,
+  [BACKFILL_CORPUS_INDEX_JOB_DETAIL_TASK]: backfillCorpusIndexJobDetail,
   [RECONCILE_CASE_LAW_CORPUS_UPLOAD_INTENTS_TASK]:
     reconcileCaseLawCorpusUploadIntentsTask,
   [RECONCILE_BUFFER_INTENTS_TASK]: reconcileBufferIntents,

--- a/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.db.test.ts
@@ -1,0 +1,280 @@
+import { panic } from "better-result";
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { asc, eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  caseLawDecisions,
+  caseLawIndexJobs,
+  caseLawSources,
+  legislationDocuments,
+  legislationIndexJobs,
+  legislationSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { runCorpusIndexJobDetailBatchTx } from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
+import type { CorpusIndexJobDetailFamily } from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const SOURCE_ID = toSafeId<"caseLawSource">(
+  "0198e331-e578-7000-8000-000000000301",
+);
+const DECISION_ID = toSafeId<"caseLawDecision">(
+  "0198e331-e578-7000-8000-000000000302",
+);
+const LEGISLATION_SOURCE_ID = toSafeId<"legislationSource">(
+  "0198e331-e578-7000-8000-000000000303",
+);
+const LEGISLATION_DOCUMENT_ID = toSafeId<"legislationDocument">(
+  "0198e331-e578-7000-8000-000000000304",
+);
+const REASON = "the stored payload re-parses to no document";
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+type ConstraintDefinitionRow = { definition: string };
+
+/**
+ * Writes rows that predate the constraint forbidding their shape. That check
+ * refuses the pair on every write, so a row holding a reason in the failure
+ * column can only have been written before it was added — which is the whole
+ * population this repair exists for. The constraint comes back as it was, read
+ * from the catalog rather than restated here, and NOT VALID so the rows just
+ * written stand exactly as the trail's own do.
+ */
+const asPreConstraintWriter = async (
+  table: string,
+  constraint: string,
+  write: () => Promise<void>,
+): Promise<void> => {
+  const { rows } = await db.execute<ConstraintDefinitionRow>(sql`
+    SELECT pg_get_constraintdef(oid) AS definition
+    FROM pg_constraint
+    WHERE conname = ${constraint}
+  `);
+  const definition =
+    rows.at(0)?.definition ??
+    panic(`The schema declares no constraint named ${constraint}`);
+  await db.execute(
+    sql.raw(`ALTER TABLE "${table}" DROP CONSTRAINT "${constraint}"`),
+  );
+  await write();
+  await db.execute(
+    sql.raw(
+      `ALTER TABLE "${table}" ADD CONSTRAINT "${constraint}" ${definition} NOT VALID`,
+    ),
+  );
+};
+
+const insertLegacyWithdrawal = async (id: string): Promise<void> => {
+  await asPreConstraintWriter(
+    "case_law_index_jobs",
+    "case_law_index_jobs_succeeded_error_message",
+    async () => {
+      await db.execute(sql`
+        INSERT INTO "case_law_index_jobs"
+          ("id", "decision_id", "generation", "operation", "status", "error_message")
+        VALUES (
+          ${id}::uuid,
+          ${DECISION_ID}::uuid,
+          'case_law_v5',
+          'withdraw',
+          'succeeded',
+          ${REASON}
+        )
+      `);
+    },
+  );
+};
+
+const caseLawRows = async () =>
+  await db
+    .select({
+      detail: caseLawIndexJobs.detail,
+      errorMessage: caseLawIndexJobs.errorMessage,
+      id: caseLawIndexJobs.id,
+    })
+    .from(caseLawIndexJobs)
+    .orderBy(asc(caseLawIndexJobs.id));
+
+const runBatch = async (options: {
+  family: CorpusIndexJobDetailFamily;
+  cursor: string | null;
+  limit?: number;
+}) =>
+  await db.transaction(
+    async (tx) =>
+      await runCorpusIndexJobDetailBatchTx(asTestRaw<Transaction>(tx), options),
+  );
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+});
+
+beforeEach(async () => {
+  await db.delete(caseLawIndexJobs).where(sql`true`);
+  await db.delete(legislationIndexJobs).where(sql`true`);
+  await db.delete(caseLawDecisions).where(sql`true`);
+  await db.delete(legislationDocuments).where(sql`true`);
+  await db.delete(caseLawSources).where(sql`true`);
+  await db.delete(legislationSources).where(sql`true`);
+
+  await db.insert(caseLawSources).values({
+    id: SOURCE_ID,
+    adapterKey: "corpus-index-job-detail-backfill",
+    name: "Corpus index job detail backfill",
+  });
+  await db.insert(caseLawDecisions).values({
+    id: DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "4 As 3/2008",
+    court: "Nejvyšší správní soud",
+    country: "CZE",
+    language: "cs",
+  });
+  await db.insert(legislationSources).values({
+    id: LEGISLATION_SOURCE_ID,
+    adapterKey: "corpus-index-job-detail-backfill",
+    name: "Corpus index job detail backfill",
+  });
+  await db.insert(legislationDocuments).values({
+    id: LEGISLATION_DOCUMENT_ID,
+    sourceId: LEGISLATION_SOURCE_ID,
+    eli: "eli/cz/sb/2012/89",
+    title: "Občanský zákoník",
+    country: "CZE",
+    language: "cs",
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("a page moves the withdrawal reasons it covers and no others", async () => {
+  await insertLegacyWithdrawal("0198e331-e578-7000-8000-000000000401");
+  // A failure keeps its message: the repair moves reasons, not failures.
+  await db.insert(caseLawIndexJobs).values({
+    id: toSafeId<"caseLawIndexJob">("0198e331-e578-7000-8000-000000000402"),
+    decisionId: DECISION_ID,
+    generation: "case_law_v5",
+    operation: "index",
+    status: "failed",
+    errorMessage: "the index write did not land",
+  });
+  // A row the new writer wrote is already in its final shape.
+  await db.insert(caseLawIndexJobs).values({
+    id: toSafeId<"caseLawIndexJob">("0198e331-e578-7000-8000-000000000403"),
+    decisionId: DECISION_ID,
+    generation: "case_law_v5",
+    operation: "withdraw",
+    status: "succeeded",
+    detail: REASON,
+  });
+
+  const first = await runBatch({ cursor: null, family: "case_law" });
+  expect(first).toEqual({
+    movedCount: 1,
+    nextCursor: "0198e331-e578-7000-8000-000000000403",
+  });
+  expect(await caseLawRows()).toEqual([
+    {
+      detail: REASON,
+      errorMessage: null,
+      id: toSafeId<"caseLawIndexJob">("0198e331-e578-7000-8000-000000000401"),
+    },
+    {
+      detail: null,
+      errorMessage: "the index write did not land",
+      id: toSafeId<"caseLawIndexJob">("0198e331-e578-7000-8000-000000000402"),
+    },
+    {
+      detail: REASON,
+      errorMessage: null,
+      id: toSafeId<"caseLawIndexJob">("0198e331-e578-7000-8000-000000000403"),
+    },
+  ]);
+
+  // Replaying the same page moves nothing a second time, and the walk ends
+  // when the range past the cursor is empty.
+  expect(await runBatch({ cursor: null, family: "case_law" })).toEqual({
+    movedCount: 0,
+    nextCursor: "0198e331-e578-7000-8000-000000000403",
+  });
+  expect(
+    await runBatch({
+      cursor: "0198e331-e578-7000-8000-000000000403",
+      family: "case_law",
+    }),
+  ).toEqual({ movedCount: 0, nextCursor: null });
+});
+
+test("the walk resumes from its cursor across pages", async () => {
+  const ids = [
+    "0198e331-e578-7000-8000-000000000411",
+    "0198e331-e578-7000-8000-000000000412",
+    "0198e331-e578-7000-8000-000000000413",
+  ];
+  for (const id of ids) {
+    await insertLegacyWithdrawal(id);
+  }
+
+  const first = await runBatch({ cursor: null, family: "case_law", limit: 2 });
+  expect(first).toEqual({ movedCount: 2, nextCursor: ids[1] ?? "" });
+  // The page stops where the cursor says it did: the third row is untouched.
+  expect((await caseLawRows()).map(({ detail }) => detail)).toEqual([
+    REASON,
+    REASON,
+    null,
+  ]);
+
+  const second = await runBatch({
+    cursor: first.nextCursor,
+    family: "case_law",
+    limit: 2,
+  });
+  expect(second).toEqual({ movedCount: 1, nextCursor: ids[2] ?? "" });
+  expect((await caseLawRows()).map(({ errorMessage }) => errorMessage)).toEqual(
+    [null, null, null],
+  );
+});
+
+test("legislation is walked the same way", async () => {
+  const id = "0198e331-e578-7000-8000-000000000421";
+  await asPreConstraintWriter(
+    "legislation_index_jobs",
+    "legislation_index_jobs_succeeded_error_message",
+    async () => {
+      await db.execute(sql`
+        INSERT INTO "legislation_index_jobs"
+          ("id", "document_id", "generation", "operation", "status", "error_message")
+        VALUES (
+          ${id}::uuid,
+          ${LEGISLATION_DOCUMENT_ID}::uuid,
+          'legislation_v2',
+          'withdraw',
+          'succeeded',
+          ${REASON}
+        )
+      `);
+    },
+  );
+
+  expect(await runBatch({ cursor: null, family: "legislation" })).toEqual({
+    movedCount: 1,
+    nextCursor: id,
+  });
+  expect(
+    await db
+      .select({
+        detail: legislationIndexJobs.detail,
+        errorMessage: legislationIndexJobs.errorMessage,
+      })
+      .from(legislationIndexJobs)
+      .where(eq(legislationIndexJobs.documentId, LEGISLATION_DOCUMENT_ID)),
+  ).toEqual([{ detail: REASON, errorMessage: null }]);
+});

--- a/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.db.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.db.test.ts
@@ -5,6 +5,7 @@ import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
 import {
+  CORPUS_INDEX_JOB_SUCCEEDED_CHECKS,
   caseLawDecisions,
   caseLawIndexJobs,
   caseLawSources,
@@ -13,7 +14,10 @@ import {
   legislationSources,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
-import { runCorpusIndexJobDetailBatchTx } from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
+import {
+  runCorpusIndexJobDetailBatchTx,
+  validateCorpusIndexJobChecksTx,
+} from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
 import type { CorpusIndexJobDetailFamily } from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
@@ -72,7 +76,7 @@ const asPreConstraintWriter = async (
 const insertLegacyWithdrawal = async (id: string): Promise<void> => {
   await asPreConstraintWriter(
     "case_law_index_jobs",
-    "case_law_index_jobs_succeeded_error_message",
+    CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.case_law_index_jobs,
     async () => {
       await db.execute(sql`
         INSERT INTO "case_law_index_jobs"
@@ -88,6 +92,39 @@ const insertLegacyWithdrawal = async (id: string): Promise<void> => {
       `);
     },
   );
+};
+
+const insertLegacyLegislationWithdrawal = async (id: string): Promise<void> => {
+  await asPreConstraintWriter(
+    "legislation_index_jobs",
+    CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.legislation_index_jobs,
+    async () => {
+      await db.execute(sql`
+        INSERT INTO "legislation_index_jobs"
+          ("id", "document_id", "generation", "operation", "status", "error_message")
+        VALUES (
+          ${id}::uuid,
+          ${LEGISLATION_DOCUMENT_ID}::uuid,
+          'legislation_v2',
+          'withdraw',
+          'succeeded',
+          ${REASON}
+        )
+      `);
+    },
+  );
+};
+
+type ValidatedRow = { isValidated: boolean };
+
+/** What PostgreSQL says about the check, which is the repair's completion. */
+const isCheckValidated = async (constraint: string): Promise<boolean> => {
+  const { rows } = await db.execute<ValidatedRow>(sql`
+    SELECT convalidated AS "isValidated"
+    FROM pg_catalog.pg_constraint
+    WHERE conname = ${constraint}
+  `);
+  return rows.at(0)?.isValidated ?? panic(`No constraint named ${constraint}`);
 };
 
 const caseLawRows = async () =>
@@ -245,24 +282,7 @@ test("the walk resumes from its cursor across pages", async () => {
 
 test("legislation is walked the same way", async () => {
   const id = "0198e331-e578-7000-8000-000000000421";
-  await asPreConstraintWriter(
-    "legislation_index_jobs",
-    "legislation_index_jobs_succeeded_error_message",
-    async () => {
-      await db.execute(sql`
-        INSERT INTO "legislation_index_jobs"
-          ("id", "document_id", "generation", "operation", "status", "error_message")
-        VALUES (
-          ${id}::uuid,
-          ${LEGISLATION_DOCUMENT_ID}::uuid,
-          'legislation_v2',
-          'withdraw',
-          'succeeded',
-          ${REASON}
-        )
-      `);
-    },
-  );
+  await insertLegacyLegislationWithdrawal(id);
 
   expect(await runBatch({ cursor: null, family: "legislation" })).toEqual({
     movedCount: 1,
@@ -277,4 +297,49 @@ test("legislation is walked the same way", async () => {
       .from(legislationIndexJobs)
       .where(eq(legislationIndexJobs.documentId, LEGISLATION_DOCUMENT_ID)),
   ).toEqual([{ detail: REASON, errorMessage: null }]);
+});
+
+test("the walked trails end with both checks validated", async () => {
+  await insertLegacyWithdrawal("0198e331-e578-7000-8000-000000000431");
+  await insertLegacyLegislationWithdrawal(
+    "0198e331-e578-7000-8000-000000000432",
+  );
+  // The rows exist, so the checks stand unvalidated: PostgreSQL enforces them
+  // on every write and has never read what was already there.
+  expect([
+    await isCheckValidated(
+      CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.case_law_index_jobs,
+    ),
+    await isCheckValidated(
+      CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.legislation_index_jobs,
+    ),
+  ]).toEqual([false, false]);
+
+  await runBatch({ cursor: null, family: "case_law" });
+  await runBatch({ cursor: null, family: "legislation" });
+  await db.transaction(
+    async (tx) =>
+      await validateCorpusIndexJobChecksTx(asTestRaw<Transaction>(tx)),
+  );
+
+  expect([
+    await isCheckValidated(
+      CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.case_law_index_jobs,
+    ),
+    await isCheckValidated(
+      CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.legislation_index_jobs,
+    ),
+  ]).toEqual([true, true]);
+
+  // Validating again is what lets the repair be retried: a validated check is
+  // a no-op, not a second scan or an error.
+  await db.transaction(
+    async (tx) =>
+      await validateCorpusIndexJobChecksTx(asTestRaw<Transaction>(tx)),
+  );
+  expect(
+    await isCheckValidated(
+      CORPUS_INDEX_JOB_SUCCEEDED_CHECKS.case_law_index_jobs,
+    ),
+  ).toBe(true);
 });

--- a/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { DrizzleQueryError } from "drizzle-orm";
+
+import { PG_ERROR } from "@/api/lib/pg-error";
+import { isRetriableBackfillFailure } from "@/api/lib/scheduler/tasks/corpus-index-job-detail-backfill";
+
+/** A driver failure as the task meets it: wrapped by the query that raised it. */
+const queryFailure = (sqlState: string) =>
+  new DrizzleQueryError(
+    "query failed",
+    [],
+    Object.assign(new Error("pg"), { errno: sqlState }),
+  );
+
+describe("corpus index-job detail backfill retries", () => {
+  it("retries a page that was refused a lock, and only that", () => {
+    expect(
+      isRetriableBackfillFailure(
+        queryFailure(PG_ERROR.LOCK_NOT_AVAILABLE),
+        "page",
+      ),
+    ).toBe(true);
+    // A page's statement budget is sized for a bounded write, so a page that
+    // runs into it is not doing what it says and belongs in the failed runs.
+    expect(
+      isRetriableBackfillFailure(queryFailure(PG_ERROR.QUERY_CANCELED), "page"),
+    ).toBe(false);
+  });
+
+  it("retries a validation that gave up on either of its budgets", () => {
+    expect(
+      isRetriableBackfillFailure(
+        queryFailure(PG_ERROR.LOCK_NOT_AVAILABLE),
+        "validate",
+      ),
+    ).toBe(true);
+    expect(
+      isRetriableBackfillFailure(
+        queryFailure(PG_ERROR.QUERY_CANCELED),
+        "validate",
+      ),
+    ).toBe(true);
+  });
+
+  it("reports anything else as the failure it is", () => {
+    expect(
+      isRetriableBackfillFailure(
+        queryFailure(PG_ERROR.UNIQUE_VIOLATION),
+        "validate",
+      ),
+    ).toBe(false);
+    expect(isRetriableBackfillFailure(new Error("plain"), "page")).toBe(false);
+  });
+});

--- a/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
+++ b/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
@@ -10,7 +10,7 @@
  * both tables are walked.
  */
 
-import { panic, Result } from "better-result";
+import { panic, Result, TaggedError } from "better-result";
 import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
@@ -24,7 +24,10 @@ import {
 import { isUuid } from "@/api/lib/custom-schema";
 import type { CorpusIndexProjectionSubject } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { isPgError, PG_ERROR } from "@/api/lib/pg-error";
-import type { SchedulerTask } from "@/api/lib/scheduler/types";
+import type {
+  SchedulerTask,
+  SchedulerTaskContext,
+} from "@/api/lib/scheduler/types";
 import { isRecord } from "@/api/lib/type-guards";
 
 export const BACKFILL_CORPUS_INDEX_JOB_DETAIL_TASK =
@@ -216,6 +219,30 @@ const executedRows = (result: unknown): Record<string, unknown>[] => {
     : [];
 };
 
+type IndexJobTable = keyof typeof CORPUS_INDEX_JOB_SUCCEEDED_CHECKS;
+
+/**
+ * One trail's check, read back from the catalog rather than assumed: a
+ * validation that did not take must leave the repair unfinished.
+ */
+const validateCheck = async (
+  tx: Transaction,
+  table: IndexJobTable,
+): Promise<void> => {
+  const constraint = CORPUS_INDEX_JOB_SUCCEEDED_CHECKS[table];
+  await tx.execute(
+    sql.raw(
+      `ALTER TABLE public."${table}" VALIDATE CONSTRAINT "${constraint}"`,
+    ),
+  );
+  const state = executedRows(
+    await tx.execute(CONSTRAINT_STATE_QUERY(table, constraint)),
+  ).at(0);
+  if (state?.["isValidated"] !== true) {
+    panic(`Constraint ${constraint} on ${table} is not validated`);
+  }
+};
+
 /**
  * Check both trails against the rows that predate their constraints.
  *
@@ -223,32 +250,44 @@ const executedRows = (result: unknown): Record<string, unknown>[] => {
  * write but has never read the rows already there; until it does,
  * `pg_constraint.convalidated` stays false and the invariant holds only for
  * what the new writers wrote. Validating is the last step of the repair and a
- * no-op once done, which is what makes running it again harmless. It reads the
- * catalog back rather than trusting the statement: a validation that did not
- * take must leave the repair unfinished.
+ * no-op once done, which is what makes running it again harmless.
  */
 export const validateCorpusIndexJobChecksTx = async (
   tx: Transaction,
 ): Promise<void> => {
-  // SAFETY: two entries, fixed at compile time — the two trails the corpus
-  // keeps. The statements are DDL, so they cannot be batched into one query.
-  // oxlint-disable no-db-await-in-loop/no-db-await-in-loop -- bounded by the constant map above
-  for (const [table, constraint] of Object.entries(
-    CORPUS_INDEX_JOB_SUCCEEDED_CHECKS,
-  )) {
-    await tx.execute(
-      sql.raw(
-        `ALTER TABLE public."${table}" VALIDATE CONSTRAINT "${constraint}"`,
-      ),
-    );
-    const state = executedRows(
-      await tx.execute(CONSTRAINT_STATE_QUERY(table, constraint)),
-    ).at(0);
-    if (state?.["isValidated"] !== true) {
-      panic(`Constraint ${constraint} on ${table} is not validated`);
-    }
+  // Both trails, named rather than iterated: DDL cannot be batched, and each
+  // statement waits on its own table's lock.
+  await validateCheck(tx, "case_law_index_jobs");
+  await validateCheck(tx, "legislation_index_jobs");
+};
+
+class CorpusIndexJobDetailBackfillError extends TaggedError(
+  "CorpusIndexJobDetailBackfillError",
+)<{ message: string; cause?: unknown }> {}
+
+type BackfillFailureReport = {
+  event: string;
+  family: CorpusIndexJobDetailFamily;
+  logger: SchedulerTaskContext["logger"];
+};
+
+/**
+ * What a step that did not commit means for the sweep.
+ *
+ * A step refused a lock is not a failure: it moved nothing and checkpointed
+ * nothing, so the next tick asks for the same range again and the repair still
+ * converges. Anything else is the runner's to record, and a scheduler task
+ * reports that through the promise it returns, the way a readiness probe does.
+ */
+const reportBackfillFailure = async (
+  failure: CorpusIndexJobDetailBackfillError,
+  { event, family, logger }: BackfillFailureReport,
+): Promise<void> => {
+  if (!isPgError(failure, PG_ERROR.LOCK_NOT_AVAILABLE)) {
+    await Promise.reject(failure);
+    return;
   }
-  // oxlint-enable no-db-await-in-loop/no-db-await-in-loop
+  logger.info(event, { "corpusIndexJobDetail.family": family });
 };
 
 type BackfillPosition = {
@@ -330,19 +369,18 @@ export const backfillCorpusIndexJobDetail: SchedulerTask = async ({
           .where(leaseFence);
         return { family, movedCount, status: "progress" as const };
       }),
-    catch: (cause) => cause,
+    catch: (cause) =>
+      new CorpusIndexJobDetailBackfillError({
+        message: "A corpus index-job detail page did not commit",
+        cause,
+      }),
   });
   if (Result.isError(page)) {
-    // A row this page wanted is held by a writer. The page moved nothing and
-    // checkpointed nothing, so the next tick asks for the same range again;
-    // anything else is a failure of the sweep and is the runner's to record.
-    if (!isPgError(page.error, PG_ERROR.LOCK_NOT_AVAILABLE)) {
-      throw page.error;
-    }
-    logger.info("scheduler.corpus_index_job_detail_contended", {
-      "corpusIndexJobDetail.family": family,
+    return await reportBackfillFailure(page.error, {
+      event: "scheduler.corpus_index_job_detail_contended",
+      family,
+      logger,
     });
-    return;
   }
 
   logger.info("scheduler.corpus_index_job_detail_backfilled", {
@@ -378,14 +416,18 @@ export const backfillCorpusIndexJobDetail: SchedulerTask = async ({
           .set({ enabled: false })
           .where(leaseFence);
       }),
-    catch: (cause) => cause,
+    catch: (cause) =>
+      new CorpusIndexJobDetailBackfillError({
+        message: "The corpus index-job checks were not validated",
+        cause,
+      }),
   });
   if (Result.isError(validated)) {
-    if (!isPgError(validated.error, PG_ERROR.LOCK_NOT_AVAILABLE)) {
-      throw validated.error;
-    }
-    logger.info("scheduler.corpus_index_job_detail_validation_contended", {});
-    return;
+    return await reportBackfillFailure(validated.error, {
+      event: "scheduler.corpus_index_job_detail_validation_contended",
+      family,
+      logger,
+    });
   }
 
   logger.info("scheduler.corpus_index_job_detail_validated", {});

--- a/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
+++ b/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
@@ -10,19 +10,22 @@
  * both tables are walked.
  */
 
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import { rootDb } from "@/api/db/root";
 import {
+  CORPUS_INDEX_JOB_SUCCEEDED_CHECKS,
   caseLawIndexJobs,
   legislationIndexJobs,
   schedulerJobs,
 } from "@/api/db/schema";
 import { isUuid } from "@/api/lib/custom-schema";
 import type { CorpusIndexProjectionSubject } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { isPgError, PG_ERROR } from "@/api/lib/pg-error";
 import type { SchedulerTask } from "@/api/lib/scheduler/types";
+import { isRecord } from "@/api/lib/type-guards";
 
 export const BACKFILL_CORPUS_INDEX_JOB_DETAIL_TASK =
   "corpusIndex.backfillJobDetail" as const;
@@ -36,6 +39,40 @@ const BACKFILL_LIMIT = 1000;
 
 /** A page that found work leaves more behind it; the next one follows at once. */
 const CONTINUATION_DELAY_MS = 1000;
+
+/**
+ * Budgets LOCAL to a page's transaction. A page reads and writes a bounded
+ * set of rows by primary key, so it owes nothing to a lock it cannot get at
+ * once: without these a row held by a writer would keep the task, and the
+ * connection under it, past the scheduler lease that says it is still running.
+ */
+const BATCH_LOCK_TIMEOUT = "5s";
+const BATCH_STATEMENT_TIMEOUT = "30s";
+/**
+ * VALIDATE takes SHARE UPDATE EXCLUSIVE, which lets writers through but queues
+ * behind an autovacuum of the table until that vacuum yields, so the wait is
+ * longer than a page's. Its own scan is bounded only by the size of the trail,
+ * which is why it runs with no statement budget at all.
+ */
+const VALIDATE_LOCK_TIMEOUT = "1min";
+const VALIDATE_STATEMENT_TIMEOUT = "0";
+
+type TransactionBudget = { lockTimeout: string; statementTimeout: string };
+
+/**
+ * Both budgets, set LOCAL so they end with the transaction. Written as raw
+ * statements because `SET LOCAL` takes a literal, not a bind parameter; the
+ * values are this module's own constants.
+ */
+const setTransactionBudget = async (
+  tx: Transaction,
+  { lockTimeout, statementTimeout }: TransactionBudget,
+): Promise<void> => {
+  await tx.execute(sql.raw(`SET LOCAL lock_timeout = '${lockTimeout}'`));
+  await tx.execute(
+    sql.raw(`SET LOCAL statement_timeout = '${statementTimeout}'`),
+  );
+};
 
 export type CorpusIndexJobDetailBatch = {
   movedCount: number;
@@ -157,6 +194,63 @@ export const runCorpusIndexJobDetailBatchTx = async (
 ): Promise<CorpusIndexJobDetailBatch> =>
   await CORPUS_INDEX_JOB_DETAIL_BATCHES[family](tx, { cursor, limit });
 
+const CONSTRAINT_STATE_QUERY = (table: string, constraint: string) => sql`
+  SELECT constraint_state.convalidated AS "isValidated"
+  FROM pg_catalog.pg_constraint constraint_state
+  JOIN pg_catalog.pg_class table_relation
+    ON table_relation.oid = constraint_state.conrelid
+  JOIN pg_catalog.pg_namespace table_namespace
+    ON table_namespace.oid = table_relation.relnamespace
+  WHERE table_namespace.nspname = 'public'
+    AND table_relation.relname = ${table}
+    AND constraint_state.conname = ${constraint}
+`;
+
+/** `execute` answers with an array on one driver and `{ rows }` on the other. */
+const executedRows = (result: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(result)) {
+    return result.filter((row: unknown) => isRecord(row));
+  }
+  return isRecord(result) && Array.isArray(result["rows"])
+    ? result["rows"].filter((row: unknown) => isRecord(row))
+    : [];
+};
+
+/**
+ * Check both trails against the rows that predate their constraints.
+ *
+ * The migration added each check NOT VALID, so PostgreSQL enforces it on every
+ * write but has never read the rows already there; until it does,
+ * `pg_constraint.convalidated` stays false and the invariant holds only for
+ * what the new writers wrote. Validating is the last step of the repair and a
+ * no-op once done, which is what makes running it again harmless. It reads the
+ * catalog back rather than trusting the statement: a validation that did not
+ * take must leave the repair unfinished.
+ */
+export const validateCorpusIndexJobChecksTx = async (
+  tx: Transaction,
+): Promise<void> => {
+  // SAFETY: two entries, fixed at compile time — the two trails the corpus
+  // keeps. The statements are DDL, so they cannot be batched into one query.
+  // oxlint-disable no-db-await-in-loop/no-db-await-in-loop -- bounded by the constant map above
+  for (const [table, constraint] of Object.entries(
+    CORPUS_INDEX_JOB_SUCCEEDED_CHECKS,
+  )) {
+    await tx.execute(
+      sql.raw(
+        `ALTER TABLE public."${table}" VALIDATE CONSTRAINT "${constraint}"`,
+      ),
+    );
+    const state = executedRows(
+      await tx.execute(CONSTRAINT_STATE_QUERY(table, constraint)),
+    ).at(0);
+    if (state?.["isValidated"] !== true) {
+      panic(`Constraint ${constraint} on ${table} is not validated`);
+    }
+  }
+  // oxlint-enable no-db-await-in-loop/no-db-await-in-loop
+};
+
 type BackfillPosition = {
   family: CorpusIndexJobDetailFamily;
   cursor: string | null;
@@ -204,46 +298,95 @@ export const backfillCorpusIndexJobDetail: SchedulerTask = async ({
     eq(schedulerJobs.lockedBy, leaseToken),
   );
 
-  const outcome = await rootDb.transaction(async (tx) => {
-    const { movedCount, nextCursor } = await runCorpusIndexJobDetailBatchTx(
-      tx,
-      {
-        cursor,
-        family,
-      },
-    );
-    if (nextCursor !== null) {
-      // Checkpoint last: replaying a page moves nothing a second time, while
-      // advancing first could step over rows the update did not reach.
-      await tx
-        .update(schedulerJobs)
-        .set({ payload: { cursor: nextCursor, family } })
-        .where(leaseFence);
-      return { family, movedCount, status: "progress" as const };
-    }
+  const page = await Result.tryPromise({
+    try: async () =>
+      await rootDb.transaction(async (tx) => {
+        await setTransactionBudget(tx, {
+          lockTimeout: BATCH_LOCK_TIMEOUT,
+          statementTimeout: BATCH_STATEMENT_TIMEOUT,
+        });
+        const { movedCount, nextCursor } = await runCorpusIndexJobDetailBatchTx(
+          tx,
+          { cursor, family },
+        );
+        if (nextCursor !== null) {
+          // Checkpoint last: replaying a page moves nothing a second time,
+          // while advancing first could step over rows the update did not
+          // reach.
+          await tx
+            .update(schedulerJobs)
+            .set({ payload: { cursor: nextCursor, family } })
+            .where(leaseFence);
+          return { family, movedCount, status: "progress" as const };
+        }
 
-    const following = nextFamily(family);
-    if (following !== null) {
-      await tx
-        .update(schedulerJobs)
-        .set({ payload: { cursor: null, family: following } })
-        .where(leaseFence);
-      return { family, movedCount, status: "progress" as const };
-    }
-
-    // audit: skip — retires a versioned one-shot repair; scheduler job runs
-    // retain the operator trail.
-    await tx.update(schedulerJobs).set({ enabled: false }).where(leaseFence);
-    return { family, movedCount, status: "complete" as const };
+        const following = nextFamily(family);
+        if (following === null) {
+          return { family, movedCount, status: "swept" as const };
+        }
+        await tx
+          .update(schedulerJobs)
+          .set({ payload: { cursor: null, family: following } })
+          .where(leaseFence);
+        return { family, movedCount, status: "progress" as const };
+      }),
+    catch: (cause) => cause,
   });
+  if (Result.isError(page)) {
+    // A row this page wanted is held by a writer. The page moved nothing and
+    // checkpointed nothing, so the next tick asks for the same range again;
+    // anything else is a failure of the sweep and is the runner's to record.
+    if (!isPgError(page.error, PG_ERROR.LOCK_NOT_AVAILABLE)) {
+      throw page.error;
+    }
+    logger.info("scheduler.corpus_index_job_detail_contended", {
+      "corpusIndexJobDetail.family": family,
+    });
+    return;
+  }
 
   logger.info("scheduler.corpus_index_job_detail_backfilled", {
-    "corpusIndexJobDetail.family": outcome.family,
-    "corpusIndexJobDetail.moved": outcome.movedCount,
-    "corpusIndexJobDetail.status": outcome.status,
+    "corpusIndexJobDetail.family": page.value.family,
+    "corpusIndexJobDetail.moved": page.value.movedCount,
+    "corpusIndexJobDetail.status": page.value.status,
   });
 
-  if (outcome.status === "progress" && !signal.aborted) {
-    scheduleContinuation(new Date(Date.now() + CONTINUATION_DELAY_MS));
+  if (page.value.status === "progress") {
+    if (!signal.aborted) {
+      scheduleContinuation(new Date(Date.now() + CONTINUATION_DELAY_MS));
+    }
+    return;
   }
+
+  // Both trails are walked, so no row can hold the old shape any more and the
+  // constraints the migration left NOT VALID can be checked against the rows
+  // that predate them. The job retires in the same transaction: a validation
+  // that does not finish leaves the job enabled, and the next tick, finding
+  // nothing left to move, tries again.
+  const validated = await Result.tryPromise({
+    try: async () =>
+      await rootDb.transaction(async (tx) => {
+        await setTransactionBudget(tx, {
+          lockTimeout: VALIDATE_LOCK_TIMEOUT,
+          statementTimeout: VALIDATE_STATEMENT_TIMEOUT,
+        });
+        await validateCorpusIndexJobChecksTx(tx);
+        // audit: skip — retires a versioned one-shot repair; scheduler job
+        // runs retain the operator trail.
+        await tx
+          .update(schedulerJobs)
+          .set({ enabled: false })
+          .where(leaseFence);
+      }),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(validated)) {
+    if (!isPgError(validated.error, PG_ERROR.LOCK_NOT_AVAILABLE)) {
+      throw validated.error;
+    }
+    logger.info("scheduler.corpus_index_job_detail_validation_contended", {});
+    return;
+  }
+
+  logger.info("scheduler.corpus_index_job_detail_validated", {});
 };

--- a/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
+++ b/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
@@ -1,0 +1,249 @@
+/**
+ * Moves a withdrawal's reason out of `error_message` and into `detail` on the
+ * index-job trail.
+ *
+ * The column split landed as DDL; the rows written before it still hold their
+ * reason in the failure column. Neither table has an index on `operation`, so
+ * the repair cannot be a single statement over the whole trail: it walks the
+ * primary key in bounded pages, each page one short statement, and checkpoints
+ * the cursor so a lost run resumes where it stopped. It retires itself once
+ * both tables are walked.
+ */
+
+import { panic } from "better-result";
+import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import { rootDb } from "@/api/db/root";
+import {
+  caseLawIndexJobs,
+  legislationIndexJobs,
+  schedulerJobs,
+} from "@/api/db/schema";
+import { isUuid } from "@/api/lib/custom-schema";
+import type { CorpusIndexProjectionSubject } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+
+export const BACKFILL_CORPUS_INDEX_JOB_DETAIL_TASK =
+  "corpusIndex.backfillJobDetail" as const;
+
+/**
+ * One page of primary keys per statement. Large enough that a whole trail is
+ * walked in a bounded number of runs, small enough that the page read and the
+ * update it drives stay short.
+ */
+const BACKFILL_LIMIT = 1000;
+
+/** A page that found work leaves more behind it; the next one follows at once. */
+const CONTINUATION_DELAY_MS = 1000;
+
+export type CorpusIndexJobDetailBatch = {
+  movedCount: number;
+  /** The last key the page read; null when the table is walked to its end. */
+  nextCursor: string | null;
+};
+
+type CorpusIndexJobDetailBatchOptions = {
+  cursor: string | null;
+  limit: number;
+};
+
+const caseLawDetailBatch = async (
+  tx: Transaction,
+  { cursor, limit }: CorpusIndexJobDetailBatchOptions,
+): Promise<CorpusIndexJobDetailBatch> => {
+  const page = await tx
+    .select({ id: caseLawIndexJobs.id })
+    .from(caseLawIndexJobs)
+    .where(
+      cursor === null ? undefined : sql`${caseLawIndexJobs.id} > ${cursor}`,
+    )
+    .orderBy(asc(caseLawIndexJobs.id))
+    .limit(limit);
+  const lastId = page.at(-1)?.id;
+  if (lastId === undefined) {
+    return { movedCount: 0, nextCursor: null };
+  }
+  const moved = await tx
+    .update(caseLawIndexJobs)
+    // The SET list reads the row as it was, so the reason lands in `detail`
+    // before the column it came from is cleared.
+    .set({ detail: sql`${caseLawIndexJobs.errorMessage}`, errorMessage: null })
+    .where(
+      and(
+        inArray(
+          caseLawIndexJobs.id,
+          page.map(({ id }) => id),
+        ),
+        eq(caseLawIndexJobs.operation, "withdraw"),
+        eq(caseLawIndexJobs.status, "succeeded"),
+        isNotNull(caseLawIndexJobs.errorMessage),
+      ),
+    )
+    .returning({ id: caseLawIndexJobs.id });
+  return { movedCount: moved.length, nextCursor: lastId };
+};
+
+const legislationDetailBatch = async (
+  tx: Transaction,
+  { cursor, limit }: CorpusIndexJobDetailBatchOptions,
+): Promise<CorpusIndexJobDetailBatch> => {
+  const page = await tx
+    .select({ id: legislationIndexJobs.id })
+    .from(legislationIndexJobs)
+    .where(
+      cursor === null ? undefined : sql`${legislationIndexJobs.id} > ${cursor}`,
+    )
+    .orderBy(asc(legislationIndexJobs.id))
+    .limit(limit);
+  const lastId = page.at(-1)?.id;
+  if (lastId === undefined) {
+    return { movedCount: 0, nextCursor: null };
+  }
+  const moved = await tx
+    .update(legislationIndexJobs)
+    .set({
+      detail: sql`${legislationIndexJobs.errorMessage}`,
+      errorMessage: null,
+    })
+    .where(
+      and(
+        inArray(
+          legislationIndexJobs.id,
+          page.map(({ id }) => id),
+        ),
+        eq(legislationIndexJobs.operation, "withdraw"),
+        eq(legislationIndexJobs.status, "succeeded"),
+        isNotNull(legislationIndexJobs.errorMessage),
+      ),
+    )
+    .returning({ id: legislationIndexJobs.id });
+  return { movedCount: moved.length, nextCursor: lastId };
+};
+
+/**
+ * The families in the order the sweep walks them. Total over the corpus
+ * families, so a third family cannot be added without a decision here.
+ */
+const CORPUS_INDEX_JOB_DETAIL_BATCHES = {
+  case_law: caseLawDetailBatch,
+  legislation: legislationDetailBatch,
+} as const satisfies Record<
+  CorpusIndexProjectionSubject["family"],
+  (
+    tx: Transaction,
+    options: CorpusIndexJobDetailBatchOptions,
+  ) => Promise<CorpusIndexJobDetailBatch>
+>;
+
+export type CorpusIndexJobDetailFamily =
+  keyof typeof CORPUS_INDEX_JOB_DETAIL_BATCHES;
+
+const FAMILY_ORDER = [
+  "case_law",
+  "legislation",
+] as const satisfies readonly CorpusIndexJobDetailFamily[];
+
+type CorpusIndexJobDetailRunOptions = {
+  family: CorpusIndexJobDetailFamily;
+  cursor: string | null;
+  limit?: number;
+};
+
+/** One bounded page of the named family's trail. */
+export const runCorpusIndexJobDetailBatchTx = async (
+  tx: Transaction,
+  { family, cursor, limit = BACKFILL_LIMIT }: CorpusIndexJobDetailRunOptions,
+): Promise<CorpusIndexJobDetailBatch> =>
+  await CORPUS_INDEX_JOB_DETAIL_BATCHES[family](tx, { cursor, limit });
+
+type BackfillPosition = {
+  family: CorpusIndexJobDetailFamily;
+  cursor: string | null;
+};
+
+const isDetailFamily = (value: unknown): value is CorpusIndexJobDetailFamily =>
+  typeof value === "string" && value in CORPUS_INDEX_JOB_DETAIL_BATCHES;
+
+/** Where the last run stopped; an absent payload starts the first family. */
+const parsePosition = (
+  payload: Record<string, unknown> | null,
+): BackfillPosition => {
+  const family = payload?.["family"] ?? FAMILY_ORDER[0];
+  const cursor = payload?.["cursor"] ?? null;
+  if (!isDetailFamily(family)) {
+    return panic(
+      "Corpus index-job detail backfill family is not a corpus family",
+    );
+  }
+  if (cursor !== null && (typeof cursor !== "string" || !isUuid(cursor))) {
+    return panic("Corpus index-job detail backfill cursor must be a UUID");
+  }
+  return { cursor, family };
+};
+
+/** The family after this one, or null when the sweep has walked them all. */
+const nextFamily = (
+  family: CorpusIndexJobDetailFamily,
+): CorpusIndexJobDetailFamily | null =>
+  FAMILY_ORDER[FAMILY_ORDER.indexOf(family) + 1] ?? null;
+
+export const backfillCorpusIndexJobDetail: SchedulerTask = async ({
+  job,
+  logger,
+  scheduleContinuation,
+  signal,
+}) => {
+  signal.throwIfAborted();
+  const { cursor, family } = parsePosition(job.payload);
+  const leaseToken =
+    job.lockedBy ??
+    panic("Corpus index-job detail backfill requires a scheduler lease");
+  const leaseFence = and(
+    eq(schedulerJobs.id, job.id),
+    eq(schedulerJobs.lockedBy, leaseToken),
+  );
+
+  const outcome = await rootDb.transaction(async (tx) => {
+    const { movedCount, nextCursor } = await runCorpusIndexJobDetailBatchTx(
+      tx,
+      {
+        cursor,
+        family,
+      },
+    );
+    if (nextCursor !== null) {
+      // Checkpoint last: replaying a page moves nothing a second time, while
+      // advancing first could step over rows the update did not reach.
+      await tx
+        .update(schedulerJobs)
+        .set({ payload: { cursor: nextCursor, family } })
+        .where(leaseFence);
+      return { family, movedCount, status: "progress" as const };
+    }
+
+    const following = nextFamily(family);
+    if (following !== null) {
+      await tx
+        .update(schedulerJobs)
+        .set({ payload: { cursor: null, family: following } })
+        .where(leaseFence);
+      return { family, movedCount, status: "progress" as const };
+    }
+
+    // audit: skip — retires a versioned one-shot repair; scheduler job runs
+    // retain the operator trail.
+    await tx.update(schedulerJobs).set({ enabled: false }).where(leaseFence);
+    return { family, movedCount, status: "complete" as const };
+  });
+
+  logger.info("scheduler.corpus_index_job_detail_backfilled", {
+    "corpusIndexJobDetail.family": outcome.family,
+    "corpusIndexJobDetail.moved": outcome.movedCount,
+    "corpusIndexJobDetail.status": outcome.status,
+  });
+
+  if (outcome.status === "progress" && !signal.aborted) {
+    scheduleContinuation(new Date(Date.now() + CONTINUATION_DELAY_MS));
+  }
+};

--- a/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
+++ b/apps/api/src/lib/scheduler/tasks/corpus-index-job-detail-backfill.ts
@@ -54,11 +54,13 @@ const BATCH_STATEMENT_TIMEOUT = "30s";
 /**
  * VALIDATE takes SHARE UPDATE EXCLUSIVE, which lets writers through but queues
  * behind an autovacuum of the table until that vacuum yields, so the wait is
- * longer than a page's. Its own scan is bounded only by the size of the trail,
- * which is why it runs with no statement budget at all.
+ * longer than a page's. Its scan reads the trail once, which is far more than a
+ * page does and still finite: the budget is sized for that scan rather than
+ * lifted, so a validation that is not making progress is cancelled and tried
+ * again on the next tick instead of holding its connection indefinitely.
  */
 const VALIDATE_LOCK_TIMEOUT = "1min";
-const VALIDATE_STATEMENT_TIMEOUT = "0";
+const VALIDATE_STATEMENT_TIMEOUT = "30min";
 
 type TransactionBudget = { lockTimeout: string; statementTimeout: string };
 
@@ -265,25 +267,51 @@ class CorpusIndexJobDetailBackfillError extends TaggedError(
   "CorpusIndexJobDetailBackfillError",
 )<{ message: string; cause?: unknown }> {}
 
+/** The two steps a run takes, which give up on different terms. */
+export type BackfillStep = "page" | "validate";
+
+/**
+ * What a step may lose to and still be tried again, by step.
+ *
+ * A page is refused a lock or it commits, and its statement budget is sized
+ * for a bounded write: a page cancelled by that budget is a page that is not
+ * doing what it says, which the runner should record. A validation gives up on
+ * both terms — the lock it waits for and the scan it runs — and neither leaves
+ * anything behind, so the next tick simply asks again.
+ */
+const BACKFILL_RETRY_CODES = {
+  page: [PG_ERROR.LOCK_NOT_AVAILABLE],
+  validate: [PG_ERROR.LOCK_NOT_AVAILABLE, PG_ERROR.QUERY_CANCELED],
+} as const satisfies Record<BackfillStep, readonly string[]>;
+
+/** True when the step gave up without committing, so running it again converges. */
+export const isRetriableBackfillFailure = (
+  failure: unknown,
+  step: BackfillStep,
+): boolean =>
+  BACKFILL_RETRY_CODES[step].some((code) => isPgError(failure, code));
+
 type BackfillFailureReport = {
   event: string;
   family: CorpusIndexJobDetailFamily;
   logger: SchedulerTaskContext["logger"];
+  step: BackfillStep;
 };
 
 /**
  * What a step that did not commit means for the sweep.
  *
- * A step refused a lock is not a failure: it moved nothing and checkpointed
- * nothing, so the next tick asks for the same range again and the repair still
- * converges. Anything else is the runner's to record, and a scheduler task
- * reports that through the promise it returns, the way a readiness probe does.
+ * A step that gave up on its own budget is not a failure: it moved nothing and
+ * checkpointed nothing, so the next tick asks for the same range again and the
+ * repair still converges. Anything else is the runner's to record, and a
+ * scheduler task reports that through the promise it returns, the way a
+ * readiness probe does.
  */
 const reportBackfillFailure = async (
   failure: CorpusIndexJobDetailBackfillError,
-  { event, family, logger }: BackfillFailureReport,
+  { event, family, logger, step }: BackfillFailureReport,
 ): Promise<void> => {
-  if (!isPgError(failure, PG_ERROR.LOCK_NOT_AVAILABLE)) {
+  if (!isRetriableBackfillFailure(failure, step)) {
     await Promise.reject(failure);
     return;
   }
@@ -380,6 +408,7 @@ export const backfillCorpusIndexJobDetail: SchedulerTask = async ({
       event: "scheduler.corpus_index_job_detail_contended",
       family,
       logger,
+      step: "page",
     });
   }
 
@@ -427,6 +456,7 @@ export const backfillCorpusIndexJobDetail: SchedulerTask = async ({
       event: "scheduler.corpus_index_job_detail_validation_contended",
       family,
       logger,
+      step: "validate",
     });
   }
 

--- a/apps/api/src/scripts/seed-migration-rehearsal-plan.ts
+++ b/apps/api/src/scripts/seed-migration-rehearsal-plan.ts
@@ -33,16 +33,19 @@ export const REHEARSAL_ROWS_PER_DECISION = {
   case_law_citations: 5,
   case_law_decision_identifiers: 1,
   case_law_decisions: 1,
+  case_law_index_jobs: 1,
   case_law_provision_citations: 2,
   case_law_search_document_preview_passages: 2,
   case_law_search_documents: 1,
   corpus_index_projection_intents: 1,
   corpus_index_projection_states: 1,
+  legislation_index_jobs: 1,
 } as const satisfies Record<HighVolumeTable, number>;
 
 const SOURCE_ID = "0b4f7d84-2f5e-4d8c-9a1a-6c8b7e2d5f01";
 const PREVIEW_GENERATION = "0b4f7d84-2f5e-4d8c-9a1a-6c8b7e2d5f02";
 const CORPUS_GENERATION = "case_law_v999";
+const LEGISLATION_GENERATION = "legislation_v999";
 const CORPUS_INDEX_ID = "rehearsal_cze";
 const ZERO_DIGEST = "repeat('0', 64)";
 /**
@@ -218,6 +221,21 @@ export const REHEARSAL_SEEDERS = {
     SELECT 'case_law', '${CORPUS_GENERATION}', d.id, 'upsert', ${PROJECTION_EPOCH},
            ${ZERO_DIGEST}, '${CORPUS_INDEX_ID}'
     FROM rehearsal_decisions d`,
+  case_law_index_jobs: () => `
+    INSERT INTO case_law_index_jobs
+      (id, decision_id, generation, operation, status, content_hash)
+    SELECT gen_random_uuid(), d.id, '${CORPUS_GENERATION}', 'index', 'succeeded',
+           ${ZERO_DIGEST}
+    FROM rehearsal_decisions d`,
+  // The rehearsal seeds no legislation documents, so these are the rows the
+  // trail keeps for a whole-index operation, which carry no document. The
+  // volume is what a migration meets; the shape of the trail is the same.
+  legislation_index_jobs: () => `
+    INSERT INTO legislation_index_jobs
+      (id, document_id, generation, operation, status, content_hash)
+    SELECT gen_random_uuid(), NULL, '${LEGISLATION_GENERATION}', 'rebuild',
+           'succeeded', ${ZERO_DIGEST}
+    FROM rehearsal_decisions d`,
 } as const satisfies Record<HighVolumeTable, Seeder>;
 
 /**
@@ -236,6 +254,8 @@ export const REHEARSAL_SEED_ORDER = [
   "case_law_search_document_preview_passages",
   "corpus_index_projection_states",
   "corpus_index_projection_intents",
+  "case_law_index_jobs",
+  "legislation_index_jobs",
 ] as const satisfies readonly HighVolumeTable[];
 
 export type RehearsalSeedStep = {

--- a/scripts/check-migration-safety.test.ts
+++ b/scripts/check-migration-safety.test.ts
@@ -762,6 +762,29 @@ describe("check-migration-safety", () => {
       );
     });
 
+    it("rejects the index-job backfill that outran the migration budget", () => {
+      // The trail carries one row per document per index operation and has no
+      // index on `operation`, so this filtered UPDATE scans it whole. It is
+      // registered now; the repair belongs to a bounded online pass.
+      const result = runChecker(`
+        UPDATE "case_law_index_jobs"
+          SET "detail" = "error_message", "error_message" = NULL
+          WHERE "operation" = 'withdraw'
+            AND "status" = 'succeeded'
+            AND "error_message" IS NOT NULL;
+      `);
+
+      expectFinding(result, "high-volume-table-dml");
+      expectFinding(
+        runChecker(`
+          UPDATE "legislation_index_jobs"
+            SET "detail" = "error_message", "error_message" = NULL
+            WHERE "operation" = 'withdraw';
+        `),
+        "high-volume-table-dml",
+      );
+    });
+
     it("ignores the table name inside comments, strings and routine bodies", () => {
       expectClean(
         runChecker(`

--- a/scripts/knip-exports-baseline.json
+++ b/scripts/knip-exports-baseline.json
@@ -1,6 +1,6 @@
 {
   "apps/api": {
-    "count": 782,
+    "count": 780,
     "files": {
       "apps/api/scripts/lib/capability-catalog.ts": 9,
       "apps/api/scripts/lib/enumerate-safe-handlers.ts": 7,
@@ -11,7 +11,6 @@
       "apps/api/src/db/online-migrations.ts": 1,
       "apps/api/src/db/schema-validators.ts": 7,
       "apps/api/src/db/schema/common.ts": 2,
-      "apps/api/src/db/schema/corpus-index-jobs.ts": 2,
       "apps/api/src/env-base.ts": 1,
       "apps/api/src/handlers/ai-config/validate-provider.ts": 1,
       "apps/api/src/handlers/bilingual-translations/schemas.ts": 2,


### PR DESCRIPTION
## What

- `20260905200000_corpus_index_job_detail` keeps only its DDL (column and check); the two backfill UPDATEs are gone and the rewrite is registered in `rewrittenMigrationHistories` with the prior hash, so a database that recorded the earlier version stays consistent and one where it rolled back runs the DDL-only version.
- The backfill is a one-shot scheduler task (`corpusIndex.backfillJobDetail`): keyset walk of each trail's primary key in pages of 1000, one bounded UPDATE per page, checkpointed and resumable, disabling itself when done.
- `case_law_index_jobs` and `legislation_index_jobs` join `HIGH_VOLUME_TABLES`, so a bulk DML statement on them in a migration is refused by the safety checker; a checker test runs the exact previous statement and asserts the finding. The rehearsal plan gains seeders for both tables, which the total maps demanded.

## Why

The backfill scanned a table of tens of millions of rows without an index on its predicate and exceeded the migration's statement timeout, so the upgrade rolled back on every attempt. A migration is not the place for data movement over a high-volume table; the same rule already governs the decisions table.

## Tests

pglite: backfill over both tables, the moves-reasons-not-failures boundary, replay, cursor resumption across pages; migration-history property test recomputes the rewritten hash; checker suite; rehearsal plan; scheduler registry. Migration coverage check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated detail field for corpus indexing job records, keeping withdrawal reasons separate from failure messages.
  - Added automatic migration of eligible existing withdrawal reasons into the new detail field.

- **Bug Fixes**
  - Improved consistency and clarity of indexing job history by preserving withdrawal explanations independently from error information.

- **Tests**
  - Added coverage for migration processing, pagination, repeat runs, validation, and both case-law and legislation indexing records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->