### PR TITLE
perf(api): case-law ingestion status reads per-source figures in one pass

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/status.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/status.db.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { authRelationsPart } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  caseLawCoverageSlices,
+  caseLawDecisions,
+  caseLawIngestionEvents,
+  caseLawIngestionFailures,
+  caseLawReconciliationItems,
+  caseLawSources,
+  RECONCILIATION_ITEM_STATUS,
+  relations,
+} from "@/api/db/schema";
+import { getIngestionStatus } from "@/api/handlers/case-law/ingestion/status";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createSafeId } from "@/api/lib/branded-types";
+import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+/**
+ * The report reads every per-source figure with one grouped statement, so the
+ * numbers are only right if each row lands against its own source. Two seeded
+ * sources with deliberately different counts is the smallest arrangement that
+ * can catch a group key going astray; a single-source fixture cannot.
+ */
+
+const connect = (client: Awaited<ReturnType<typeof createTestPglite>>) =>
+  drizzle({ client, relations: { ...relations, ...authRelationsPart } });
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof connect>;
+
+const scopedDb: ScopedDb = async (callback) =>
+  // SAFETY: pglite stands in for the transaction the handler expects.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- the pglite handle is the test's transaction
+  await callback(db as unknown as Transaction);
+
+const busyId = createSafeId<"caseLawSource">();
+const quietId = createSafeId<"caseLawSource">();
+
+const now = Date.now();
+const minutesAgo = (minutes: number) => new Date(now - minutes * 60 * 1000);
+
+const decision = (sourceId: SafeId<"caseLawSource">, ordinal: number) => ({
+  sourceId,
+  id: createSafeId<"caseLawDecision">(),
+  court: "Krajský soud",
+  country: "CZE",
+  language: "cs",
+  caseNumber: `11 C ${ordinal}/2025`,
+  citationKey: `11c/${ordinal}/2025`,
+  decisionDate: "2025-03-01",
+  slug: `decision-${ordinal}`,
+  languageGroupKey: `decision-${ordinal}`,
+});
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = connect(client);
+
+  await db.insert(caseLawSources).values([
+    { id: busyId, adapterKey: ADAPTER_KEYS.CZ_REGIONAL, name: "busy source" },
+    { id: quietId, adapterKey: ADAPTER_KEYS.CZ_NS, name: "quiet source" },
+  ]);
+
+  await db
+    .insert(caseLawDecisions)
+    .values([
+      decision(busyId, 1),
+      decision(busyId, 2),
+      decision(busyId, 3),
+      decision(quietId, 4),
+    ]);
+
+  await db.insert(caseLawIngestionEvents).values([
+    {
+      sourceId: busyId,
+      status: "completed",
+      inserted: 5,
+      skipped: 1,
+      durationMs: 100,
+      startedAt: minutesAgo(30),
+      finishedAt: minutesAgo(29),
+    },
+    {
+      // Inside the day window, outside the hour window.
+      sourceId: busyId,
+      status: "failed",
+      inserted: 7,
+      skipped: 2,
+      durationMs: 200,
+      errorMessage: "publisher timeout",
+      startedAt: minutesAgo(300),
+      finishedAt: minutesAgo(299),
+    },
+    {
+      sourceId: quietId,
+      status: "completed",
+      inserted: 1,
+      skipped: 0,
+      durationMs: 50,
+      startedAt: minutesAgo(10),
+      finishedAt: minutesAgo(9),
+    },
+  ]);
+
+  await db.insert(caseLawIngestionFailures).values([
+    {
+      sourceId: busyId,
+      caseNumber: "11 C 1/2025",
+      errorType: "parse",
+      errorMessage: "bad document",
+      createdAt: minutesAgo(20),
+    },
+    {
+      sourceId: busyId,
+      caseNumber: "11 C 2/2025",
+      errorType: "parse",
+      errorMessage: "bad document",
+      createdAt: minutesAgo(21),
+    },
+    {
+      sourceId: busyId,
+      caseNumber: "11 C 3/2025",
+      errorType: "fetch",
+      errorMessage: "timeout",
+      createdAt: minutesAgo(22),
+    },
+    {
+      sourceId: quietId,
+      caseNumber: "22 C 1/2025",
+      errorType: "fetch",
+      errorMessage: "timeout",
+      createdAt: minutesAgo(23),
+    },
+  ]);
+
+  await db.insert(caseLawCoverageSlices).values([
+    { sourceId: busyId, slice: "2025-03-01", reported: 10, collected: 4 },
+    { sourceId: busyId, slice: "2025-03-02", reported: 3, collected: 3 },
+    { sourceId: busyId, slice: "2025-03-03", walkError: "listing refused" },
+  ]);
+
+  await db.insert(caseLawReconciliationItems).values([
+    {
+      sourceId: busyId,
+      slice: "2025-03-01",
+      identityKey: "document:1",
+      payload: {},
+      status: RECONCILIATION_ITEM_STATUS.PARKED,
+      nextAttemptAt: minutesAgo(-60),
+    },
+    {
+      sourceId: busyId,
+      slice: "2025-03-01",
+      identityKey: "document:2",
+      payload: {},
+      status: RECONCILIATION_ITEM_STATUS.TERMINAL,
+    },
+  ]);
+}, 120_000);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("per-source figures stay with their own source", async () => {
+  const status = await getIngestionStatus(scopedDb);
+
+  const busy = status.sources.find((source) => source.name === "busy source");
+  const quiet = status.sources.find((source) => source.name === "quiet source");
+
+  expect(busy?.totalDecisions).toBe(3);
+  expect(quiet?.totalDecisions).toBe(1);
+
+  expect(busy?.insertedLastHour).toBe(5);
+  expect(busy?.inserted24h).toBe(12);
+  expect(quiet?.insertedLastHour).toBe(1);
+  expect(quiet?.inserted24h).toBe(1);
+
+  expect(busy?.failures24h).toBe(3);
+  expect(quiet?.failures24h).toBe(1);
+
+  expect(status.totalDecisions).toBe(4);
+  expect(status.totalEvents).toBe(3);
+  expect(status.failures24h).toBe(4);
+});
+
+test("the last event is the source's own newest run", async () => {
+  const status = await getIngestionStatus(scopedDb);
+
+  const busy = status.sources.find((source) => source.name === "busy source");
+  const quiet = status.sources.find((source) => source.name === "quiet source");
+
+  expect(busy?.lastEvent?.inserted).toBe(5);
+  expect(busy?.lastEvent?.status).toBe("completed");
+  expect(busy?.lastEvent?.failed).toBe(false);
+  expect(quiet?.lastEvent?.inserted).toBe(1);
+});
+
+test("top error types are ranked within each source", async () => {
+  const status = await getIngestionStatus(scopedDb);
+
+  const busy = status.sources.find((source) => source.name === "busy source");
+  const quiet = status.sources.find((source) => source.name === "quiet source");
+
+  expect(busy?.topErrors).toEqual([
+    { errorType: "parse", count: 2 },
+    { errorType: "fetch", count: 1 },
+  ]);
+  expect(quiet?.topErrors).toEqual([{ errorType: "fetch", count: 1 }]);
+});
+
+test("reconciliation totals are grouped per source", async () => {
+  const status = await getIngestionStatus(scopedDb);
+
+  const busy = status.sources.find((source) => source.name === "busy source");
+  const quiet = status.sources.find((source) => source.name === "quiet source");
+
+  expect(busy?.reconciliation).toMatchObject({
+    slices: 2,
+    shortSlices: 1,
+    failedSlices: 1,
+    parked: 1,
+    terminal: 1,
+  });
+  expect(quiet?.reconciliation).toBeNull();
+});

--- a/apps/api/src/handlers/case-law/ingestion/status.ts
+++ b/apps/api/src/handlers/case-law/ingestion/status.ts
@@ -1,8 +1,9 @@
-import { Result } from "better-result";
-import { count, desc, gte, sql } from "drizzle-orm";
+import { panic, Result } from "better-result";
+import { and, count, desc, gte, inArray, lte, max, sql } from "drizzle-orm";
 
 import { DAY_IN_MS } from "@stll/time";
 
+import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
   caseLawCoverageSlices,
@@ -16,6 +17,7 @@ import {
 import type { SourceTotalOrigin } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import { boundedAll } from "@/api/lib/db/bounded-all";
 import {
   CASE_LAW_SOURCE_ROWS_BOUND,
@@ -95,6 +97,247 @@ type IngestionStatus = {
   failures24h: number;
 };
 
+/** Error types reported per source, ranked by occurrences in the last day. */
+const TOP_ERROR_TYPES_PER_SOURCE = 3;
+
+/**
+ * Everything the report says about one source beyond its own row. Every field
+ * has a zero value, so a source no grouped read matched still reports the
+ * figures it had before: nothing, rather than a hole.
+ */
+type SourceAggregate = {
+  decisions: number;
+  insertedLastHour: number;
+  inserted24h: number;
+  failures24h: number;
+  topErrors: SourceStatus["topErrors"];
+  lastEvent: SourceStatus["lastEvent"];
+  slices: number;
+  shortSlices: number;
+  failedSlices: number;
+  lastCheckedAt: string | null;
+  parked: number;
+  terminal: number;
+};
+
+type SourceAggregates = Map<string, SourceAggregate>;
+
+const emptyAggregate = (): SourceAggregate => ({
+  decisions: 0,
+  insertedLastHour: 0,
+  inserted24h: 0,
+  failures24h: 0,
+  topErrors: [],
+  lastEvent: null,
+  slices: 0,
+  shortSlices: 0,
+  failedSlices: 0,
+  lastCheckedAt: null,
+  parked: 0,
+  terminal: 0,
+});
+
+/**
+ * Every source the caller asked about has an entry, because the map is seeded
+ * from the same id list the reads are filtered by. A miss is a defect in that
+ * pairing rather than a state a caller could handle.
+ */
+const requireAggregate = (
+  aggregates: SourceAggregates,
+  sourceId: SafeId<"caseLawSource">,
+): SourceAggregate =>
+  aggregates.get(sourceId) ??
+  panic(`Ingestion status read no aggregate slot for source ${sourceId}`);
+
+/**
+ * Every per-source figure as one grouped read, so the report costs a fixed
+ * number of statements however many sources exist.
+ *
+ * The reads run one after another rather than concurrently: a scoped-db
+ * callback holds a single transaction connection, which carries one in-flight
+ * statement at a time.
+ */
+const readSourceAggregates = async ({
+  db,
+  oneDayAgo,
+  oneHourAgo,
+  sourceIds,
+}: {
+  db: Transaction;
+  oneDayAgo: Date;
+  oneHourAgo: Date;
+  sourceIds: SafeId<"caseLawSource">[];
+}): Promise<SourceAggregates> => {
+  if (sourceIds.length === 0) {
+    return new Map();
+  }
+
+  const decisionRows = await db
+    .select({ sourceId: caseLawDecisions.sourceId, total: count() })
+    .from(caseLawDecisions)
+    .where(inArray(caseLawDecisions.sourceId, sourceIds))
+    .groupBy(caseLawDecisions.sourceId);
+
+  // Both cutoffs are cast in SQL so the comparison happens at the column's own
+  // precision rather than at the millisecond a JS Date carries.
+  const dayCutoff = sql`${oneDayAgo}::timestamptz`;
+  const hourCutoff = sql`${oneHourAgo}::timestamptz`;
+
+  // The hour window is a subset of the day window, so one pass over the day's
+  // events answers both: the filter narrows the sum, the row set stays shared.
+  const insertedRows = await db
+    .select({
+      sourceId: caseLawIngestionEvents.sourceId,
+      lastHour: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}) filter (where ${caseLawIngestionEvents.finishedAt} >= ${hourCutoff}), 0)::int`,
+      lastDay: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}), 0)::int`,
+    })
+    .from(caseLawIngestionEvents)
+    .where(
+      and(
+        inArray(caseLawIngestionEvents.sourceId, sourceIds),
+        gte(caseLawIngestionEvents.finishedAt, dayCutoff),
+      ),
+    )
+    .groupBy(caseLawIngestionEvents.sourceId);
+
+  const failureRows = await db
+    .select({ sourceId: caseLawIngestionFailures.sourceId, total: count() })
+    .from(caseLawIngestionFailures)
+    .where(
+      and(
+        inArray(caseLawIngestionFailures.sourceId, sourceIds),
+        gte(caseLawIngestionFailures.createdAt, dayCutoff),
+      ),
+    )
+    .groupBy(caseLawIngestionFailures.sourceId);
+
+  // Ranking inside the database keeps "top N per source" one statement; a
+  // plain group-by would have to ship every error type to rank it here.
+  const rankedFailures = db
+    .select({
+      sourceId: caseLawIngestionFailures.sourceId,
+      errorType: caseLawIngestionFailures.errorType,
+      total: count().as("error_type_total"),
+      rank: sql<number>`row_number() over (partition by ${caseLawIngestionFailures.sourceId} order by count(*) desc)`.as(
+        "error_type_rank",
+      ),
+    })
+    .from(caseLawIngestionFailures)
+    .where(
+      and(
+        inArray(caseLawIngestionFailures.sourceId, sourceIds),
+        gte(caseLawIngestionFailures.createdAt, dayCutoff),
+      ),
+    )
+    .groupBy(
+      caseLawIngestionFailures.sourceId,
+      caseLawIngestionFailures.errorType,
+    )
+    .as("ranked_failures");
+
+  const topErrorRows = await db
+    .select({
+      sourceId: rankedFailures.sourceId,
+      errorType: rankedFailures.errorType,
+      total: rankedFailures.total,
+    })
+    .from(rankedFailures)
+    .where(lte(rankedFailures.rank, TOP_ERROR_TYPES_PER_SOURCE))
+    .orderBy(rankedFailures.sourceId, rankedFailures.rank)
+    .limit(sourceIds.length * TOP_ERROR_TYPES_PER_SOURCE);
+
+  const lastEventRows = await db
+    .selectDistinctOn([caseLawIngestionEvents.sourceId], {
+      sourceId: caseLawIngestionEvents.sourceId,
+      status: caseLawIngestionEvents.status,
+      inserted: caseLawIngestionEvents.inserted,
+      skipped: caseLawIngestionEvents.skipped,
+      durationMs: caseLawIngestionEvents.durationMs,
+      finishedAt: caseLawIngestionEvents.finishedAt,
+      errorMessage: caseLawIngestionEvents.errorMessage,
+    })
+    .from(caseLawIngestionEvents)
+    .where(inArray(caseLawIngestionEvents.sourceId, sourceIds))
+    .orderBy(
+      caseLawIngestionEvents.sourceId,
+      desc(caseLawIngestionEvents.finishedAt),
+    )
+    .limit(sourceIds.length);
+
+  const coverageRows = await db
+    .select({
+      sourceId: caseLawCoverageSlices.sourceId,
+      // Surveyed means listed at least once; a row that only ever failed
+      // is counted under `failedSlices` alone.
+      slices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.reported} is not null then 1 else 0 end), 0)::int`,
+      shortSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.collected} < ${caseLawCoverageSlices.reported} then 1 else 0 end), 0)::int`,
+      failedSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.walkError} is not null then 1 else 0 end), 0)::int`,
+      // `max()` rather than raw SQL: drizzle then decodes the column with its
+      // own timestamp mapper instead of handing back whatever the driver
+      // returns for an untyped expression.
+      lastCheckedAt: max(caseLawCoverageSlices.checkedAt),
+    })
+    .from(caseLawCoverageSlices)
+    .where(inArray(caseLawCoverageSlices.sourceId, sourceIds))
+    .groupBy(caseLawCoverageSlices.sourceId);
+
+  const reconciliationItemRows = await db
+    .select({
+      sourceId: caseLawReconciliationItems.sourceId,
+      parked: sql<number>`coalesce(sum(case when ${caseLawReconciliationItems.status} = ${RECONCILIATION_ITEM_STATUS.PARKED} then 1 else 0 end), 0)::int`,
+      terminal: sql<number>`coalesce(sum(case when ${caseLawReconciliationItems.status} = ${RECONCILIATION_ITEM_STATUS.TERMINAL} then 1 else 0 end), 0)::int`,
+    })
+    .from(caseLawReconciliationItems)
+    .where(inArray(caseLawReconciliationItems.sourceId, sourceIds))
+    .groupBy(caseLawReconciliationItems.sourceId);
+
+  const aggregates: SourceAggregates = new Map(
+    sourceIds.map((sourceId) => [sourceId, emptyAggregate()]),
+  );
+
+  for (const row of decisionRows) {
+    requireAggregate(aggregates, row.sourceId).decisions = row.total;
+  }
+  for (const row of insertedRows) {
+    const aggregate = requireAggregate(aggregates, row.sourceId);
+    aggregate.insertedLastHour = row.lastHour;
+    aggregate.inserted24h = row.lastDay;
+  }
+  for (const row of failureRows) {
+    requireAggregate(aggregates, row.sourceId).failures24h = row.total;
+  }
+  for (const row of topErrorRows) {
+    requireAggregate(aggregates, row.sourceId).topErrors.push({
+      errorType: row.errorType,
+      count: row.total,
+    });
+  }
+  for (const row of lastEventRows) {
+    requireAggregate(aggregates, row.sourceId).lastEvent = {
+      status: row.status,
+      inserted: row.inserted,
+      skipped: row.skipped,
+      durationMs: row.durationMs,
+      finishedAt: row.finishedAt.toISOString(),
+      failed: row.errorMessage !== null,
+    };
+  }
+  for (const row of coverageRows) {
+    const aggregate = requireAggregate(aggregates, row.sourceId);
+    aggregate.slices = row.slices;
+    aggregate.shortSlices = row.shortSlices;
+    aggregate.failedSlices = row.failedSlices;
+    aggregate.lastCheckedAt = row.lastCheckedAt?.toISOString() ?? null;
+  }
+  for (const row of reconciliationItemRows) {
+    const aggregate = requireAggregate(aggregates, row.sourceId);
+    aggregate.parked = row.parked;
+    aggregate.terminal = row.terminal;
+  }
+
+  return aggregates;
+};
+
 export const getIngestionStatus = async (
   scopedDb: ScopedDb,
 ): Promise<IngestionStatus> => {
@@ -123,114 +366,32 @@ export const getIngestionStatus = async (
           .limit(limit),
     });
 
+    const aggregates = await readSourceAggregates({
+      db,
+      oneDayAgo,
+      oneHourAgo,
+      sourceIds: sources.map((source) => source.id),
+    });
+
     const sourceStatuses: SourceStatus[] = [];
     const reportUnrecognizedSource = createUnrecognizedSourceReporter(
       "case_law.ingestion_status",
     );
 
     for (const source of sources) {
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential by design: single scoped-db transaction client, must not be parallelized
-      const [totalRow] = await db
-        .select({ total: count() })
-        .from(caseLawDecisions)
-        .where(sql`${caseLawDecisions.sourceId} = ${source.id}`);
-
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
-      const [hourRow] = await db
-        .select({
-          inserted: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}), 0)::int`,
-        })
-        .from(caseLawIngestionEvents)
-        .where(
-          sql`${caseLawIngestionEvents.sourceId} = ${source.id}
-            AND ${caseLawIngestionEvents.finishedAt} >= ${oneHourAgo}`,
-        );
-
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
-      const [dayRow] = await db
-        .select({
-          inserted: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}), 0)::int`,
-        })
-        .from(caseLawIngestionEvents)
-        .where(
-          sql`${caseLawIngestionEvents.sourceId} = ${source.id}
-            AND ${caseLawIngestionEvents.finishedAt} >= ${oneDayAgo}`,
-        );
-
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
-      const [failRow] = await db
-        .select({ total: count() })
-        .from(caseLawIngestionFailures)
-        .where(
-          sql`${caseLawIngestionFailures.sourceId} = ${source.id}
-            AND ${caseLawIngestionFailures.createdAt} >= ${oneDayAgo}`,
-        );
-
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
-      const [lastEvent] = await db
-        .select({
-          status: caseLawIngestionEvents.status,
-          inserted: caseLawIngestionEvents.inserted,
-          skipped: caseLawIngestionEvents.skipped,
-          durationMs: caseLawIngestionEvents.durationMs,
-          finishedAt: caseLawIngestionEvents.finishedAt,
-          errorMessage: caseLawIngestionEvents.errorMessage,
-        })
-        .from(caseLawIngestionEvents)
-        .where(sql`${caseLawIngestionEvents.sourceId} = ${source.id}`)
-        .orderBy(desc(caseLawIngestionEvents.finishedAt))
-        .limit(1);
-
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
-      const topFailures = await db
-        .select({
-          errorType: caseLawIngestionFailures.errorType,
-          count: count(),
-        })
-        .from(caseLawIngestionFailures)
-        .where(
-          sql`${caseLawIngestionFailures.sourceId} = ${source.id}
-            AND ${caseLawIngestionFailures.createdAt} >= ${oneDayAgo}`,
-        )
-        .groupBy(caseLawIngestionFailures.errorType)
-        .orderBy(desc(count()))
-        .limit(3);
-
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
-      const [sliceRow] = await db
-        .select({
-          // Surveyed means listed at least once; a row that only ever failed
-          // is counted under `failedSlices` alone.
-          slices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.reported} is not null then 1 else 0 end), 0)::int`,
-          shortSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.collected} < ${caseLawCoverageSlices.reported} then 1 else 0 end), 0)::int`,
-          failedSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.walkError} is not null then 1 else 0 end), 0)::int`,
-          lastCheckedAt: sql<Date | null>`max(${caseLawCoverageSlices.checkedAt})`,
-        })
-        .from(caseLawCoverageSlices)
-        .where(sql`${caseLawCoverageSlices.sourceId} = ${source.id}`);
-
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
-      const [itemRow] = await db
-        .select({
-          parked: sql<number>`coalesce(sum(case when ${caseLawReconciliationItems.status} = ${RECONCILIATION_ITEM_STATUS.PARKED} then 1 else 0 end), 0)::int`,
-          terminal: sql<number>`coalesce(sum(case when ${caseLawReconciliationItems.status} = ${RECONCILIATION_ITEM_STATUS.TERMINAL} then 1 else 0 end), 0)::int`,
-        })
-        .from(caseLawReconciliationItems)
-        .where(sql`${caseLawReconciliationItems.sourceId} = ${source.id}`);
-
-      const slices = sliceRow?.slices ?? 0;
-      const parked = itemRow?.parked ?? 0;
-      const terminal = itemRow?.terminal ?? 0;
+      const aggregate = requireAggregate(aggregates, source.id);
       const reconciliation: SourceReconciliationStatus | null =
-        slices === 0 && parked === 0 && terminal === 0
+        aggregate.slices === 0 &&
+        aggregate.parked === 0 &&
+        aggregate.terminal === 0
           ? null
           : {
-              slices,
-              shortSlices: sliceRow?.shortSlices ?? 0,
-              failedSlices: sliceRow?.failedSlices ?? 0,
-              parked,
-              terminal,
-              lastCheckedAt: sliceRow?.lastCheckedAt?.toISOString() ?? null,
+              slices: aggregate.slices,
+              shortSlices: aggregate.shortSlices,
+              failedSlices: aggregate.failedSlices,
+              parked: aggregate.parked,
+              terminal: aggregate.terminal,
+              lastCheckedAt: aggregate.lastCheckedAt,
             };
 
       const membership = sourceRegistryMembership(source.adapterKey);
@@ -244,27 +405,15 @@ export const getIngestionStatus = async (
         name: source.name,
         enabled: source.enabled,
         syncCursor: source.syncCursor,
-        totalDecisions: totalRow?.total ?? 0,
+        totalDecisions: aggregate.decisions,
         reportedTotal: source.reportedTotal,
         reportedTotalAsOf: source.reportedTotalAsOf?.toISOString() ?? null,
         reportedTotalOrigin: source.reportedTotalOrigin,
-        insertedLastHour: hourRow?.inserted ?? 0,
-        inserted24h: dayRow?.inserted ?? 0,
-        failures24h: failRow?.total ?? 0,
-        lastEvent: lastEvent
-          ? {
-              status: lastEvent.status,
-              inserted: lastEvent.inserted,
-              skipped: lastEvent.skipped,
-              durationMs: lastEvent.durationMs,
-              finishedAt: lastEvent.finishedAt.toISOString(),
-              failed: lastEvent.errorMessage !== null,
-            }
-          : null,
-        topErrors: topFailures.map((f) => ({
-          errorType: f.errorType,
-          count: f.count,
-        })),
+        insertedLastHour: aggregate.insertedLastHour,
+        inserted24h: aggregate.inserted24h,
+        failures24h: aggregate.failures24h,
+        lastEvent: aggregate.lastEvent,
+        topErrors: aggregate.topErrors,
         reconciliation,
       });
     }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -777,7 +777,7 @@
     }
   },
   "no-db-await-in-loop-suppressions": {
-    "count": 124,
+    "count": 116,
     "files": {
       "apps/api/scripts/backfill-image-thumbnails.ts": 3,
       "apps/api/scripts/backfill-search-previews.ts": 1,
@@ -789,7 +789,6 @@
       "apps/api/src/handlers/case-law/ingestion/decision-identifier-backfill.ts": 1,
       "apps/api/src/handlers/case-law/ingestion/pipeline.ts": 2,
       "apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts": 2,
-      "apps/api/src/handlers/case-law/ingestion/status.ts": 8,
       "apps/api/src/handlers/case-law/research/columns-reorder.ts": 1,
       "apps/api/src/handlers/chat/delete-thread.ts": 2,
       "apps/api/src/handlers/chat/tools/external-mcp-tools.ts": 1,


### PR DESCRIPTION
First of a series that walks the `no-db-await-in-loop` suppression count
down to the sites that genuinely need it.

## The site

`getIngestionStatus` looped over `case_law_sources` and issued seven
aggregate queries per source:

- decision count
- inserts in the last hour
- inserts in the last day
- failures in the last day
- top three error types in the last day
- the latest ingestion event
- coverage-slice totals and reconciliation-item totals

Eight suppressions, and a query count that grows with the source
catalogue.

## The batching shape

Each figure is now one grouped statement over every source id, folded
into a per-source aggregate that the assembly loop reads out of a map:

- `count(*) ... group by source_id` for decisions and for failures.
- One pass over the day's events answers both insert windows: the hour
  figure is `sum(inserted) filter (where finished_at >= <hour cutoff>)`,
  the day figure the unfiltered sum. The hour window is a subset of the
  day window, so the narrower one costs a filter rather than a query.
- Top error types rank inside the database
  (`row_number() over (partition by source_id order by count(*) desc)`,
  cut at `TOP_ERROR_TYPES_PER_SOURCE`), so "top N per source" stays one
  statement rather than shipping every error type back to be sorted here.
- The latest event uses `DISTINCT ON (source_id) ... ORDER BY source_id,
  finished_at DESC`.
- Coverage slices and reconciliation items keep their conditional sums,
  grouped by `source_id`.

Cost is a fixed eight statements whatever the catalogue holds.

The reads stay sequential rather than moving to `Promise.all`: a
scoped-db callback holds one transaction connection, which carries one
in-flight statement at a time.

## Two details worth a reviewer's eye

- The aggregate map is seeded from the same id list the reads are
  filtered by, so every source has an entry and a miss is a defect, not
  a state to handle — `requireAggregate` panics rather than falling back
  to a default. This also keeps `nullish-array-fallback` where it was.
- `max(checked_at)` moves from a raw `sql` expression to drizzle's
  `max()`, so the column's own decoder runs. The raw form returned
  whatever the driver produced for an untyped expression, which is a
  string on pglite and made `.toISOString()` throw; the batched read is
  now driver-independent.
- The two cutoffs are cast `::timestamptz` in SQL, since as parameters
  they are no longer visibly clock-derived to
  `no-truncated-timestamp-comparison`.

## Test

New `status.db.test.ts` (pglite) seeds two sources with deliberately
different counts across all five tables and asserts the per-source
figures, the latest event, the error ranking and the reconciliation
totals. Two sources is the smallest fixture that can catch a group key
landing on the wrong row; a single-source fixture cannot.

## Ratchet

`no-db-await-in-loop-suppressions`: 124 -> 116. No other metric touched.
(Rebased onto main after the rule widened; the count is the same eight
directives removed, measured against the new ceiling.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved ingestion status reporting by consolidating data processing, which can reduce loading times for status views.
  - Status summaries now provide consistent per-source metrics, including event counts, failures, error rankings, coverage, and reconciliation totals.

- **Reliability**
  - Expanded validation of ingestion status results across multiple sources and event conditions to help ensure accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->