### PR TITLE
perf(api): rows built in a loop go in as one insert

### DIFF
--- a/apps/api/src/handlers/properties/create-batch.ts
+++ b/apps/api/src/handlers/properties/create-batch.ts
@@ -8,6 +8,7 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditEvent } from "@/api/lib/audit-log";
+import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
@@ -121,55 +122,46 @@ const createPropertiesBatch = createSafeHandler(
           }
         }
 
-        const insertedIds: string[] = [];
+        const propertyRows: (typeof properties.$inferInsert)[] = [];
+        const dependencyRows: (typeof propertyDependencies.$inferInsert)[] = [];
+        const insertedIds: SafeId<"property">[] = [];
         const auditEvents: AuditEvent[] = [];
 
+        // Ids are minted here rather than read back from `returning`, so the
+        // rows, their dependency rows and their audit events can be assembled
+        // in full before anything is written: three statements for the batch
+        // instead of two per item.
         for (const { name, built } of builtItems) {
           if ("status" in built) {
             continue;
           }
           const { content, tool, dependencies, role } = built;
-          const initialStatus = tool.type === "ai-model" ? "stale" : "fresh";
+          const propertyId = createSafeId<"property">();
 
-          // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential property inserts in one transaction; each row's id feeds its dependency rows and audit event
-          const [inserted] = await tx
-            .insert(properties)
-            .values({
+          propertyRows.push({
+            id: propertyId,
+            workspaceId,
+            name,
+            content,
+            tool,
+            kinds: propertyKindsForTool(tool),
+            role,
+            status: tool.type === "ai-model" ? "stale" : "fresh",
+          });
+
+          for (const { dependsOnPropertyId, condition } of dependencies) {
+            dependencyRows.push({
               workspaceId,
-              name,
-              content,
-              tool,
-              kinds: propertyKindsForTool(tool),
-              role,
-              status: initialStatus,
-            })
-            .returning({ id: properties.id });
-
-          if (!inserted) {
-            // Earlier iterations of this loop already inserted properties,
-            // dependency rows, and audit events that would otherwise commit.
-            throw new HandlerError({
-              status: 500,
-              message: "Failed to create property",
+              propertyId,
+              dependsOnPropertyId,
+              condition,
             });
-          }
-
-          if (dependencies.length > 0) {
-            // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- dependency rows reference the property id just inserted above in this iteration
-            await tx.insert(propertyDependencies).values(
-              dependencies.map(({ dependsOnPropertyId, condition }) => ({
-                workspaceId,
-                propertyId: inserted.id,
-                dependsOnPropertyId,
-                condition,
-              })),
-            );
           }
 
           auditEvents.push({
             action: AUDIT_ACTION.CREATE,
             resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,
-            resourceId: inserted.id,
+            resourceId: propertyId,
             changes: {
               created: {
                 old: null,
@@ -182,7 +174,14 @@ const createPropertiesBatch = createSafeHandler(
             },
           });
 
-          insertedIds.push(inserted.id);
+          insertedIds.push(propertyId);
+        }
+
+        if (propertyRows.length > 0) {
+          await tx.insert(properties).values(propertyRows);
+        }
+        if (dependencyRows.length > 0) {
+          await tx.insert(propertyDependencies).values(dependencyRows);
         }
 
         // The recorder inserts an array in one statement, and one request is

--- a/apps/api/src/handlers/time-entries/split.ts
+++ b/apps/api/src/handlers/time-entries/split.ts
@@ -163,8 +163,10 @@ const splitEntry = createSafeHandler(
           durationMinutes: number;
           billedMinutes: number;
         }[] = [];
+        const successorRows: (typeof timeEntries.$inferInsert)[] = [];
 
-        // Create split entries
+        // Ids are minted here, so the successors go in as one insert and the
+        // audit events below need nothing read back.
         for (let i = 0; i < body.splits.length; i++) {
           const split = body.splits[i];
           const durationMinutes = durations[i];
@@ -172,44 +174,44 @@ const splitEntry = createSafeHandler(
             continue;
           }
           const billedMinutes = roundToBillingIncrement(durationMinutes);
+          const entryId = createSafeId<"timeEntry">();
 
-          // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential inserts create ordered successor rows for the split entry
-          const [entry] = await tx
-            .insert(timeEntries)
-            .values({
-              organizationId: original.organizationId,
-              workspaceId,
-              userId: original.userId,
-              workItemId: split.workItemId,
-              dateWorked: original.dateWorked,
-              timezoneId: original.timezoneId,
-              durationMinutes,
-              billedMinutes,
-              rateAtEntry: original.rateAtEntry,
-              currency: original.currency,
-              narrative: original.narrative,
-              invoiceNarrative: original.invoiceNarrative,
-              billable: original.billable,
-              noCharge: original.noCharge,
-              status: original.status,
-              source: original.source,
-              taskCode: original.taskCode,
-              activityCode: original.activityCode,
-              splitGroupId,
-              createdAt: now,
-              updatedAt: now,
-            })
-            .returning({ id: timeEntries.id });
+          successorRows.push({
+            id: entryId,
+            organizationId: original.organizationId,
+            workspaceId,
+            userId: original.userId,
+            workItemId: split.workItemId,
+            dateWorked: original.dateWorked,
+            timezoneId: original.timezoneId,
+            durationMinutes,
+            billedMinutes,
+            rateAtEntry: original.rateAtEntry,
+            currency: original.currency,
+            narrative: original.narrative,
+            invoiceNarrative: original.invoiceNarrative,
+            billable: original.billable,
+            noCharge: original.noCharge,
+            status: original.status,
+            source: original.source,
+            taskCode: original.taskCode,
+            activityCode: original.activityCode,
+            splitGroupId,
+            createdAt: now,
+            updatedAt: now,
+          });
 
-          if (entry) {
-            newEntryIds.push(entry.id);
-            createdEntries.push({
-              id: entry.id,
-              workItemId: split.workItemId,
-              durationMinutes,
-              billedMinutes,
-            });
-          }
+          newEntryIds.push(entryId);
+          createdEntries.push({
+            id: entryId,
+            workItemId: split.workItemId,
+            durationMinutes,
+            billedMinutes,
+          });
+        }
+
+        if (successorRows.length > 0) {
+          await tx.insert(timeEntries).values(successorRows);
         }
 
         const events: AuditEvent[] = [

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -78,11 +78,9 @@ const createTemplatePropertyValidationTx = () => {
 };
 
 const createTemplateDependencyTx = () => {
-  const createdPropertyIds = ["created_a", "created_b"];
-  const returningMock = mock(async () => [{ id: createdPropertyIds.shift() }]);
-  const propertyValuesMock = mock(() => ({
-    returning: returningMock,
-  }));
+  const propertyValuesMock = mock(
+    (_rows: (typeof properties.$inferInsert)[]) => undefined,
+  );
   const dependencyValuesMock = mock(() => ({
     onConflictDoNothing: mock(async () => undefined),
   }));
@@ -120,7 +118,7 @@ const createTemplateDependencyTx = () => {
   return {
     dependencyValuesMock,
     executeMock,
-    returningMock,
+    propertyValuesMock,
     tx: asTestRaw<Transaction>(tx),
   };
 };
@@ -152,10 +150,9 @@ const createTemplateReuseTx = (
   const existingProperties = Array.isArray(existingProperty)
     ? existingProperty
     : [existingProperty];
-  const returningMock = mock(async () => [{ id: "created_property" }]);
-  const propertyValuesMock = mock((_row: typeof properties.$inferInsert) => ({
-    returning: returningMock,
-  }));
+  const propertyValuesMock = mock(
+    (_rows: (typeof properties.$inferInsert)[]) => undefined,
+  );
   const dependencyValuesMock = mock(() => ({
     onConflictDoNothing: mock(async () => undefined),
   }));
@@ -198,9 +195,22 @@ const createTemplateReuseTx = (
     insert: insertMock,
   };
 
+  /** Every column row the resolver wrote, in insert order. */
+  const createdPropertyRows = (): (typeof properties.$inferInsert)[] =>
+    propertyValuesMock.mock.calls.flatMap(([rows]) => rows);
+
+  // The resolver mints column ids before writing, so the id it hands back is
+  // only correct if it is the id it inserted. Reading the ids off the insert
+  // is what pins that; a fixture id would pin the fixture instead.
+  const createdPropertyIds = (): string[] =>
+    createdPropertyRows().map((row) =>
+      typeof row.id === "string" ? row.id : "",
+    );
+
   return {
+    createdPropertyIds,
+    createdPropertyRows,
     propertyValuesMock,
-    returningMock,
     tx: asTestRaw<Transaction>(tx),
   };
 };
@@ -555,7 +565,7 @@ describe("resolveTemplateProperties", () => {
   });
 
   test("rejects cyclic dependencies between newly created template columns", async () => {
-    const { dependencyValuesMock, executeMock, returningMock, tx } =
+    const { dependencyValuesMock, executeMock, propertyValuesMock, tx } =
       createTemplateDependencyTx();
     const propertyA = {
       version: 1,
@@ -590,12 +600,12 @@ describe("resolveTemplateProperties", () => {
     expect(rejection.status).toBe(422);
     expect(rejection.message).toBe("Circular template dependency detected");
     expect(executeMock).toHaveBeenCalledTimes(1);
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
     expect(dependencyValuesMock).not.toHaveBeenCalled();
   });
 
   test("reuses existing shape matches only once", async () => {
-    const { returningMock, tx } = createTemplateReuseTx();
+    const { createdPropertyIds, tx } = createTemplateReuseTx();
     const firstProperty = {
       version: 1,
       sourceId: "source_a",
@@ -628,18 +638,22 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
+    expect(createdPropertyIds()).toHaveLength(1);
+    const [createdId] = createdPropertyIds();
+    if (createdId === undefined) {
+      throw new TypeError("Expected the resolver to create one column");
+    }
     expect(result).toEqual({
       layout: {
         ...layout,
-        columnOrder: ["existing_property", "created_property"],
+        columnOrder: ["existing_property", createdId],
       },
-      propertyIds: ["existing_property", "created_property"],
+      propertyIds: ["existing_property", createdId],
     });
-    expect(returningMock).toHaveBeenCalledTimes(1);
   });
 
   test("does not reuse AI shape matches when either side has dependencies", async () => {
-    const { returningMock, tx } = createTemplateReuseTx(
+    const { createdPropertyIds, tx } = createTemplateReuseTx(
       {
         id: "existing_property",
         name: "Summary",
@@ -676,23 +690,28 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
+    expect(createdPropertyIds()).toHaveLength(1);
+    const [createdId] = createdPropertyIds();
+    if (createdId === undefined) {
+      throw new TypeError("Expected the resolver to create one column");
+    }
     expect(result).toEqual({
       layout: {
         ...layout,
-        columnOrder: ["created_property"],
+        columnOrder: [createdId],
       },
-      propertyIds: ["existing_property", "created_property"],
+      propertyIds: ["existing_property", createdId],
     });
-    expect(returningMock).toHaveBeenCalledTimes(1);
   });
 
   test("sanitizes AI prompt markup before persisting template-created columns", async () => {
-    const { propertyValuesMock, returningMock, tx } = createTemplateReuseTx({
-      id: "existing_property",
-      name: "Other",
-      content: { version: 1, type: "text" },
-      tool: { version: 1, type: "manual-input" },
-    });
+    const { createdPropertyIds, createdPropertyRows, tx } =
+      createTemplateReuseTx({
+        id: "existing_property",
+        name: "Other",
+        content: { version: 1, type: "text" },
+        tool: { version: 1, type: "manual-input" },
+      });
     const templateProperty = {
       version: 1,
       sourceId: "source_unsafe_ai",
@@ -715,8 +734,8 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
-    expect(returningMock).toHaveBeenCalledTimes(1);
-    const persistedTool = propertyValuesMock.mock.calls[0]?.[0].tool;
+    expect(createdPropertyIds()).toHaveLength(1);
+    const persistedTool = createdPropertyRows().at(0)?.tool;
     expect(persistedTool?.type).toBe("ai-model");
     const prompt =
       persistedTool?.type === "ai-model" ? persistedTool.prompt : "";
@@ -736,13 +755,14 @@ describe("resolveTemplateProperties", () => {
       type: "ai-model",
       prompt: "Classify the document type.",
     } satisfies ViewTemplateProperty["tool"];
-    const { propertyValuesMock, returningMock, tx } = createTemplateReuseTx({
-      id: "existing_property",
-      name: "Type de document",
-      content,
-      tool,
-      role: null,
-    });
+    const { createdPropertyIds, createdPropertyRows, tx } =
+      createTemplateReuseTx({
+        id: "existing_property",
+        name: "Type de document",
+        content,
+        tool,
+        role: null,
+      });
     const templateProperty = {
       version: 1,
       sourceId: "source_document_type",
@@ -762,8 +782,8 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
-    expect(returningMock).toHaveBeenCalledTimes(1);
-    expect(propertyValuesMock.mock.calls[0]?.[0]).toEqual(
+    expect(createdPropertyIds()).toHaveLength(1);
+    expect(createdPropertyRows().at(0)).toEqual(
       expect.objectContaining({
         role: DOCUMENT_TYPE_CLASSIFIER_ROLE,
       }),
@@ -771,7 +791,7 @@ describe("resolveTemplateProperties", () => {
   });
 
   test("rejects structural roles on non-classifier templates", async () => {
-    const { returningMock, tx } = createTemplateReuseTx();
+    const { propertyValuesMock, tx } = createTemplateReuseTx();
     const templateProperty = {
       version: 1,
       sourceId: "source_notes",
@@ -797,7 +817,7 @@ describe("resolveTemplateProperties", () => {
     expect(rejection.message).toBe(
       "Document type classifier templates must be AI single-select columns",
     );
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("rejects duplicate classifier roles in one template payload", async () => {
@@ -855,7 +875,7 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { returningMock, tx } = createTemplateReuseTx({
+    const { propertyValuesMock, tx } = createTemplateReuseTx({
       id: "existing_property",
       name: "Dokumenttyp",
       content: {
@@ -899,7 +919,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout("existing_property"),
       propertyIds: ["existing_property"],
     });
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("falls through exact-id reuse for stale role-bearing templates", async () => {
@@ -909,7 +929,7 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { returningMock, tx } = createTemplateReuseTx([
+    const { propertyValuesMock, tx } = createTemplateReuseTx([
       {
         id: "source_document_type",
         name: "Document Type",
@@ -956,7 +976,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout("tagged_classifier"),
       propertyIds: ["source_document_type", "tagged_classifier"],
     });
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("falls through exact-id reuse for stale inferred legacy classifiers", async () => {
@@ -966,7 +986,7 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { returningMock, tx } = createTemplateReuseTx([
+    const { propertyValuesMock, tx } = createTemplateReuseTx([
       {
         id: "source_document_type",
         name: "Document Type",
@@ -1012,7 +1032,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout("tagged_classifier"),
       propertyIds: ["source_document_type", "tagged_classifier"],
     });
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("reuses legacy classifiers for explicit role templates", async () => {
@@ -1022,7 +1042,7 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { returningMock, tx } = createTemplateReuseTx({
+    const { propertyValuesMock, tx } = createTemplateReuseTx({
       id: "existing_property",
       name: "Document Type",
       content: templateContent,
@@ -1060,7 +1080,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout("existing_property"),
       propertyIds: ["existing_property"],
     });
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("rejects malformed structural role matches", async () => {
@@ -1070,7 +1090,7 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { returningMock, tx } = createTemplateReuseTx({
+    const { propertyValuesMock, tx } = createTemplateReuseTx({
       id: "existing_property",
       name: "Document Type",
       content: { version: 1, type: "text" },
@@ -1106,7 +1126,7 @@ describe("resolveTemplateProperties", () => {
     expect(rejection.message).toBe(
       "Document type classifier role is attached to an incompatible column",
     );
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("reuses role-tagged classifiers for legacy roleless templates", async () => {
@@ -1116,7 +1136,7 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { returningMock, tx } = createTemplateReuseTx({
+    const { propertyValuesMock, tx } = createTemplateReuseTx({
       id: "existing_property",
       name: "Type de document",
       content: templateContent,
@@ -1153,7 +1173,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout("existing_property"),
       propertyIds: ["existing_property"],
     });
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("reuses roleless legacy classifiers for legacy roleless templates", async () => {
@@ -1168,7 +1188,7 @@ describe("resolveTemplateProperties", () => {
       type: "ai-model",
       prompt: "Classify the document type.",
     } satisfies ViewTemplateProperty["tool"];
-    const { returningMock, tx } = createTemplateReuseTx({
+    const { propertyValuesMock, tx } = createTemplateReuseTx({
       id: "existing_property",
       name: "Document Type",
       content: templateContent,
@@ -1197,7 +1217,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout("existing_property"),
       propertyIds: ["existing_property"],
     });
-    expect(returningMock).not.toHaveBeenCalled();
+    expect(propertyValuesMock).not.toHaveBeenCalled();
   });
 
   test("tags legacy roleless classifier templates when creating", async () => {
@@ -1207,7 +1227,8 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { propertyValuesMock, returningMock, tx } = createTemplateReuseTx();
+    const { createdPropertyIds, createdPropertyRows, tx } =
+      createTemplateReuseTx();
     const templateProperty = {
       version: 1,
       sourceId: "source_document_type",
@@ -1230,8 +1251,8 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
-    expect(returningMock).toHaveBeenCalledTimes(1);
-    expect(propertyValuesMock.mock.calls[0]?.[0]).toEqual(
+    expect(createdPropertyIds()).toHaveLength(1);
+    expect(createdPropertyRows().at(0)).toEqual(
       expect.objectContaining({
         role: DOCUMENT_TYPE_CLASSIFIER_ROLE,
       }),
@@ -1245,7 +1266,8 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { propertyValuesMock, returningMock, tx } = createTemplateReuseTx();
+    const { createdPropertyIds, createdPropertyRows, tx } =
+      createTemplateReuseTx();
     const templateProperty = {
       version: 1,
       sourceId: "source_document_type",
@@ -1269,8 +1291,8 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
-    expect(returningMock).toHaveBeenCalledTimes(1);
-    expect(propertyValuesMock.mock.calls[0]?.[0]).toEqual(
+    expect(createdPropertyIds()).toHaveLength(1);
+    expect(createdPropertyRows().at(0)).toEqual(
       expect.objectContaining({
         role: null,
       }),
@@ -1278,7 +1300,8 @@ describe("resolveTemplateProperties", () => {
   });
 
   test("allows explicit roleless ordinary templates when creating", async () => {
-    const { propertyValuesMock, returningMock, tx } = createTemplateReuseTx();
+    const { createdPropertyIds, createdPropertyRows, tx } =
+      createTemplateReuseTx();
     const templateProperty = {
       version: 1,
       sourceId: "source_notes",
@@ -1298,8 +1321,8 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
-    expect(returningMock).toHaveBeenCalledTimes(1);
-    expect(propertyValuesMock.mock.calls[0]?.[0]).toEqual(
+    expect(createdPropertyIds()).toHaveLength(1);
+    expect(createdPropertyRows().at(0)).toEqual(
       expect.objectContaining({
         role: null,
       }),
@@ -1313,7 +1336,8 @@ describe("resolveTemplateProperties", () => {
       options: [{ color: "blue", value: "Contract" }],
       fallback: null,
     } satisfies ViewTemplateProperty["content"];
-    const { propertyValuesMock, returningMock, tx } = createTemplateReuseTx();
+    const { createdPropertyIds, createdPropertyRows, tx } =
+      createTemplateReuseTx();
     const explicitClassifier = {
       version: 1,
       sourceId: "source_document_type_tagged",
@@ -1359,19 +1383,15 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
-    expect(returningMock).toHaveBeenCalledTimes(2);
-    const insertedRows = propertyValuesMock.mock.calls.flatMap((call) => {
-      const row = call.at(0);
-      return row ? [row] : [];
-    });
-    expect(insertedRows.map(({ role }) => role)).toEqual([
+    expect(createdPropertyIds()).toHaveLength(2);
+    expect(createdPropertyRows().map(({ role }) => role)).toEqual([
       DOCUMENT_TYPE_CLASSIFIER_ROLE,
       null,
     ]);
   });
 
   test("does not reuse shape matches with different config", async () => {
-    const { returningMock, tx } = createTemplateReuseTx({
+    const { createdPropertyIds, tx } = createTemplateReuseTx({
       id: "existing_property",
       name: "Status",
       content: {
@@ -1415,13 +1435,17 @@ describe("resolveTemplateProperties", () => {
       recordAuditEvent: noopAuditRecorder,
     });
 
+    expect(createdPropertyIds()).toHaveLength(1);
+    const [createdId] = createdPropertyIds();
+    if (createdId === undefined) {
+      throw new TypeError("Expected the resolver to create one column");
+    }
     expect(result).toEqual({
       layout: {
         ...layout,
-        columnOrder: ["created_property"],
+        columnOrder: [createdId],
       },
-      propertyIds: ["existing_property", "created_property"],
+      propertyIds: ["existing_property", createdId],
     });
-    expect(returningMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/lib/views/template-properties.db.test.ts
+++ b/apps/api/src/lib/views/template-properties.db.test.ts
@@ -249,3 +249,44 @@ test("the resolver rejects an invalid template before writing anything", async (
     dependencies: 0,
   });
 });
+
+// The columns go in as one multi-row insert, so nothing but the assembly order
+// decides which id belongs to which template column. This pins that the ids the
+// caller is handed name the rows the template asked for, in its order, and that
+// the dependency edge connects the right two of them.
+test("batched column creation keeps ids paired with their template columns", async () => {
+  const workspaceId = await seedWorkspace();
+
+  const outcome = await runResolve(workspaceId, "commit");
+
+  expect(Result.isOk(outcome)).toBe(true);
+  if (!Result.isOk(outcome)) {
+    throw new TypeError("Expected the resolver to commit");
+  }
+
+  const persisted = await testDb
+    .select({ id: properties.id, name: properties.name })
+    .from(properties)
+    .where(eq(properties.workspaceId, workspaceId));
+  const nameById = new Map(persisted.map((row) => [row.id, row.name]));
+
+  expect(outcome.value.propertyIds.map((id) => nameById.get(id))).toEqual([
+    "Counterparty",
+    "Summary",
+  ]);
+
+  const edges = await testDb
+    .select({
+      propertyId: propertyDependencies.propertyId,
+      dependsOnPropertyId: propertyDependencies.dependsOnPropertyId,
+    })
+    .from(propertyDependencies)
+    .where(eq(propertyDependencies.workspaceId, workspaceId));
+
+  expect(
+    edges.map((edge) => [
+      nameById.get(edge.propertyId),
+      nameById.get(edge.dependsOnPropertyId),
+    ]),
+  ).toEqual([["Summary", "Counterparty"]]);
+});

--- a/apps/api/src/lib/views/template-properties.db.test.ts
+++ b/apps/api/src/lib/views/template-properties.db.test.ts
@@ -268,7 +268,11 @@ test("batched column creation keeps ids paired with their template columns", asy
     .select({ id: properties.id, name: properties.name })
     .from(properties)
     .where(eq(properties.workspaceId, workspaceId));
-  const nameById = new Map(persisted.map((row) => [row.id, row.name]));
+  // Widened to `string` because the resolver hands back the branded and the
+  // unbranded id types on different paths; only the name matters here.
+  const nameById = new Map<string, string>(
+    persisted.map((row) => [row.id, row.name]),
+  );
 
   expect(outcome.value.propertyIds.map((id) => nameById.get(id))).toEqual([
     "Counterparty",

--- a/apps/api/src/lib/views/template-properties.ts
+++ b/apps/api/src/lib/views/template-properties.ts
@@ -8,6 +8,7 @@ import { properties, propertyDependencies } from "@/api/db/schema";
 import { arrayOrEmpty } from "@/api/lib/array";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
+import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   collectNodePropertyIds,
@@ -335,38 +336,34 @@ export const resolveTemplateProperties = async ({
   }
 
   const auditEvents: AuditEvent[] = [];
+  const propertyRows: (typeof properties.$inferInsert)[] = [];
 
+  // Ids are minted here rather than read back from `returning`: the source-id
+  // mapping and the audit rows then need nothing from the database, so the
+  // whole set of new columns goes in as one statement. Column order still
+  // comes from `templatePropertiesToCreate`, which is what `nextPropertyIds`
+  // records.
   for (const templateProperty of templatePropertiesToCreate) {
-    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential inserts preserve column order and feed the source-id mapping
-    const [inserted] = await tx
-      .insert(properties)
-      .values({
-        workspaceId,
-        name: templateProperty.name,
-        content: templateProperty.content,
-        tool: sanitizeTemplatePropertyTool(templateProperty.tool),
-        kinds: propertyKindsForTool(templateProperty.tool),
-        role: resolveTemplatePropertyRole(templateProperty, roleResolution),
-        status: templateProperty.tool.type === "ai-model" ? "stale" : "fresh",
-      })
-      .returning({ id: properties.id });
+    const propertyId = createSafeId<"property">();
 
-    if (!inserted) {
-      // Earlier iterations already inserted their columns and audit rows, so
-      // returning here would commit them behind the error.
-      throw new HandlerError({
-        status: 400,
-        message: "Failed to create template column",
-      });
-    }
+    propertyRows.push({
+      id: propertyId,
+      workspaceId,
+      name: templateProperty.name,
+      content: templateProperty.content,
+      tool: sanitizeTemplatePropertyTool(templateProperty.tool),
+      kinds: propertyKindsForTool(templateProperty.tool),
+      role: resolveTemplatePropertyRole(templateProperty, roleResolution),
+      status: templateProperty.tool.type === "ai-model" ? "stale" : "fresh",
+    });
 
-    propertyIdBySourceId.set(templateProperty.sourceId, inserted.id);
-    nextPropertyIds.push(inserted.id);
+    propertyIdBySourceId.set(templateProperty.sourceId, propertyId);
+    nextPropertyIds.push(propertyId);
 
     auditEvents.push({
       action: AUDIT_ACTION.CREATE,
       resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,
-      resourceId: inserted.id,
+      resourceId: propertyId,
       changes: {
         createdFromViewTemplate: {
           old: null,
@@ -380,8 +377,11 @@ export const resolveTemplateProperties = async ({
     });
   }
 
-  // Column order comes from the inserts above; the audit rows carry it in
-  // their own order and go in as one statement.
+  if (propertyRows.length > 0) {
+    await tx.insert(properties).values(propertyRows);
+  }
+
+  // The audit rows carry the same order and go in as one statement.
   if (auditEvents.length > 0) {
     await recordAuditEvent(tx, auditEvents);
   }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -88,7 +88,7 @@
     "files": {}
   },
   "throw-outside-boundary": {
-    "count": 1118,
+    "count": 1116,
     "files": {
       "apps/api/src/handlers/case-law/corpus-index.ts": 12,
       "apps/api/src/handlers/case-law/decisions/latest.ts": 3,
@@ -149,7 +149,7 @@
       "apps/api/src/handlers/legislation/search-index.ts": 1,
       "apps/api/src/handlers/lists/generation-candidates/acceptance/create.ts": 1,
       "apps/api/src/handlers/mcp-connectors/create-connector.ts": 1,
-      "apps/api/src/handlers/properties/create-batch.ts": 4,
+      "apps/api/src/handlers/properties/create-batch.ts": 3,
       "apps/api/src/handlers/properties/create.ts": 4,
       "apps/api/src/handlers/rates/create.ts": 2,
       "apps/api/src/handlers/rates/entries-create.ts": 3,
@@ -247,7 +247,7 @@
       "apps/api/src/lib/tasks/update-task.ts": 3,
       "apps/api/src/lib/two-factor.ts": 1,
       "apps/api/src/lib/user-shortcuts.ts": 1,
-      "apps/api/src/lib/views/template-properties.ts": 11,
+      "apps/api/src/lib/views/template-properties.ts": 10,
       "apps/api/src/lib/web-search/jina.ts": 2,
       "apps/api/src/lib/web-search/tavily.ts": 2,
       "apps/api/src/lib/workflow/ai-generate-batch.ts": 1,
@@ -777,7 +777,7 @@
     }
   },
   "no-db-await-in-loop-suppressions": {
-    "count": 116,
+    "count": 112,
     "files": {
       "apps/api/scripts/backfill-image-thumbnails.ts": 3,
       "apps/api/scripts/backfill-search-previews.ts": 1,
@@ -807,11 +807,9 @@
       "apps/api/src/handlers/mcp-connectors/create-connector.ts": 1,
       "apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts": 2,
       "apps/api/src/handlers/playbooks/auto-run.ts": 1,
-      "apps/api/src/handlers/properties/create-batch.ts": 2,
       "apps/api/src/handlers/reports/build-report-data.ts": 1,
       "apps/api/src/handlers/search/ai.ts": 2,
       "apps/api/src/handlers/templates/categories.ts": 1,
-      "apps/api/src/handlers/time-entries/split.ts": 1,
       "apps/api/src/handlers/uploads/entity-create-tree.ts": 4,
       "apps/api/src/handlers/views/table-export.ts": 1,
       "apps/api/src/handlers/workspaces/duplicate.ts": 4,
@@ -833,7 +831,6 @@
       "apps/api/src/lib/search/index-global.ts": 2,
       "apps/api/src/lib/search/pg-fts-provider.ts": 1,
       "apps/api/src/lib/template-clause-links.ts": 1,
-      "apps/api/src/lib/views/template-properties.ts": 1,
       "apps/api/src/lib/workflow-queue.ts": 2,
       "apps/api/src/lib/workflow-target-queries.ts": 2,
       "apps/api/src/lib/workflow/route-playbooks.ts": 1,


### PR DESCRIPTION
Second of the `no-db-await-in-loop` burn-down series: three places that
inserted rows one at a time inside a transaction, each reading the new id
back with `returning`.

## The sites

- `handlers/properties/create-batch.ts` — up to ten columns per request,
  each an `insert ... returning` plus its own dependency insert.
- `lib/views/template-properties.ts` — the same shape for the columns a
  view template is missing.
- `handlers/time-entries/split.ts` — between two and ten successor
  entries, each inserted on its own so the audit event could carry the
  returned id.

Four suppressions between them.

## The batching shape

Ids are minted with `createSafeId` before anything is written. Nothing
downstream needs the database to say what a row's id is, so each batch is
assembled in full and then written:

- properties: one multi-row `insert into properties`, one into
  `property_dependencies`, and the audit insert that was already one
  statement.
- template columns: the same, with the source-id mapping filled from the
  minted ids.
- time-entry split: one multi-row insert of the successors.

The order the callers return (`ids`, `propertyIds`, `newEntryIds`) now
comes from the input order rather than from the sequence of round trips,
which is the same order as before.

## Removed guards

`Failed to create property` and `Failed to create template column`
existed to handle `returning` coming back empty, and the split's
`if (entry)` did the same job silently. With the id chosen here there is
nothing to read back: the insert either lands or throws. That drops
`throw-outside-boundary` by two.

Every write was already inside its caller's transaction, so failure
semantics are unchanged.

## Test

Extends `template-properties.db.test.ts` with the pairing a multi-row
insert has to preserve: the ids handed back name the template's columns
in the template's order, and the dependency edge connects Summary to
Counterparty rather than the reverse. The existing commit and rollback
cases already run two columns and one edge through the new path.

## Ratchet

`no-db-await-in-loop-suppressions`: 116 -> 112.
`throw-outside-boundary`: 1118 -> 1116.
No other metric touched.

## Mock-based test that pinned the old implementation

`handlers/view-templates/properties.test.ts` mocked
`insert().values().returning()` and asserted the fixture id that mock
handed back, so six of its tests were pinning where an id comes from
rather than what the resolver does with it. With ids minted before the
write there is no `returning` to intercept.

The mock now records the inserted rows, and the assertions derive the
created id from them -- the ids the resolver returns are the ids it
wrote, which is the invariant worth holding. Counting inserts becomes
counting created rows, since one call carries the whole batch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved batch property creation, template property creation, and time-entry splitting by processing records in batches, reducing the number of database operations.
* **Reliability**
  * Preserved property and time-entry identifiers and relationships during batched processing.
* **Tests**
  * Added coverage confirming template property identifiers and dependency relationships remain correctly paired and ordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->