### PR TITLE
docs(api): every no-db-await-in-loop directive names why it stands

### DIFF
--- a/apps/api/src/handlers/chat/delete-thread.ts
+++ b/apps/api/src/handlers/chat/delete-thread.ts
@@ -86,7 +86,7 @@ const deleteThread = createSafeRootHandler(
         conditions.push(gt(userFiles.id, lastFileId));
       }
       // SAFETY: sequential keyset pagination keeps each cleanup page bounded; the next page depends on this cursor.
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
+      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- keyset page walk: this page's last id is the next iteration's cursor, so the reads cannot be batched
       const files = yield* Result.await(
         safeDb((tx) =>
           tx
@@ -132,7 +132,7 @@ const deleteThread = createSafeRootHandler(
       }
 
       // SAFETY: storage deletion must succeed before the corresponding bounded page of rows is removed.
-      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
+      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- one delete per page of the keyset walk, already an inArray over the whole page, and ordered after that page's storage delete
       yield* Result.await(
         // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
         safeDb((tx) => {

--- a/apps/api/src/lib/account-deletion-steps.ts
+++ b/apps/api/src/lib/account-deletion-steps.ts
@@ -517,7 +517,7 @@ export const reassignActiveTaskAssignmentsAndDropMemberships = async ({
     // the enforced LIMITS.accountDeletionTaskAssignmentsMax check above
     // (throws before reaching here if exceeded), not unbounded tenant
     // data.
-    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
+    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- bounded fan-out: one deleted user's reassignments, capped by LIMITS.accountDeletionTaskAssignmentsMax
     await Promise.all(
       updates.map((item) =>
         tx
@@ -607,7 +607,7 @@ export const reassignActiveTaskAssignmentsAndDropMemberships = async ({
     const now = new Date();
     // SAFETY: one deleted user's mutable obligations, bounded by the enforced
     // accountDeletionTaskAssignmentsMax check immediately above.
-    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
+    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- bounded fan-out: one deleted user's obligations, capped by LIMITS.accountDeletionTaskAssignmentsMax; each row takes a different owner
     await Promise.all(
       ownedMutableWork.map((work) => {
         const nextOwnerUserId =


### PR DESCRIPTION
Comment-only companion to the `no-db-await-in-loop` burn-down.

Four of the directives carried no reason on the line. The suppression
ledger records those the same as any other, so the count included four
entries with nothing stating what makes the loop acceptable; the prose
above each said what the code does, which is a different question.

Each directive now names its category:

- `handlers/chat/delete-thread.ts` (two): keyset page walks. The page's
  last id is the next iteration's cursor, and the row delete is one
  `inArray` over the whole page, ordered after that page's storage
  delete.
- `lib/account-deletion-steps.ts` (two): bounded fan-outs over one
  deleted user's task assignments and work obligations, capped by
  `LIMITS.accountDeletionTaskAssignmentsMax` before the loop is
  reached — the handler throws above it when the cap is exceeded.

No behaviour change, no ratchet movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal code comments explaining bounded database operations during account and thread deletion.
  * Documented pagination behaviour and safe limits for task reassignment and work-obligation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->