### PR TITLE
feat(api): MCP initialize records the client name and version

### DIFF
--- a/apps/api/src/lib/analytics/types.ts
+++ b/apps/api/src/lib/analytics/types.ts
@@ -78,8 +78,9 @@ export type AIGenerationFailedProperties = SafeAIAnalyticsMetadata & {
 /**
  * Which client opened an MCP session, from the `initialize` handshake. The
  * name and version are caller-reported, so they are capped and type-checked
- * before they reach telemetry (see `mcp/client-identity.ts`); `unspecified`
- * stands in for a handshake that named neither.
+ * before they reach telemetry (see `mcp/client-identity.ts`). Every event
+ * carries a name, falling back to `unspecified`, so the count of events is the
+ * count of handshakes; an unreported version is left out rather than invented.
  */
 export type McpSessionInitializedProperties = {
   client_name: string;

--- a/apps/api/src/lib/analytics/types.ts
+++ b/apps/api/src/lib/analytics/types.ts
@@ -1,11 +1,14 @@
 import type { SafeId } from "@/api/lib/branded-types";
 import type { ResolvedTanStackTextModelInfo } from "@/api/lib/tanstack-ai-models";
+import type { McpCredentialType } from "@/api/mcp/auth";
+import type { McpMode } from "@/api/mcp/constants";
 
 export const SERVER_ANALYTICS_EVENTS = {
   aiGeneration: "$ai_generation",
   aiGenerationCompleted: "ai_generation_completed",
   aiGenerationFailed: "ai_generation_failed",
   exception: "$exception",
+  mcpSessionInitialized: "mcp_session_initialized",
 } as const;
 
 export type AnalyticsPrimitive = boolean | number | string;
@@ -72,6 +75,19 @@ export type AIGenerationFailedProperties = SafeAIAnalyticsMetadata & {
   region?: string;
 };
 
+/**
+ * Which client opened an MCP session, from the `initialize` handshake. The
+ * name and version are caller-reported, so they are capped and type-checked
+ * before they reach telemetry (see `mcp/client-identity.ts`); `unspecified`
+ * stands in for a handshake that named neither.
+ */
+export type McpSessionInitializedProperties = {
+  client_name: string;
+  client_version?: string;
+  credential_type: McpCredentialType | "unspecified";
+  mode: McpMode;
+};
+
 export type ExceptionListEntry = {
   mechanism: { handled: boolean; synthetic: boolean; type: string };
   type: string;
@@ -118,6 +134,10 @@ export type ServerAnalyticsCaptureParams = ServerAnalyticsCaptureBase &
     | {
         event: typeof SERVER_ANALYTICS_EVENTS.exception;
         properties: ExceptionProperties;
+      }
+    | {
+        event: typeof SERVER_ANALYTICS_EVENTS.mcpSessionInitialized;
+        properties: McpSessionInitializedProperties;
       }
   );
 

--- a/apps/api/src/mcp/auth.ts
+++ b/apps/api/src/mcp/auth.ts
@@ -46,6 +46,9 @@ export type McpSession = {
   workspaceIds?: string[];
 };
 
+/** Which kind of credential opened a session, for telemetry and reporting. */
+export type McpCredentialType = NonNullable<McpSession["credential"]>["type"];
+
 let verifyBearerToken:
   | ReturnType<
       ReturnType<typeof oauthProviderResourceClient>["getActions"]

--- a/apps/api/src/mcp/client-identity.test.ts
+++ b/apps/api/src/mcp/client-identity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { sanitizeMcpClientIdentity } from "@/api/mcp/client-identity";
+
+describe("sanitizeMcpClientIdentity", () => {
+  test("keeps a well-formed identity", () => {
+    expect(
+      sanitizeMcpClientIdentity({ name: "claude-ai", version: "1.4.2" }),
+    ).toEqual({ clientName: "claude-ai", clientVersion: "1.4.2" });
+  });
+
+  test("caps each reported field at 128 characters", () => {
+    const identity = sanitizeMcpClientIdentity({
+      name: "n".repeat(400),
+      version: "1.".repeat(400),
+    });
+
+    expect(identity.clientName).toHaveLength(128);
+    expect(identity.clientVersion).toHaveLength(128);
+  });
+
+  test("drops non-string fields instead of reporting them", () => {
+    expect(
+      sanitizeMcpClientIdentity({
+        name: { toString: () => "injected" },
+        version: 42,
+      }),
+    ).toEqual({ clientName: "unspecified" });
+    expect(sanitizeMcpClientIdentity("claude-ai")).toEqual({
+      clientName: "unspecified",
+    });
+    expect(sanitizeMcpClientIdentity(undefined)).toEqual({
+      clientName: "unspecified",
+    });
+  });
+
+  test("treats a blank name as unreported", () => {
+    expect(sanitizeMcpClientIdentity({ name: "   ", version: "  " })).toEqual({
+      clientName: "unspecified",
+    });
+  });
+});

--- a/apps/api/src/mcp/client-identity.test.ts
+++ b/apps/api/src/mcp/client-identity.test.ts
@@ -34,6 +34,12 @@ describe("sanitizeMcpClientIdentity", () => {
     });
   });
 
+  test("leaves an unreported version out rather than inventing one", () => {
+    expect(sanitizeMcpClientIdentity({ name: "claude-ai" })).toEqual({
+      clientName: "claude-ai",
+    });
+  });
+
   test("treats a blank name as unreported", () => {
     expect(sanitizeMcpClientIdentity({ name: "   ", version: "  " })).toEqual({
       clientName: "unspecified",

--- a/apps/api/src/mcp/client-identity.ts
+++ b/apps/api/src/mcp/client-identity.ts
@@ -1,0 +1,83 @@
+import { getAnalytics } from "@/api/lib/analytics/client";
+import type { McpSessionInitializedProperties } from "@/api/lib/analytics/types";
+import { SERVER_ANALYTICS_EVENTS } from "@/api/lib/analytics/types";
+import type { McpSession } from "@/api/mcp/auth";
+import type { McpMode } from "@/api/mcp/constants";
+
+/**
+ * A client names itself in the `initialize` handshake, so its identity is
+ * caller input: it is type-checked and capped here before anything stores or
+ * reports it. The cap is generous next to the real names (`claude-ai`,
+ * `stella-cli`, `Claude Code`) and short enough that a client cannot turn a
+ * telemetry property into a payload.
+ */
+const MAX_CLIENT_IDENTITY_CHARS = 128;
+
+/** Stands in for a field the handshake left out or reported as a non-string. */
+const UNSPECIFIED_CLIENT_FIELD = "unspecified";
+
+type McpClientIdentity = {
+  clientName: string;
+  clientVersion?: string;
+};
+
+const identityField = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const capped = value.trim().slice(0, MAX_CLIENT_IDENTITY_CHARS);
+  return capped.length > 0 ? capped : undefined;
+};
+
+/**
+ * The reported `{ name, version }` reduced to what telemetry may carry. The
+ * name always resolves (to `unspecified` when the client reported none) so the
+ * event count still equals the number of handshakes; the version is omitted
+ * rather than invented when the client reported none.
+ */
+export const sanitizeMcpClientIdentity = (
+  clientInfo: unknown,
+): McpClientIdentity => {
+  if (typeof clientInfo !== "object" || clientInfo === null) {
+    return { clientName: UNSPECIFIED_CLIENT_FIELD };
+  }
+  const { name, version }: Record<string, unknown> = { ...clientInfo };
+  const clientVersion = identityField(version);
+  return {
+    clientName: identityField(name) ?? UNSPECIFIED_CLIENT_FIELD,
+    ...(clientVersion === undefined ? {} : { clientVersion }),
+  };
+};
+
+export type RecordMcpSessionInitialized = (args: {
+  clientInfo: unknown;
+  mode: McpMode;
+  session: McpSession;
+}) => void;
+
+/**
+ * One event per `initialize`: which client opened the session, under which
+ * credential kind and endpoint mode. The endpoint keeps no session state, so
+ * this handshake is the only point at which a client identifies itself on the
+ * 2025-era protocol; later requests carry no identity to attribute.
+ */
+export const recordMcpSessionInitialized: RecordMcpSessionInitialized = ({
+  clientInfo,
+  mode,
+  session,
+}) => {
+  const { clientName, clientVersion } = sanitizeMcpClientIdentity(clientInfo);
+  const properties: McpSessionInitializedProperties = {
+    client_name: clientName,
+    ...(clientVersion === undefined ? {} : { client_version: clientVersion }),
+    credential_type: session.credential?.type ?? UNSPECIFIED_CLIENT_FIELD,
+    mode,
+  };
+
+  getAnalytics().capture({
+    distinctId: session.userId,
+    event: SERVER_ANALYTICS_EVENTS.mcpSessionInitialized,
+    groups: { organization: session.organizationId },
+    properties,
+  });
+};

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -13,7 +13,7 @@ import type {
   ReadResourceResult,
   Resource,
 } from "@modelcontextprotocol/server";
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 
 import { detached } from "@/api/lib/detached";
 import { isMcpSession, type McpSession } from "@/api/mcp/auth";
@@ -810,17 +810,21 @@ export const createMcpHttpRequestHandler = ({
       }
       // Telemetry does not decide whether a handshake succeeds. This callback
       // runs inside `handleRequest`, so a throwing analytics sink would reject
-      // it and answer a valid `initialize` with a 503. The catch sits on a
-      // framework callback boundary and reports the failure rather than
-      // swallowing it.
-      try {
+      // it and answer a valid `initialize` with a 503. Convert the failure to a
+      // result and report it rather than swallowing it.
+      const recorded = Result.try(() =>
         recordMcpSessionInitialized({
           clientInfo: message.params.clientInfo,
           mode,
           session,
+        }),
+      );
+      if (recorded.isErr()) {
+        captureError(recorded.error, {
+          phase: "initialize",
+          mode,
+          source: "mcp",
         });
-      } catch (error) {
-        captureError(error, { phase: "initialize", mode, source: "mcp" });
       }
     };
     Reflect.set(transport, "onmessage", observeHandshake);

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -1,5 +1,6 @@
 import {
   createMcpHandler,
+  isInitializeRequest,
   isLegacyRequest,
   Server,
   WebStandardStreamableHTTPServerTransport,
@@ -16,6 +17,7 @@ import { panic } from "better-result";
 
 import { detached } from "@/api/lib/detached";
 import { isMcpSession, type McpSession } from "@/api/mcp/auth";
+import type { RecordMcpSessionInitialized } from "@/api/mcp/client-identity";
 import {
   MCP_MAX_REQUEST_BODY_BYTES,
   MCP_NOTIFICATION_KEEP_ALIVE_MS,
@@ -151,6 +153,7 @@ type McpServerDependencies = {
     uri: string,
     mode: McpMode,
   ) => ReadResourceResult | Promise<ReadResourceResult>;
+  recordMcpSessionInitialized: RecordMcpSessionInitialized;
   resolveMcpSessionContext: (
     session: McpSession,
     options: { clientIp?: string | null; request: Request },
@@ -593,6 +596,7 @@ export const createMcpHttpRequestHandler = ({
   listMcpResources,
   listMcpTools,
   readMcpResource,
+  recordMcpSessionInitialized,
   resolveMcpSessionContext,
 }: McpServerDependencies) => {
   const createMcpServer = async ({
@@ -787,6 +791,29 @@ export const createMcpHttpRequestHandler = ({
       enableJsonResponse: true,
       keepAliveMs: MCP_NOTIFICATION_KEEP_ALIVE_MS,
     });
+    // Where a session's client names itself: the SDK classifies `initialize`
+    // as 2025-era whatever revision it claims, so every handshake arrives on
+    // this leg. `connect` chains this observer ahead of its own dispatch, and
+    // the instance is per-request, so the identity is recorded once per
+    // handshake rather than once per call. Modern-era requests carry the
+    // identity in each request's `_meta` envelope instead and open no session.
+    //
+    // The transport is not an `EventTarget` and exposes only this callback
+    // slot, so `Reflect.set` performs the assignment the
+    // `prefer-add-event-listener` rule bans, as `redis-client.ts` does for
+    // Bun's client. The handler is typed from the slot it fills.
+    const observeHandshake: NonNullable<typeof transport.onmessage> = (
+      message,
+    ) => {
+      if (isInitializeRequest(message)) {
+        recordMcpSessionInitialized({
+          clientInfo: message.params.clientInfo,
+          mode,
+          session,
+        });
+      }
+    };
+    Reflect.set(transport, "onmessage", observeHandshake);
     const reportTransportError = (error: unknown, operation: string) => {
       captureError(error, {
         mode,

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -805,12 +805,22 @@ export const createMcpHttpRequestHandler = ({
     const observeHandshake: NonNullable<typeof transport.onmessage> = (
       message,
     ) => {
-      if (isInitializeRequest(message)) {
+      if (!isInitializeRequest(message)) {
+        return;
+      }
+      // Telemetry does not decide whether a handshake succeeds. This callback
+      // runs inside `handleRequest`, so a throwing analytics sink would reject
+      // it and answer a valid `initialize` with a 503. The catch sits on a
+      // framework callback boundary and reports the failure rather than
+      // swallowing it.
+      try {
         recordMcpSessionInitialized({
           clientInfo: message.params.clientInfo,
           mode,
           session,
         });
+      } catch (error) {
+        captureError(error, { phase: "initialize", mode, source: "mcp" });
       }
     };
     Reflect.set(transport, "onmessage", observeHandshake);

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -812,13 +812,15 @@ export const createMcpHttpRequestHandler = ({
       // runs inside `handleRequest`, so a throwing analytics sink would reject
       // it and answer a valid `initialize` with a 503. Convert the failure to a
       // result and report it rather than swallowing it.
-      const recorded = Result.try(() =>
-        recordMcpSessionInitialized({
-          clientInfo: message.params.clientInfo,
-          mode,
-          session,
-        }),
-      );
+      const recorded = Result.try({
+        try: () =>
+          recordMcpSessionInitialized({
+            clientInfo: message.params.clientInfo,
+            mode,
+            session,
+          }),
+        catch: (cause) => cause,
+      });
       if (recorded.isErr()) {
         captureError(recorded.error, {
           phase: "initialize",

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -18,6 +18,12 @@ import { panic } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  resetAnalyticsForTesting,
+  setAnalyticsForTesting,
+} from "@/api/lib/analytics/client";
+import type { ServerAnalyticsCaptureParams } from "@/api/lib/analytics/types";
+import { recordMcpSessionInitialized } from "@/api/mcp/client-identity";
+import {
   MCP_ALL_RESOURCE_SCOPES,
   MCP_MAX_REQUEST_BODY_BYTES,
   MCP_STATELESS_ALLOW_HEADER,
@@ -71,6 +77,10 @@ const handleMcpHttpRequest = createMcpHttpRequestHandler({
   listMcpResources: listMcpResourcesMock,
   listMcpTools: listMcpToolsMock,
   readMcpResource: readMcpResourceMock,
+  // The real recorder, so the assertions below cover the sanitization it
+  // applies rather than a fake's idea of it; its analytics sink is replaced
+  // per test through the module's own seam.
+  recordMcpSessionInitialized,
   resolveMcpSessionContext: resolveMcpSessionContextMock,
 });
 
@@ -180,6 +190,7 @@ describe("handleMcpHttpRequest", () => {
     readMcpResourceMock.mockReset();
     readMcpResourceMock.mockImplementation(() => ({ contents: [] }));
     resolveMcpSessionContextMock.mockReset();
+    resetAnalyticsForTesting();
   });
 
   test("returns a generic 401 for token validation failures", async () => {
@@ -593,6 +604,60 @@ describe("handleMcpHttpRequest", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("WWW-Authenticate")).not.toBeNull();
     expect(authenticateMcpRequestMock).not.toHaveBeenCalled();
+  });
+
+  test("records the initializing client once, under a capped identity", async () => {
+    const captured: ServerAnalyticsCaptureParams[] = [];
+    setAnalyticsForTesting({
+      capture: (params) => {
+        captured.push(params);
+      },
+      identifyOrganizationGroup: () => undefined,
+      flush: async () => await Promise.resolve(),
+    });
+    authenticateMcpRequestMock.mockResolvedValue({
+      credential: { clientId: "client_1", type: "oauth_client" },
+      organizationId: "org_1",
+      scopes: ["stella:read"],
+      userId: "user_1",
+    });
+    resolveMcpSessionContextMock.mockResolvedValue({ type: "mcp-context" });
+
+    const response = await handleMcpHttpRequest(
+      createMcpRequest({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: `  ${"n".repeat(200)}  `, version: "1.2.3" },
+          protocolVersion: "2025-06-18",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(captured).toEqual([
+      {
+        distinctId: "user_1",
+        event: "mcp_session_initialized",
+        groups: { organization: "org_1" },
+        properties: {
+          client_name: "n".repeat(128),
+          client_version: "1.2.3",
+          credential_type: "oauth_client",
+          mode: "default",
+        },
+      },
+    ]);
+
+    // One event per handshake, not per request: a later call on the same
+    // credentials carries no new client identity to record.
+    await handleMcpHttpRequest(
+      createMcpRequest({ id: 2, jsonrpc: "2.0", method: "tools/list" }),
+    );
+
+    expect(captured).toHaveLength(1);
   });
 
   test("keeps POST buffered and DELETE non-streaming", async () => {

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -660,6 +660,46 @@ describe("handleMcpHttpRequest", () => {
     expect(captured).toHaveLength(1);
   });
 
+  test("serves the handshake when the analytics sink throws", async () => {
+    const sinkFailure = new Error("analytics sink unavailable");
+    setAnalyticsForTesting({
+      capture: () => {
+        throw sinkFailure;
+      },
+      identifyOrganizationGroup: () => undefined,
+      flush: async () => await Promise.resolve(),
+    });
+    authenticateMcpRequestMock.mockResolvedValue({
+      credential: { clientId: "client_1", type: "oauth_client" },
+      organizationId: "org_1",
+      scopes: ["stella:read"],
+      userId: "user_1",
+    });
+    resolveMcpSessionContextMock.mockResolvedValue({ type: "mcp-context" });
+
+    const response = await handleMcpHttpRequest(
+      createMcpRequest({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "claude-ai", version: "1.2.3" },
+          protocolVersion: "2025-06-18",
+        },
+      }),
+    );
+
+    // Telemetry is not part of the protocol contract: a failed capture is
+    // reported, and the client still completes its handshake.
+    expect(response.status).toBe(200);
+    expect(captureErrorMock).toHaveBeenCalledWith(sinkFailure, {
+      mode: "default",
+      phase: "initialize",
+      source: "mcp",
+    });
+  });
+
   test("keeps POST buffered and DELETE non-streaming", async () => {
     authenticateMcpRequestMock.mockResolvedValue({
       organizationId: "org_1",

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { captureError } from "@/api/lib/analytics/capture";
 import { authenticateMcpRequest } from "@/api/mcp/auth";
+import { recordMcpSessionInitialized } from "@/api/mcp/client-identity";
 import { resolveMcpSessionContext } from "@/api/mcp/context";
 import { listMcpResources, readMcpResource } from "@/api/mcp/resources";
 import { createMcpHttpRequestHandler } from "@/api/mcp/server-core";
@@ -19,5 +20,6 @@ export const handleMcpHttpRequest = createMcpHttpRequestHandler({
   listMcpResources,
   listMcpTools,
   readMcpResource,
+  recordMcpSessionInitialized,
   resolveMcpSessionContext,
 });


### PR DESCRIPTION
The MCP endpoint builds a server per request and never read the client identity
the `initialize` handshake carries, so traffic from different clients was
indistinguishable in telemetry.

- Observe the handshake on the 2025-era leg. The SDK classifies every
  `initialize` as 2025-era whatever protocol version it names, so every
  handshake arrives there; modern-era requests carry the identity in each
  request's `_meta` envelope instead and open no session.
- Emit one `mcp_session_initialized` analytics event per handshake with
  `client_name`, `client_version`, `credential_type`, and `mode`, under the
  session's user (`distinctId`) and organization group.
- Treat the reported name and version as caller input: each is trimmed, capped
  at 128 characters, and dropped when it is not a string, so a client cannot
  turn a telemetry property into a payload. A field the client left out reads
  as `unspecified` rather than being invented.

`credential_type` is derived from the session credential union and the event's
property type joins the analytics capture union, so a new credential kind or
endpoint mode cannot drift away from the event's shape.

Instructions are unchanged and nothing branches on the client. The recorder is
injected into the request handler, so the identity is available at the one place
that consumes it today.

Not included, and why:

- No session persistence. This endpoint is deliberately stateless (a `DELETE`
  answers 405 "this endpoint serves no session"), and `mcp_user_connections`
  belongs to outbound connectors, so there is no session row to carry a
  `client_name` column. Storing per-handshake identity would need a new table
  and a retention decision rather than a small change.
- No `client_name` in the request log. `logger.request` takes a fixed
  `RequestLogOptions` shape with no extra-attribute slot, and the route-level
  completion hook has no access to the handshake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added analytics tracking for MCP session initialisation.
  - Session analytics now include sanitised client name and version, credential type, and endpoint mode.
  - Client identity values are validated, trimmed, and capped for safe reporting.

- **Bug Fixes**
  - Prevented duplicate session-initialisation events for subsequent requests using the same credentials.

- **Tests**
  - Added coverage for client identity sanitisation and session analytics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->