### PR TITLE
fix(api): floor the budget-edge probe ceiling at the tool-probe budget

### DIFF
--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -11,6 +11,7 @@ import {
   CANARY_PROVIDERS,
   missingCanaryProviders,
   modelRoleMaxOutputTokens,
+  structuredOutputBudgetEdgeMaxOutputTokens,
   structuredOutputModelRoleMaxOutputTokens,
   TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
   WEEKLY_TOOL_SHAPES,
@@ -55,6 +56,25 @@ describe("AI provider canary role budgets", () => {
     // Amazon Nova v1 accepts at most 10,000 output tokens and takes part in
     // the weekly rotation; a larger ceiling is rejected before the tool call.
     expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeLessThanOrEqual(10_000);
+  });
+
+  test("budgets the budget-edge probe above a truncating ceiling", () => {
+    // A one-property schema still gets the tool-execution headroom: the
+    // "fast"-role default is a provider's smallest model, and a structured
+    // object cut off mid-tool-use is rejected, not shortened.
+    expect(
+      structuredOutputBudgetEdgeMaxOutputTokens({
+        modelId: model,
+        propertyCount: 1,
+      }),
+    ).toBe(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS);
+    // Past that floor the ceiling still grows with the schema actually sent.
+    expect(
+      structuredOutputBudgetEdgeMaxOutputTokens({
+        modelId: model,
+        propertyCount: 200,
+      }),
+    ).toBeGreaterThan(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS);
   });
 
   test("clamps role budgets to a model's output limit", () => {

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -192,6 +192,15 @@ export const TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS = 4096;
 const BUDGET_EDGE_PROBE_OUTPUT_TOKENS_BASE = 256;
 const BUDGET_EDGE_PROBE_OUTPUT_TOKENS_PER_PROPERTY = 50;
 
+// The per-property estimate above prices the answer the prompt asks for. The
+// probe runs at the "fast" role, whose default is a provider's smallest
+// model, and a small model fills the fields it was told to leave empty; the
+// object then stops at the ceiling, and a truncated structured object is not
+// a short answer but a failed one. Bedrock rejects the cut-off tool use
+// outright ("Model produced invalid sequence as part of ToolUse"), Google
+// reports `max_tokens`, and either reads as provider drift the provider did
+// not cause. Floor the ceiling at the same value the tool-execution probes
+// already use, so only a schema past ~77 properties needs the scale above.
 export const structuredOutputBudgetEdgeMaxOutputTokens = ({
   modelId,
   propertyCount,
@@ -201,8 +210,11 @@ export const structuredOutputBudgetEdgeMaxOutputTokens = ({
 }) =>
   clampToModelOutputLimit(
     modelId,
-    BUDGET_EDGE_PROBE_OUTPUT_TOKENS_BASE +
-      propertyCount * BUDGET_EDGE_PROBE_OUTPUT_TOKENS_PER_PROPERTY,
+    Math.max(
+      TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
+      BUDGET_EDGE_PROBE_OUTPUT_TOKENS_BASE +
+        propertyCount * BUDGET_EDGE_PROBE_OUTPUT_TOKENS_PER_PROPERTY,
+    ),
   );
 
 export const isCanaryProvider = (value: string): value is CanaryProvider =>


### PR DESCRIPTION
## Proposed change

The scheduled AI provider canary has failed `bedrock/structured-output-budget-edge` on every run since the probe landed in #2811 ([126](https://github.com/stella/stella/actions/runs/33715994050), [127](https://github.com/stella/stella/actions/runs/33833331283), [128](https://github.com/stella/stella/actions/runs/33941889747), [129](https://github.com/stella/stella/actions/runs/34009068476)), each time with Bedrock's `Model produced invalid sequence as part of ToolUse` on `bedrock-converse.structuredOutputStream`. Run 128 failed the same probe on Google with `provider error (max_tokens)`.

The probe sized its output ceiling from the property count of the schema it built: 256 tokens plus 50 per property, so 956 tokens for the 14-property schema Bedrock's placeholder budget yields. That estimate prices the answer the prompt asks for (`null` answer, empty justification). The probe runs at the `fast` role, whose default is a provider's smallest model (`us.amazon.nova-micro-v1:0` on Bedrock), and a small model fills the fields it was told to leave empty. The object then stops at the ceiling, and a truncated structured object is not a short answer but a failed one: Bedrock rejects the cut-off tool use outright, Google reports `max_tokens`, and either reads as provider drift the provider did not cause. The same probe passes where the ceiling is comfortable: Anthropic at 4 properties (456 tokens) and OpenAI at 74 properties (3,956 tokens).

Floor the ceiling at `TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS` (4,096), the value the tool-execution probes already carry for the same reason (#2560), still clamped to each model's output limit, so the Bedrock rotation stays under Nova's 10,000. The per-property scale keeps growing the ceiling past ~77 properties, above the 74 that OpenAI's documented budget reaches today. The config test binds both bounds: the floor at one property, and growth beyond it at 200.

## Verification

- `bun test scripts/ai-provider-canary-config.test.ts scripts/ai-provider-canary-coverage.test.ts scripts/ai-provider-canary-weekly.test.ts`
- `bun test --env-file=.env.example scripts/ai-provider-canary.test.ts`
- `bun --filter @stll/api typecheck`, `bun --filter @stll/api lint`

The probe itself calls the providers, so the fix is confirmed by the next scheduled run.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved structured-output handling for small AI models by ensuring the output-token limit does not fall below the required minimum.
  - Prevented truncated structured responses and related provider-side rejections when models return more fields than expected.

- **Tests**
  - Added coverage confirming minimum output-token limits and scaling behaviour for larger structured schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
