### PR TITLE
perf(api): the always-mask list is replaced with one upsert

### DIFF
--- a/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
+++ b/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
@@ -1,14 +1,13 @@
 import { Result } from "better-result";
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { t } from "elysia";
 
-import { anonymizationBlacklistEntries } from "@/api/db/schema";
-import { normalizeAnonymizationBlacklistEntries } from "@/api/lib/anonymization-blacklist";
-import { loadOrganizationAnonymizationTermsForWrite } from "@/api/lib/anonymization-write-cap";
+import {
+  normalizeAnonymizationBlacklistEntries,
+  replaceOrganizationAnonymizationBlacklist,
+} from "@/api/lib/anonymization-blacklist";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
-import { createSafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 
 const blacklistEntrySchema = t.Object({
@@ -48,91 +47,19 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
       return Result.err(entries.error);
     }
 
-    // Restrict every read/write below to org-wide rows
-    // (workspace_id IS NULL). Workspace-scoped terms created from
-    // the inspector live in the same table and must not be visible
-    // to — or deletable by — the firm-wide settings page.
     yield* Result.await(
       safeDb(async (tx) => {
-        // Locks the org-wide set for the rest of this transaction. The
-        // replace deletes only the rows its own read saw, so two
-        // concurrent replacements would otherwise each keep their own
-        // set and leave the union of both behind: twice the cap.
-        const existingRows = await loadOrganizationAnonymizationTermsForWrite(
-          tx,
-          session.activeOrganizationId,
-        );
-
-        const existingByCanonical = new Map(
-          existingRows.map((row) => [row.canonical.toLocaleLowerCase(), row]),
-        );
-        const incomingCanonicalKeys = new Set(
-          entries.value.map((entry) => entry.canonical.toLocaleLowerCase()),
-        );
-
-        const idsToDelete: (typeof existingRows)[number]["id"][] = [];
-        for (const row of existingRows) {
-          if (!incomingCanonicalKeys.has(row.canonical.toLocaleLowerCase())) {
-            idsToDelete.push(row.id);
-          }
-        }
-
-        if (idsToDelete.length > 0) {
-          await tx
-            .delete(anonymizationBlacklistEntries)
-            .where(
-              and(
-                eq(
-                  anonymizationBlacklistEntries.organizationId,
-                  session.activeOrganizationId,
-                ),
-                isNull(anonymizationBlacklistEntries.workspaceId),
-                inArray(anonymizationBlacklistEntries.id, idsToDelete),
-              ),
-            );
-        }
-
-        if (entries.value.length === 0) {
-          return;
-        }
-
-        const now = new Date();
-
-        // One upsert for the whole list. A term already on it keeps its row:
-        // the id comes from the read above, so the conflict target is the
-        // primary key and `createdBy` survives. A new term gets a fresh id.
-        // `setWhere` repeats the tenant scope the per-row update carried, so a
-        // row outside this organization's org-wide set stays unreachable.
-        const rows = entries.value.map((entry) => ({
-          id:
-            existingByCanonical.get(entry.canonical.toLocaleLowerCase())?.id ??
-            createSafeId<"anonymizationBlacklistEntry">(),
-          organizationId: session.activeOrganizationId,
-          label: entry.label,
-          canonical: entry.canonical,
-          variants: entry.variants,
-          enabled: entry.enabled,
-          createdBy: user.id,
-          updatedBy: user.id,
-        }));
-
-        await tx
-          .insert(anonymizationBlacklistEntries)
-          .values(rows)
-          .onConflictDoUpdate({
-            target: anonymizationBlacklistEntries.id,
-            set: {
-              label: sql`excluded.label`,
-              canonical: sql`excluded.canonical`,
-              variants: sql`excluded.variants`,
-              enabled: sql`excluded.enabled`,
-              updatedBy: sql`excluded.updated_by`,
-              updatedAt: now,
-            },
-            setWhere: sql`${anonymizationBlacklistEntries.organizationId} = ${session.activeOrganizationId}
-              AND ${anonymizationBlacklistEntries.workspaceId} IS NULL`,
+        const { deletedCount } =
+          await replaceOrganizationAnonymizationBlacklist({
+            entries: entries.value,
+            organizationId: session.activeOrganizationId,
+            tx,
+            userId: user.id,
           });
 
+        // Outside the write above, and unconditional: clearing the list is
+        // the most destructive shape this endpoint has, and it used to
+        // return before reaching the audit row.
         await recordAuditEvent(tx, {
           action: AUDIT_ACTION.UPDATE,
           resourceType: AUDIT_RESOURCE_TYPE.ORGANIZATION_SETTINGS,
@@ -140,7 +67,7 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
           metadata: {
             field: "anonymizationBlacklist",
             entryCount: entries.value.length,
-            deletedCount: idsToDelete.length,
+            deletedCount,
           },
         });
       }),

--- a/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
+++ b/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { anonymizationBlacklistEntries } from "@/api/db/schema";
@@ -98,48 +98,40 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
 
         const now = new Date();
 
-        for (const entry of entries.value) {
-          const existing = existingByCanonical.get(
-            entry.canonical.toLocaleLowerCase(),
-          );
+        // One upsert for the whole list. A term already on it keeps its row:
+        // the id comes from the read above, so the conflict target is the
+        // primary key and `createdBy` survives. A new term gets a fresh id.
+        // `setWhere` repeats the tenant scope the per-row update carried, so a
+        // row outside this organization's org-wide set stays unreachable.
+        const rows = entries.value.map((entry) => ({
+          id:
+            existingByCanonical.get(entry.canonical.toLocaleLowerCase())?.id ??
+            createSafeId<"anonymizationBlacklistEntry">(),
+          organizationId: session.activeOrganizationId,
+          label: entry.label,
+          canonical: entry.canonical,
+          variants: entry.variants,
+          enabled: entry.enabled,
+          createdBy: user.id,
+          updatedBy: user.id,
+        }));
 
-          if (existing) {
-            // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential by design: sequential blacklist upserts inside one transaction
-            await tx
-              .update(anonymizationBlacklistEntries)
-              .set({
-                label: entry.label,
-                canonical: entry.canonical,
-                variants: entry.variants,
-                enabled: entry.enabled,
-                updatedBy: user.id,
-                updatedAt: now,
-              })
-              .where(
-                and(
-                  eq(anonymizationBlacklistEntries.id, existing.id),
-                  eq(
-                    anonymizationBlacklistEntries.organizationId,
-                    session.activeOrganizationId,
-                  ),
-                  isNull(anonymizationBlacklistEntries.workspaceId),
-                ),
-              );
-            continue;
-          }
-
-          // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential blacklist upserts inside one transaction
-          await tx.insert(anonymizationBlacklistEntries).values({
-            id: createSafeId<"anonymizationBlacklistEntry">(),
-            organizationId: session.activeOrganizationId,
-            label: entry.label,
-            canonical: entry.canonical,
-            variants: entry.variants,
-            enabled: entry.enabled,
-            createdBy: user.id,
-            updatedBy: user.id,
+        await tx
+          .insert(anonymizationBlacklistEntries)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: anonymizationBlacklistEntries.id,
+            set: {
+              label: sql`excluded.label`,
+              canonical: sql`excluded.canonical`,
+              variants: sql`excluded.variants`,
+              enabled: sql`excluded.enabled`,
+              updatedBy: sql`excluded.updated_by`,
+              updatedAt: now,
+            },
+            setWhere: sql`${anonymizationBlacklistEntries.organizationId} = ${session.activeOrganizationId}
+              AND ${anonymizationBlacklistEntries.workspaceId} IS NULL`,
           });
-        }
 
         await recordAuditEvent(tx, {
           action: AUDIT_ACTION.UPDATE,

--- a/apps/api/src/lib/anonymization-blacklist.db.test.ts
+++ b/apps/api/src/lib/anonymization-blacklist.db.test.ts
@@ -1,0 +1,242 @@
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import { organization, user } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import { anonymizationBlacklistEntries, workspaces } from "@/api/db/schema";
+import {
+  normalizeAnonymizationBlacklistEntry,
+  replaceOrganizationAnonymizationBlacklist,
+} from "@/api/lib/anonymization-blacklist";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+/**
+ * Three tenancy tiers share this table: an organization's firm-wide terms,
+ * another organization's, and matter-scoped terms the settings page owns
+ * neither way. The fixture seeds all three and asserts only the first moves.
+ *
+ * The row a term already on the list keeps is the other property under test.
+ * It carries `createdBy` and `createdAt` — who first asked for a name to be
+ * masked, and when — so a replace that re-created the row instead of updating
+ * it would quietly rewrite that history while looking correct from outside.
+ *
+ * What this cannot reach: the `isNull(workspace_id)` on the delete and the
+ * `setWhere` on the upsert are defence in depth, not the acting guard. The
+ * ids both statements address come from
+ * `loadOrganizationAnonymizationTermsForWrite`, which is already scoped to
+ * this organization's org-wide rows, so no fixture driving this function can
+ * put a foreign id in front of them. Removing either guard leaves these tests
+ * green; the scope they duplicate is pinned in
+ * `anonymization-write-cap.db.test.ts`.
+ */
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+
+const organizationId = toSafeId<"organization">(`org_${Bun.randomUUIDv7()}`);
+const otherOrganizationId = toSafeId<"organization">(
+  `org_${Bun.randomUUIDv7()}`,
+);
+const userId = toSafeId<"user">(`user_${Bun.randomUUIDv7()}`);
+const originalAuthorId = toSafeId<"user">(`user_${Bun.randomUUIDv7()}`);
+const workspaceId = toSafeId<"workspace">(Bun.randomUUIDv7());
+
+const keptId = createSafeId<"anonymizationBlacklistEntry">();
+const droppedId = createSafeId<"anonymizationBlacklistEntry">();
+const otherOrgId = createSafeId<"anonymizationBlacklistEntry">();
+const matterScopedId = createSafeId<"anonymizationBlacklistEntry">();
+
+const CREATED_AT = new Date("2026-01-02T03:04:05.000Z");
+
+const runReplace = async (terms: { canonical: string; label: string }[]) =>
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    return await replaceOrganizationAnonymizationBlacklist({
+      entries: terms.map((term) => normalizeAnonymizationBlacklistEntry(term)),
+      organizationId,
+      tx: asTestRaw<Transaction>(tx),
+      userId,
+    });
+  });
+
+const orgWideRows = async (owner: SafeId<"organization">) =>
+  await testDb
+    .select({
+      id: anonymizationBlacklistEntries.id,
+      canonical: anonymizationBlacklistEntries.canonical,
+      label: anonymizationBlacklistEntries.label,
+      createdBy: anonymizationBlacklistEntries.createdBy,
+      createdAt: anonymizationBlacklistEntries.createdAt,
+      updatedBy: anonymizationBlacklistEntries.updatedBy,
+    })
+    .from(anonymizationBlacklistEntries)
+    .where(
+      and(
+        eq(anonymizationBlacklistEntries.organizationId, owner),
+        isNull(anonymizationBlacklistEntries.workspaceId),
+      ),
+    );
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx.insert(organization).values([
+      {
+        id: organizationId,
+        name: "Masking firm",
+        slug: organizationId,
+        createdAt: new Date(),
+      },
+      {
+        id: otherOrganizationId,
+        name: "Other firm",
+        slug: otherOrganizationId,
+        createdAt: new Date(),
+      },
+    ]);
+    await tx.insert(user).values([
+      { id: userId, name: "Editor", email: `${userId}@test.local` },
+      {
+        id: originalAuthorId,
+        name: "First author",
+        email: `${originalAuthorId}@test.local`,
+      },
+    ]);
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      organizationId,
+      name: "Matter",
+      reference: Bun.randomUUIDv7().slice(0, 8),
+    });
+    await tx.insert(anonymizationBlacklistEntries).values([
+      {
+        // Stays on the submitted list, so its row has to survive intact.
+        id: keptId,
+        organizationId,
+        label: "Client",
+        canonical: "Acme Holdings",
+        variants: ["Acme"],
+        createdBy: originalAuthorId,
+        updatedBy: originalAuthorId,
+        createdAt: CREATED_AT,
+      },
+      {
+        // Absent from the submitted list, so the replace drops it.
+        id: droppedId,
+        organizationId,
+        label: "Client",
+        canonical: "Stale Term",
+        variants: [],
+        createdBy: originalAuthorId,
+        updatedBy: originalAuthorId,
+      },
+      {
+        // Another firm's firm-wide term.
+        id: otherOrgId,
+        organizationId: otherOrganizationId,
+        label: "Client",
+        canonical: "Acme Holdings",
+        variants: [],
+        createdBy: originalAuthorId,
+        updatedBy: originalAuthorId,
+      },
+      {
+        // This firm's matter-scoped term, which the settings page owns
+        // neither way.
+        id: matterScopedId,
+        organizationId,
+        workspaceId,
+        label: "Witness",
+        canonical: "Matter Only",
+        variants: [],
+        createdBy: originalAuthorId,
+        updatedBy: originalAuthorId,
+      },
+    ]);
+  });
+});
+
+afterAll(async () => {
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx.delete(workspaces).where(eq(workspaces.id, workspaceId));
+    await tx
+      .delete(organization)
+      .where(eq(organization.id, otherOrganizationId));
+    await tx.delete(organization).where(eq(organization.id, organizationId));
+    await tx.delete(user).where(eq(user.id, userId));
+    await tx.delete(user).where(eq(user.id, originalAuthorId));
+  });
+  await releaseTestDb();
+});
+
+test("a term already on the list keeps its row, and a new one is added", async () => {
+  const result = await runReplace([
+    // Same term, re-cased and relabelled: it must update the existing row
+    // rather than create a second one.
+    { canonical: "ACME Holdings", label: "Counterparty" },
+    { canonical: "Fresh Term", label: "Client" },
+  ]);
+
+  expect(result).toEqual({ deletedCount: 1 });
+
+  const rows = await orgWideRows(organizationId);
+  expect(rows).toHaveLength(2);
+
+  const kept = rows.find((row) => row.id === keptId);
+  expect(kept?.canonical).toBe("ACME Holdings");
+  expect(kept?.label).toBe("Counterparty");
+  // The provenance of the original entry survives the replace.
+  expect(kept?.createdBy).toBe(originalAuthorId);
+  expect(kept?.createdAt).toEqual(CREATED_AT);
+  expect(kept?.updatedBy).toBe(userId);
+
+  const added = rows.find((row) => row.canonical === "Fresh Term");
+  expect(added?.createdBy).toBe(userId);
+  expect(rows.some((row) => row.id === droppedId)).toBe(false);
+});
+
+test("another organization's terms and this one's matter terms are untouched", async () => {
+  const otherRows = await orgWideRows(otherOrganizationId);
+  expect(otherRows).toEqual([
+    expect.objectContaining({
+      id: otherOrgId,
+      canonical: "Acme Holdings",
+      label: "Client",
+      updatedBy: originalAuthorId,
+    }),
+  ]);
+
+  const matterRows = await testDb
+    .select({
+      id: anonymizationBlacklistEntries.id,
+      label: anonymizationBlacklistEntries.label,
+      updatedBy: anonymizationBlacklistEntries.updatedBy,
+    })
+    .from(anonymizationBlacklistEntries)
+    .where(eq(anonymizationBlacklistEntries.workspaceId, workspaceId));
+  expect(matterRows).toEqual([
+    { id: matterScopedId, label: "Witness", updatedBy: originalAuthorId },
+  ]);
+});
+
+test("an empty list clears this organization's firm-wide terms only", async () => {
+  const result = await runReplace([]);
+
+  expect(result).toEqual({ deletedCount: 2 });
+  expect(await orgWideRows(organizationId)).toEqual([]);
+  expect(await orgWideRows(otherOrganizationId)).toHaveLength(1);
+
+  const matterRows = await testDb
+    .select({ id: anonymizationBlacklistEntries.id })
+    .from(anonymizationBlacklistEntries)
+    .where(eq(anonymizationBlacklistEntries.workspaceId, workspaceId));
+  expect(matterRows).toEqual([{ id: matterScopedId }]);
+});

--- a/apps/api/src/lib/anonymization-blacklist.ts
+++ b/apps/api/src/lib/anonymization-blacklist.ts
@@ -1,13 +1,15 @@
 import { panic, Result } from "better-result";
 import type { SQL } from "drizzle-orm";
-import { and, asc, eq, inArray, isNull, or } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 
 import type { GazetteerEntry } from "@stll/anonymize";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { anonymizationBlacklistEntries } from "@/api/db/schema";
+import { loadOrganizationAnonymizationTermsForWrite } from "@/api/lib/anonymization-write-cap";
 import { arrayOrEmpty } from "@/api/lib/array";
+import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { boundedAll } from "@/api/lib/db/bounded-all";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
@@ -48,6 +50,10 @@ export const normalizeAnonymizationBlacklistEntry = ({
   variants: normalizeVariants(arrayOrEmpty(variants)),
 });
 
+export type NormalizedAnonymizationBlacklistEntry = ReturnType<
+  typeof normalizeAnonymizationBlacklistEntry
+>;
+
 export const normalizeAnonymizationBlacklistEntries = (
   entries: AnonymizationBlacklistEntryInput[],
 ) => {
@@ -81,6 +87,106 @@ export const normalizeAnonymizationBlacklistEntries = (
   }
 
   return Result.ok(normalized);
+};
+
+/**
+ * Replace an organization's firm-wide always-mask list with `entries`.
+ *
+ * Every read and write here is confined to org-wide rows
+ * (`workspace_id IS NULL`). Matter-scoped terms created from the inspector
+ * live in the same table and must be neither visible to nor deletable by the
+ * firm-wide settings page.
+ *
+ * Two statements, whatever the list's length: one delete for the terms that
+ * are gone, one upsert for the rest. A term already on the list keeps its
+ * row, because the id comes from the locked read, which makes the conflict
+ * target the primary key and leaves `createdBy` and `createdAt` untouched; a
+ * new term gets a fresh id. `setWhere` repeats the tenant scope the delete
+ * carries, so the upsert can reach nothing outside this organization's
+ * org-wide set even if an id from elsewhere reached it.
+ */
+export const replaceOrganizationAnonymizationBlacklist = async ({
+  entries,
+  organizationId,
+  tx,
+  userId,
+}: {
+  entries: readonly NormalizedAnonymizationBlacklistEntry[];
+  organizationId: SafeId<"organization">;
+  tx: Transaction;
+  userId: SafeId<"user">;
+}): Promise<{ deletedCount: number }> => {
+  // Locks the org-wide set for the rest of this transaction. The replace
+  // deletes only the rows its own read saw, so two concurrent replacements
+  // would otherwise each keep their own set and leave the union of both
+  // behind: twice the cap.
+  const existingRows = await loadOrganizationAnonymizationTermsForWrite(
+    tx,
+    organizationId,
+  );
+
+  const existingByCanonical = new Map(
+    existingRows.map((row) => [row.canonical.toLocaleLowerCase(), row]),
+  );
+  const incomingCanonicalKeys = new Set(
+    entries.map((entry) => entry.canonical.toLocaleLowerCase()),
+  );
+
+  const idsToDelete: (typeof existingRows)[number]["id"][] = [];
+  for (const row of existingRows) {
+    if (!incomingCanonicalKeys.has(row.canonical.toLocaleLowerCase())) {
+      idsToDelete.push(row.id);
+    }
+  }
+
+  if (idsToDelete.length > 0) {
+    await tx
+      .delete(anonymizationBlacklistEntries)
+      .where(
+        and(
+          eq(anonymizationBlacklistEntries.organizationId, organizationId),
+          isNull(anonymizationBlacklistEntries.workspaceId),
+          inArray(anonymizationBlacklistEntries.id, idsToDelete),
+        ),
+      );
+  }
+
+  if (entries.length === 0) {
+    return { deletedCount: idsToDelete.length };
+  }
+
+  const now = new Date();
+  const rows = entries.map((entry) => ({
+    id:
+      existingByCanonical.get(entry.canonical.toLocaleLowerCase())?.id ??
+      createSafeId<"anonymizationBlacklistEntry">(),
+    organizationId,
+    label: entry.label,
+    canonical: entry.canonical,
+    variants: entry.variants,
+    enabled: entry.enabled,
+    createdBy: userId,
+    updatedBy: userId,
+  }));
+
+  await tx
+    .insert(anonymizationBlacklistEntries)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: anonymizationBlacklistEntries.id,
+      set: {
+        label: sql`excluded.label`,
+        canonical: sql`excluded.canonical`,
+        variants: sql`excluded.variants`,
+        enabled: sql`excluded.enabled`,
+        updatedBy: sql`excluded.updated_by`,
+        updatedAt: now,
+      },
+      setWhere: sql`${anonymizationBlacklistEntries.organizationId} = ${organizationId}
+        AND ${anonymizationBlacklistEntries.workspaceId} IS NULL`,
+    });
+
+  return { deletedCount: idsToDelete.length };
 };
 
 /**

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -777,7 +777,7 @@
     }
   },
   "no-db-await-in-loop-suppressions": {
-    "count": 112,
+    "count": 110,
     "files": {
       "apps/api/scripts/backfill-image-thumbnails.ts": 3,
       "apps/api/scripts/backfill-search-previews.ts": 1,
@@ -805,7 +805,6 @@
       "apps/api/src/handlers/legislation/ingestion.ts": 1,
       "apps/api/src/handlers/legislation/search-index.ts": 1,
       "apps/api/src/handlers/mcp-connectors/create-connector.ts": 1,
-      "apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts": 2,
       "apps/api/src/handlers/playbooks/auto-run.ts": 1,
       "apps/api/src/handlers/reports/build-report-data.ts": 1,
       "apps/api/src/handlers/search/ai.ts": 2,


### PR DESCRIPTION
Third of the `no-db-await-in-loop` burn-down series.

## The site

`update-anonymization-blacklist` replaces the organization-wide
always-mask list. It walked the submitted terms and, per term, either
updated the matching row by id or inserted a new one. The request schema
admits up to `LIMITS.anonymizationBlacklistEntriesPerOrganization` (1000)
terms, so a full replacement cost up to a thousand statements inside one
transaction. Two suppressions.

## The batching shape

One multi-row insert with `onConflictDoUpdate`:

- The id for a term already on the list comes from the locked read above,
  so the conflict target is the primary key. `createdBy` and `createdAt`
  are not in the update set, so an existing row keeps both.
- A term not on the list gets a fresh `createSafeId`, and the same
  statement inserts it.
- `updatedAt` is set explicitly, since `$onUpdate` does not fire on the
  conflict path.

`normalizeAnonymizationBlacklistEntries` rejects duplicate canonicals
before this point, so no two rows in the statement address the same id.

## Tenant scope

The per-row update carried
`organization_id = <active> AND workspace_id IS NULL`. That guard moves
to `setWhere`, which lands as the `WHERE` on `DO UPDATE`, so the
statement still cannot touch a matter-scoped term or another
organization's row. The ids come from
`loadOrganizationAnonymizationTermsForWrite`, which is already scoped
the same way and holds the lock that makes the replacement whole.

The delete of dropped terms and the audit row are unchanged.

## Ratchet

`no-db-await-in-loop-suppressions`: 112 -> 110. No other metric touched.

## Test

The transaction body moves to `lib/anonymization-blacklist.ts`, which
already owns this data's normalization and reads, so a pglite suite can
drive the real statements; the handler calls it and keeps the audit row.

`anonymization-blacklist.db.test.ts` seeds the three tenancy tiers that
share the table -- this organization's firm-wide terms, another
organization's, and a matter-scoped term -- and asserts:

- a term already on the list keeps its row, with `createdBy` and
  `createdAt` intact, while its label and canonical are updated
- a term absent from the submitted list is deleted
- a new term is inserted with the editor as `createdBy`
- the other organization's term and the matter-scoped term do not move
- an empty list clears this organization's firm-wide terms alone

I checked the suite is not vacuous by mutation: making every term take a
fresh id fails it, and skipping the delete fails it. Removing the
`isNull(workspace_id)` from the delete or the `setWhere` from the upsert
does **not** fail it, and the test's header says so -- those two are
defence in depth, because the ids both statements address come from
`loadOrganizationAnonymizationTermsForWrite`, which is already scoped.
The scope they duplicate is pinned in `anonymization-write-cap.db.test.ts`.

## Unaudited clear, fixed here

Found while extracting: submitting an empty list deleted every firm-wide
term and then `return`ed before reaching the audit row, so the most
destructive shape this endpoint has left no trace. The audit event now
lands outside the write and unconditionally, with the deleted count
returned by the replace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Organisation-wide anonymisation blacklist updates now reliably add, update and remove entries without affecting matter-specific terms or other organisations’ entries.
  * Existing entries retain their original ownership and creation details when updated.
  * Clearing the blacklist now removes all applicable organisation-wide terms and records the change in the audit history.

* **Tests**
  * Added coverage for replacing, clearing and isolating anonymisation blacklist entries across different scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->