### PR TITLE
perf(api): an ancestor walk and a tenant settle each take one statement

### DIFF
--- a/apps/api/src/handlers/templates/categories.db.test.ts
+++ b/apps/api/src/handlers/templates/categories.db.test.ts
@@ -1,3 +1,4 @@
+import { Panic } from "better-result";
 import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
 import { eq, sql } from "drizzle-orm";
 
@@ -22,7 +23,8 @@ import type { TestDatabase } from "@/api/tests/security/test-utils";
  *
  * So the fixture builds a real chain, root -> middle -> leaf, and asks for each
  * outcome: a legal move, a move onto a descendant at depth one and at depth
- * two, and a chain that already loops.
+ * two, a chain that already loops, and a read the guard cannot interpret —
+ * which has to refuse the move rather than report the permissive answer.
  */
 
 setDefaultTimeout(120_000);
@@ -173,6 +175,42 @@ test("a chain that already loops is reported rather than walked forever", async 
     response: { message: "Cannot create circular category hierarchy" },
   });
   expect(await parentOf(mover)).toBeNull();
+});
+
+// A guard that cannot read its own answer must not report the permissive one.
+// Every other read in the handler stays real; only `execute` returns a shape
+// the reader does not recognise, which is what a driver change would look like.
+test("a cycle check that cannot read its answer refuses rather than allowing", async () => {
+  const brokenExecute: ScopedDb = async (callback) =>
+    await testDb.transaction(async (tx) => {
+      await tx.execute(sql.raw("RESET ROLE"));
+      const proxied = new Proxy(tx, {
+        get: (target, property) => {
+          if (property === "execute") {
+            return async () => ({ unexpected: true });
+          }
+          const value = Reflect.get(target, property);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+      return await callback(asTestRaw<Transaction>(proxied));
+    });
+
+  let thrown: unknown;
+  try {
+    await updateTemplateCategoryHandler({
+      scopedDb: brokenExecute,
+      organizationId,
+      categoryId: root,
+      body: { parentId: middle },
+      recordAuditEvent: noAuditRows,
+    });
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(thrown).toBeInstanceOf(Panic);
+  expect(await parentOf(root)).toBeNull();
 });
 
 test("another firm's category is not reachable from this firm's walk", async () => {

--- a/apps/api/src/handlers/templates/categories.db.test.ts
+++ b/apps/api/src/handlers/templates/categories.db.test.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+
+import { organization } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import { templateCategories } from "@/api/db/schema";
+import { updateTemplateCategoryHandler } from "@/api/handlers/templates/categories";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+/**
+ * Re-parenting a category asks one question of the database: would the move
+ * close a loop? A recursive CTE answers it, and hand-assembled recursive SQL is
+ * unreviewable until something runs it — a wrong join direction reads as a
+ * plausible query and silently answers "no cycle" for every input, which is the
+ * failure that lets a firm's category tree become unwalkable.
+ *
+ * So the fixture builds a real chain, root -> middle -> leaf, and asks for each
+ * outcome: a legal move, a move onto a descendant at depth one and at depth
+ * two, and a chain that already loops.
+ */
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+
+const organizationId = toSafeId<"organization">(`org_${Bun.randomUUIDv7()}`);
+const otherOrganizationId = toSafeId<"organization">(
+  `org_${Bun.randomUUIDv7()}`,
+);
+
+const root = createSafeId<"templateCategory">();
+const middle = createSafeId<"templateCategory">();
+const leaf = createSafeId<"templateCategory">();
+const sibling = createSafeId<"templateCategory">();
+const foreign = createSafeId<"templateCategory">();
+
+const scopedDb: ScopedDb = async (callback) =>
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    return await callback(asTestRaw<Transaction>(tx));
+  });
+
+const noAuditRows: AuditRecorder = async () => undefined;
+
+const reparent = async (
+  categoryId: SafeId<"templateCategory">,
+  parentId: SafeId<"templateCategory">,
+) =>
+  await updateTemplateCategoryHandler({
+    scopedDb,
+    organizationId,
+    categoryId,
+    body: { parentId },
+    recordAuditEvent: noAuditRows,
+  });
+
+const parentOf = async (categoryId: SafeId<"templateCategory">) =>
+  (
+    await testDb
+      .select({ parentId: templateCategories.parentId })
+      .from(templateCategories)
+      .where(eq(templateCategories.id, categoryId))
+      .limit(1)
+  ).at(0)?.parentId;
+
+const category = (
+  id: SafeId<"templateCategory">,
+  name: string,
+  parentId: SafeId<"templateCategory"> | null,
+  owner: SafeId<"organization"> = organizationId,
+) => ({ id, organizationId: owner, name, parentId });
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx.insert(organization).values([
+      {
+        id: organizationId,
+        name: "Category firm",
+        slug: organizationId,
+        createdAt: new Date(),
+      },
+      {
+        id: otherOrganizationId,
+        name: "Other firm",
+        slug: otherOrganizationId,
+        createdAt: new Date(),
+      },
+    ]);
+    await tx
+      .insert(templateCategories)
+      .values([
+        category(root, "Root", null),
+        category(middle, "Middle", root),
+        category(leaf, "Leaf", middle),
+        category(sibling, "Sibling", null),
+        category(foreign, "Foreign root", null, otherOrganizationId),
+      ]);
+  });
+});
+
+afterAll(async () => {
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx
+      .delete(organization)
+      .where(eq(organization.id, otherOrganizationId));
+    await tx.delete(organization).where(eq(organization.id, organizationId));
+  });
+  await releaseTestDb();
+});
+
+test("a move that closes no loop is applied", async () => {
+  const result = await reparent(sibling, leaf);
+
+  expect(result).toMatchObject({ id: sibling, parentId: leaf });
+  expect(await parentOf(sibling)).toBe(leaf);
+});
+
+test("a move onto a direct child is refused", async () => {
+  const result = await reparent(root, middle);
+
+  expect(result).toMatchObject({
+    code: 400,
+    response: { message: "Cannot create circular category hierarchy" },
+  });
+  expect(await parentOf(root)).toBeNull();
+});
+
+test("a move onto a grandchild is refused, so the walk climbs past one level", async () => {
+  const result = await reparent(root, leaf);
+
+  expect(result).toMatchObject({
+    code: 400,
+    response: { message: "Cannot create circular category hierarchy" },
+  });
+  expect(await parentOf(root)).toBeNull();
+});
+
+test("a chain that already loops is reported rather than walked forever", async () => {
+  // A stored cycle is a state this endpoint cannot create; the FK allows it and
+  // a repair could leave one behind. The walk has to end and say so.
+  const loopedA = createSafeId<"templateCategory">();
+  const loopedB = createSafeId<"templateCategory">();
+  const mover = createSafeId<"templateCategory">();
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql.raw("RESET ROLE"));
+    await tx
+      .insert(templateCategories)
+      .values([
+        category(loopedA, "Looped A", null),
+        category(loopedB, "Looped B", loopedA),
+        category(mover, "Mover", null),
+      ]);
+    await tx
+      .update(templateCategories)
+      .set({ parentId: loopedB })
+      .where(eq(templateCategories.id, loopedA));
+  });
+
+  const result = await reparent(mover, loopedB);
+
+  expect(result).toMatchObject({
+    code: 400,
+    response: { message: "Cannot create circular category hierarchy" },
+  });
+  expect(await parentOf(mover)).toBeNull();
+});
+
+test("another firm's category is not reachable from this firm's walk", async () => {
+  const result = await updateTemplateCategoryHandler({
+    scopedDb,
+    organizationId,
+    categoryId: sibling,
+    body: { parentId: foreign },
+    recordAuditEvent: noAuditRows,
+  });
+
+  expect(result).toMatchObject({
+    code: 404,
+    response: { message: "Parent category not found" },
+  });
+});

--- a/apps/api/src/handlers/templates/categories.ts
+++ b/apps/api/src/handlers/templates/categories.ts
@@ -10,8 +10,66 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
+import { executedRows } from "@/api/lib/db/executed-rows";
 import { LIMITS } from "@/api/lib/limits";
 import { pickDefined } from "@/api/lib/pick-defined";
+import { isRecord } from "@/api/lib/type-guards";
+
+// ── Hierarchy ───────────────────────────────────────
+
+/**
+ * Would re-parenting `categoryId` under `parentId` close a loop?
+ *
+ * One recursive walk up the chain inside the database, rather than a read per
+ * level: the depth is a property of the caller's data, so a per-level read made
+ * the round trips grow with how deeply a firm nests its categories.
+ *
+ * `path` carries the ids already seen so the walk also terminates on a cycle
+ * that is already stored — a state this endpoint cannot create but must not
+ * hang on — and reports it, which is what the per-level walk's `visited` set
+ * did. Every row is confined to the caller's organization at both the seed and
+ * the step, so a category from another firm can neither be reached nor make
+ * this answer differ.
+ */
+const parentChainWouldCycle = async ({
+  categoryId,
+  organizationId,
+  parentId,
+  scopedDb,
+}: {
+  categoryId: SafeId<"templateCategory">;
+  organizationId: SafeId<"organization">;
+  parentId: SafeId<"templateCategory">;
+  scopedDb: ScopedDb;
+}): Promise<boolean> => {
+  const rows = await scopedDb((tx) =>
+    tx.execute(sql`
+      WITH RECURSIVE ancestor AS (
+        SELECT seed.id, seed.parent_id, ARRAY[seed.id] AS path, false AS looped
+          FROM ${templateCategories} AS seed
+         WHERE seed.id = ${parentId}
+           AND seed.organization_id = ${organizationId}
+        UNION ALL
+        SELECT step.id,
+               step.parent_id,
+               ancestor.path || step.id,
+               step.id = ANY(ancestor.path)
+          FROM ${templateCategories} AS step
+          JOIN ancestor ON step.id = ancestor.parent_id
+         WHERE step.organization_id = ${organizationId}
+           AND NOT ancestor.looped
+      )
+      SELECT coalesce(
+               bool_or(ancestor.looped OR ancestor.id = ${categoryId}),
+               false
+             ) AS cycle
+        FROM ancestor
+    `),
+  );
+
+  const row = executedRows(rows).at(0);
+  return isRecord(row) && row["cycle"] === true;
+};
 
 // ── Schemas ─────────────────────────────────────────
 
@@ -199,30 +257,17 @@ export const updateTemplateCategoryHandler = async ({
       });
     }
 
-    // Walk the ancestor chain to detect cycles
-    const visited = new Set([categoryId]);
-    let checkId: SafeId<"templateCategory"> | null = parentId;
-    while (checkId) {
-      if (visited.has(checkId)) {
-        return status(400, {
-          message: "Cannot create circular category hierarchy",
-        });
-      }
-      visited.add(checkId);
-      const currentId: SafeId<"templateCategory"> = checkId;
-      const ancestor:
-        | { parentId: SafeId<"templateCategory"> | null }
-        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- walks the parent chain one read per level; a recursive CTE is the batch shape
-        | undefined = await scopedDb((tx) =>
-        tx.query.templateCategories.findFirst({
-          where: {
-            id: { eq: currentId },
-            organizationId: { eq: organizationId },
-          },
-          columns: { parentId: true },
-        }),
-      );
-      checkId = ancestor?.parentId ?? null;
+    if (
+      await parentChainWouldCycle({
+        categoryId,
+        organizationId,
+        parentId,
+        scopedDb,
+      })
+    ) {
+      return status(400, {
+        message: "Cannot create circular category hierarchy",
+      });
     }
   }
 

--- a/apps/api/src/handlers/templates/categories.ts
+++ b/apps/api/src/handlers/templates/categories.ts
@@ -67,8 +67,19 @@ const parentChainWouldCycle = async ({
     `),
   );
 
-  const row = executedRows(rows).at(0);
-  return isRecord(row) && row["cycle"] === true;
+  // An aggregate over a `WITH RECURSIVE` is exactly one row carrying exactly
+  // one boolean, whatever the tree looks like — `bool_or` over an empty set is
+  // NULL, which the `coalesce` makes `false`. Anything else means the statement
+  // is no longer the statement this reader was written for, and reading it as
+  // "no cycle" would let the move through: a guard has to fail closed.
+  const [row, ...extra] = executedRows(rows);
+  if (extra.length > 0 || !isRecord(row) || typeof row["cycle"] !== "boolean") {
+    return panic(
+      "Category cycle check expected exactly one row with a boolean `cycle`",
+    );
+  }
+
+  return row["cycle"];
 };
 
 // ── Schemas ─────────────────────────────────────────

--- a/apps/api/src/lib/db/executed-rows.test.ts
+++ b/apps/api/src/lib/db/executed-rows.test.ts
@@ -1,0 +1,41 @@
+import { Panic } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { executedRows } from "@/api/lib/db/executed-rows";
+
+/**
+ * The failure this pins is the quiet one. Returning `[]` for a shape the
+ * function does not recognise reads to every caller as "the query found
+ * nothing", which for a guard is indistinguishable from "you may proceed". A
+ * driver change would then turn every such guard off at once, with nothing
+ * failing and nothing logged.
+ */
+describe("executedRows", () => {
+  test("returns the rows the server driver yields directly", () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+
+    expect(executedRows(rows)).toEqual(rows);
+  });
+
+  test("unwraps the { rows } shape pglite yields", () => {
+    const rows = [{ id: 1 }];
+
+    expect(executedRows({ rows, rowCount: 1 })).toEqual(rows);
+  });
+
+  test("an empty result is empty under either shape", () => {
+    expect(executedRows([])).toEqual([]);
+    expect(executedRows({ rows: [] })).toEqual([]);
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a number", 7],
+    ["a string", "rows"],
+    ["an object with no rows key", { rowCount: 0 }],
+    ["an object whose rows is not an array", { rows: { 0: { id: 1 } } }],
+  ])("panics rather than reading %s as no rows", (_label, result) => {
+    expect(() => executedRows(result)).toThrow(Panic);
+  });
+});

--- a/apps/api/src/lib/db/executed-rows.ts
+++ b/apps/api/src/lib/db/executed-rows.ts
@@ -1,0 +1,20 @@
+import { isRecord } from "@/api/lib/type-guards";
+
+/**
+ * Rows from `execute` under either driver shape.
+ *
+ * The server driver yields the rows directly; pglite, which the database tests
+ * run on, wraps them in `{ rows }`. A reader that assumes one shape works in
+ * exactly one of the two places, so a query verified by a test can still return
+ * nothing in production, and the reverse. Every caller of `execute` that reads
+ * rows back goes through here so neither half can be forgotten.
+ */
+export const executedRows = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
+};

--- a/apps/api/src/lib/db/executed-rows.ts
+++ b/apps/api/src/lib/db/executed-rows.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import { isRecord } from "@/api/lib/type-guards";
 
 /**
@@ -8,6 +10,12 @@ import { isRecord } from "@/api/lib/type-guards";
  * exactly one of the two places, so a query verified by a test can still return
  * nothing in production, and the reverse. Every caller of `execute` that reads
  * rows back goes through here so neither half can be forgotten.
+ *
+ * A third shape is not an empty result, it is a driver this function has never
+ * seen. Answering `[]` would hand every caller the reading that looks like
+ * success — no rows found — which for a guard means the guard passes. That is
+ * the wrong direction to fail in, so an unrecognised shape panics with what it
+ * received instead.
  */
 export const executedRows = (result: unknown): unknown[] => {
   if (Array.isArray(result)) {
@@ -16,5 +24,7 @@ export const executedRows = (result: unknown): unknown[] => {
   if (isRecord(result) && Array.isArray(result["rows"])) {
     return result["rows"];
   }
-  return [];
+  return panic(
+    `Unsupported execute() result shape: ${typeof result === "object" && result !== null ? Object.keys(result).join(", ") || "{}" : typeof result}`,
+  );
 };

--- a/apps/api/src/lib/scheduler/tasks/memory-extractor-queue.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/memory-extractor-queue.test.ts
@@ -91,7 +91,7 @@ describe("memory extraction tenant queue", () => {
       buildSettleMemoryExtractionQueueQuery({
         leaseExpiresAt,
         now: new Date("2026-07-31T00:10:00.000Z"),
-        organizationId,
+        organizationIds: [organizationId],
       }),
     );
 
@@ -103,8 +103,44 @@ describe("memory extraction tenant queue", () => {
       "compaction.memory_extraction_consent_at = settings.memory_extraction_enabled_at",
     );
     expect(query.sql).toContain("LIMIT 1");
-    expect(query.params).toContain(organizationId);
+    expect(query.params).toContainEqual([organizationId]);
     expect(query.params).toContain(leaseExpiresAt);
+  });
+
+  // The ids ride in as one array parameter, so the statement a two-tenant pass
+  // sends is character-for-character the statement a one-tenant pass sends.
+  // A bare array would be expanded into one bind per id, putting `::text[]` on
+  // the last of them and changing the shape with the batch.
+  test("settles a whole claimed batch with one statement shape", () => {
+    const leaseExpiresAt = new Date("2026-07-31T00:30:00.000Z");
+    const now = new Date("2026-07-31T00:10:00.000Z");
+    const organizationIds = [
+      safeId<"organization">(1),
+      safeId<"organization">(2),
+    ];
+
+    const batch = dialect.sqlToQuery(
+      buildSettleMemoryExtractionQueueQuery({
+        leaseExpiresAt,
+        now,
+        organizationIds,
+      }),
+    );
+    const single = dialect.sqlToQuery(
+      buildSettleMemoryExtractionQueueQuery({
+        leaseExpiresAt,
+        now,
+        organizationIds: [organizationIds[0] ?? safeId<"organization">(1)],
+      }),
+    );
+
+    expect(batch.sql).toBe(single.sql);
+    expect(batch.sql).toContain("settings.organization_id = ANY(");
+    expect(batch.sql).toContain("::text[])");
+    // The compare-and-set stays per row, so one tenant's stale lease cannot
+    // settle another's.
+    expect(batch.sql).toContain("settings.memory_extraction_scheduled_at = $3");
+    expect(batch.params).toContainEqual(organizationIds);
   });
 });
 

--- a/apps/api/src/lib/scheduler/tasks/memory-extractor-queue.ts
+++ b/apps/api/src/lib/scheduler/tasks/memory-extractor-queue.ts
@@ -137,18 +137,25 @@ export const buildClaimMemoryExtractionQueueQuery = ({
 type BuildSettleMemoryExtractionQueueQueryOptions = {
   leaseExpiresAt: Date;
   now: Date;
-  organizationId: SafeId<"organization">;
+  organizationIds: readonly SafeId<"organization">[];
 };
 
 /**
- * Release one claimed tenant with compare-and-set semantics. A compaction
- * trigger that wakes the tenant while work is in flight changes scheduled_at,
- * causing this stale settlement to no-op instead of erasing the wakeup.
+ * Release every claimed tenant of one pass with compare-and-set semantics. A
+ * compaction trigger that wakes a tenant while work is in flight changes its
+ * scheduled_at, causing this stale settlement to no-op for that tenant instead
+ * of erasing the wakeup; the CAS is per row, so one statement settles the whole
+ * batch without any tenant borrowing another's outcome.
+ *
+ * The ids go in as a single array parameter rather than a list of binds, so the
+ * statement's shape does not change with the batch size. `sql.param` is
+ * load-bearing: a bare array is expanded into one bind per element, which would
+ * put the cast on the last one alone.
  */
 export const buildSettleMemoryExtractionQueueQuery = ({
   leaseExpiresAt,
   now,
-  organizationId,
+  organizationIds,
 }: BuildSettleMemoryExtractionQueueQueryOptions) => sql`
   UPDATE organization_settings AS settings
   SET memory_extraction_scheduled_at = CASE
@@ -164,7 +171,7 @@ export const buildSettleMemoryExtractionQueueQuery = ({
     ) THEN ${now}
     ELSE NULL
   END
-  WHERE settings.organization_id = ${organizationId}
+  WHERE settings.organization_id = ANY(${sql.param([...organizationIds])}::text[])
     AND settings.memory_extraction_enabled = true
     AND settings.memory_extraction_enabled_at IS NOT NULL
     AND settings.memory_extraction_scheduled_at = ${leaseExpiresAt}::timestamptz

--- a/apps/api/src/lib/scheduler/tasks/memory-extractor.ts
+++ b/apps/api/src/lib/scheduler/tasks/memory-extractor.ts
@@ -272,18 +272,17 @@ const settleMemoryExtractionBatch = async ({
   leaseExpiresAt,
   organizations,
 }: ClaimedMemoryExtractionBatch): Promise<void> => {
-  const now = new Date();
-  // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- one settle statement per claimed organization; a single VALUES join is the batch shape
-  await Promise.all(
-    organizations.map((organization) =>
-      rootDb.execute(
-        buildSettleMemoryExtractionQueueQuery({
-          leaseExpiresAt,
-          now,
-          organizationId: organization.organizationId,
-        }),
+  if (organizations.length === 0) {
+    return;
+  }
+  await rootDb.execute(
+    buildSettleMemoryExtractionQueueQuery({
+      leaseExpiresAt,
+      now: new Date(),
+      organizationIds: organizations.map(
+        (organization) => organization.organizationId,
       ),
-    ),
+    }),
   );
 };
 

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -777,7 +777,7 @@
     }
   },
   "no-db-await-in-loop-suppressions": {
-    "count": 108,
+    "count": 106,
     "files": {
       "apps/api/scripts/backfill-image-thumbnails.ts": 3,
       "apps/api/scripts/backfill-search-previews.ts": 1,
@@ -807,7 +807,6 @@
       "apps/api/src/handlers/playbooks/auto-run.ts": 1,
       "apps/api/src/handlers/reports/build-report-data.ts": 1,
       "apps/api/src/handlers/search/ai.ts": 2,
-      "apps/api/src/handlers/templates/categories.ts": 1,
       "apps/api/src/handlers/uploads/entity-create-tree.ts": 4,
       "apps/api/src/handlers/views/table-export.ts": 1,
       "apps/api/src/handlers/workspaces/duplicate.ts": 4,
@@ -824,7 +823,6 @@
       "apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry.ts": 4,
       "apps/api/src/lib/scheduler/tasks/infosoud.ts": 1,
       "apps/api/src/lib/scheduler/tasks/memory-curator.ts": 1,
-      "apps/api/src/lib/scheduler/tasks/memory-extractor.ts": 1,
       "apps/api/src/lib/scouts/work-attention.ts": 1,
       "apps/api/src/lib/search/index-global.ts": 2,
       "apps/api/src/lib/search/pg-fts-provider.ts": 1,


### PR DESCRIPTION
The two batch candidates the widened loop rule surfaced in #3018.

## Ancestor walk (`handlers/templates/categories.ts`)

Re-parenting a category asked one question — would this move close a
loop? — with one read per level of the parent chain, so the round trips
grew with how deeply a firm nests its categories.

One recursive CTE now answers it. The walk carries the ids it has
already seen in a `path` array, so a chain that **already** loops
terminates and is reported rather than recursing forever; that is what
the old walk's `visited` set did, and it is not hypothetical, since
`parent_id` is `ON DELETE SET NULL` and nothing in the schema forbids a
stored cycle. Both the seed row and the recursive step are confined to
the caller's organization, so a category belonging to another firm can
neither be reached nor change the answer.

The `parentId === categoryId` check keeps its own earlier branch, so
that case still returns "Category cannot be its own parent" rather than
the cycle message.

## Tenant settle (`lib/scheduler/tasks/memory-extractor.ts`)

Settling the memory-extraction queue issued one update per claimed
tenant. The compare-and-set that protects a concurrent wakeup is
evaluated per row, so a single statement settles the whole batch without
any tenant borrowing another's outcome. The ids ride in as one array
parameter, which keeps the statement's shape identical whatever the
batch size.

`sql.param` around that array is load-bearing and worth a reviewer's
eye: drizzle expands a bare interpolated array into one bind per
element, so `${ids}::text[]` renders as `$1, $2::text[]` and fails at
runtime with `42846 cannot cast type`. I hit exactly that while probing
this, and the unit test now pins the shape.

## Tests

`categories.db.test.ts` is new. Hand-assembled recursive SQL is
unreviewable until something runs it — a reversed join reads as a
plausible query and answers "no cycle" for every input — so the suite
builds a real `root -> middle -> leaf` chain and covers a legal move, a
move onto a direct child, a move onto a grandchild (which is what proves
the walk climbs past one level), a chain that already loops, and another
firm's category as a parent.

Checked by mutation, not just by green:

- reversing the recursive join direction: **2 of 5 fail**
- removing the `path` cycle guard: the suite **hangs** (infinite
  recursion), which is the behaviour that guard exists to prevent

`memory-extractor-queue.test.ts` gains a case asserting that a
two-tenant batch and a one-tenant batch produce a character-identical
statement, and that the ids arrive as one array parameter.

## `lib/db/executed-rows.ts`

The CTE reader needs the driver split `execute` has: rows directly on
the server driver, wrapped in `{ rows }` under pglite. A reader that
assumes one shape works in exactly one of the two places, so a query a
test verifies can still return nothing in production.

Three places had each open-coded this already — `executedRows` in
`scripts/repair-decision-dates-plan.ts`, `rowsOf` in
`scripts/build-expansion-dictionary.ts`, and a private copy in
`normalize-case-numbers.db.test.ts`. Rather than add a fourth, this puts
one in `lib/db/` and uses it here. **The three existing copies are left
alone**: consolidating them touches two operator scripts and a test that
this change has no other reason to enter, so it belongs in its own diff.
Happy to follow up if wanted.

## Ratchet

`no-db-await-in-loop-suppressions`: 108 -> 106. No other metric touched.
