### PR TITLE
perf(api): stem each distinct term once per batch

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
@@ -397,3 +397,49 @@ test("v5 emits neither stem field", () => {
     ).toBe(true);
   }
 });
+
+/**
+ * Stems are remembered between calls (see the memo in morphology/stem.ts), so
+ * what a revision projects to must not depend on what was projected before
+ * it: not on the other revisions in the batch, not on their order, and not on
+ * whether this one has been built already.
+ */
+test("a revision projects to the same documents whatever preceded it", () => {
+  const revisions = [
+    "Nájemního bytu se to netýká, uvedl Nejvyšší správní soud.",
+    "Soud rozhodl o nájemním vztahu a o náhradě nákladů řízení.",
+    "Nejvyšší soud zrušil rozsudek krajského soudu a věc mu vrátil.",
+  ].map((text, index) => ({
+    text,
+    input: {
+      ...CASE_LAW_INPUT,
+      language: "cs",
+      metadata: { legalSentence: text },
+    },
+    revision: toSafeId<"corpusIndexProjectionIntent">(
+      `0198e331-e578-7000-8000-00000000001${index}`,
+    ),
+  }));
+
+  const project = ({
+    text,
+    input,
+    revision,
+  }: (typeof revisions)[number]): string =>
+    JSON.stringify(
+      buildCaseLawProjectionDocuments({
+        manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
+        input,
+        payload: { text, ast: null },
+        revision,
+      }),
+    );
+
+  const first = revisions.map(project);
+  // Again in reverse, so every revision is now built with the memo carrying
+  // the terms of the ones that followed it the first time round.
+  const reversed = revisions.toReversed().map(project);
+
+  expect<string[]>(reversed.toReversed()).toEqual(first);
+  expect<string[]>(revisions.map(project)).toEqual(first);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.db.test.ts
@@ -83,6 +83,7 @@ test("every cycle reports one timing per phase, in both commit modes", async () 
       reservationMs: expect.any(Number),
       materialReadMs: 0,
       payloadLoadMs: 0,
+      documentBuildMs: 0,
       ingestMs: 0,
       storeCommitMs: 0,
     });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -128,7 +128,23 @@ type ExecuteCorpusProjectionAppendCycleOptions<
 export type CorpusProjectionAppendCycleTiming = {
   reservationMs: number;
   materialReadMs: number;
+  /**
+   * The payload window end to end: object reads, which run concurrently, and
+   * the document build for each revision, which does not.
+   */
   payloadLoadMs: number;
+  /**
+   * The build's share of `payloadLoadMs`: parsing a payload into documents and
+   * serializing them, summed over the revisions.
+   *
+   * Measured apart from the window it sits inside because the two answer
+   * opposite questions. The window is wall clock over concurrent reads, so it
+   * says nothing about where the time went; this is synchronous work on one
+   * thread, so it adds up to real elapsed time and a cycle whose window is
+   * mostly build is CPU-bound, not I/O-bound. Without the split the phase
+   * reads as object-storage latency however it is actually spent.
+   */
+  documentBuildMs: number;
   ingestMs: number;
   storeCommitMs: number;
 };
@@ -443,18 +459,11 @@ export const advanceCorpusProjectionAppendTails = <
   return { flush, tails: nextTails };
 };
 
-const buildPreparedEntry = async (
-  runInTransaction: ProjectionTransactionRunner,
+/** The synchronous half of a prepared entry: payload in, append request out. */
+const prepareProjectionEntry = (
   material: CorpusProjectionMaterial,
-): Promise<Result<PreparedProjectionEntry, PreparedProjectionFailure>> => {
-  const payload = await Result.tryPromise(
-    async () => await loadCorpusProjectionPayload(runInTransaction, material),
-  );
-  if (payload.isErr()) {
-    return Result.err(
-      classifyCorpusProjectionPayloadReadFailure(payload.error),
-    );
-  }
+  payload: Awaited<ReturnType<typeof loadCorpusProjectionPayload>>,
+): Result<PreparedProjectionEntry, PreparedProjectionFailure> => {
   const built = Result.try(() => {
     switch (material.family) {
       case "case_law":
@@ -462,7 +471,7 @@ const buildPreparedEntry = async (
           family: material.family,
           manifest: material.manifest,
           input: material.input,
-          payload: payload.value,
+          payload,
           revision: material.lease.intentId,
         });
       case "legislation":
@@ -470,7 +479,7 @@ const buildPreparedEntry = async (
           family: material.family,
           manifest: material.manifest,
           input: material.input,
-          payload: payload.value,
+          payload,
           revision: material.lease.intentId,
         });
       default:
@@ -513,6 +522,36 @@ const buildPreparedEntry = async (
     ndjsonBytes: Buffer.byteLength(request.ndjson, "utf-8") + 1,
     leaseExpiresAtMs: material.lease.leaseExpiresAt.getTime(),
   });
+};
+
+type BuildPreparedEntryOptions = {
+  runInTransaction: ProjectionTransactionRunner;
+  material: CorpusProjectionMaterial;
+  /** Records the synchronous build's share of the payload window. */
+  recordBuildMs: (elapsedMs: number) => void;
+};
+
+const buildPreparedEntry = async ({
+  runInTransaction,
+  material,
+  recordBuildMs,
+}: BuildPreparedEntryOptions): Promise<
+  Result<PreparedProjectionEntry, PreparedProjectionFailure>
+> => {
+  const payload = await Result.tryPromise(
+    async () => await loadCorpusProjectionPayload(runInTransaction, material),
+  );
+  if (payload.isErr()) {
+    return Result.err(
+      classifyCorpusProjectionPayloadReadFailure(payload.error),
+    );
+  }
+  // The build is synchronous, so one span covers all of it and the spans of
+  // concurrent revisions cannot overlap.
+  const buildStartedAt = Date.now();
+  const prepared = prepareProjectionEntry(material, payload.value);
+  recordBuildMs(Date.now() - buildStartedAt);
+  return prepared;
 };
 
 const addCancellation = (
@@ -747,7 +786,13 @@ const processPreparedWindows = async ({
       await Promise.all(
         window.map(async (material) => ({
           material,
-          loaded: await buildPreparedEntry(runInTransaction, material),
+          loaded: await buildPreparedEntry({
+            runInTransaction,
+            material,
+            recordBuildMs: (elapsedMs) => {
+              result.timing.documentBuildMs += elapsedMs;
+            },
+          }),
         })),
       ),
     (elapsedMs) => {
@@ -865,6 +910,7 @@ export const executeCorpusProjectionAppendCycle = async <
     reservationMs: 0,
     materialReadMs: 0,
     payloadLoadMs: 0,
+    documentBuildMs: 0,
     ingestMs: 0,
     storeCommitMs: 0,
   };

--- a/apps/api/src/lib/legal-search/morphology/stem-memo.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem-memo.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { createBoundedMemo } from "@/api/lib/legal-search/morphology/stem-memo";
+
+/** A compute that records what it was asked for, so hits are observable. */
+const counting = () => {
+  const computed: string[] = [];
+  return {
+    computed,
+    compute: (key: string) => () => {
+      computed.push(key);
+      return `${key}!`;
+    },
+  };
+};
+
+describe("bounded memo", () => {
+  test("computes a key once and answers repeats from the memo", () => {
+    const { computed, compute } = counting();
+    const memo = createBoundedMemo(8);
+
+    expect<string>(memo.get("a", compute("a"))).toBe("a!");
+    expect<string>(memo.get("a", compute("a"))).toBe("a!");
+    expect<string>(memo.get("b", compute("b"))).toBe("b!");
+
+    expect<string[]>(computed).toEqual(["a", "b"]);
+  });
+
+  test("a key never answers with another key's value", () => {
+    const memo = createBoundedMemo(4);
+    const keys = Array.from({ length: 200 }, (_unused, index) => `k${index}`);
+
+    for (const key of keys) {
+      memo.get(key, () => `${key}!`);
+    }
+
+    // Read back in a different order than they were written, so a rotation
+    // that mixed generations would surface here.
+    for (const key of keys.toReversed()) {
+      expect<string>(memo.get(key, () => `${key}!`)).toBe(`${key}!`);
+    }
+  });
+
+  test("live entries stay within twice the generation ceiling", () => {
+    const memo = createBoundedMemo(10);
+
+    for (let index = 0; index < 500; index += 1) {
+      memo.get(`k${index}`, () => `v${index}`);
+      expect<number>(memo.size()).toBeLessThanOrEqual(20);
+    }
+  });
+
+  test("a key still in use survives a rotation without recomputing", () => {
+    const { computed, compute } = counting();
+    const memo = createBoundedMemo(4);
+
+    memo.get("hot", compute("hot"));
+    // Fill past the ceiling twice over, touching "hot" once per generation so
+    // it is promoted forward instead of aging out.
+    for (let index = 0; index < 12; index += 1) {
+      memo.get(`cold${index}`, compute(`cold${index}`));
+      memo.get("hot", compute("hot"));
+    }
+
+    expect<string[]>(computed.filter((key) => key === "hot")).toEqual(["hot"]);
+  });
+
+  test("a key evicted with its generation is recomputed, not lost", () => {
+    const { computed, compute } = counting();
+    const memo = createBoundedMemo(2);
+
+    memo.get("stale", compute("stale"));
+    for (let index = 0; index < 20; index += 1) {
+      memo.get(`other${index}`, compute(`other${index}`));
+    }
+
+    expect<string>(memo.get("stale", compute("stale"))).toBe("stale!");
+    expect<number>(computed.filter((key) => key === "stale").length).toBe(2);
+  });
+});

--- a/apps/api/src/lib/legal-search/morphology/stem-memo.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem-memo.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import { createBoundedMemo } from "@/api/lib/legal-search/morphology/stem-memo";
 
+/** Wide enough that the length ceiling is out of the way of the other tests. */
+const KEY_LENGTH = 64;
+
 /** A compute that records what it was asked for, so hits are observable. */
 const counting = () => {
   const computed: string[] = [];
@@ -17,7 +20,7 @@ const counting = () => {
 describe("bounded memo", () => {
   test("computes a key once and answers repeats from the memo", () => {
     const { computed, compute } = counting();
-    const memo = createBoundedMemo(8);
+    const memo = createBoundedMemo({ maxEntries: 8, maxKeyLength: KEY_LENGTH });
 
     expect<string>(memo.get("a", compute("a"))).toBe("a!");
     expect<string>(memo.get("a", compute("a"))).toBe("a!");
@@ -27,7 +30,7 @@ describe("bounded memo", () => {
   });
 
   test("a key never answers with another key's value", () => {
-    const memo = createBoundedMemo(4);
+    const memo = createBoundedMemo({ maxEntries: 4, maxKeyLength: KEY_LENGTH });
     const keys = Array.from({ length: 200 }, (_unused, index) => `k${index}`);
 
     for (const key of keys) {
@@ -42,7 +45,10 @@ describe("bounded memo", () => {
   });
 
   test("live entries stay within twice the generation ceiling", () => {
-    const memo = createBoundedMemo(10);
+    const memo = createBoundedMemo({
+      maxEntries: 10,
+      maxKeyLength: KEY_LENGTH,
+    });
 
     for (let index = 0; index < 500; index += 1) {
       memo.get(`k${index}`, () => `v${index}`);
@@ -52,7 +58,7 @@ describe("bounded memo", () => {
 
   test("a key still in use survives a rotation without recomputing", () => {
     const { computed, compute } = counting();
-    const memo = createBoundedMemo(4);
+    const memo = createBoundedMemo({ maxEntries: 4, maxKeyLength: KEY_LENGTH });
 
     memo.get("hot", compute("hot"));
     // Fill past the ceiling twice over, touching "hot" once per generation so
@@ -65,9 +71,34 @@ describe("bounded memo", () => {
     expect<string[]>(computed.filter((key) => key === "hot")).toEqual(["hot"]);
   });
 
+  test("a key past the length ceiling is answered but never retained", () => {
+    const { computed, compute } = counting();
+    const memo = createBoundedMemo({ maxEntries: 1000, maxKeyLength: 8 });
+    const oversized = "x".repeat(9);
+
+    expect<string>(memo.get(oversized, compute(oversized))).toBe(
+      `${oversized}!`,
+    );
+    expect<string>(memo.get(oversized, compute(oversized))).toBe(
+      `${oversized}!`,
+    );
+
+    // Recomputed every time, and holding nothing: the entry ceiling alone
+    // would have kept this key resident for the next 999 distinct terms.
+    expect<number>(computed.length).toBe(2);
+    expect<number>(memo.size()).toBe(0);
+    // The key exactly at the ceiling is remembered, so the boundary is not
+    // off by one in the direction that stops memoizing real terms.
+    const atCeiling = "y".repeat(8);
+    memo.get(atCeiling, compute(atCeiling));
+    memo.get(atCeiling, compute(atCeiling));
+
+    expect<number>(computed.filter((key) => key === atCeiling).length).toBe(1);
+  });
+
   test("a key evicted with its generation is recomputed, not lost", () => {
     const { computed, compute } = counting();
-    const memo = createBoundedMemo(2);
+    const memo = createBoundedMemo({ maxEntries: 2, maxKeyLength: KEY_LENGTH });
 
     memo.get("stale", compute("stale"));
     for (let index = 0; index < 20; index += 1) {

--- a/apps/api/src/lib/legal-search/morphology/stem-memo.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem-memo.ts
@@ -1,0 +1,68 @@
+/**
+ * A bounded memo for a pure key → value function.
+ *
+ * Stemming is a pure function of the term and the language, and a corpus
+ * repeats its terms heavily: inside one document, and far more across the
+ * documents of one indexing batch. Answering a repeat from the previous
+ * answer is therefore identical to re-running the algorithm, which is what
+ * lets the projection keep byte-identical output while paying the stemmer
+ * once per distinct term.
+ *
+ * Two generations rather than a linked-list LRU: a hit is one `Map` lookup,
+ * an insertion is one `Map` set, and eviction is dropping a whole generation,
+ * so nothing per entry has to be tracked to keep the ceiling. A key still in
+ * use when the young generation fills is promoted out of the old one instead
+ * of being lost at the rotation boundary, so a working set that fits the
+ * ceiling survives rotations.
+ */
+
+export type BoundedMemo = {
+  /**
+   * The remembered value for `key`, or what `compute` returns, remembered.
+   * The caller supplies `compute` per call so the memo never has to decode a
+   * key back into the arguments that produced it.
+   */
+  get: (key: string, compute: () => string) => string;
+  /** Live entries across both generations. Exposed for the bound's tests. */
+  size: () => number;
+};
+
+/**
+ * @param maxEntries Entries the young generation holds before it rotates.
+ * Live entries are bounded by twice this, since the previous generation is
+ * retained until the next rotation.
+ */
+export const createBoundedMemo = (maxEntries: number): BoundedMemo => {
+  let young = new Map<string, string>();
+  let old = new Map<string, string>();
+  const remember = (key: string, value: string): string => {
+    if (young.size >= maxEntries) {
+      old = young;
+      young = new Map<string, string>();
+    }
+    young.set(key, value);
+    return value;
+  };
+  return {
+    get: (key, compute) => {
+      const fresh = young.get(key);
+      if (fresh !== undefined) {
+        return fresh;
+      }
+      const aged = old.get(key);
+      // Promoted rather than read in place: the old generation is dropped at
+      // the next rotation, so a key still in use has to move forward to
+      // survive it.
+      return remember(key, aged ?? compute());
+    },
+    size: () => {
+      let live = young.size;
+      for (const key of old.keys()) {
+        if (!young.has(key)) {
+          live += 1;
+        }
+      }
+      return live;
+    },
+  };
+};

--- a/apps/api/src/lib/legal-search/morphology/stem-memo.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem-memo.ts
@@ -14,6 +14,11 @@
  * use when the young generation fills is promoted out of the old one instead
  * of being lost at the rotation boundary, so a working set that fits the
  * ceiling survives rotations.
+ *
+ * The ceiling is on entries *and* on key length. Counting entries alone
+ * bounds memory only if entries are of bounded size, which is not something a
+ * memo can assume of its caller's keys: one pathological key would otherwise
+ * stay resident until tens of thousands of ordinary ones displaced it.
  */
 
 export type BoundedMemo = {
@@ -27,12 +32,29 @@ export type BoundedMemo = {
   size: () => number;
 };
 
-/**
- * @param maxEntries Entries the young generation holds before it rotates.
- * Live entries are bounded by twice this, since the previous generation is
- * retained until the next rotation.
- */
-export const createBoundedMemo = (maxEntries: number): BoundedMemo => {
+type BoundedMemoOptions = {
+  /**
+   * Entries the young generation holds before it rotates. Live entries are
+   * bounded by twice this, since the previous generation is retained until
+   * the next rotation.
+   */
+  maxEntries: number;
+  /**
+   * Longest key the memo will retain. A key past it is computed and returned
+   * but never stored, so the resident bytes are bounded by the entry ceiling
+   * times this rather than by the entry ceiling alone.
+   *
+   * The two ceilings are not interchangeable, and only together do they bound
+   * memory: a caller whose keys have no natural length limit can otherwise
+   * pin arbitrarily many bytes in a structure that counts only entries.
+   */
+  maxKeyLength: number;
+};
+
+export const createBoundedMemo = ({
+  maxEntries,
+  maxKeyLength,
+}: BoundedMemoOptions): BoundedMemo => {
   let young = new Map<string, string>();
   let old = new Map<string, string>();
   const remember = (key: string, value: string): string => {
@@ -45,6 +67,9 @@ export const createBoundedMemo = (maxEntries: number): BoundedMemo => {
   };
   return {
     get: (key, compute) => {
+      if (key.length > maxKeyLength) {
+        return compute();
+      }
       const fresh = young.get(key);
       if (fresh !== undefined) {
         return fresh;

--- a/apps/api/src/lib/legal-search/morphology/stem.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem.test.ts
@@ -338,6 +338,27 @@ describe("remembered stems", () => {
     }
   });
 
+  test("a term too long to remember still stems like the algorithm", () => {
+    // Tokenisation caps no length, so a malformed payload can hand the module
+    // a token of any size. Those are not memoized (the memo's key ceiling),
+    // which must cost the caller nothing but a recomputation.
+    const stemmer = new CzechStemmer();
+    for (const length of [8, 66, 67, 5000]) {
+      const term = `${"rozhodnut".repeat(length)}ími`.slice(0, length);
+      const normalized = term.normalize("NFC").toLowerCase();
+      const expected = stemmer.stem(normalized);
+
+      expect<[number, string]>([length, stemLegalTerm(term, "cs")]).toEqual([
+        length,
+        expected === "" ? normalized : expected,
+      ]);
+      expect<[number, string]>([length, stemLegalTerm(term, "cs")]).toEqual([
+        length,
+        expected === "" ? normalized : expected,
+      ]);
+    }
+  });
+
   test("one term stems the same under every language that reads it", () => {
     // The shared memo is keyed by language as well as term; a key collision
     // would make whichever language asked first answer for the rest.

--- a/apps/api/src/lib/legal-search/morphology/stem.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { readConformanceVocabulary } from "@/api/lib/legal-search/morphology/snowball/__fixtures__/vocabulary";
+import { CzechStemmer } from "@/api/lib/legal-search/morphology/snowball/czech.gen";
+import { PolishStemmer } from "@/api/lib/legal-search/morphology/snowball/polish.gen";
 import {
   MORPHOLOGY_LANGUAGES,
   stemLegalTerm,
@@ -283,5 +285,70 @@ describe("stemLegalTerm", () => {
 
     expect<string>(stemLegalTerm("absolwentów", "pl")).toBe("absolwent");
     expect<string>(stemLegalTerm("absolwentow", "pl")).toBe("absolwentow");
+  });
+});
+
+/**
+ * Stems are remembered between calls (see the memo in stem.ts). What the
+ * memo may never do is change an answer, so these hold the public surface to
+ * the algorithms it stands in front of.
+ */
+describe("remembered stems", () => {
+  test("every language code is two characters, which the memo key relies on", () => {
+    // The memo keys one shared structure as the code followed by the term.
+    // A code of another width would let one language's term address another's
+    // entry, so the width is a property of the list, not of the memo.
+    expect<readonly string[]>(
+      MORPHOLOGY_LANGUAGES.filter((language) => language.length !== 2),
+    ).toEqual([]);
+  });
+
+  test("a remembered stem equals the algorithm's, over the whole vocabulary", () => {
+    const cases = [
+      { language: "cs", stemmer: new CzechStemmer(), algorithm: "czech" },
+      { language: "pl", stemmer: new PolishStemmer(), algorithm: "polish" },
+    ] as const satisfies readonly {
+      language: (typeof MORPHOLOGY_LANGUAGES)[number];
+      stemmer: { stem: (term: string) => string };
+      algorithm: string;
+    }[];
+
+    for (const { language, stemmer, algorithm } of cases) {
+      const pairs = readConformanceVocabulary(algorithm);
+      expect<number>(pairs.length).toBeGreaterThan(2000);
+
+      // Twice through, so the second pass reads what the first remembered,
+      // and interleaved with the other language, so a shared structure that
+      // confused the two would answer with the neighbour's stem.
+      for (const pass of [1, 2]) {
+        const divergent = pairs
+          .filter(({ word }) => {
+            const normalized = word.normalize("NFC").toLowerCase();
+            const expected = stemmer.stem(normalized);
+            return (
+              stemLegalTerm(word, language) !==
+              (expected === "" ? normalized : expected)
+            );
+          })
+          .slice(0, 10)
+          .map(({ word }) => `${algorithm} pass ${pass}: ${word}`);
+
+        expect<readonly string[]>(divergent).toEqual([]);
+      }
+    }
+  });
+
+  test("one term stems the same under every language that reads it", () => {
+    // The shared memo is keyed by language as well as term; a key collision
+    // would make whichever language asked first answer for the rest.
+    const term = "rozhodnutia";
+    const stems = MORPHOLOGY_LANGUAGES.map((language) =>
+      stemLegalTerm(term, language),
+    );
+
+    expect<number>(new Set(stems).size).toBeGreaterThan(1);
+    expect<readonly string[]>(
+      MORPHOLOGY_LANGUAGES.map((language) => stemLegalTerm(term, language)),
+    ).toEqual(stems);
   });
 });

--- a/apps/api/src/lib/legal-search/morphology/stem.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem.ts
@@ -125,11 +125,32 @@ const STEMMERS = {
  * Sized against one indexing batch rather than the corpus: a batch of a few
  * hundred documents carries a few hundred thousand tokens over tens of
  * thousands of distinct terms, so a ceiling in this range answers nearly
- * every repeat inside a batch while the retained entries (at most twice this,
- * across both generations) stay a few megabytes. A larger ceiling would buy
- * hits only across batches, where the term distribution has already moved.
+ * every repeat inside a batch. A larger ceiling would buy hits only across
+ * batches, where the term distribution has already moved. Retained entries
+ * are at most twice this across both generations, each bounded in size by
+ * {@link STEM_MEMO_MAX_KEY_LENGTH}; the two ceilings together are what put a
+ * number on the memory.
  */
 const STEM_MEMO_MAX_ENTRIES = 50_000;
+
+/**
+ * Longest memo key: 64 characters of term, plus the two-character language
+ * prefix.
+ *
+ * Tokenisation splits on anything that is not a letter or a digit but caps no
+ * length, and a corpus payload may be tens of millions of characters, so a
+ * single malformed document can hand this module a token of arbitrary size.
+ * Counting entries would then bound the memo's population but not its bytes,
+ * and one such token would stay resident until tens of thousands of ordinary
+ * terms displaced it. Past the ceiling a term is still stemmed, just not
+ * remembered — it is a term that occurs once, which is precisely the case a
+ * memo cannot pay for.
+ *
+ * 64 clears every word any of these algorithms is written for, German and
+ * Finnish compounds included, by a wide margin. A stem never grows past its
+ * term (see stem.property.test.ts), so bounding the key bounds the value too.
+ */
+const STEM_MEMO_MAX_KEY_LENGTH = 66;
 
 /**
  * Stems already computed, across every language.
@@ -147,7 +168,10 @@ const STEM_MEMO_MAX_ENTRIES = 50_000;
  * can spell its way into another language's entry (`stem.test.ts` holds the
  * language list to that width).
  */
-const stemMemo = createBoundedMemo(STEM_MEMO_MAX_ENTRIES);
+const stemMemo = createBoundedMemo({
+  maxEntries: STEM_MEMO_MAX_ENTRIES,
+  maxKeyLength: STEM_MEMO_MAX_KEY_LENGTH,
+});
 
 /**
  * Reduce a term to its stem for the given language.

--- a/apps/api/src/lib/legal-search/morphology/stem.ts
+++ b/apps/api/src/lib/legal-search/morphology/stem.ts
@@ -38,6 +38,7 @@ import { PortugueseStemmer } from "@/api/lib/legal-search/morphology/snowball/po
 import { RomanianStemmer } from "@/api/lib/legal-search/morphology/snowball/romanian.gen";
 import { SpanishStemmer } from "@/api/lib/legal-search/morphology/snowball/spanish.gen";
 import { SwedishStemmer } from "@/api/lib/legal-search/morphology/snowball/swedish.gen";
+import { createBoundedMemo } from "@/api/lib/legal-search/morphology/stem-memo";
 
 /** ISO 639-1 codes this module can stem. */
 export const MORPHOLOGY_LANGUAGES = [
@@ -119,6 +120,36 @@ const STEMMERS = {
 >;
 
 /**
+ * Distinct terms the memo keeps before rotating a generation.
+ *
+ * Sized against one indexing batch rather than the corpus: a batch of a few
+ * hundred documents carries a few hundred thousand tokens over tens of
+ * thousands of distinct terms, so a ceiling in this range answers nearly
+ * every repeat inside a batch while the retained entries (at most twice this,
+ * across both generations) stay a few megabytes. A larger ceiling would buy
+ * hits only across batches, where the term distribution has already moved.
+ */
+const STEM_MEMO_MAX_ENTRIES = 50_000;
+
+/**
+ * Stems already computed, across every language.
+ *
+ * Stemming is the dominant cost of projecting a document into the index, and
+ * a legal corpus repeats its terms: inside one decision, and far more across
+ * the decisions of one batch. A stem is a pure function of the term and the
+ * language, so a remembered answer is the algorithm's answer — the
+ * projection's output is unchanged, only the work is.
+ *
+ * One shared structure rather than one per language, so the memory ceiling is
+ * a single number instead of one multiplied by however many languages a
+ * deployment touches. Keys are the language code followed by the term; every
+ * ISO 639-1 code is two characters, so the prefix is fixed width and no term
+ * can spell its way into another language's entry (`stem.test.ts` holds the
+ * language list to that width).
+ */
+const stemMemo = createBoundedMemo(STEM_MEMO_MAX_ENTRIES);
+
+/**
  * Reduce a term to its stem for the given language.
  *
  * Two normalisations happen here, and both are preconditions the underlying
@@ -142,8 +173,13 @@ const STEMMERS = {
 export const stemLegalTerm = (
   term: string,
   language: MorphologyLanguage,
-): string => {
-  const normalized = term.normalize("NFC").toLowerCase();
-  const stem = STEMMERS[language].stem(normalized);
-  return stem === "" ? normalized : stem;
-};
+): string =>
+  // Keyed by the term as it arrived, not by its normalised form: the memo
+  // then answers a repeat without normalising it again, and a key that is
+  // already a live string keeps the hash the engine cached for it rather than
+  // rehashing a freshly built one on every lookup.
+  stemMemo.get(`${language}${term}`, () => {
+    const normalized = term.normalize("NFC").toLowerCase();
+    const stem = STEMMERS[language].stem(normalized);
+    return stem === "" ? normalized : stem;
+  });


### PR DESCRIPTION
## What this changes

Two things, both about where a corpus-index append cycle spends its payload
window.

1. **Stems are remembered.** `stemLegalTerm` now answers a repeated term from a
   bounded memo instead of re-running the algorithm.
2. **The append cycle reports the build's share of the payload window**, so the
   phase stops reading as object-storage latency when it is CPU.

## Where the time goes

Measured on a committed judgment fixture
(`__fixtures__/eu-ecj/62018CJ0311.en.html.gz`: 168 KiB of text, 28k tokens,
329 blocks, 122 passages), best of 11 passes per phase, shares of the
per-revision payload work:

| phase | share |
| --- | --- |
| stemming the passages | 80–92% |
| decompressing the two objects | 3–12% |
| `JSON.parse` of the AST | ~1% |
| persisted-AST schema parse | 1–3% |
| AST degradation scan | ~1% |
| chunking | <1% |
| NDJSON serialization | 1–2% |

Stemming is synchronous, so it does not overlap with the stemming of the other
revisions in the same read window: with reads running concurrently and the
builds serialized on one thread, the window's wall clock is the sum of the
builds. Object reads themselves amortize across the window's concurrency and
are not what the window is waiting on.

## The fix

A stem is a pure function of the term and the language, and a legal corpus
repeats its terms hard. In the same fixture set: ~8% of a judgment's tokens are
distinct, and the next judgments in a batch add 4–6% each. So the algorithm is
being asked the same question ten or more times per document, and many more
times per batch.

`morphology/stem-memo.ts` holds a bounded two-generation memo: a hit is one map
lookup, an insertion is one map set, eviction drops a whole generation, and
live entries never exceed twice the ceiling (50k per generation, a few
megabytes). A key still in use when the young generation fills is promoted out
of the old one, so a working set that fits the ceiling survives rotations.

Keys are the language code followed by the term as it arrived. Every ISO 639-1
code is two characters, so the prefix is fixed width and no term can spell its
way into another language's entry; a test holds the language list to that
width. Keying on the term rather than on its normalized form means a hit skips
the per-term NFC pass as well, and the key is a string the engine has already
hashed rather than one built fresh per lookup — worth about 40% of the hit path
in measurement.

Effect on the same fixture: stemming 2.7–3.1x less time, per-revision payload
work 2.1–2.7x less.

## Output is unchanged

The memo stands in front of a pure function, so this is an invariant, not a
hope, and it is tested as one:

- the whole committed Czech and Polish conformance vocabulary, twice through
  and interleaved across languages, must equal what the Snowball classes
  produce directly (`stem.test.ts`);
- a revision must project to byte-identical documents whatever preceded it —
  the batch is built forwards and backwards and the JSON compared
  (`corpus-index-projection-builder.test.ts`);
- the memo itself: computes once per key, never answers with another key's
  value across rotations, stays within twice the ceiling, promotes a key still
  in use, recomputes one that aged out (`stem-memo.test.ts`).

## Timing split

`payloadLoadMs` covered the concurrent reads and the synchronous build
together, which is why the phase read as I/O. `documentBuildMs` now reports the
build's share of it. The build is synchronous, so the spans of concurrent
revisions cannot overlap and the sum is real elapsed time; a window that is
mostly build is CPU-bound. Nothing else about the cycle changes.

## Not changed here

- **Pack-range coalescing.** The pack format and its ranged-read path exist,
  but nothing in the repository writes a pack outside its own tests, so there
  are no packed addresses to coalesce and no request count to save. Worth
  revisiting when a writer lands, though the measurement above says reads are
  not the phase's cost at this concurrency.
- **`CORPUS_PROJECTION_PAYLOAD_READ_CONCURRENCY_MAX`.** Raising it would widen
  a window whose wall clock is serialized CPU, so it would not help until the
  build itself moves off the event loop.
- **Store commit.** Occasional multi-second waits in the store phase line up
  with the exclusive projection fence being taken by a reader
  (`lockCorpusIndexProjectionRevisionTx`). Noted, not touched: fence semantics
  are out of scope for a performance change.

## Verification

`bun scripts/lint-changed.ts`, `bun scripts/ratchet.ts --check` (69 metrics at
or below baseline), `bun scripts/knip-exports-ratchet.ts --check` (9 workspaces
at or below baseline), `bun --filter @stll/api typecheck`, and the affected
tests: `morphology/`, the projection builder, the projection executor, the
executor DB test, and `corpus-query`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved legal search processing by reusing previously calculated language stems, helping repeated searches complete more efficiently.
  - Memory usage remains bounded during extended processing.

- **Reliability**
  - Improved consistency of case-law document generation, ensuring results remain identical regardless of revision processing order.

- **Monitoring**
  - More detailed processing timings are now available, including time spent building search documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->