### PR TITLE
fix(api): the compat fetch tool validates its id as a UUID

### DIFF
--- a/.changeset/compat-fetch-uuid-id.md
+++ b/.changeset/compat-fetch-uuid-id.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": patch
+---
+
+The `fetch` tool declares its `id` input as a UUID. An id that is not UUID-shaped is now rejected as a validation error naming the field, instead of reaching the database and failing there as an opaque internal error.

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -53,7 +53,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document/entity ID"
         },
         "cursor": {
@@ -3319,7 +3319,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document/entity ID"
         },
         "cursor": {

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -25,6 +25,7 @@ import {
   MAX_CURSOR_LENGTH,
   notFoundResult,
   structuredErrorResult,
+  uuidInputSchema,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
@@ -248,7 +249,7 @@ const compatSearchArgsSchema = v.strictObject({
 });
 
 const compatFetchArgsSchema = v.strictObject({
-  id: v.pipe(v.string(), v.minLength(1), v.description("Document/entity ID")),
+  id: uuidInputSchema("Document/entity ID"),
   cursor: v.optional(
     v.pipe(
       v.string(),

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -1082,6 +1082,25 @@ describe("OpenAI-compatible MCP tools", () => {
     });
   });
 
+  test("fetch rejects a malformed id instead of querying with it", async () => {
+    const scopedDb = createScopedDb(
+      [],
+      createExtractedContentRow({ name: "Share Purchase Agreement" }),
+    );
+
+    const result = await handleMcpToolCall({
+      args: { id: "not-a-uuid" },
+      context: createContext({ scopedDb }),
+      toolName: "fetch",
+    });
+
+    // The id reaches SQL as a uuid column, so a malformed one has to fail
+    // here, naming the field, rather than as a cast failure the caller sees
+    // as an opaque internal error.
+    expect(validationEnvelope(result)["code"]).toBe("validation_error");
+    expect(scopedDb).not.toHaveBeenCalled();
+  });
+
   test("fetch pages long document text via the returned cursor", async () => {
     const longText = "x".repeat(8000) + "y".repeat(1000);
     const context = createContext({

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -47,7 +47,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document/entity ID"
         },
         "cursor": {


### PR DESCRIPTION
## Proposed change

`compatFetchArgsSchema` accepts the `fetch` tool's `id` as `v.pipe(v.string(), v.minLength(1))`, and the handler then brands it with `brandPersistedEntityId`, which asserts the branded type without checking the shape. The id is matched against `extractedContent.entityId`, a `uuid` column, so an id that is not UUID-shaped is not rejected by the schema: it reaches SQL and fails there as a cast error. The tool dispatcher turns any thrown error into the generic `internal_error` envelope, so the caller is told "Tool execution failed" rather than which field was malformed.

`tool-utils.ts` already has `uuidInputSchema` for exactly this boundary, and its comment states the rule this schema was missing:

> A UUID-shaped id input. Ids reach SQL as uuid columns, so a malformed one must fail here as a validation error naming the field rather than as a database cast failure reported as an internal error.

This switches `id` to that helper. The accepted input is unchanged in practice: the tool's own description says to use ids returned by `search`, and those are entity UUIDs.

The advertised input schema consequently carries `format: "uuid"` where it carried `minLength: 1`. The registry surface snapshot and the generated CLI registry snapshot are regenerated to match, and a changeset covers the `@stll/cli` snapshot.

### Note on scope

`uuidInputSchema` is the documented convention but the minority one: most id inputs across the MCP tool surface are still declared as plain non-empty strings (`list_matters.matter_id`, `read_contact.contact_id`, `save_document.entity_id`, and roughly forty more). Several of those validate at runtime instead (`stella-tools.ts` checks `source_id` with `isUuid`), so they are not all the same defect, but the split means a new tool can pick either pattern. Unifying them, and enforcing the choice with a lint rule so the loose pattern can only shrink, is a larger change than this fix and is left as a follow-up rather than folded in here.

### Testing

- `fetch rejects a malformed id instead of querying with it` asserts the `validation_error` envelope and that the scoped database handle is never called. Verified it fails against the unfixed schema: the malformed id passes validation, reaches the query layer, and the tool answers successfully.
- `bun run test -- src/mcp/` green (702 tests).
- `oxlint --type-aware apps/api` and `apps/api` typecheck clean.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface, this is an API tool input schema.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbLqshdqXirThnYvcfHjMk)_