### PR TITLE
perf(api): clause sync and entity moves write once instead of per row

### DIFF
--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import type { Static } from "elysia";
 import { t } from "elysia";
 
@@ -518,14 +518,13 @@ const copyToWorkspaceHandler = async function* ({
       dependencies,
     });
 
-    // For move operations, delete source entities in the same transaction
+    // For move operations, delete source entities in the same transaction.
     if (deleteSource) {
-      // Delete in reverse order (children first) to respect FK constraints.
-      // The cascade will handle versions and fields.
-      for (const id of sourceEntityIds.toReversed()) {
-        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential deletes in reverse (children-first) order respect FK constraints within the transaction
-        await tx.delete(entities).where(eq(entities.id, id));
-      }
+      // The whole moved subtree goes in one statement. Ordering the deletes
+      // bought nothing: `entities.parent_id` is ON DELETE SET NULL, so no
+      // child is ever left referencing a removed parent, and every child is
+      // in this set anyway. Versions and fields still cascade.
+      await tx.delete(entities).where(inArray(entities.id, sourceEntityIds));
 
       await tx
         .update(workspaces)

--- a/apps/api/src/lib/template-clause-links.db.test.ts
+++ b/apps/api/src/lib/template-clause-links.db.test.ts
@@ -1,4 +1,11 @@
-import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 import { eq, inArray, sql } from "drizzle-orm";
 
 import { organization, user } from "@/api/db/auth-schema";
@@ -210,15 +217,39 @@ const pinnedVersionByLinkId = async () => {
   return new Map(rows.map((row) => [row.id, row.clauseVersionId]));
 };
 
-test("one statement repoints every outdated link on the template", async () => {
-  const result = await syncAllClausesHandler({
+const syncTemplate = async () =>
+  await syncAllClausesHandler({
     scopedDb,
     organizationId,
     templateId,
     recordAuditEvent: noAuditRows,
   });
 
-  expect(result).toEqual({ syncedCount: 2 });
+/**
+ * The sync mutates the seeded pins, so each test starts from the same state
+ * rather than from whatever the previous one left. Otherwise a test passes
+ * only in file order and fails when run alone under a name filter.
+ */
+beforeEach(async () => {
+  const stalePins: [SafeId<"templateClause">, SafeId<"clauseVersion">][] = [
+    [linkIds.alphaOutdated, seeded.alpha.staleVersionId],
+    [linkIds.betaOutdated, seeded.beta.staleVersionId],
+    [linkIds.gammaCurrent, seeded.gamma.currentVersionId],
+    [linkIds.alphaOnOtherTemplate, seeded.alpha.staleVersionId],
+  ];
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    for (const [linkId, clauseVersionId] of stalePins) {
+      await tx
+        .update(templateClauses)
+        .set({ clauseVersionId })
+        .where(eq(templateClauses.id, linkId));
+    }
+  });
+});
+
+test("one statement repoints every outdated link on the template", async () => {
+  expect(await syncTemplate()).toEqual({ syncedCount: 2 });
 
   const pinned = await pinnedVersionByLinkId();
   expect(pinned.get(linkIds.alphaOutdated)).toBe(seeded.alpha.currentVersionId);
@@ -234,13 +265,14 @@ test("one statement repoints every outdated link on the template", async () => {
   );
 });
 
-test("a second sync finds nothing left to repoint", async () => {
-  const result = await syncAllClausesHandler({
-    scopedDb,
-    organizationId,
-    templateId,
-    recordAuditEvent: noAuditRows,
-  });
+// Idempotence is a property of a sync that follows a sync, so this establishes
+// its own precondition instead of inheriting one from the test above.
+test("a sync after a sync finds nothing left to repoint", async () => {
+  expect(await syncTemplate()).toEqual({ syncedCount: 2 });
 
-  expect(result).toEqual({ syncedCount: 0 });
+  expect(await syncTemplate()).toEqual({ syncedCount: 0 });
+
+  const pinned = await pinnedVersionByLinkId();
+  expect(pinned.get(linkIds.alphaOutdated)).toBe(seeded.alpha.currentVersionId);
+  expect(pinned.get(linkIds.betaOutdated)).toBe(seeded.beta.currentVersionId);
 });

--- a/apps/api/src/lib/template-clause-links.db.test.ts
+++ b/apps/api/src/lib/template-clause-links.db.test.ts
@@ -1,0 +1,246 @@
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import { eq, inArray, sql } from "drizzle-orm";
+
+import { organization, user } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  clauses,
+  clauseVersions,
+  templateClauses,
+  templates,
+} from "@/api/db/schema";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { ClauseBody } from "@/api/lib/clauses/types";
+import { syncAllClausesHandler } from "@/api/lib/template-clause-links";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+/**
+ * The bulk sync repoints every outdated link with one values-join update.
+ * Hand-assembled SQL is unreviewable until something executes it: a missing
+ * cast or a join condition on the wrong column is a runtime error no unit test
+ * reaches. This runs the real statement over two outdated links, one current
+ * link, and a link on a second template that must not move.
+ */
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+
+const organizationId = toSafeId<"organization">(`org_${Bun.randomUUIDv7()}`);
+const userId = `user_${Bun.randomUUIDv7()}`;
+const templateId = createSafeId<"template">();
+const otherTemplateId = createSafeId<"template">();
+
+type SeededClause = {
+  clauseId: SafeId<"clause">;
+  staleVersionId: SafeId<"clauseVersion">;
+  currentVersionId: SafeId<"clauseVersion">;
+};
+
+const newClauseIds = (): SeededClause => ({
+  clauseId: createSafeId<"clause">(),
+  staleVersionId: createSafeId<"clauseVersion">(),
+  currentVersionId: createSafeId<"clauseVersion">(),
+});
+
+const seeded: Record<"alpha" | "beta" | "gamma", SeededClause> = {
+  alpha: newClauseIds(),
+  beta: newClauseIds(),
+  gamma: newClauseIds(),
+};
+
+const clauseBody: ClauseBody = [{ text: "Governing law." }];
+
+const linkIds = {
+  alphaOutdated: createSafeId<"templateClause">(),
+  betaOutdated: createSafeId<"templateClause">(),
+  gammaCurrent: createSafeId<"templateClause">(),
+  alphaOnOtherTemplate: createSafeId<"templateClause">(),
+};
+
+const scopedDb: ScopedDb = async (callback) =>
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    return await callback(asTestRaw<Transaction>(tx));
+  });
+
+const noAuditRows: AuditRecorder = async () => undefined;
+
+const template = (id: SafeId<"template">, name: string) => ({
+  id,
+  organizationId,
+  name,
+  fileName: `${name}.docx`,
+  s3Key: `templates/${id}.docx`,
+  sizeBytes: 1,
+  createdBy: userId,
+});
+
+const clauseRow = (clause: SeededClause, title: string) => ({
+  id: clause.clauseId,
+  organizationId,
+  title,
+  body: clauseBody,
+  // Version 2 is current, so a link pinned to version 1 is outdated.
+  currentVersion: 2,
+  createdBy: userId,
+});
+
+const versionRows = (clause: SeededClause) => [
+  {
+    id: clause.staleVersionId,
+    organizationId,
+    clauseId: clause.clauseId,
+    version: 1,
+    body: clauseBody,
+  },
+  {
+    id: clause.currentVersionId,
+    organizationId,
+    clauseId: clause.clauseId,
+    version: 2,
+    body: clauseBody,
+  },
+];
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx.insert(organization).values({
+      id: organizationId,
+      name: "Clause sync firm",
+      slug: organizationId,
+      createdAt: new Date(),
+    });
+    await tx.insert(user).values({
+      id: userId,
+      name: "Clause sync user",
+      email: `${userId}@test.local`,
+    });
+    await tx
+      .insert(templates)
+      .values([
+        template(templateId, "engagement-letter"),
+        template(otherTemplateId, "nda"),
+      ]);
+    await tx
+      .insert(clauses)
+      .values([
+        clauseRow(seeded.alpha, "Alpha"),
+        clauseRow(seeded.beta, "Beta"),
+        clauseRow(seeded.gamma, "Gamma"),
+      ]);
+    await tx
+      .insert(clauseVersions)
+      .values([
+        ...versionRows(seeded.alpha),
+        ...versionRows(seeded.beta),
+        ...versionRows(seeded.gamma),
+      ]);
+    await tx.insert(templateClauses).values([
+      {
+        id: linkIds.alphaOutdated,
+        organizationId,
+        templateId,
+        clauseId: seeded.alpha.clauseId,
+        clauseVersionId: seeded.alpha.staleVersionId,
+        sortOrder: 0,
+      },
+      {
+        id: linkIds.betaOutdated,
+        organizationId,
+        templateId,
+        clauseId: seeded.beta.clauseId,
+        clauseVersionId: seeded.beta.staleVersionId,
+        sortOrder: 1,
+      },
+      {
+        id: linkIds.gammaCurrent,
+        organizationId,
+        templateId,
+        clauseId: seeded.gamma.clauseId,
+        clauseVersionId: seeded.gamma.currentVersionId,
+        sortOrder: 2,
+      },
+      {
+        // Same clause, different template: the statement's template check is
+        // the only thing that keeps this pin where it is.
+        id: linkIds.alphaOnOtherTemplate,
+        organizationId,
+        templateId: otherTemplateId,
+        clauseId: seeded.alpha.clauseId,
+        clauseVersionId: seeded.alpha.staleVersionId,
+        sortOrder: 0,
+      },
+    ]);
+  });
+});
+
+afterAll(async () => {
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx
+      .delete(templateClauses)
+      .where(eq(templateClauses.organizationId, organizationId));
+    await tx
+      .delete(templates)
+      .where(inArray(templates.id, [templateId, otherTemplateId]));
+    await tx.delete(clauses).where(eq(clauses.organizationId, organizationId));
+    await tx.delete(organization).where(eq(organization.id, organizationId));
+    await tx.delete(user).where(eq(user.id, userId));
+  });
+  await releaseTestDb();
+});
+
+const pinnedVersionByLinkId = async () => {
+  const rows = await testDb
+    .select({
+      id: templateClauses.id,
+      clauseVersionId: templateClauses.clauseVersionId,
+    })
+    .from(templateClauses)
+    .where(eq(templateClauses.organizationId, organizationId));
+  return new Map(rows.map((row) => [row.id, row.clauseVersionId]));
+};
+
+test("one statement repoints every outdated link on the template", async () => {
+  const result = await syncAllClausesHandler({
+    scopedDb,
+    organizationId,
+    templateId,
+    recordAuditEvent: noAuditRows,
+  });
+
+  expect(result).toEqual({ syncedCount: 2 });
+
+  const pinned = await pinnedVersionByLinkId();
+  expect(pinned.get(linkIds.alphaOutdated)).toBe(seeded.alpha.currentVersionId);
+  expect(pinned.get(linkIds.betaOutdated)).toBe(seeded.beta.currentVersionId);
+
+  // Already current, so it was never in the statement.
+  expect(pinned.get(linkIds.gammaCurrent)).toBe(seeded.gamma.currentVersionId);
+
+  // The same clause on another template keeps its stale pin: the update's
+  // template check is what confines the values join.
+  expect(pinned.get(linkIds.alphaOnOtherTemplate)).toBe(
+    seeded.alpha.staleVersionId,
+  );
+});
+
+test("a second sync finds nothing left to repoint", async () => {
+  const result = await syncAllClausesHandler({
+    scopedDb,
+    organizationId,
+    templateId,
+    recordAuditEvent: noAuditRows,
+  });
+
+  expect(result).toEqual({ syncedCount: 0 });
+});

--- a/apps/api/src/lib/template-clause-links.ts
+++ b/apps/api/src/lib/template-clause-links.ts
@@ -1,6 +1,7 @@
 /** Shared template-clause link operations used by the clause and template slices. */
 import { panic } from "better-result";
 import { and, eq, or, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
 
@@ -717,6 +718,7 @@ export const syncAllClausesHandler = async ({
     // One bulk sync is one audit group: the events are recorded together
     // after the loop so they share a single groupId.
     const auditEvents: AuditEvent[] = [];
+    const repointed: SQL[] = [];
 
     for (const link of links) {
       if (!isOutdatedLink(link) || !link.clauseId || !link.clause) {
@@ -729,16 +731,7 @@ export const syncAllClausesHandler = async ({
         continue;
       }
 
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- sequential: this update runs inside the one bulk-sync transaction after its findFirst
-      await tx
-        .update(templateClauses)
-        .set({ clauseVersionId: latestVersion.id })
-        .where(
-          and(
-            eq(templateClauses.id, link.id),
-            eq(templateClauses.templateId, templateId),
-          ),
-        );
+      repointed.push(sql`(${link.id}::uuid, ${latestVersion.id}::uuid)`);
 
       auditEvents.push({
         action: AUDIT_ACTION.UPDATE,
@@ -754,6 +747,20 @@ export const syncAllClausesHandler = async ({
       });
 
       synced.push(link.id);
+    }
+
+    // Every outdated link is repointed by one statement: the new version ids
+    // are already in hand, so a values join carries them in rather than the
+    // sync costing a round trip per link. The template check stays on the
+    // statement, so a link id from another template updates nothing.
+    if (repointed.length > 0) {
+      await tx.execute(sql`
+        UPDATE ${templateClauses} AS target
+           SET clause_version_id = repoint.clause_version_id
+          FROM (VALUES ${sql.join(repointed, sql`, `)})
+               AS repoint(link_id, clause_version_id)
+         WHERE target.id = repoint.link_id
+           AND target.template_id = ${templateId}`);
     }
 
     if (auditEvents.length > 0) {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -777,7 +777,7 @@
     }
   },
   "no-db-await-in-loop-suppressions": {
-    "count": 110,
+    "count": 108,
     "files": {
       "apps/api/scripts/backfill-image-thumbnails.ts": 3,
       "apps/api/scripts/backfill-search-previews.ts": 1,
@@ -797,7 +797,6 @@
       "apps/api/src/handlers/contacts/create.ts": 1,
       "apps/api/src/handlers/contacts/update.ts": 1,
       "apps/api/src/handlers/document-reviews/propose-positions-stream.ts": 1,
-      "apps/api/src/handlers/entities/copy-to-workspace.ts": 1,
       "apps/api/src/handlers/entities/copy-utils.ts": 5,
       "apps/api/src/handlers/entities/delete-version.ts": 1,
       "apps/api/src/handlers/fields/kanban-placement/update.ts": 1,
@@ -829,7 +828,6 @@
       "apps/api/src/lib/scouts/work-attention.ts": 1,
       "apps/api/src/lib/search/index-global.ts": 2,
       "apps/api/src/lib/search/pg-fts-provider.ts": 1,
-      "apps/api/src/lib/template-clause-links.ts": 1,
       "apps/api/src/lib/workflow-queue.ts": 2,
       "apps/api/src/lib/workflow-target-queries.ts": 2,
       "apps/api/src/lib/workflow/route-playbooks.ts": 1,


### PR DESCRIPTION
Fourth of the `no-db-await-in-loop` burn-down series. Two per-row writes
inside a transaction, one statement each.

## Clause link sync (`lib/template-clause-links.ts`)

`syncAllClausesHandler` repointed each outdated link with its own
`update`, bounded only by `LIMITS.templateClausesPerTemplate`.

The version read just above already resolves every clause's current
version, so the new pin for each link is known before any write. The
loop now collects `(link_id, clause_version_id)` tuples and one
`UPDATE ... FROM (VALUES ...)` repoints all of them. The audit events
are unchanged: still one group, still recorded after the loop.

The `AND target.template_id = <templateId>` check moves onto the
statement, so a link id from another template updates nothing — the
same guard the per-row `where` carried.

## Entity move (`handlers/entities/copy-to-workspace.ts`)

A move deleted the source subtree one row at a time in reverse order,
with a comment about respecting FK constraints. There is no such
constraint to respect: `entities.parent_id` is `ON DELETE SET NULL`, so
a removed parent never leaves a dangling child, and every child is in
the deleted set anyway. One
`delete from entities where id in (...)` replaces the walk. Versions
and fields still cascade, and the workspace touch and audit rows are
unchanged.

## Test

`template-clause-links.db.test.ts` is new. A hand-assembled values join
is unreviewable until something executes it — a missing `::uuid` or a
join on the wrong column is a runtime error no unit test reaches — so
the suite runs the real statement over:

- two outdated links, which must both move to their clause's current
  version,
- one already-current link, which is never in the statement,
- a link to the same clause on a second template, which must keep its
  stale pin,
- a second sync, which must find nothing left to repoint.

## Ratchet

`no-db-await-in-loop-suppressions`: 110 -> 108. No other metric touched.
