### PR TITLE
feat(api): corpus projection appends choose their commit mode

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -810,6 +810,46 @@ test("final-generation ingest requires the exact committed V2 receipt", async ()
   expect(requests.at(0)?.search).toBe("?commit=wait_for");
 });
 
+test("the two final-generation ingests differ only in their commit mode", async () => {
+  responseBody = {
+    num_docs_for_processing: 2,
+    num_ingested_docs: 2,
+    num_rejected_docs: 0,
+  };
+  const client = getCorpusIndexClient("q08");
+  const ndjson = '{"document_id":"a"}\n{"document_id":"b"}';
+
+  expect(
+    (await client.ingestCommittedBatch("case_law_v5_cs_sk", ndjson)).isOk(),
+  ).toBe(true);
+  expect(
+    (await client.ingestQueuedBatch("case_law_v5_cs_sk", ndjson)).isOk(),
+  ).toBe(true);
+
+  // Both persist their acceptance, so both demand the exact receipt; only
+  // when that acceptance becomes visible differs, and that is the commit
+  // value. A queued call sent as `wait_for` would silently be the slow path.
+  expect(requests.map(({ search }) => search)).toEqual([
+    `?commit=${CORPUS_INDEX_COMMIT.waitFor}`,
+    `?commit=${CORPUS_INDEX_COMMIT.auto}`,
+  ]);
+});
+
+test("queued ingest rejects a partial V2 receipt", async () => {
+  responseBody = {
+    num_docs_for_processing: 2,
+    num_ingested_docs: 1,
+    num_rejected_docs: 0,
+  };
+
+  const result = await getCorpusIndexClient("q08").ingestQueuedBatch(
+    "case_law_v5_cs_sk",
+    '{"document_id":"a"}\n{"document_id":"b"}',
+  );
+
+  expect(result.isErr()).toBe(true);
+});
+
 test("final-generation ingest rejects missing or partial V2 counters", async () => {
   for (const receipt of [
     { num_docs_for_processing: 2, num_rejected_docs: 0 },

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -67,11 +67,16 @@ const SETTLEMENT_SCAN_TIMEOUT_MS = 60_000;
  * Postgres, and the row is then neither missing nor stale, so nothing
  * ever selects it again. `wait_for` holds the response until the split
  * is published, which makes the acceptance mean durability.
+ *
+ * A caller that persists an `auto` acceptance therefore owes two things:
+ * a census that can still find documents the commit window lost, and a
+ * publish fence, because the documents stay invisible to search and to
+ * delete-by-query until the engine's own commit timer fires.
  */
 export const CORPUS_INDEX_COMMIT = {
-  /** Buffered for indexing. Bulk paths only, with a census behind them. */
+  /** Buffered for indexing. Needs a census and a publish fence behind it. */
   auto: "auto",
-  /** Published as a split. Required wherever acceptance is persisted. */
+  /** Published as a split. Acceptance means durability at that instant. */
   waitFor: "wait_for",
 } as const;
 
@@ -165,6 +170,15 @@ export type CorpusIndexClient = {
   ) => Promise<Result<void, CorpusIndexError>>;
   /** Final-generation append: durable commit plus an exact V2 receipt. */
   ingestCommittedBatch: (
+    indexId: string,
+    ndjson: string,
+  ) => Promise<Result<void, CorpusIndexError>>;
+  /**
+   * Final-generation append that returns on acceptance instead of on the
+   * commit, with the same exact V2 receipt. Throughput path only: the
+   * caller owns the publish fence every observer of the acceptance needs.
+   */
+  ingestQueuedBatch: (
     indexId: string,
     ndjson: string,
   ) => Promise<Result<void, CorpusIndexError>>;
@@ -652,6 +666,15 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
       indexId,
       ndjson,
       commit: CORPUS_INDEX_COMMIT.waitFor,
+      receiptMode: "exact-v2",
+    }),
+
+  ingestQueuedBatch: async (indexId, ndjson) =>
+    await ingestBatch({
+      baseUrl: mutationBaseUrl(cluster),
+      indexId,
+      ndjson,
+      commit: CORPUS_INDEX_COMMIT.auto,
       receiptMode: "exact-v2",
     }),
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-census-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-census-store.ts
@@ -14,6 +14,10 @@ import {
   readRegisteredCorpusProjectionManifestForCleanup,
 } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { CORPUS_PROJECTION_DELETE_MAX_REVISIONS } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import {
+  corpusProjectionAcceptedAppendCleanupFence,
+  corpusProjectionAppendIsPublished,
+} from "@/api/lib/legal-search/corpus-index-projection-publish-fence";
 import { brandValidatedCorpusIndexProjectionIntentId } from "@/api/lib/safe-id-boundaries";
 
 type ProjectionRevision = SafeId<"corpusIndexProjectionIntent">;
@@ -92,7 +96,11 @@ const requireAppliedCandidateDocumentCount = ({
   return { entityId, revision, expectedDocumentCount };
 };
 
-/** Bounded authoritative revisions that the engine must currently contain. */
+/**
+ * Bounded authoritative revisions that the engine must currently contain.
+ * A revision the engine has accepted but not yet published is not one of
+ * them: reading it now would report a queued append as drift.
+ */
 export const readAppliedCorpusProjectionCensusPageTx = async (
   tx: Transaction,
   options: CorpusProjectionCensusPageOptions,
@@ -100,7 +108,7 @@ export const readAppliedCorpusProjectionCensusPageTx = async (
   CorpusProjectionCensusPage<AppliedCorpusProjectionCensusCandidate>
 > => {
   validateCensusPage(options);
-  await readRegisteredCorpusProjectionManifestForCleanup(
+  const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
     tx,
     options.family,
     options.generation,
@@ -127,6 +135,7 @@ export const readAppliedCorpusProjectionCensusPageTx = async (
         eq(corpusIndexProjectionStates.appliedIndexId, options.indexId),
         isNotNull(corpusIndexProjectionStates.appliedRevision),
         eq(corpusIndexProjectionIntents.status, "applied"),
+        corpusProjectionAppendIsPublished(manifest),
         options.after === null
           ? undefined
           : gt(corpusIndexProjectionStates.entityId, options.after),
@@ -211,7 +220,7 @@ export const repairAppliedCorpusProjectionDriftTx = async (
   ) {
     return panic("Corpus projection census repair batch is invalid");
   }
-  await lockRegisteredCorpusProjectionManifestForMutation(
+  const manifest = await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     options.family,
     options.generation,
@@ -276,8 +285,7 @@ export const repairAppliedCorpusProjectionDriftTx = async (
     .update(corpusIndexProjectionIntents)
     .set({
       status: "cleanup_pending",
-      appendPublishBarrierAt: corpusIndexProjectionIntents.appendCommittedAt,
-      cleanupNotBefore: repairAt,
+      ...corpusProjectionAcceptedAppendCleanupFence(manifest, repairAt),
       lastError: "applied census observed engine drift",
       updatedAt: repairAt,
     })

--- a/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
@@ -9,7 +9,12 @@ import {
   corpusIndexProjectionStates,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
 import { readCorpusIndexProjectionConvergenceTx } from "@/api/lib/legal-search/corpus-index-projection-convergence";
+import { corpusIndexAppendPublishDelayMs } from "@/api/lib/legal-search/corpus-index-projection-engine";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
@@ -49,7 +54,9 @@ beforeAll(async () => {
   await db.insert(corpusIndexGenerations).values({
     ...TARGET,
     cluster: "q09",
-    manifestDigest: "a".repeat(64),
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
     status: "building",
   });
 });
@@ -167,4 +174,40 @@ test("the launch probe requires populated current state before census", async ()
     cleanupNotBefore: NOW,
   });
   expect(await readStatus()).toBe("intent_outstanding");
+});
+
+test("the launch probe waits out the engine publish delay", async () => {
+  await db
+    .delete(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, CLEANUP_INTENT_ID));
+  expect(await readStatus()).toBe("ready_for_census");
+
+  const acceptedAt = new Date();
+  await db
+    .update(corpusIndexProjectionIntents)
+    .set({
+      appendStartedAt: acceptedAt,
+      appendCommittedAt: acceptedAt,
+      appliedAt: acceptedAt,
+    })
+    .where(eq(corpusIndexProjectionIntents.id, APPLIED_INTENT_ID));
+  // Every revision is applied, but a queued one is not searchable yet. A
+  // census run now would inspect a strict subset and still read as complete,
+  // which is a proof of nothing.
+  expect(await readStatus()).toBe("publish_pending");
+
+  const published = new Date(
+    Date.now() -
+      corpusIndexAppendPublishDelayMs(CORPUS_INDEX_MANIFESTS.case_law_v5) -
+      1000,
+  );
+  await db
+    .update(corpusIndexProjectionIntents)
+    .set({
+      appendStartedAt: published,
+      appendCommittedAt: published,
+      appliedAt: published,
+    })
+    .where(eq(corpusIndexProjectionIntents.id, APPLIED_INTENT_ID));
+  expect(await readStatus()).toBe("ready_for_census");
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-convergence.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-convergence.ts
@@ -8,6 +8,8 @@ import {
 } from "@/api/db/schema";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import { CORPUS_INDEX_LAUNCH_BLOCKING_INTENT_STATUSES } from "@/api/lib/legal-search/corpus-index-projection-contract";
+import { readRegisteredCorpusProjectionManifestForCleanup } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { corpusProjectionAppendIsPublished } from "@/api/lib/legal-search/corpus-index-projection-publish-fence";
 import {
   corpusIndexProjectionIsBlocked,
   corpusIndexProjectionNeedsWork,
@@ -19,6 +21,12 @@ export const CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS = {
   blocked: "blocked",
   pending: "pending",
   intentOutstanding: "intent_outstanding",
+  /**
+   * Every revision is applied, but the engine has not certainly published
+   * the most recent ones. A census run now would inspect a strict subset of
+   * the generation and still read as complete, so the proof waits.
+   */
+  publishPending: "publish_pending",
   readyForCensus: "ready_for_census",
 } as const;
 
@@ -49,7 +57,11 @@ const rowsOf = (result: unknown): unknown[] => {
   return [];
 };
 
-/** Constant-time PostgreSQL precondition for a fresh zero-drift engine census. */
+/**
+ * Constant-time PostgreSQL precondition for a fresh zero-drift engine census.
+ * The publish probe runs only once the queue is otherwise converged, so the
+ * common answer still costs one round trip.
+ */
 export const readCorpusIndexProjectionConvergenceTx = async (
   tx: Transaction,
   target: CorpusIndexProjectionConvergenceTarget,
@@ -118,7 +130,26 @@ export const readCorpusIndexProjectionConvergenceTx = async (
   if (observation["hasPendingState"]) {
     return CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.pending;
   }
-  return observation["hasOutstandingIntent"]
-    ? CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.intentOutstanding
-    : CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.readyForCensus;
+  if (observation["hasOutstandingIntent"]) {
+    return CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.intentOutstanding;
+  }
+  const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
+    tx,
+    target.family,
+    target.generation,
+  );
+  const unpublished = await tx
+    .select({ id: corpusIndexProjectionIntents.id })
+    .from(corpusIndexProjectionIntents)
+    .where(
+      and(
+        intentScope,
+        eq(corpusIndexProjectionIntents.status, "applied"),
+        sql`NOT ${corpusProjectionAppendIsPublished(manifest)}`,
+      ),
+    )
+    .limit(1);
+  return unpublished.length === 0
+    ? CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.readyForCensus
+    : CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.publishPending;
 };

--- a/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
@@ -26,6 +26,31 @@ export const CORPUS_PROJECTION_APPEND_MAX_SINGLE_REVISION_BYTES =
 export const CORPUS_PROJECTION_DELETE_MAX_REVISIONS = 128;
 export const CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS = 5000;
 
+/**
+ * What an accepted append is allowed to mean for the store row behind it.
+ *
+ * `published` waits for the split, so a revision the store marks applied is
+ * searchable the instant it is applied. `queued` returns on acceptance, so a
+ * catch-up generation can keep more than one request in flight per commit
+ * period instead of paying a wall-clock commit for each one, and its
+ * documents stay invisible to search and to delete-by-query until the
+ * engine's own commit timer fires.
+ *
+ * Nothing persists which mode wrote a revision, and nothing should: the mode
+ * is a per-cycle choice, several cycles can append into one generation, and a
+ * reader that guessed wrong would delete documents that are not there yet or
+ * read absence as drift. Every observer of an accepted revision instead
+ * fences on `corpusIndexAppendPublishDelayMs`, which holds for both modes:
+ * a published append has already spent that delay inside the ingest call.
+ */
+export const CORPUS_PROJECTION_APPEND_COMMIT_MODE = {
+  published: "published",
+  queued: "queued",
+} as const;
+
+export type CorpusProjectionAppendCommitMode =
+  (typeof CORPUS_PROJECTION_APPEND_COMMIT_MODE)[keyof typeof CORPUS_PROJECTION_APPEND_COMMIT_MODE];
+
 export type CorpusProjectionAppendEntry = {
   revision: ProjectionRevision;
   documents: readonly Record<string, unknown>[];
@@ -425,6 +450,18 @@ export const corpusIndexUnknownAppendBarrierAt = (
 
 export const corpusIndexUnknownAppendBarrierDelayMs = (
   manifest: CorpusIndexManifest,
+): number =>
+  CORPUS_INDEX_INGEST_TIMEOUT_MS + corpusIndexAppendPublishDelayMs(manifest);
+
+/**
+ * Milliseconds after the engine accepts an append when its documents are
+ * guaranteed observable: committed by the engine's own commit timer and
+ * published as a split. Under `published` the ingest call has already spent
+ * this delay; under `queued` the caller still owes all of it, so search,
+ * census, convergence, and delete-by-query all fence on it.
+ */
+export const corpusIndexAppendPublishDelayMs = (
+  manifest: CorpusIndexManifest,
 ): number => {
   const commitTimeoutSecs =
     manifest.engine.indexConfig.indexing_settings.commit_timeout_secs;
@@ -435,9 +472,5 @@ export const corpusIndexUnknownAppendBarrierDelayMs = (
   ) {
     return panic("Corpus projection append barrier contract is invalid");
   }
-  return (
-    CORPUS_INDEX_INGEST_TIMEOUT_MS +
-    commitTimeoutSecs * 1000 +
-    CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS
-  );
+  return commitTimeoutSecs * 1000 + CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS;
 };

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
@@ -11,6 +11,7 @@ import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-cont
 import { CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES } from "@/api/lib/legal-search/corpus-index-projection-contract";
 import { lockRegisteredCorpusProjectionManifestForMutation } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { corpusIndexUnknownAppendBarrierAt } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { corpusProjectionAcceptedAppendCleanupFence } from "@/api/lib/legal-search/corpus-index-projection-publish-fence";
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   entityIdsForCorpusProjectionWorkScope,
@@ -243,8 +244,7 @@ export const advanceCorpusProjectionErasuresTx = async <
         status: "cleanup_pending",
         leaseToken: null,
         leaseExpiresAt: null,
-        appendPublishBarrierAt: sql`${corpusIndexProjectionIntents.appendCommittedAt}`,
-        cleanupNotBefore: transitionAt,
+        ...corpusProjectionAcceptedAppendCleanupFence(manifest, transitionAt),
         lastError: "projection revision scheduled by erasure",
         updatedAt: transitionAt,
       })

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.db.test.ts
@@ -1,0 +1,91 @@
+import { panic } from "better-result";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import { corpusIndexGenerations } from "@/api/db/schema";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { CORPUS_PROJECTION_APPEND_COMMIT_MODE } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { executeCorpusProjectionAppendCycle } from "@/api/lib/legal-search/corpus-index-projection-executor";
+import { CORPUS_PROJECTION_GENERATION_SCOPE } from "@/api/lib/legal-search/corpus-index-projection-scope";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const TARGET = {
+  family: "case_law",
+  generation: "case_law_v5",
+} as const;
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const runInTransaction = async <TResult>(
+  operation: (tx: Transaction) => Promise<TResult>,
+): Promise<TResult> =>
+  await db.transaction(
+    async (tx) => await operation(asTestRaw<Transaction>(tx)),
+  );
+
+const unusedIngest = async () =>
+  panic("An idle projection cycle must not reach the engine");
+
+const runCycle = async (
+  commitMode: (typeof CORPUS_PROJECTION_APPEND_COMMIT_MODE)[keyof typeof CORPUS_PROJECTION_APPEND_COMMIT_MODE],
+) =>
+  await executeCorpusProjectionAppendCycle({
+    runInTransaction,
+    client: {
+      ingestCommittedBatch: unusedIngest,
+      ingestQueuedBatch: unusedIngest,
+    },
+    commitMode,
+    family: TARGET.family,
+    generation: TARGET.generation,
+    scope: CORPUS_PROJECTION_GENERATION_SCOPE,
+    limit: 8,
+    leaseMs: 60_000,
+    payloadReadConcurrency: 4,
+    retryDelayMs: 5000,
+    payloadRetryLimit: 3,
+  });
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+  await db.insert(corpusIndexGenerations).values({
+    ...TARGET,
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
+    status: "building",
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("every cycle reports one timing per phase, in both commit modes", async () => {
+  for (const commitMode of Object.values(
+    CORPUS_PROJECTION_APPEND_COMMIT_MODE,
+  )) {
+    const result = await runCycle(commitMode);
+
+    expect(result.status).toBe("idle");
+    expect(result.requestCount).toBe(0);
+    // The caller logs these, so a phase that stops being measured has to
+    // fail here rather than quietly report zero forever.
+    expect(result.timing).toEqual({
+      reservationMs: expect.any(Number),
+      materialReadMs: 0,
+      payloadLoadMs: 0,
+      ingestMs: 0,
+      storeCommitMs: 0,
+    });
+    expect(result.timing.reservationMs).toBeGreaterThanOrEqual(0);
+  }
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.test.ts
@@ -1,10 +1,15 @@
+import { Result } from "better-result";
 import { expect, test } from "bun:test";
 
 import { PayloadBudgetError } from "@/api/lib/compression";
-import { CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import {
+  CORPUS_PROJECTION_APPEND_COMMIT_MODE,
+  CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES,
+} from "@/api/lib/legal-search/corpus-index-projection-engine";
 import {
   advanceCorpusProjectionAppendTails,
   classifyCorpusProjectionPayloadReadFailure,
+  ingestCorpusProjectionRequest,
 } from "@/api/lib/legal-search/corpus-index-projection-executor";
 import { S3ObjectBudgetError } from "@/api/lib/s3";
 
@@ -128,4 +133,34 @@ test("append tails flush before crossing the physical request budget", () => {
   expect(
     result.tails.get("case_law_v5_cs_sk")?.entries.map(({ ndjson }) => ndjson),
   ).toEqual(["cs-2"]);
+});
+
+test("the commit mode picks the ingest the request runs through", async () => {
+  const calls: string[] = [];
+  const client = {
+    ingestCommittedBatch: async () => {
+      calls.push(CORPUS_PROJECTION_APPEND_COMMIT_MODE.published);
+      return Result.ok(undefined);
+    },
+    ingestQueuedBatch: async () => {
+      calls.push(CORPUS_PROJECTION_APPEND_COMMIT_MODE.queued);
+      return Result.ok(undefined);
+    },
+  };
+
+  for (const commitMode of Object.values(
+    CORPUS_PROJECTION_APPEND_COMMIT_MODE,
+  )) {
+    expect(
+      (
+        await ingestCorpusProjectionRequest(client, {
+          commitMode,
+          indexId: "case_law_v5_cs_sk",
+          ndjson: '{"document_id":"a"}',
+        })
+      ).isOk(),
+    ).toBe(true);
+  }
+
+  expect(calls).toEqual(Object.values(CORPUS_PROJECTION_APPEND_COMMIT_MODE));
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -8,10 +8,12 @@ import { settleBoth } from "@/api/lib/corpus-index/core";
 import type { CorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import { buildCorpusProjectionDocuments } from "@/api/lib/legal-search/corpus-index-projection-builder";
 import {
+  CORPUS_PROJECTION_APPEND_COMMIT_MODE,
   CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES,
   CORPUS_PROJECTION_APPEND_MAX_REVISIONS,
   CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS,
   planCorpusProjectionAppendRequests,
+  type CorpusProjectionAppendCommitMode,
   type CorpusProjectionAppendEntry,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
 import {
@@ -44,7 +46,48 @@ import type { IngestionTransactionRunner } from "@/api/lib/replay-safe-ingestion
 import { S3ObjectBudgetError } from "@/api/lib/s3";
 
 type ProjectionTransactionRunner = IngestionTransactionRunner<Transaction>;
-type ProjectionAppendClient = Pick<CorpusIndexClient, "ingestCommittedBatch">;
+type ProjectionAppendClient = Pick<
+  CorpusIndexClient,
+  "ingestCommittedBatch" | "ingestQueuedBatch"
+>;
+
+/**
+ * The cycle's only mode-dependent step. Everything after it (the batch start,
+ * the commit, the abandon on an unknown outcome) reads the same durable
+ * state either way, so a queued cycle settles exactly like a published one.
+ */
+export const ingestCorpusProjectionRequest = async (
+  client: ProjectionAppendClient,
+  {
+    commitMode,
+    indexId,
+    ndjson,
+  }: {
+    commitMode: CorpusProjectionAppendCommitMode;
+    indexId: string;
+    ndjson: string;
+  },
+) => {
+  switch (commitMode) {
+    case CORPUS_PROJECTION_APPEND_COMMIT_MODE.published:
+      return await client.ingestCommittedBatch(indexId, ndjson);
+    case CORPUS_PROJECTION_APPEND_COMMIT_MODE.queued:
+      return await client.ingestQueuedBatch(indexId, ndjson);
+    default:
+      commitMode satisfies never;
+      return panic(`Unhandled append commit mode: ${String(commitMode)}`);
+  }
+};
+
+const measured = async <Value>(
+  operation: () => Promise<Value>,
+  record: (elapsedMs: number) => void,
+): Promise<Value> => {
+  const startedAt = Date.now();
+  const value = await operation();
+  record(Date.now() - startedAt);
+  return value;
+};
 
 const mapSequentially = async <Input, Output>(
   values: readonly Input[],
@@ -68,11 +111,26 @@ type ExecuteCorpusProjectionAppendCycleOptions<
   runInTransaction: ProjectionTransactionRunner;
   client: ProjectionAppendClient;
   generation: string;
+  /**
+   * Required, like the client's own `commit`: the two modes differ in what
+   * the persisted acceptance means, and a default would let a caller inherit
+   * the wrong one silently.
+   */
+  commitMode: CorpusProjectionAppendCommitMode;
   limit: number;
   leaseMs: number;
   payloadReadConcurrency: number;
   retryDelayMs: number;
   payloadRetryLimit: number;
+};
+
+/** Wall-clock milliseconds per phase, summed over the cycle, for the caller's logs. */
+export type CorpusProjectionAppendCycleTiming = {
+  reservationMs: number;
+  materialReadMs: number;
+  payloadLoadMs: number;
+  ingestMs: number;
+  storeCommitMs: number;
 };
 
 export type CorpusProjectionAppendCycleResult = {
@@ -88,13 +146,16 @@ export type CorpusProjectionAppendCycleResult = {
   retryScheduled: number;
   blocked: number;
   requestCount: number;
+  timing: CorpusProjectionAppendCycleTiming;
 };
 
 const emptyResult = (
   replacementCleanupScheduled: number,
+  timing: CorpusProjectionAppendCycleTiming,
 ): CorpusProjectionAppendCycleResult => ({
   status: "idle",
   replacementCleanupScheduled,
+  timing,
   reserved: 0,
   applied: 0,
   staleCleanupPending: 0,
@@ -465,6 +526,7 @@ const addCancellation = (
 type ProcessPreparedRequestsOptions = {
   runInTransaction: ProjectionTransactionRunner;
   client: ProjectionAppendClient;
+  commitMode: CorpusProjectionAppendCommitMode;
   requests: readonly PreparedProjectionRequest[];
   requestIndex: number;
   unattemptedLeases: readonly CorpusProjectionIntentLease[];
@@ -474,6 +536,7 @@ type ProcessPreparedRequestsOptions = {
 const processPreparedRequests = async ({
   runInTransaction,
   client,
+  commitMode,
   requests,
   requestIndex,
   unattemptedLeases,
@@ -486,11 +549,17 @@ const processPreparedRequests = async ({
   // Start one physical request as a batch. Its shared timestamp is read from
   // PostgreSQL only after all state locks are held, immediately before
   // external I/O; crash recovery cannot settle ahead of a late append.
-  const starts = await runInTransaction(
-    async (tx) =>
-      await startCorpusProjectionAppendBatchTx(tx, {
-        leases: request.entries.map(({ material }) => material.lease),
-      }),
+  const starts = await measured(
+    async () =>
+      await runInTransaction(
+        async (tx) =>
+          await startCorpusProjectionAppendBatchTx(tx, {
+            leases: request.entries.map(({ material }) => material.lease),
+          }),
+      ),
+    (elapsedMs) => {
+      result.timing.storeCommitMs += elapsedMs;
+    },
   );
   result.cancelled += starts.filter(
     ({ status }) => status === "stale_cancelled",
@@ -514,6 +583,7 @@ const processPreparedRequests = async ({
     return await processPreparedRequests({
       runInTransaction,
       client,
+      commitMode,
       requests,
       requestIndex: requestIndex + 1,
       unattemptedLeases,
@@ -521,9 +591,16 @@ const processPreparedRequests = async ({
     });
   }
   result.requestCount += 1;
-  const appended = await client.ingestCommittedBatch(
-    request.indexId,
-    started.map(({ ndjson }) => ndjson).join("\n"),
+  const appended = await measured(
+    async () =>
+      await ingestCorpusProjectionRequest(client, {
+        commitMode,
+        indexId: request.indexId,
+        ndjson: started.map(({ ndjson }) => ndjson).join("\n"),
+      }),
+    (elapsedMs) => {
+      result.timing.ingestMs += elapsedMs;
+    },
   );
   if (appended.isErr()) {
     const abandoned = await runInTransaction(async (tx) => {
@@ -566,41 +643,48 @@ const processPreparedRequests = async ({
     return "append_unknown";
   }
 
-  const committed = await runInTransaction(async (tx) => {
-    const outcomes = await mapSequentially(
-      started,
-      async (preparedEntry) =>
-        await commitCorpusProjectionAppendTx(tx, {
-          intentId: preparedEntry.material.lease.intentId,
-          leaseToken: preparedEntry.material.lease.leaseToken,
-          documentCount: preparedEntry.documentCount,
-        }),
-    );
-    const counts = { applied: 0, staleCleanupPending: 0, leaseLost: 0 };
-    for (const outcome of outcomes) {
-      switch (outcome.status) {
-        case "applied":
-          counts.applied += 1;
-          break;
-        case "stale_cleanup_pending":
-          counts.staleCleanupPending += 1;
-          break;
-        case "lease_lost":
-          counts.leaseLost += 1;
-          break;
-        default:
-          outcome satisfies never;
-          panic(`Unhandled outcome: ${String(outcome)}`);
-      }
-    }
-    return counts;
-  });
+  const committed = await measured(
+    async () =>
+      await runInTransaction(async (tx) => {
+        const outcomes = await mapSequentially(
+          started,
+          async (preparedEntry) =>
+            await commitCorpusProjectionAppendTx(tx, {
+              intentId: preparedEntry.material.lease.intentId,
+              leaseToken: preparedEntry.material.lease.leaseToken,
+              documentCount: preparedEntry.documentCount,
+            }),
+        );
+        const counts = { applied: 0, staleCleanupPending: 0, leaseLost: 0 };
+        for (const outcome of outcomes) {
+          switch (outcome.status) {
+            case "applied":
+              counts.applied += 1;
+              break;
+            case "stale_cleanup_pending":
+              counts.staleCleanupPending += 1;
+              break;
+            case "lease_lost":
+              counts.leaseLost += 1;
+              break;
+            default:
+              outcome satisfies never;
+              panic(`Unhandled outcome: ${String(outcome)}`);
+          }
+        }
+        return counts;
+      }),
+    (elapsedMs) => {
+      result.timing.storeCommitMs += elapsedMs;
+    },
+  );
   result.applied += committed.applied;
   result.staleCleanupPending += committed.staleCleanupPending;
   result.leaseLost += committed.leaseLost;
   return await processPreparedRequests({
     runInTransaction,
     client,
+    commitMode,
     requests,
     requestIndex: requestIndex + 1,
     unattemptedLeases,
@@ -611,6 +695,7 @@ const processPreparedRequests = async ({
 type ProcessPreparedWindowsOptions = {
   runInTransaction: ProjectionTransactionRunner;
   client: ProjectionAppendClient;
+  commitMode: CorpusProjectionAppendCommitMode;
   materialsReady: readonly CorpusProjectionMaterial[];
   tails: Map<string, ProjectionAppendTail<PreparedProjectionEntry>>;
   windowStart: number;
@@ -623,6 +708,7 @@ type ProcessPreparedWindowsOptions = {
 const processPreparedWindows = async ({
   runInTransaction,
   client,
+  commitMode,
   materialsReady,
   tails,
   windowStart,
@@ -641,6 +727,7 @@ const processPreparedWindows = async ({
     return await processPreparedRequests({
       runInTransaction,
       client,
+      commitMode,
       requests: final.flush,
       requestIndex: 0,
       unattemptedLeases: [],
@@ -655,11 +742,17 @@ const processPreparedWindows = async ({
     materialsReady.length,
   );
   const window = materialsReady.slice(windowStart, windowEnd);
-  const loaded = await Promise.all(
-    window.map(async (material) => ({
-      material,
-      loaded: await buildPreparedEntry(runInTransaction, material),
-    })),
+  const loaded = await measured(
+    async () =>
+      await Promise.all(
+        window.map(async (material) => ({
+          material,
+          loaded: await buildPreparedEntry(runInTransaction, material),
+        })),
+      ),
+    (elapsedMs) => {
+      result.timing.payloadLoadMs += elapsedMs;
+    },
   );
   const preparationFailures: ReservationFailure[] = [];
   const prepared: PreparedProjectionEntry[] = [];
@@ -718,6 +811,7 @@ const processPreparedWindows = async ({
   const requestStatus = await processPreparedRequests({
     runInTransaction,
     client,
+    commitMode,
     requests: advanced.flush,
     requestIndex: 0,
     unattemptedLeases,
@@ -729,6 +823,7 @@ const processPreparedWindows = async ({
   return await processPreparedWindows({
     runInTransaction,
     client,
+    commitMode,
     materialsReady,
     tails: advanced.tails,
     windowStart: windowEnd,
@@ -740,14 +835,18 @@ const processPreparedWindows = async ({
 };
 
 /**
- * Execute one bounded append cycle. Plane chooses scope, cadence, limits, and
- * concurrency; this primitive owns durable ordering and exact outcomes.
+ * Execute one bounded append cycle. Plane chooses scope, cadence, limits,
+ * concurrency, and what an acceptance means; this primitive owns durable
+ * ordering and exact outcomes. A queued cycle no longer waits a commit period
+ * per request, so a backlog is bounded by payload and index throughput rather
+ * than by in-flight requests times the commit period.
  */
 export const executeCorpusProjectionAppendCycle = async <
   Family extends CorpusProjectionIntentLease["family"],
 >({
   runInTransaction,
   client,
+  commitMode,
   family,
   generation,
   scope,
@@ -762,31 +861,51 @@ export const executeCorpusProjectionAppendCycle = async <
     retryDelayMs,
     payloadRetryLimit,
   );
-  const { replacements, leases } = await runInTransaction(async (tx) => ({
-    replacements: await prepareCorpusProjectionReplacementsTx(tx, {
-      family,
-      generation,
-      scope,
-      limit,
-    }),
-    leases: await reserveCorpusProjectionIntentsTx(tx, {
-      family,
-      generation,
-      scope,
-      limit,
-      leaseMs,
-    }),
-  }));
+  const timing: CorpusProjectionAppendCycleTiming = {
+    reservationMs: 0,
+    materialReadMs: 0,
+    payloadLoadMs: 0,
+    ingestMs: 0,
+    storeCommitMs: 0,
+  };
+  const { replacements, leases } = await measured(
+    async () =>
+      await runInTransaction(async (tx) => ({
+        replacements: await prepareCorpusProjectionReplacementsTx(tx, {
+          family,
+          generation,
+          scope,
+          limit,
+        }),
+        leases: await reserveCorpusProjectionIntentsTx(tx, {
+          family,
+          generation,
+          scope,
+          limit,
+          leaseMs,
+        }),
+      })),
+    (elapsedMs) => {
+      timing.reservationMs += elapsedMs;
+    },
+  );
   if (leases.length === 0) {
-    return emptyResult(replacements.length);
+    return emptyResult(replacements.length, timing);
   }
   const result: CorpusProjectionAppendCycleResult = {
-    ...emptyResult(replacements.length),
+    ...emptyResult(replacements.length, timing),
     status: "completed",
     reserved: leases.length,
   };
-  const materials = await runInTransaction(
-    async (tx) => await readReservedCorpusProjectionMaterialsTx(tx, { leases }),
+  const materials = await measured(
+    async () =>
+      await runInTransaction(
+        async (tx) =>
+          await readReservedCorpusProjectionMaterialsTx(tx, { leases }),
+      ),
+    (elapsedMs) => {
+      result.timing.materialReadMs += elapsedMs;
+    },
   );
   const rejectedLeases = materials.rejected
     .filter(({ status }) => status === "stale")
@@ -827,6 +946,7 @@ export const executeCorpusProjectionAppendCycle = async <
   await processPreparedWindows({
     runInTransaction,
     client,
+    commitMode,
     materialsReady: materials.ready,
     tails: new Map(),
     windowStart: 0,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-publish-fence.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-publish-fence.db.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  readAppliedCorpusProjectionCensusPageTx,
+  repairAppliedCorpusProjectionDriftTx,
+} from "@/api/lib/legal-search/corpus-index-projection-census-store";
+import { corpusIndexAppendPublishDelayMs } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const TARGET = {
+  family: "case_law",
+  generation: "case_law_v5",
+} as const;
+const ENTITY_ID = "0198e331-e578-7000-8000-000000000401";
+const REVISION = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000402",
+);
+const INDEX_ID = "case_law_v5_cs_sk";
+const FINGERPRINT = "a".repeat(64);
+const PUBLISH_DELAY_MS = corpusIndexAppendPublishDelayMs(
+  CORPUS_INDEX_MANIFESTS.case_law_v5,
+);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const acceptAppendAt = async (acceptedAt: Date) =>
+  await db
+    .update(corpusIndexProjectionIntents)
+    .set({
+      appendStartedAt: acceptedAt,
+      appendCommittedAt: acceptedAt,
+      appliedAt: acceptedAt,
+    })
+    .where(eq(corpusIndexProjectionIntents.id, REVISION));
+
+const censusCandidates = async () =>
+  await db.transaction(
+    async (tx) =>
+      await readAppliedCorpusProjectionCensusPageTx(
+        asTestRaw<Transaction>(tx),
+        {
+          ...TARGET,
+          indexId: INDEX_ID,
+          after: null,
+          limit: 8,
+        },
+      ),
+  );
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+  await db.insert(corpusIndexGenerations).values({
+    ...TARGET,
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
+    status: "building",
+  });
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: REVISION,
+    ...TARGET,
+    entityId: ENTITY_ID,
+    epoch: 1n,
+    fingerprint: FINGERPRINT,
+    indexId: INDEX_ID,
+    status: "applied",
+    appendStartedAt: new Date(),
+    appendCommittedAt: new Date(),
+    expectedDocumentCount: 1,
+    appliedAt: new Date(),
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    ...TARGET,
+    entityId: ENTITY_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+    appliedAction: "upsert",
+    appliedEpoch: 1n,
+    appliedRevision: REVISION,
+    appliedFingerprint: FINGERPRINT,
+    appliedIndexId: INDEX_ID,
+    appliedAt: new Date(),
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("the applied census inspects a revision only once the engine published it", async () => {
+  // A queued append is accepted before its documents are committed. Reading
+  // one now would find no documents and repair a revision that is merely
+  // late, so the census must not see it at all.
+  expect((await censusCandidates()).candidates).toEqual([]);
+
+  await acceptAppendAt(new Date(Date.now() - PUBLISH_DELAY_MS + 5000));
+  expect((await censusCandidates()).candidates).toEqual([]);
+
+  await acceptAppendAt(new Date(Date.now() - PUBLISH_DELAY_MS - 1000));
+  expect((await censusCandidates()).candidates).toEqual([
+    { entityId: ENTITY_ID, revision: REVISION, expectedDocumentCount: 1 },
+  ]);
+});
+
+test("cleanup of an accepted append waits out the same publish barrier", async () => {
+  const repairAt = new Date();
+  const acceptedAt = new Date(repairAt.getTime() - 1000);
+  await acceptAppendAt(acceptedAt);
+
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await repairAppliedCorpusProjectionDriftTx(asTestRaw<Transaction>(tx), {
+          ...TARGET,
+          indexId: INDEX_ID,
+          revisions: [REVISION],
+          testNow: repairAt,
+        }),
+    ),
+  ).toBe(1);
+
+  // A delete issued inside the commit window never reaches documents the
+  // engine has not published yet, and they would stay in the index forever.
+  const [fenced] = await db
+    .select({
+      appendPublishBarrierAt:
+        corpusIndexProjectionIntents.appendPublishBarrierAt,
+      cleanupNotBefore: corpusIndexProjectionIntents.cleanupNotBefore,
+    })
+    .from(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, REVISION));
+  const publishedAt = new Date(acceptedAt.getTime() + PUBLISH_DELAY_MS);
+  expect(fenced?.appendPublishBarrierAt).toEqual(publishedAt);
+  expect(fenced?.cleanupNotBefore).toEqual(publishedAt);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-publish-fence.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-publish-fence.ts
@@ -9,6 +9,15 @@ import { corpusIndexAppendPublishDelayMs } from "@/api/lib/legal-search/corpus-i
  * from "the engine published it". Every reader and every delete that
  * observes an accepted revision goes through here, so a queued append
  * cannot be read as drift by one caller and deleted early by another.
+ *
+ * The barrier schedules, it does not prove: the commit policy bounds the
+ * engine's own commit window, not the queueing in front of it, so a
+ * backlogged or restarting engine can still publish later than this. What
+ * proves the two observations behind it is exact, and repairs them when the
+ * engine was late, is unchanged: a cleanup settles only once published
+ * splits cross its delete opstamp and a revision query observes zero
+ * remaining documents, and a census that inspects a revision too early
+ * reports drift, which repairs the entity rather than losing it.
  */
 const publishBarrierFrom = (
   acceptedAt: SQL,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-publish-fence.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-publish-fence.ts
@@ -1,0 +1,72 @@
+import { sql, type SQL } from "drizzle-orm";
+
+import { corpusIndexProjectionIntents } from "@/api/db/schema";
+import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+import { corpusIndexAppendPublishDelayMs } from "@/api/lib/legal-search/corpus-index-projection-engine";
+
+/**
+ * One owner of the rule that separates "the engine accepted this append"
+ * from "the engine published it". Every reader and every delete that
+ * observes an accepted revision goes through here, so a queued append
+ * cannot be read as drift by one caller and deleted early by another.
+ */
+const publishBarrierFrom = (
+  acceptedAt: SQL,
+  manifest: CorpusIndexManifest,
+): SQL =>
+  sql`(${acceptedAt}::timestamptz + ${corpusIndexAppendPublishDelayMs(manifest)}::double precision * interval '1 millisecond')`;
+
+const publishBarrier = (manifest: CorpusIndexManifest): SQL =>
+  publishBarrierFrom(
+    sql`${corpusIndexProjectionIntents.appendCommittedAt}`,
+    manifest,
+  );
+
+/**
+ * Whether the engine has certainly published an accepted append. Only a
+ * published revision may be observed: an earlier census reads a queued
+ * append's absence as drift and repairs a revision that is merely late.
+ */
+export const corpusProjectionAppendIsPublished = (
+  manifest: CorpusIndexManifest,
+): SQL => sql`${publishBarrier(manifest)} <= clock_timestamp()`;
+
+type CorpusProjectionCleanupFence = {
+  appendPublishBarrierAt: SQL;
+  cleanupNotBefore: SQL;
+};
+
+const cleanupFence = (
+  barrier: SQL,
+  transitionAt: Date | SQL,
+): CorpusProjectionCleanupFence => ({
+  appendPublishBarrierAt: barrier,
+  cleanupNotBefore: sql`GREATEST(${transitionAt}::timestamptz, ${barrier})`,
+});
+
+/**
+ * The cleanup fence for a revision the engine has already accepted. Deletes
+ * are opstamp-ordered against published splits, so a delete issued before
+ * the barrier never reaches the documents still inside the commit window and
+ * leaves them in the index forever; the barrier is what keeps cleanup exact
+ * under a queued append.
+ */
+export const corpusProjectionAcceptedAppendCleanupFence = (
+  manifest: CorpusIndexManifest,
+  transitionAt: Date | SQL,
+): CorpusProjectionCleanupFence =>
+  cleanupFence(publishBarrier(manifest), transitionAt);
+
+/**
+ * The same fence for the one path that retires an acceptance it is still
+ * holding, before `append_committed_at` is on the row. The transition is
+ * later than the acceptance it stands in for, so the barrier stays sound.
+ */
+export const corpusProjectionUnrecordedAppendCleanupFence = (
+  manifest: CorpusIndexManifest,
+  transitionAt: Date | SQL,
+): CorpusProjectionCleanupFence =>
+  cleanupFence(
+    publishBarrierFrom(sql`${transitionAt}`, manifest),
+    transitionAt,
+  );

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -35,7 +35,10 @@ import {
   settleCorpusProjectionCleanupTx,
 } from "@/api/lib/legal-search/corpus-index-projection-cleanup-store";
 import { advanceCorpusProjectionDesiredStateTx } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
-import { corpusIndexUnknownAppendBarrierAt } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import {
+  corpusIndexAppendPublishDelayMs,
+  corpusIndexUnknownAppendBarrierAt,
+} from "@/api/lib/legal-search/corpus-index-projection-engine";
 import {
   advanceCorpusProjectionErasuresTx,
   CORPUS_PROJECTION_ERASURE_MAX_REVISIONS,
@@ -1303,12 +1306,22 @@ test("replacement deletes and settles the old revision before reserving the new 
   );
   expect(first).toHaveLength(1);
   const firstLease = first.at(0) ?? panic("Expected first projection lease");
+  // The census and the cleanup below both observe the index, and neither may
+  // run inside the engine's commit window, so this append is accepted far
+  // enough in the past to be published. The fence itself is proven in the
+  // publish-fence test.
+  const acceptedAt = new Date(
+    Date.now() -
+      corpusIndexAppendPublishDelayMs(CORPUS_INDEX_MANIFESTS.case_law_v5) -
+      1000,
+  );
   expect(
     await db.transaction(
       async (tx) =>
         await startCorpusProjectionAppendTx(asTestRaw<Transaction>(tx), {
           intentId: firstLease.intentId,
           leaseToken: firstLease.leaseToken,
+          testNow: acceptedAt,
         }),
     ),
   ).toBe("started");
@@ -1319,6 +1332,7 @@ test("replacement deletes and settles the old revision before reserving the new 
           intentId: firstLease.intentId,
           leaseToken: firstLease.leaseToken,
           documentCount: 1,
+          testNow: acceptedAt,
         }),
     ),
   ).toMatchObject({ status: "applied", entityId: DECISION_ID });
@@ -1812,6 +1826,14 @@ test("production transitions preserve PostgreSQL clock ordering under process sk
       );
     }),
   ).toEqual({ epoch: 3n, generationCount: 1 });
+  // Cleanup deletes by query, so it starts only once the engine has
+  // certainly published what it is deleting.
+  const publishedAt = new Date(
+    databaseNow.getTime() +
+      corpusIndexAppendPublishDelayMs(CORPUS_INDEX_MANIFESTS.case_law_v5),
+  );
+  const cleanupNow = new Date(publishedAt.getTime() + 1000);
+  await setDatabaseClock(cleanupNow);
   const cleanup = await withDatabaseClock(
     async (tx) =>
       await claimCorpusProjectionCleanupTx(tx, {
@@ -1926,7 +1948,7 @@ test("production transitions preserve PostgreSQL clock ordering under process sk
     ),
   ).toHaveLength(1);
 
-  const recoveryNow = new Date(databaseNow.getTime() + 2 * 60_000);
+  const recoveryNow = new Date(cleanupNow.getTime() + 2 * 60_000);
   await setDatabaseClock(recoveryNow);
   expect(
     await withDatabaseClock(
@@ -1960,8 +1982,8 @@ test("production transitions preserve PostgreSQL clock ordering under process sk
       appendStartedAt: databaseNow,
       appendCommittedAt: databaseNow,
       appliedAt: databaseNow,
-      appendPublishBarrierAt: databaseNow,
-      cleanupNotBefore: databaseNow,
+      appendPublishBarrierAt: publishedAt,
+      cleanupNotBefore: cleanupNow,
       cleanupStartedAt: null,
       settledAt: null,
       updatedAt: recoveryNow,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -18,6 +18,10 @@ import {
   CORPUS_PROJECTION_APPEND_MAX_REVISIONS,
   corpusIndexUnknownAppendBarrierAt,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import {
+  corpusProjectionAcceptedAppendCleanupFence,
+  corpusProjectionUnrecordedAppendCleanupFence,
+} from "@/api/lib/legal-search/corpus-index-projection-publish-fence";
 import { lockCorpusIndexProjectionMutationsTx } from "@/api/lib/legal-search/corpus-index-projection-revision";
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
@@ -416,8 +420,7 @@ export const prepareCorpusProjectionReplacementsTx = async <
       status: "cleanup_pending",
       leaseToken: null,
       leaseExpiresAt: null,
-      appendPublishBarrierAt: sql`${corpusIndexProjectionIntents.appendCommittedAt}`,
-      cleanupNotBefore: transitionAt,
+      ...corpusProjectionAcceptedAppendCleanupFence(manifest, transitionAt),
       lastError: null,
       updatedAt: transitionAt,
     })
@@ -785,9 +788,9 @@ export type CommitCorpusProjectionAppendResult =
   | { status: "lease_lost" };
 
 /**
- * Finalize a successful wait_for append and its authoritative state in one
- * transaction. A desired-state race cannot publish: the exact new revision is
- * redirected to cleanup instead.
+ * Finalize an accepted append and its authoritative state in one transaction.
+ * A desired-state race cannot publish: the exact new revision is redirected to
+ * cleanup instead, behind the barrier that makes that cleanup exact.
  */
 export const commitCorpusProjectionAppendTx = async (
   tx: Transaction,
@@ -814,7 +817,7 @@ export const commitCorpusProjectionAppendTx = async (
   if (identity === undefined) {
     return { status: "lease_lost" };
   }
-  await lockRegisteredCorpusProjectionManifestForMutation(
+  const manifest = await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     identity.family,
     identity.generation,
@@ -875,8 +878,9 @@ export const commitCorpusProjectionAppendTx = async (
         status: "cleanup_pending",
         leaseToken: null,
         leaseExpiresAt: null,
-        appendPublishBarrierAt: transitionAt,
-        cleanupNotBefore: transitionAt,
+        ...(intent.appendCommittedAt === null
+          ? corpusProjectionUnrecordedAppendCleanupFence(manifest, transitionAt)
+          : corpusProjectionAcceptedAppendCleanupFence(manifest, transitionAt)),
         expectedDocumentCount: documentCount,
         lastError: "projection desired state changed after append committed",
         updatedAt: transitionAt,

--- a/scripts/knip-exports-baseline.json
+++ b/scripts/knip-exports-baseline.json
@@ -1,6 +1,6 @@
 {
   "apps/api": {
-    "count": 780,
+    "count": 779,
     "files": {
       "apps/api/scripts/lib/capability-catalog.ts": 9,
       "apps/api/scripts/lib/enumerate-safe-handlers.ts": 7,
@@ -234,7 +234,7 @@
       "apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts": 2,
       "apps/api/src/lib/legal-search/corpus-index-projection-engine.ts": 3,
       "apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts": 1,
-      "apps/api/src/lib/legal-search/corpus-index-projection-executor.ts": 3,
+      "apps/api/src/lib/legal-search/corpus-index-projection-executor.ts": 2,
       "apps/api/src/lib/legal-search/corpus-index-projection-materials.ts": 1,
       "apps/api/src/lib/legal-search/corpus-index-projection-scope.ts": 1,
       "apps/api/src/lib/legal-search/corpus-location.ts": 1,


### PR DESCRIPTION
The append executor sends every request with `commit=wait_for`, so a
generation catching up on a backlog spends most of each in-flight chain
waiting for a commit that batches by wall clock. Throughput is then
bounded by (in-flight x request size / commit period), whatever the
indexer, database, and storage can do.

## Two commit modes

`executeCorpusProjectionAppendCycle` now takes a required `commitMode`:

- `published` (`commit=wait_for`): unchanged behaviour. A revision the
  store marks applied is searchable at that instant. Steady state, where
  a single revision must be searchable as soon as its row says so.
- `queued` (`commit=auto`): the request returns on acceptance and the
  engine commits on its own timer. Backlog catch-up, where a census
  sweep follows.

The option is required rather than defaulted, matching the client's own
`commit` parameter and the rest of the cycle options, which take no
defaults either: the two modes differ in what a persisted acceptance
means, and a default lets a new call site inherit the wrong one
silently. `CorpusIndexClient.ingestQueuedBatch` sits next to
`ingestCommittedBatch` and demands the same exact V2 receipt; deletes,
erasures, and every other path stay on the committed call.

## The publish barrier

A queued acceptance is only safe if nothing observes a revision the
engine has accepted but not yet published. Two things would:

- The applied census compares expected document counts against the
  index. An unpublished revision looks like drift, gets repaired, and is
  re-ingested for no reason.
- Cleanup deletes by query. Quickwit applies a delete task against
  splits already published; documents still inside the commit window are
  published afterwards and the delete never reaches them, so they stay
  in the index forever. `abandonCorpusProjectionAppendTx` already fenced
  the unknown-outcome case for exactly this reason; a queued append
  needs the same fence on the known-outcome paths.

Nothing records which mode wrote a revision, and nothing should: the
mode is a per-cycle choice, several cycles can append into one
generation, and a reader that guessed wrong would delete documents that
are not there yet. The fence is therefore mode-blind, derived from the
registered manifest's `commit_timeout_secs` plus the existing
unknown-append margin (`corpusIndexAppendPublishDelayMs`, which the
unknown-append barrier is now expressed in terms of, so the two cannot
drift apart):

- `readAppliedCorpusProjectionCensusPageTx` skips revisions whose
  barrier has not elapsed, so absence is never read as drift.
- `readCorpusIndexProjectionConvergenceTx` gains `publish_pending`
  between `intent_outstanding` and `ready_for_census`. Skipping
  unpublished revisions alone would let a census sweep inspect a strict
  subset of a generation and still report complete, which proves
  nothing. The extra probe runs only once the queue is otherwise
  converged. `CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS` is the source
  of the status union, so a consumer switching on it has to answer for
  the new member.
- Every cleanup of an accepted append (replacement, stale commit,
  census repair, erasure) goes through one owner,
  `corpus-index-projection-publish-fence.ts`, which sets
  `append_publish_barrier_at` and holds `cleanup_not_before` at or after
  it. Four hand-written copies of that rule are now one.

Cost in `published` mode: an audit or a cleanup of a superseded revision
waits out the commit period once. Both are background paths, and
cleanup was already asynchronous.

## Timings

The cycle result carries a `timing` record of per-phase milliseconds
(reservation, material read, payload load, ingest summed over requests,
store commit) for the caller to log. The library still logs nothing.

## Request sizing

Left at 8 MiB. A request is byte-bound, not revision-bound: 512
revisions against an 8 MiB budget breaks even at 16 KiB per revision,
and a revision is one document's passages, each carrying the full
document metadata, so realistic revisions pass that well before the
count cap. Nothing in either repository configures a request body limit
for the engine, and its own default is not visible from here, so raising
the budget would be an unverified change. It is also not the lever:
queued mode removes the wall-clock commit from the throughput bound,
which is what the request size was standing in for.

## Tests

- Client: the two final-generation ingests differ only in their commit
  value, and the queued one still rejects a partial receipt.
- Executor: the commit mode picks the ingest (the cycle's only
  mode-dependent step); a cycle reports one timing per phase in both
  modes.
- Publish fence (pglite): the applied census inspects a revision only
  once the barrier has elapsed, and cleanup of an accepted append is
  fenced to the same instant.
- Convergence (pglite): a fresh acceptance reads `publish_pending` and
  becomes `ready_for_census` once the delay has passed. Both tests
  compute the delay from the manifest, so a changed commit policy cannot
  leave them asserting a stale constant.

Verified with `lint-changed`, `ratchet --check`, the knip export ratchet
(one export freed, baseline tightened), `@stll/api typecheck`, and the
`legal-search`, `corpus-index`, and projection handler test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added queued processing for corpus index updates, allowing accepted batches to complete before publication.
  - Added clearer processing states, including when updates are awaiting publication and when they are ready for census checks.
  - Added detailed timing information for each stage of projection processing.

- **Bug Fixes**
  - Improved safeguards so recently accepted updates are not reported as missing or included in cleanup before publication is complete.
  - Improved validation of ingestion receipts to reject incomplete results.

- **Tests**
  - Expanded coverage for queued and published processing, publication delays, cleanup safeguards, and idle execution cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->