### PR TITLE
fix(api): a scheduler pass claims only jobs its build can run

### DIFF
--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -144,11 +144,13 @@ describe("acquireNextDueJob claim exclusivity", () => {
     const first = await acquireNextDueJob({
       db,
       leaseMs: LEASE_MS,
+      registry: noopRegistry,
       runnerId: "runner-a",
     });
     const second = await acquireNextDueJob({
       db,
       leaseMs: LEASE_MS,
+      registry: noopRegistry,
       runnerId: "runner-b",
     });
 
@@ -160,6 +162,66 @@ describe("acquireNextDueJob claim exclusivity", () => {
     // unique suffix), not the bare runnerId.
     expect(job.lockedBy).toMatch(/^runner-a#/u);
     expect(first?.lockedBy).toBe(job.lockedBy);
+  });
+});
+
+describe("acquireNextDueJob task registration", () => {
+  test("leaves a due job this build has no handler for untouched", async () => {
+    await seedJob({ id: "foreign.job", task: "test.unregistered" });
+
+    const claimed = await acquireNextDueJob({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "runner-a",
+    });
+
+    expect(claimed).toBeNull();
+    // Unlocked and still due, so a replica that registers the task can run it
+    // on its own schedule rather than inheriting a pushed-out nextRunAt.
+    const job = await readJob("foreign.job");
+    expect(job.lockedBy).toBeNull();
+    expect(job.lockedUntil).toBeNull();
+    expect(job.nextRunAt).toEqual(PAST);
+    expect(job.lastError).toBeNull();
+  });
+
+  test("an unrunnable job does not shadow a runnable one behind it", async () => {
+    await seedJob({
+      id: "foreign.job",
+      nextRunAt: new Date(PAST.getTime() - 60_000),
+      task: "test.unregistered",
+    });
+    await seedJob({ id: "own.job", task: "test.noop" });
+
+    const claimed = await acquireNextDueJob({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "runner-a",
+    });
+
+    expect(claimed?.id).toBe("own.job");
+  });
+
+  test("a sweep records no run for a job it cannot execute", async () => {
+    await seedJob({ id: "foreign.job", task: "test.unregistered" });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "runner-a",
+    });
+
+    expect(result.acquired).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(
+      await testDb
+        .select()
+        .from(schedulerJobRuns)
+        .where(eq(schedulerJobRuns.jobId, "foreign.job")),
+    ).toHaveLength(0);
   });
 });
 

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -1,5 +1,5 @@
 import { panic } from "better-result";
-import { and, asc, eq, isNull, lte, or } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lte, or } from "drizzle-orm";
 import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 
 import { rootDb } from "@/api/db/root";
@@ -116,7 +116,7 @@ export const runSchedulerOnce = async ({
     // Claim immediately before execution. A pass never leases work it cannot
     // start yet, so another scheduler replica remains free to process it.
     // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- claims one job immediately before running it so replicas can take the rest
-    const job = await acquireNextDueJob({ db, leaseMs, runnerId });
+    const job = await acquireNextDueJob({ db, leaseMs, registry, runnerId });
     if (!job) {
       break;
     }
@@ -240,15 +240,24 @@ type AcquireNextDueJobOptions = {
   db: SchedulerDb;
   runnerId: string;
   leaseMs: number;
+  registry: SchedulerTaskRegistry;
 };
 
 export const acquireNextDueJob = async ({
   db,
   leaseMs,
+  registry,
   runnerId,
 }: AcquireNextDueJobOptions): Promise<SchedulerJob | null> => {
   if (!Number.isInteger(leaseMs) || leaseMs < MIN_LEASE_MS) {
     return panic("Scheduler lease must be at least three poll intervals");
+  }
+
+  // The claim filter is derived from the very registry `runJob` resolves the
+  // task against, so the two can never disagree about what this build can run.
+  const runnableTasks = [...registry.keys()];
+  if (runnableTasks.length === 0) {
+    return null;
   }
 
   const now = new Date();
@@ -257,7 +266,7 @@ export const acquireNextDueJob = async ({
     const [candidate] = await tx
       .select()
       .from(schedulerJobs)
-      .where(dueJobPredicate(now))
+      .where(dueJobPredicate(now, runnableTasks))
       .orderBy(asc(schedulerJobs.nextRunAt), asc(schedulerJobs.id))
       .limit(1)
       .for("update", { skipLocked: true });
@@ -273,15 +282,27 @@ export const acquireNextDueJob = async ({
         lockedBy: leaseToken,
         lockedUntil: leaseExpiresAt,
       })
-      .where(and(eq(schedulerJobs.id, candidate.id), dueJobPredicate(now)))
+      .where(
+        and(
+          eq(schedulerJobs.id, candidate.id),
+          dueJobPredicate(now, runnableTasks),
+        ),
+      )
       .returning();
 
     return job ?? panic("Locked scheduler job disappeared before lease update");
   });
 };
 
-const dueJobPredicate = (now: Date) =>
+// A row whose task this build has no handler for is not claimable work: running
+// it can only raise `ConfigurationError`, and the failure would still consume
+// the row's schedule slot by advancing `nextRunAt`, delaying the replica that
+// can run it. Registration retires such rows, but only at startup, so a build
+// that declares a new task leaves every older replica able to claim it until
+// they stop; the claim itself has to hold the line.
+const dueJobPredicate = (now: Date, runnableTasks: string[]) =>
   and(
+    inArray(schedulerJobs.task, runnableTasks),
     eq(schedulerJobs.enabled, true),
     // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
     lte(schedulerJobs.nextRunAt, now),


### PR DESCRIPTION
## Proposed change

`acquireNextDueJob` picks the next due `scheduler_jobs` row from `enabled`, `nextRunAt` and `lockedUntil` alone. Nothing in that predicate restricts the row to a task the running build registers, so a runner can lease a job it has no handler for: `runJob` resolves the handler only after the claim (`registry.get(job.task)`) and throws `ConfigurationError` when it is missing.

The cost is not confined to that one run. `finishRunFailure` writes `lastError`/`lastFailureAt` and advances `nextRunAt` by the job's schedule, so a runner that cannot execute the task still consumes the row's slot and pushes out a replica that can. The sweep already documents the invariant this breaks:

> Claim immediately before execution. A pass never leases work it cannot start yet, so another scheduler replica remains free to process it.

`ensureDefaultSchedulerJobs` treats the registry as exactly this discriminator, disabling rows whose task "this build cannot run". But it runs once per process, at startup (`server.ts`), so it cannot reach a row that another replica declares while this process is already live. Whenever two builds with different task sets are up at once, the older one can claim the newer one's rows, and each such claim costs that job an interval.

### Fix

`acquireNextDueJob` takes the `SchedulerTaskRegistry` the pass already holds and filters the claim by its keys. The claim filter and the handler lookup are then derived from one object and cannot disagree about what the build can run. A row this build cannot drive is simply not a candidate: it stays unlocked and due, for a replica that can. An empty registry claims nothing.

The filter is added to `dueJobPredicate`, so it covers both the `FOR UPDATE SKIP LOCKED` select and the guarded lease update.

### Tests

`runner.test.ts`, all three failing before the change:

- a due row whose task is unregistered is not claimed, and is left unlocked with `nextRunAt` and `lastError` untouched;
- an unrunnable row ordered ahead of a runnable one does not shadow it (the pass claims the runnable row);
- a sweep over an unrunnable row records no `scheduler_job_runs` row and reports no failure.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-facing surface.

Validated per package rather than through the combined pre-push run, which exceeds available memory locally: `bun test src/lib/scheduler/` (103 pass), `tsc --noEmit -p apps/api` clean, `oxlint apps/api/src/lib/scheduler/` clean, `bun run format` no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduler jobs are now claimed only when a registered task handler is available.
  - Jobs with missing or unrunnable tasks remain unchanged and do not block runnable jobs behind them.
  - Scheduler sweeps no longer create run records for jobs they cannot execute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
