### PR TITLE
fix(api): claim only scheduler jobs this build registers a task for

### DIFF
--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -144,11 +144,13 @@ describe("acquireNextDueJob claim exclusivity", () => {
     const first = await acquireNextDueJob({
       db,
       leaseMs: LEASE_MS,
+      registry: noopRegistry,
       runnerId: "runner-a",
     });
     const second = await acquireNextDueJob({
       db,
       leaseMs: LEASE_MS,
+      registry: noopRegistry,
       runnerId: "runner-b",
     });
 
@@ -160,6 +162,45 @@ describe("acquireNextDueJob claim exclusivity", () => {
     // unique suffix), not the bare runnerId.
     expect(job.lockedBy).toMatch(/^runner-a#/u);
     expect(first?.lockedBy).toBe(job.lockedBy);
+  });
+});
+
+describe("acquireNextDueJob task filter", () => {
+  test("a due job whose task the registry does not carry is never leased", async () => {
+    await seedJob({ id: "unregistered.job", task: "test.unregistered" });
+
+    const claimed = await acquireNextDueJob({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "runner-a",
+    });
+
+    expect(claimed).toBeNull();
+    const job = await readJob("unregistered.job");
+    expect(job.lockedBy).toBeNull();
+    expect(job.lockedUntil).toBeNull();
+  });
+
+  test("an unregistered job does not hold the candidate slot ahead of a runnable one", async () => {
+    // Sorts ahead of the runnable job on both ordering keys, so a claim that
+    // filtered after the read would take this row every pass and run nothing.
+    await seedJob({
+      id: "a.unregistered",
+      nextRunAt: new Date(PAST.getTime() - 60_000),
+      task: "test.unregistered",
+    });
+    await seedJob({ id: "b.runnable", task: "test.noop" });
+
+    const claimed = await acquireNextDueJob({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "runner-a",
+    });
+
+    expect(claimed?.id).toBe("b.runnable");
+    expect((await readJob("a.unregistered")).lockedBy).toBeNull();
   });
 });
 

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -1,5 +1,5 @@
 import { panic } from "better-result";
-import { and, asc, eq, isNull, lte, or } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lte, or } from "drizzle-orm";
 import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 
 import { rootDb } from "@/api/db/root";
@@ -7,10 +7,7 @@ import { schedulerJobRuns, schedulerJobs } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { detached } from "@/api/lib/detached";
-import {
-  ConfigurationError,
-  SchedulerJobTimeoutError,
-} from "@/api/lib/errors/tagged-errors";
+import { SchedulerJobTimeoutError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createSchedulerTaskRegistry } from "@/api/lib/scheduler/registry";
@@ -113,9 +110,10 @@ export const runSchedulerOnce = async ({
       break;
     }
 
-    // Claim immediately before execution. A pass never leases work it cannot
-    // start yet, so another scheduler replica remains free to process it.
-    const job = await acquireNextDueJob({ db, leaseMs, runnerId });
+    // Claim immediately before execution, and only what this build's registry
+    // answers for. A pass never leases work it cannot start yet or cannot run
+    // at all, so another scheduler replica remains free to process it.
+    const job = await acquireNextDueJob({ db, leaseMs, registry, runnerId });
     if (!job) {
       break;
     }
@@ -236,6 +234,7 @@ export const startSchedulerLoop = ({
 
 type AcquireNextDueJobOptions = {
   db: SchedulerDb;
+  registry: SchedulerTaskRegistry;
   runnerId: string;
   leaseMs: number;
 };
@@ -243,19 +242,23 @@ type AcquireNextDueJobOptions = {
 export const acquireNextDueJob = async ({
   db,
   leaseMs,
+  registry,
   runnerId,
 }: AcquireNextDueJobOptions): Promise<SchedulerJob | null> => {
   if (!Number.isInteger(leaseMs) || leaseMs < MIN_LEASE_MS) {
     return panic("Scheduler lease must be at least three poll intervals");
   }
 
+  // Read from the registry this pass will look the handler up in, not from the
+  // module's task list, so the claim and the execution cannot disagree.
+  const runnableTasks = [...registry.keys()];
   const now = new Date();
   const leaseExpiresAt = new Date(now.getTime() + leaseMs);
   return await db.transaction(async (tx) => {
     const [candidate] = await tx
       .select()
       .from(schedulerJobs)
-      .where(dueJobPredicate(now))
+      .where(dueJobPredicate(now, runnableTasks))
       .orderBy(asc(schedulerJobs.nextRunAt), asc(schedulerJobs.id))
       .limit(1)
       .for("update", { skipLocked: true });
@@ -271,16 +274,33 @@ export const acquireNextDueJob = async ({
         lockedBy: leaseToken,
         lockedUntil: leaseExpiresAt,
       })
-      .where(and(eq(schedulerJobs.id, candidate.id), dueJobPredicate(now)))
+      .where(
+        and(
+          eq(schedulerJobs.id, candidate.id),
+          dueJobPredicate(now, runnableTasks),
+        ),
+      )
       .returning();
 
     return job ?? panic("Locked scheduler job disappeared before lease update");
   });
 };
 
-const dueJobPredicate = (now: Date) =>
+/**
+ * Due, free, and answerable by this build.
+ *
+ * The task filter belongs in the predicate rather than after the read: a row
+ * this build has no handler for is not a candidate it should skip, it is a row
+ * it must not order ahead of the work it can run. Filtering after the select
+ * would let the oldest such row take the single candidate slot every pass and
+ * starve the rest. A build carries only the tasks its own code answers for, so
+ * the rows it leaves are the newer build's to claim; the persistent case, a
+ * task no build declares any more, is retired at registration.
+ */
+const dueJobPredicate = (now: Date, runnableTasks: string[]) =>
   and(
     eq(schedulerJobs.enabled, true),
+    inArray(schedulerJobs.task, runnableTasks),
     // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
     lte(schedulerJobs.nextRunAt, now),
     // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- cutoff read from the caller's clock, never round-tripped through the database
@@ -411,9 +431,10 @@ const runJob = async ({
 
   try {
     if (!task) {
-      throw new ConfigurationError({
-        message: `No scheduler task registered for ${job.task}`,
-      });
+      // The claim reads the same registry, so a leased job always has a
+      // handler; reaching this is a defect in the claim, not a configuration
+      // a deployment can hold.
+      panic(`No scheduler task registered for ${job.task}`);
     }
 
     // Bound the task's runtime. A JS promise cannot be force-cancelled, so on


### PR DESCRIPTION
## Proposed change

`dueJobPredicate` selects a scheduler job on `enabled`, `nextRunAt` and the lease
columns, but not on whether the running build carries a handler for the row's
task. `runSchedulerOnce` therefore leases a job it may have no way to execute:
`runJob` looks the task up in the registry, finds nothing, and raises
`ConfigurationError`. The row spends a lease and a run record, is recorded as
failed, and is rescheduled to do the same thing on the next pass.

The registry is already the discriminator for this elsewhere: `registerSchedulerJobs`
retires a persisted row whose task no build declares any more, on exactly this
reasoning ("a persisted job whose task this build cannot run is undrivable"). It
cannot cover a row that is registered by another build and not by this one, which
is what a table shared across builds gives you.

- `acquireNextDueJob` takes the registry and filters the claim by its keys, read
  from the same instance the pass will look the handler up in, so the claim and
  the execution cannot disagree.
- The filter goes into the predicate rather than after the read. The claim takes a
  single candidate ordered by `nextRunAt`, so discarding an unrunnable row after
  the select would let the oldest one hold that slot on every pass and starve the
  jobs the build can run. A test pins that ordering property.
- With the claim restricted to registered tasks, a leased job without a handler is
  an internal invariant rather than a configuration a deployment can hold, so it
  panics instead of raising `ConfigurationError`.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun --filter @stll/api test src/lib/scheduler/` (all suites pass); the two added cases fail against the unfiltered predicate. `bun --filter @stll/api typecheck`, `bun --filter @stll/api lint`.
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NGs5ALdf258KjeZc82N7n5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduler jobs are now claimed only when their tasks are available and runnable.
  - Unavailable tasks no longer block other eligible jobs from being processed.
  - Jobs that cannot be run remain unclaimed, preventing incorrect leasing and improving scheduler reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->