### PR TITLE
feat(api): template saves report marker authoring warnings

### DIFF
--- a/.changeset/template-marker-defects.md
+++ b/.changeset/template-marker-defects.md
@@ -1,0 +1,5 @@
+---
+"@stll/template-conditions": minor
+---
+
+`classifyMarkerDefect` names the authoring mistake behind a `{{...}}` span the grammar rejects — `unknown_directive` for a `{{#...}}` / `{{/...}}` token that is not a directive, `bracket_index` for `{{items[0].name}}` — and `MARKER_DEFECT_KINDS` lists those kinds so a consumer can derive its own codes from them instead of repeating the list. A span `classifyMarker` accepts is never a defect, so the directive grammar stays the only authority on which tokens exist.

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -1370,6 +1370,7 @@ const CONTRACT_CORPUS = {
           conditions: [],
           computed: [],
           arrays: [],
+          warnings: [],
         } satisfies DescribeTemplateResult);
       },
       expectRefPaths: [],

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -8,6 +8,7 @@ import {
   DOCUMENT_PROCESSING_KIND,
   DOCUMENT_PROCESSING_REQUIRED_STATUS,
 } from "@/api/lib/document-processing-contract";
+import { TEMPLATE_WARNING_CODES } from "@/api/lib/docx/template-warnings";
 
 import {
   chatEntityRef,
@@ -1490,6 +1491,17 @@ export const LOOKUP_BUSINESS_REGISTRY_PROJECTION = v.variant("type", [
   ),
 ]);
 
+const TEMPLATE_WARNINGS_PROJECTION = v.array(
+  v.strictObject({
+    // Tied to the producer's catalog: a code the warning module does not
+    // declare fails this schema's strict parse instead of reaching the model.
+    code: v.picklist(TEMPLATE_WARNING_CODES),
+    path: v.optional(v.string()),
+    message: v.string(),
+    hint: v.string(),
+  }),
+);
+
 /**
  * The describe shape (`DescribeTemplateResult` success variant,
  * `lib/templates/template-fill-service.ts`) served by list_templates' detail
@@ -1547,6 +1559,10 @@ export const TEMPLATE_DESCRIBE_PROJECTION = v.strictObject({
       itemFieldPaths: v.array(v.string()),
     }),
   ),
+  // Authoring warnings about the DOCX markers: a closed code, the marker or
+  // field path it names, and fixed guidance text. Structural, like the field
+  // paths above; no document prose is echoed.
+  warnings: TEMPLATE_WARNINGS_PROJECTION,
 });
 
 /**
@@ -1713,14 +1729,15 @@ export const SET_PRACTICE_JURISDICTIONS_PROJECTION = v.strictObject({
 });
 
 /**
- * save_template: create returns `{ templateId, name, fieldCount }` (template
- * handle); configure echoes the same describe shape list_templates' detail
- * mode serves, so the agent sees exactly what is now configured.
+ * save_template: create returns `{ templateId, name, fieldCount, warnings }`
+ * (template handle); configure echoes the same describe shape list_templates'
+ * detail mode serves, so the agent sees exactly what is now configured.
  */
 export const SAVE_TEMPLATE_CREATE_PROJECTION = v.strictObject({
   templateId: passthroughId(),
   name: v.string(),
   fieldCount: v.number(),
+  warnings: TEMPLATE_WARNINGS_PROJECTION,
 });
 
 export const SAVE_TEMPLATE_PROJECTION = v.union([

--- a/apps/api/src/lib/docx/discover-template.test.ts
+++ b/apps/api/src/lib/docx/discover-template.test.ts
@@ -556,3 +556,146 @@ describe("discoverTemplate", () => {
     expect(otherField?.visibleWhen).toBe("!isUK and !isDE");
   });
 });
+
+describe("template authoring warnings", () => {
+  const codesOf = (warnings: readonly { code: string }[]): string[] =>
+    warnings.map(({ code }) => code);
+
+  test("a loop placeholder written without its item prefix is reported", async () => {
+    const xml = WRAP(
+      [P("{{#each attorneys}}"), P("{{name}}"), P("{{/each}}")].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    // The fault the warning is about: `name` lands as a top-level scalar and
+    // the loop learns no item field, so every repeated row fills blank.
+    expect(result.fields.find((f) => f.path === "name")?.kind).toBe("string");
+    expect(
+      result.fields.find((f) => f.path === "attorneys")?.itemFields,
+    ).toBeUndefined();
+
+    expect(result.warnings).toEqual([
+      {
+        code: "unprefixed_item_path",
+        path: "name",
+        message: expect.stringContaining("{{#each attorneys}}"),
+        hint: "Write {{attorneys.name}} to fill it from each attorneys item.",
+      },
+    ]);
+  });
+
+  test("an inline loop scopes its own placeholders", async () => {
+    const unprefixed = WRAP(P("{{#each attorneys}} {{name}} {{/each}}"));
+    const prefixed = WRAP(
+      P("{{#each attorneys}} {{attorneys.name}} {{/each}}"),
+    );
+
+    expect(
+      codesOf((await discoverTemplate(await makeDocx(unprefixed))).warnings),
+    ).toEqual(["unprefixed_item_path"]);
+    expect((await discoverTemplate(await makeDocx(prefixed))).warnings).toEqual(
+      [],
+    );
+  });
+
+  test("a nested loop accepts either the declared or the qualified path", async () => {
+    const xml = WRAP(
+      [
+        P("{{#each contracts}}"),
+        P("{{#each items}}"),
+        P("{{contracts.items.name}}"),
+        P("{{/each}}"),
+        P("{{/each}}"),
+      ].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("a placeholder outside every loop is not an item-path warning", async () => {
+    const xml = WRAP(
+      [P("{{client.name}}"), P("{{#each attorneys}}"), P("{{/each}}")].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("a this-prefixed placeholder is reported", async () => {
+    const xml = WRAP(
+      [P("{{#each attorneys}}"), P("{{this.name}}"), P("{{/each}}")].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(result.warnings).toEqual([
+      {
+        code: "this_prefix",
+        path: "this.name",
+        message: expect.stringContaining("{{this.name}}"),
+        hint: "Inside {{#each items}} write the loop path: {{items.name}}.",
+      },
+    ]);
+  });
+
+  test("block tokens outside the grammar are reported as unknown directives", async () => {
+    const xml = WRAP(
+      [
+        P("{{#each attorneys}}"),
+        P("{{attorneys.name}}"),
+        P("{{#endeach}}"),
+        P("{{/endif}}"),
+      ].join(""),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(codesOf(result.warnings)).toEqual([
+      "unknown_directive",
+      "unknown_directive",
+    ]);
+    expect(result.warnings.map(({ path }) => path)).toEqual([
+      "{{#endeach}}",
+      "{{/endif}}",
+    ]);
+  });
+
+  test("bracket indexing is reported", async () => {
+    const xml = WRAP(P("{{attorneys[0].name}}"));
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    // Bracket syntax is not a placeholder at all: it survives into the filled
+    // document verbatim, which is what the warning is for.
+    expect(result.placeholders).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "bracket_index",
+        path: "{{attorneys[0].name}}",
+        message: expect.stringContaining("brackets"),
+        hint: expect.stringContaining("{{#each items}}"),
+      },
+    ]);
+  });
+
+  test("a marker split across paragraphs is reported", async () => {
+    const split = WRAP([P("Name: {{name"), P("}}")].join(""));
+    const whole = WRAP(P("Name: {{name}}"));
+
+    expect(
+      codesOf((await discoverTemplate(await makeDocx(split))).warnings),
+    ).toEqual(["split_marker", "split_marker"]);
+    expect((await discoverTemplate(await makeDocx(whole))).warnings).toEqual(
+      [],
+    );
+  });
+
+  test("condition expressions expose the paths they read", async () => {
+    const xml = WRAP(
+      [P("{{#if has_guarantor}}"), P("{{guarantor.name}}"), P("{{/if}}")].join(
+        "",
+      ),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(result.conditionPaths).toEqual(["has_guarantor"]);
+  });
+});

--- a/apps/api/src/lib/docx/discover-template.ts
+++ b/apps/api/src/lib/docx/discover-template.ts
@@ -5,7 +5,9 @@
  *
  * Returns backward-compatible `DiscoveredPlaceholder[]` plus
  * `DiscoveredField[]` with inferred kinds (string, boolean,
- * array, object) and `structureErrors` for mismatched blocks.
+ * array, object), `structureErrors` for mismatched blocks, and
+ * `warnings` for markers that parse but do not mean what the
+ * author wrote (see `template-warnings.ts`).
  */
 
 import { panic } from "better-result";
@@ -24,6 +26,11 @@ import {
   templateContentPartPaths,
   W_NS,
 } from "./ooxml";
+import {
+  boundTemplateWarnings,
+  collectParagraphWarnings,
+  type TemplateWarning,
+} from "./template-warnings";
 import type {
   DiscoveredField,
   DiscoveredPlaceholder,
@@ -78,11 +85,20 @@ const kindPriority = (kind: TemplateFieldKind): number => {
   }
 };
 
-const registerConditionFields = (
-  fields: FieldAccumulator,
-  condition: string,
-  rowPaths: readonly string[] = [],
-): void => {
+type ConditionFieldOptions = {
+  fields: FieldAccumulator;
+  /** Every path the expression reads, accumulated across containers. */
+  conditionPaths: Set<string>;
+  condition: string;
+  rowPaths?: readonly string[];
+};
+
+const registerConditionFields = ({
+  condition,
+  conditionPaths,
+  fields,
+  rowPaths = [],
+}: ConditionFieldOptions): void => {
   const root = parseCondition(condition);
   if (!root) {
     return;
@@ -90,6 +106,7 @@ const registerConditionFields = (
 
   const registerPath = (path: string, kind: "boolean" | "string"): void => {
     registerField(fields, path, kind);
+    conditionPaths.add(path);
 
     const isQualifiedRowPath = rowPaths.some(
       (rowPath) => path === rowPath || path.startsWith(`${rowPath}.`),
@@ -395,13 +412,25 @@ type AnalysisResult = {
   errors: TemplateStructureError[];
   placeholderCounts: Map<string, number>;
   fieldConditions: Map<string, string | null>;
+  warnings: TemplateWarning[];
+  conditionPaths: Set<string>;
 };
 
-const collectContainerStructure = (
-  body: slimdom.Element,
-  fields: FieldAccumulator,
-  errors: TemplateStructureError[],
-) => {
+type ContainerStructureOptions = {
+  body: slimdom.Element;
+  conditionPaths: Set<string>;
+  errors: TemplateStructureError[];
+  fields: FieldAccumulator;
+  warnings: TemplateWarning[];
+};
+
+const collectContainerStructure = ({
+  body,
+  conditionPaths,
+  errors,
+  fields,
+  warnings,
+}: ContainerStructureOptions) => {
   const paragraphs = body.getElementsByTagNameNS(W_NS, "p");
   const directives = scanBlockDirectives(body);
   const { blocks, errors: parseErrors } = parseBlockTree(directives);
@@ -417,11 +446,12 @@ const collectContainerStructure = (
       activeArrays.pop();
     }
     if (directive?.kind === "if" || directive?.kind === "elseif") {
-      registerConditionFields(
+      registerConditionFields({
+        condition: directive.expression,
+        conditionPaths,
         fields,
-        directive.expression,
-        rowScopePaths(activeArrays),
-      );
+        rowPaths: rowScopePaths(activeArrays),
+      });
     }
     if (directive?.kind === "each") {
       const scopedPath = qualifyRowScopedPath(
@@ -435,6 +465,17 @@ const collectContainerStructure = (
       });
     }
     arrayScopes.set(i, [...activeArrays]);
+
+    const paragraph = paragraphs[i];
+    if (paragraph) {
+      warnings.push(
+        ...collectParagraphWarnings({
+          loops: activeArrays,
+          paragraphIndex: i,
+          text: paragraphText(paragraph),
+        }),
+      );
+    }
   }
   const directiveIndices = new Set<number>();
   for (const d of directives) {
@@ -497,6 +538,7 @@ const collectLoopItemFields = ({
 const collectParagraphPlaceholders = ({
   arrayScopes,
   conditionMap,
+  conditionPaths,
   directiveIndices,
   errors,
   fieldConditions,
@@ -562,11 +604,12 @@ const collectParagraphPlaceholders = ({
 
         const priorConditions: string[] = [];
         for (const branch of group.branches) {
-          registerConditionFields(
+          registerConditionFields({
+            condition: branch.condition,
+            conditionPaths,
             fields,
-            branch.condition,
-            rowScopePaths(requireRowScopes(arrayScopes, i)),
-          );
+            rowPaths: rowScopePaths(requireRowScopes(arrayScopes, i)),
+          });
           const branchCondition =
             branch.condition === ""
               ? priorConditions.map(negateExpr).join(" and ")
@@ -662,17 +705,34 @@ const analyzeContainer = (body: slimdom.Element): AnalysisResult => {
   const placeholderCounts = new Map<string, number>();
   const errors: TemplateStructureError[] = [];
   const fieldConditions = new Map<string, string | null>();
-  const structure = collectContainerStructure(body, fields, errors);
+  const warnings: TemplateWarning[] = [];
+  const conditionPaths = new Set<string>();
+  const structure = collectContainerStructure({
+    body,
+    conditionPaths,
+    errors,
+    fields,
+    warnings,
+  });
   collectLoopItemFields({ ...structure, fields });
   collectParagraphPlaceholders({
     ...structure,
+    conditionPaths,
     errors,
     fieldConditions,
     fields,
     placeholderCounts,
+    warnings,
   });
 
-  return { fields, errors, placeholderCounts, fieldConditions };
+  return {
+    fields,
+    errors,
+    placeholderCounts,
+    fieldConditions,
+    warnings,
+    conditionPaths,
+  };
 };
 
 // ── Merge helpers ────────────────────────────────────────
@@ -700,6 +760,10 @@ const mergeAnalysis = (
   }
 
   primary.errors.push(...secondary.errors);
+  primary.warnings.push(...secondary.warnings);
+  for (const path of secondary.conditionPaths) {
+    primary.conditionPaths.add(path);
+  }
 
   for (const [name, count] of secondary.placeholderCounts) {
     primary.placeholderCounts.set(
@@ -729,15 +793,13 @@ const mergeAnalysis = (
 const analyzeHeadersAndFooters = async (
   zip: JSZip,
 ): Promise<AnalysisResult> => {
-  const fields: FieldAccumulator = new Map();
-  const errors: TemplateStructureError[] = [];
-  const placeholderCounts = new Map<string, number>();
-  const fieldConditions = new Map<string, string | null>();
   const result: AnalysisResult = {
-    fields,
-    errors,
-    placeholderCounts,
-    fieldConditions,
+    fields: new Map(),
+    errors: [],
+    placeholderCounts: new Map(),
+    fieldConditions: new Map(),
+    warnings: [],
+    conditionPaths: new Set(),
   };
 
   // Sort entries alphabetically to match the order used by
@@ -802,6 +864,8 @@ export const discoverTemplate = async (
     placeholders: [],
     fields: [],
     structureErrors: [],
+    warnings: [],
+    conditionPaths: [],
   };
 
   const docEntry = zip.file(MAIN_DOCUMENT_PART_PATH);
@@ -829,6 +893,7 @@ export const discoverTemplate = async (
   mergeAnalysis(primary, hfAnalysis);
 
   const { fields, errors, placeholderCounts, fieldConditions } = primary;
+  const conditionPaths = [...primary.conditionPaths].toSorted(compareCodeUnit);
 
   // Build DiscoveredPlaceholder[] (backward-compat)
   const placeholders: DiscoveredPlaceholder[] = [...placeholderCounts.entries()]
@@ -887,5 +952,7 @@ export const discoverTemplate = async (
     placeholders,
     fields: discoveredFields,
     structureErrors: errors,
+    warnings: boundTemplateWarnings(primary.warnings),
+    conditionPaths,
   };
 };

--- a/apps/api/src/lib/docx/template-manifest.test.ts
+++ b/apps/api/src/lib/docx/template-manifest.test.ts
@@ -607,6 +607,8 @@ describe("mergeManifestWithDiscovery", () => {
       },
     ],
     structureErrors: [],
+    warnings: [],
+    conditionPaths: [],
   };
 
   test("returns discovered fields when no manifest", () => {
@@ -677,6 +679,8 @@ describe("mergeManifestWithDiscovery", () => {
         { path: "rent_annual", kind: "string", count: 1 },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const manifest: TemplateManifest = {
       version: 1,
@@ -701,6 +705,8 @@ describe("mergeManifestWithDiscovery", () => {
       placeholders: [],
       fields: [{ path: "client_name", kind: "string", count: 2 }],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const manifest: TemplateManifest = {
       version: 1,
@@ -730,6 +736,8 @@ describe("mergeManifestWithDiscovery", () => {
         { path: "rent", kind: "string", count: 1 },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const resolved = mergeManifestWithDiscovery(null, discovery);
     expect(resolved.map((f) => f.path).sort()).toEqual([
@@ -757,6 +765,8 @@ describe("mergeManifestWithDiscovery", () => {
         },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
 
     const resolved = mergeManifestWithDiscovery(null, discovery);
@@ -794,6 +804,8 @@ describe("mergeManifestWithDiscovery", () => {
         { path: "company.full", kind: "string", count: 1 },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const resolved = mergeManifestWithDiscovery(manifest, discovery);
     expect(resolved.map((f) => f.path)).toEqual(["company"]);
@@ -844,6 +856,8 @@ describe("mergeManifestWithDiscovery", () => {
         },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
 
     const resolved = mergeManifestWithDiscovery(null, discovery);
@@ -864,6 +878,8 @@ describe("mergeManifestWithDiscovery", () => {
         },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const manifest: TemplateManifest = {
       version: 1,
@@ -904,6 +920,8 @@ describe("mergeManifestWithDiscovery", () => {
         },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const manifest: TemplateManifest = {
       version: 1,
@@ -1190,6 +1208,8 @@ describe("round-trip", () => {
       placeholders: [{ name: "lead_party", count: 1 }],
       fields: [{ path: "lead_party", kind: "string", count: 1 }],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
 
     const resolved = mergeManifestWithDiscovery(manifest, discovered);
@@ -1489,6 +1509,8 @@ describe("round-trip", () => {
       placeholders: [{ name: "company.krs", count: 1 }],
       fields: [{ path: "company.krs", kind: "string", count: 1 }],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const resolved = mergeManifestWithDiscovery(manifest, discovered);
     expect(resolved.find((f) => f.path === "company.krs")?.hint).toBe(
@@ -1519,6 +1541,8 @@ describe("round-trip", () => {
       placeholders: [{ name: "signature_date", count: 1 }],
       fields: [{ path: "signature_date", kind: "string", count: 1 }],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
 
     const resolved = mergeManifestWithDiscovery(manifest, discovered);
@@ -1553,6 +1577,8 @@ describe("round-trip", () => {
         },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
 
     const resolved = mergeManifestWithDiscovery(manifest, discovered);
@@ -1588,6 +1614,8 @@ describe("round-trip", () => {
         },
       ],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
     const resolved = mergeManifestWithDiscovery(readBack, discovered);
     expect(resolved.find((f) => f.path === "lawyers")?.validation).toEqual({
@@ -1620,6 +1648,8 @@ describe("round-trip", () => {
       placeholders: [{ name: "buyer_krs", count: 1 }],
       fields: [{ path: "buyer_krs", kind: "string", count: 1 }],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
 
     const resolved = mergeManifestWithDiscovery(manifest, discovered);
@@ -1650,6 +1680,8 @@ describe("round-trip", () => {
       placeholders: [{ name: "lawyer", count: 1 }],
       fields: [{ path: "lawyer", kind: "string", count: 1 }],
       structureErrors: [],
+      warnings: [],
+      conditionPaths: [],
     };
 
     const resolved = mergeManifestWithDiscovery(manifest, discovered);

--- a/apps/api/src/lib/docx/template-warnings.test.ts
+++ b/apps/api/src/lib/docx/template-warnings.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { discoverTemplate } from "./discover-template";
+import {
+  fieldOverlayWarnings,
+  type RegistryGate,
+  TEMPLATE_WARNING_CODES,
+  type TemplateWarningCode,
+} from "./template-warnings";
+
+const WRAP = (body: string) =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>${body}</w:body></w:document>`;
+
+const P = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+const makeDocx = async (documentXml: string): Promise<Buffer> => {
+  const zip = new JSZip();
+  zip.file("word/document.xml", documentXml);
+  return Buffer.from(await zip.generateAsync({ type: "nodebuffer" }));
+};
+
+/** Gates that stand in for the org's native-tool settings. `refuseAll` also
+ *  records that it ran, so a test can prove the settings read is skipped when
+ *  no field declares a lookup. */
+const allowAll: RegistryGate = async () => () => true;
+const refuseAll = (): RegistryGate & { calls: () => number } => {
+  let calls = 0;
+  const gate = async () => {
+    calls++;
+    return () => false;
+  };
+  return Object.assign(gate, { calls: () => calls });
+};
+
+describe("field overlay warnings", () => {
+  // `is_signed` drives {{#if is_signed}} AND prints as {{is_signed}}.
+  const bothRoles = {
+    conditionPaths: ["is_signed"],
+    placeholderPaths: ["is_signed", "client.name"],
+    registryGate: allowAll,
+  };
+  const SIGNED_RULE = 'status == "signed"';
+
+  test("a condition on a path the document also prints removes its input", async () => {
+    expect(
+      await fieldOverlayWarnings({
+        ...bothRoles,
+        fields: [{ path: "is_signed", condition: SIGNED_RULE }],
+      }),
+    ).toEqual([
+      {
+        code: "condition_removes_input",
+        path: "is_signed",
+        message: expect.stringContaining("{{is_signed}}"),
+        hint: expect.stringContaining("Drop the condition"),
+      },
+    ]);
+  });
+
+  test("a condition on a path used only by {{#if}} is the intended use", async () => {
+    expect(
+      await fieldOverlayWarnings({
+        conditionPaths: ["is_signed"],
+        placeholderPaths: ["client.name"],
+        registryGate: allowAll,
+        fields: [{ path: "is_signed", condition: SIGNED_RULE }],
+      }),
+    ).toEqual([]);
+  });
+
+  test("a plain boolean field keeps its input and warns about nothing", async () => {
+    expect(
+      await fieldOverlayWarnings({
+        ...bothRoles,
+        fields: [{ path: "is_signed" }],
+      }),
+    ).toEqual([]);
+  });
+
+  test("an AST-backed condition is derived the same way", async () => {
+    expect(
+      (
+        await fieldOverlayWarnings({
+          ...bothRoles,
+          fields: [
+            {
+              path: "is_signed",
+              conditionAst: { type: "predicate", op: "is_truthy" },
+            },
+          ],
+        })
+      ).map(({ code }) => code),
+    ).toEqual(["condition_removes_input"]);
+  });
+});
+
+describe("lookup field warnings", () => {
+  const lookupField = {
+    path: "company",
+    lookup: {
+      registry: "krs",
+      formats: [{ key: "default" }, { key: "address" }],
+    },
+  } as const;
+
+  test("a registry the organization has not enabled is reported", async () => {
+    const gate = refuseAll();
+    const warnings = await fieldOverlayWarnings({
+      conditionPaths: [],
+      placeholderPaths: ["company", "company.address"],
+      fields: [lookupField],
+      registryGate: gate,
+    });
+
+    expect(warnings).toEqual([
+      {
+        code: "registry_disabled",
+        path: "company",
+        message: expect.stringContaining("krs"),
+        hint: expect.stringContaining("Enable that registry"),
+      },
+    ]);
+    expect(gate.calls()).toBe(1);
+  });
+
+  test("no lookup field means no settings read", async () => {
+    const gate = refuseAll();
+    await fieldOverlayWarnings({
+      conditionPaths: [],
+      placeholderPaths: ["client.name"],
+      fields: [{ path: "client.name" }],
+      registryGate: gate,
+    });
+
+    expect(gate.calls()).toBe(0);
+  });
+
+  test("a declared format with no marker, and a marker with no format, are both reported", async () => {
+    const warnings = await fieldOverlayWarnings({
+      conditionPaths: [],
+      // `company.address` is declared but unplaced; `company.seat` is placed
+      // but undeclared. The default format rides the bare `{{company}}`.
+      placeholderPaths: ["company", "company.seat"],
+      fields: [lookupField],
+      registryGate: allowAll,
+    });
+
+    expect(warnings).toEqual([
+      {
+        code: "unmatched_lookup_format",
+        path: "company.address",
+        message: expect.stringContaining("renders nowhere"),
+        hint: expect.stringContaining("{{company.address}}"),
+      },
+      {
+        code: "unmatched_lookup_format",
+        path: "company.seat",
+        message: expect.stringContaining("names no format"),
+        hint: expect.stringContaining('"seat" format'),
+      },
+    ]);
+  });
+
+  test("a first format placed by the bare marker needs no keyed marker", async () => {
+    expect(
+      await fieldOverlayWarnings({
+        conditionPaths: [],
+        placeholderPaths: ["company", "company.address"],
+        fields: [lookupField],
+        registryGate: allowAll,
+      }),
+    ).toEqual([]);
+  });
+
+  test("the first format is addressed by the bare marker or its .value alias", async () => {
+    const placed = async (placeholderPaths: readonly string[]) =>
+      await fieldOverlayWarnings({
+        conditionPaths: [],
+        placeholderPaths,
+        fields: [
+          {
+            path: "company",
+            lookup: { registry: "krs", formats: [{ key: "default" }] },
+          },
+        ],
+        registryGate: allowAll,
+      });
+
+    expect(await placed(["company"])).toEqual([]);
+    expect(await placed(["company.value"])).toEqual([]);
+    expect((await placed(["client.name"])).map(({ code }) => code)).toEqual([
+      "unmatched_lookup_format",
+    ]);
+  });
+
+  // The resolver writes the first format to the bare marker whatever its key
+  // is, so a keyed marker for it is never filled — the case a "the key has a
+  // marker" rule would call placed.
+  test("a keyed marker for the first format is reported, not accepted", async () => {
+    const warnings = await fieldOverlayWarnings({
+      conditionPaths: [],
+      placeholderPaths: ["company.full"],
+      fields: [
+        {
+          path: "company",
+          lookup: { registry: "krs", formats: [{ key: "full" }] },
+        },
+      ],
+      registryGate: allowAll,
+    });
+
+    expect(warnings).toEqual([
+      {
+        code: "unmatched_lookup_format",
+        path: "company",
+        message: expect.stringContaining("has no {{company}} marker"),
+        hint: "Add {{company}} where the default rendering belongs.",
+      },
+      {
+        code: "unmatched_lookup_format",
+        path: "company.full",
+        message: expect.stringContaining("names the FIRST format"),
+        hint: expect.stringContaining("Write {{company}} instead"),
+      },
+    ]);
+  });
+});
+
+// A code nobody can produce is dead guidance, and a producible code with no
+// fixture is untested: both directions are asserted, so adding a code without
+// a template that triggers it fails here.
+describe("warning code census", () => {
+  test("every declared code is produced by a template that triggers it", async () => {
+    const xml = WRAP(
+      [
+        P("{{#if is_signed}}"),
+        P("Signed by {{is_signed}}"),
+        P("{{/if}}"),
+        P("{{company}} of {{company.seat}}"),
+        P("{{#each attorneys}}"),
+        P("{{name}}"),
+        P("{{this.name}}"),
+        P("{{attorneys[0].name}}"),
+        P("{{#endeach}}"),
+        P("Name: {{unclosed"),
+      ].join(""),
+    );
+    const discovered = await discoverTemplate(await makeDocx(xml));
+
+    const produced = new Set<TemplateWarningCode>([
+      ...discovered.warnings.map(({ code }) => code),
+      ...(
+        await fieldOverlayWarnings({
+          conditionPaths: discovered.conditionPaths,
+          placeholderPaths: discovered.placeholders.map(({ name }) => name),
+          fields: [
+            { path: "is_signed", condition: 'status == "signed"' },
+            {
+              path: "company",
+              lookup: {
+                registry: "krs",
+                formats: [{ key: "default" }, { key: "address" }],
+              },
+            },
+          ],
+          registryGate: refuseAll(),
+        })
+      ).map(({ code }) => code),
+    ]);
+
+    expect([...produced].toSorted()).toEqual(
+      [...TEMPLATE_WARNING_CODES].toSorted(),
+    );
+  });
+});

--- a/apps/api/src/lib/docx/template-warnings.ts
+++ b/apps/api/src/lib/docx/template-warnings.ts
@@ -1,0 +1,390 @@
+/**
+ * Authoring warnings for DOCX template markers.
+ *
+ * A warning is a marker the grammar accepts (or silently ignores), or a field
+ * configuration the save accepts, that almost certainly does not do what the
+ * author meant: it never blocks a save, it tells whoever authored the file
+ * what to fix before the first fill. Hard structural faults keep their own
+ * channels — unbalanced block directives are
+ * {@link import("./types").TemplateStructureError}s from `parseBlockTree`, and
+ * spans no recognizer sees at all are `invalidMarker` findings from the
+ * template check — so nothing here re-detects them.
+ *
+ * The paragraph scan is text-only; `discover-template.ts` supplies the loop
+ * scopes and merges the result into {@link import("./types").DiscoveredTemplate}.
+ */
+
+import type { BusinessRegistrySlug } from "@stll/api-contract";
+import {
+  assertNever,
+  classifyMarker,
+  classifyMarkerDefect,
+  MARKER_DEFECT_KINDS,
+  markerPattern,
+} from "@stll/template-conditions";
+
+/**
+ * Closed set of authoring mistakes reported at save time. The marker-shape
+ * defects are derived from the grammar package, so a new defect kind there
+ * lands here without a second list to update.
+ */
+export const TEMPLATE_WARNING_CODES = [
+  "unprefixed_item_path",
+  "this_prefix",
+  "split_marker",
+  "condition_removes_input",
+  "registry_disabled",
+  "unmatched_lookup_format",
+  ...MARKER_DEFECT_KINDS,
+] as const;
+
+export type TemplateWarningCode = (typeof TEMPLATE_WARNING_CODES)[number];
+
+export type TemplateWarning = {
+  code: TemplateWarningCode;
+  /** The field path or marker the warning is about, when it names one. */
+  path?: string;
+  /** What the marker does today, in the author's own terms. */
+  message: string;
+  /** The concrete edit that fixes it. */
+  hint: string;
+};
+
+/** Upper bound on the reported list, so a pathological file cannot return an
+ *  unbounded payload to an agent that must read all of it. */
+const MAX_TEMPLATE_WARNINGS = 50;
+
+/** `{{this}}` / `{{this.name}}`: a valid field path, but there is no `this`
+ *  scope in the grammar, so it resolves to a top-level field called `this`. */
+const THIS_PREFIX = "this.";
+
+const isItemScoped = (path: string, loopPath: string): boolean =>
+  path === loopPath || path.startsWith(`${loopPath}.`);
+
+const markerDefectWarning = (
+  raw: string,
+  inner: string,
+): TemplateWarning | null => {
+  const defect = classifyMarkerDefect(inner);
+  if (defect === null) {
+    return null;
+  }
+  switch (defect) {
+    case "unknown_directive":
+      return {
+        code: defect,
+        path: raw,
+        message: `${raw} is not a directive in the marker grammar, so it opens and closes nothing and prints literally.`,
+        hint: "Close a loop with {{/each}} and a condition with {{/if}}; the openers are {{#each path}}, {{#if expr}}, {{#elseif expr}} and {{#else}}.",
+      };
+    case "bracket_index":
+      return {
+        code: defect,
+        path: raw,
+        message: `${raw} indexes with brackets, which the marker grammar does not support, so it prints literally.`,
+        hint: "Repeat the item instead: {{#each items}} ... {{items.name}} ... {{/each}}.",
+      };
+    default:
+      return assertNever(defect);
+  }
+};
+
+/** One enclosing `{{#each}}`: the path as the author wrote it, plus the path
+ *  discovery qualified it to inside an outer loop (they differ only for a
+ *  nested loop whose declared path omits the outer prefix). A placeholder
+ *  matching either form is item-scoped. */
+type WarningLoopScope = {
+  declaredPath: string;
+  scopedPath: string;
+};
+
+type ParagraphWarningOptions = {
+  /** Concatenated text of one paragraph (`paragraphText` has already joined
+   *  the runs Word split the markers across). */
+  text: string;
+  /** The `{{#each}}` loops this paragraph sits inside, outermost first. Inline
+   *  loops opened within the paragraph are tracked by the scan itself. */
+  loops: readonly WarningLoopScope[];
+  paragraphIndex: number;
+};
+
+/**
+ * Warnings for one paragraph's markers. Walks the `{{...}}` spans in document
+ * order so an inline `{{#each x}} ... {{/each}}` scopes the placeholders
+ * between its own markers, exactly as the fill pipeline does.
+ */
+export const collectParagraphWarnings = ({
+  loops,
+  paragraphIndex,
+  text,
+}: ParagraphWarningOptions): TemplateWarning[] => {
+  const warnings: TemplateWarning[] = [];
+  const inlineLoops: WarningLoopScope[] = [];
+
+  for (const match of text.matchAll(markerPattern())) {
+    const raw = match[0];
+    const inner = (match.groups?.["inner"] ?? "").trim();
+    const meta = classifyMarker(inner);
+
+    if (meta === null) {
+      const defectWarning = markerDefectWarning(raw, inner);
+      if (defectWarning) {
+        warnings.push(defectWarning);
+      }
+      continue;
+    }
+
+    if (meta.kind === "each") {
+      inlineLoops.push({ declaredPath: meta.expr, scopedPath: meta.expr });
+      continue;
+    }
+    if (meta.kind === "endeach") {
+      inlineLoops.pop();
+      continue;
+    }
+    if (meta.kind !== "placeholder") {
+      continue;
+    }
+
+    const path = meta.expr;
+    if (path === "this" || path.startsWith(THIS_PREFIX)) {
+      const suffix = path.slice(THIS_PREFIX.length);
+      warnings.push({
+        code: "this_prefix",
+        path,
+        message: `${raw} uses "this", which is not a scope in the marker grammar: it fills from a top-level field literally named "${path}".`,
+        hint: `Inside {{#each items}} write the loop path: {{items.${suffix === "" ? "name" : suffix}}}.`,
+      });
+      continue;
+    }
+
+    const enclosingLoops = [...loops, ...inlineLoops];
+    const innermostLoop = enclosingLoops.at(-1);
+    if (
+      innermostLoop === undefined ||
+      enclosingLoops.some(
+        ({ declaredPath, scopedPath }) =>
+          isItemScoped(path, declaredPath) || isItemScoped(path, scopedPath),
+      )
+    ) {
+      continue;
+    }
+
+    const loopPath = innermostLoop.declaredPath;
+    warnings.push({
+      code: "unprefixed_item_path",
+      path,
+      message: `${raw} inside {{#each ${loopPath}}} is not an item field: it fills from a top-level "${path}", so every repeated row renders the same value (blank when no such field is filled).`,
+      hint: `Write {{${loopPath}.${path}}} to fill it from each ${loopPath} item.`,
+    });
+  }
+
+  const residue = text.replaceAll(markerPattern(), "");
+  if (residue.includes("{{") || residue.includes("}}")) {
+    warnings.push({
+      code: "split_marker",
+      message: `A "{{" or "}}" in paragraph ${paragraphIndex} of its document part has no matching half in the same paragraph, so that marker is never substituted.`,
+      hint: "Retype the marker so the whole {{...}} sits in one paragraph; a line break or a cell boundary inside it splits it.",
+    });
+  }
+
+  return warnings;
+};
+
+type OverlayLookup = {
+  registry: BusinessRegistrySlug;
+  /** Named renderings of the one resolved hit; the first is the default. */
+  formats: readonly { key: string }[];
+};
+
+type OverlayField = {
+  path: string;
+  condition?: string | undefined;
+  conditionAst?: unknown;
+  lookup?: OverlayLookup | undefined;
+};
+
+type LookupOverlayField = OverlayField & { lookup: OverlayLookup };
+
+const hasLookup = (field: OverlayField): field is LookupOverlayField =>
+  field.lookup !== undefined;
+
+/**
+ * Resolves the org's registry-enablement predicate. Awaited only when a field
+ * actually declares a lookup, so a template without one costs no settings
+ * read.
+ */
+export type RegistryGate = () => Promise<
+  (registry: BusinessRegistrySlug) => boolean
+>;
+
+type FieldOverlayWarningOptions = {
+  /** Paths referenced by a `{{#if}}` / `{{#elseif}}` expression. */
+  conditionPaths: readonly string[];
+  /** Paths that appear as a value marker `{{path}}` in the document. */
+  placeholderPaths: readonly string[];
+  /** The manifest fields as configured (create overlay or stored manifest). */
+  fields: readonly OverlayField[];
+  registryGate: RegistryGate;
+};
+
+/**
+ * A `condition` turns its field into a rule evaluated at fill time, so the
+ * fill form and the MCP field list stop asking for it. That is what an author
+ * wants for a path used only by `{{#if path}}`; it silently removes the input
+ * when the same path is also a value marker.
+ */
+const conditionWarning = (path: string): TemplateWarning => ({
+  code: "condition_removes_input",
+  path,
+  message: `"${path}" has a condition, so it is derived at fill time and nobody is asked for it, yet {{${path}}} also prints its value in the document.`,
+  hint: `Drop the condition to keep "${path}" as a yes/no input, or give the {{#if}} rule its own path.`,
+});
+
+/** The default format's nested alias: `{{company.value}}` renders the same
+ *  hit as the bare `{{company}}` marker, so it names no keyed format. */
+const DEFAULT_FORMAT_ALIAS = "value";
+
+/**
+ * Every format must have a marker to render into, and every dotted marker
+ * under a lookup field must name one: a format with no marker renders nowhere,
+ * and a marker with no format is left unfilled.
+ *
+ * Placement follows the fill resolver exactly (`lookup-fields.ts`): the FIRST
+ * format is written to the bare `{{path}}` marker and its `{{path.value}}`
+ * alias whatever its key is, and only later formats are written to
+ * `{{path.<key>}}`. A `{{path.<first key>}}` marker is therefore never filled,
+ * which is the case this reports rather than accepts.
+ */
+const lookupFormatWarnings = (
+  { lookup, path }: LookupOverlayField,
+  valueMarkers: ReadonlySet<string>,
+): TemplateWarning[] => {
+  const warnings: TemplateWarning[] = [];
+  const [defaultFormat, ...keyedFormats] = lookup.formats;
+  const keyedMarker = (key: string): string => `${path}.${key}`;
+
+  const isDefaultPlaced =
+    valueMarkers.has(path) ||
+    valueMarkers.has(keyedMarker(DEFAULT_FORMAT_ALIAS));
+  if (defaultFormat !== undefined && !isDefaultPlaced) {
+    warnings.push({
+      code: "unmatched_lookup_format",
+      path,
+      message: `The first format ("${defaultFormat.key}") of lookup field "${path}" has no {{${path}}} marker, so it renders nowhere.`,
+      hint: `Add {{${path}}} where the default rendering belongs.`,
+    });
+  }
+
+  for (const { key } of keyedFormats) {
+    if (valueMarkers.has(keyedMarker(key))) {
+      continue;
+    }
+    warnings.push({
+      code: "unmatched_lookup_format",
+      path: keyedMarker(key),
+      message: `Format "${key}" of lookup field "${path}" has no {{${keyedMarker(key)}}} marker, so it renders nowhere.`,
+      hint: `Add {{${keyedMarker(key)}}} where that rendering belongs, or drop the format.`,
+    });
+  }
+
+  const keyedKeys = new Set(keyedFormats.map((format) => format.key));
+  const markerPrefix = `${path}.`;
+  for (const marker of valueMarkers) {
+    if (!marker.startsWith(markerPrefix)) {
+      continue;
+    }
+    const key = marker.slice(markerPrefix.length);
+    if (key === DEFAULT_FORMAT_ALIAS || keyedKeys.has(key)) {
+      continue;
+    }
+    warnings.push(
+      key === defaultFormat?.key
+        ? {
+            code: "unmatched_lookup_format",
+            path: marker,
+            message: `{{${marker}}} names the FIRST format of lookup field "${path}", which is written to the bare {{${path}}} marker, so {{${marker}}} is left unfilled.`,
+            hint: `Write {{${path}}} instead, or move "${key}" after the first entry in formats.`,
+          }
+        : {
+            code: "unmatched_lookup_format",
+            path: marker,
+            message: `{{${marker}}} names no format of lookup field "${path}", so it is left unfilled.`,
+            hint: `Add a "${key}" format to the field's formats, or remove the marker.`,
+          },
+    );
+  }
+
+  return warnings;
+};
+
+export const fieldOverlayWarnings = async ({
+  conditionPaths,
+  fields,
+  placeholderPaths,
+  registryGate,
+}: FieldOverlayWarningOptions): Promise<TemplateWarning[]> => {
+  const conditionDriven = new Set(conditionPaths);
+  const valueMarkers = new Set(placeholderPaths);
+  const warnings: TemplateWarning[] = [];
+
+  for (const field of fields) {
+    const isDerived =
+      field.condition !== undefined || field.conditionAst !== undefined;
+    if (
+      isDerived &&
+      conditionDriven.has(field.path) &&
+      valueMarkers.has(field.path)
+    ) {
+      warnings.push(conditionWarning(field.path));
+    }
+    if (hasLookup(field)) {
+      warnings.push(...lookupFormatWarnings(field, valueMarkers));
+    }
+  }
+
+  // A registry the organization has not enabled is refused by the resolver at
+  // every fill, and until now only there: the save that introduced it reported
+  // nothing.
+  const lookupFields = fields.filter(hasLookup);
+  if (lookupFields.length > 0) {
+    const isRegistryEnabled = await registryGate();
+    for (const { lookup, path } of lookupFields) {
+      if (isRegistryEnabled(lookup.registry)) {
+        continue;
+      }
+      warnings.push({
+        code: "registry_disabled",
+        path,
+        message: `Lookup field "${path}" resolves from the ${lookup.registry} registry, which is not enabled for this organization, so every fill of the field fails at lookup time.`,
+        hint: `Enable that registry in the organization's tool settings, or replace the lookup on "${path}" with a plain input.`,
+      });
+    }
+  }
+
+  return warnings;
+};
+
+/**
+ * Deduplicate (the same defective marker repeated across paragraphs is one
+ * finding) and cap. Order of first appearance is kept: it follows document
+ * order, so the author reads the list top-down against the file.
+ */
+export const boundTemplateWarnings = (
+  warnings: readonly TemplateWarning[],
+): TemplateWarning[] => {
+  const seen = new Set<string>();
+  const bounded: TemplateWarning[] = [];
+  for (const warning of warnings) {
+    const key = `${warning.code}|${warning.path ?? ""}|${warning.message}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    bounded.push(warning);
+    if (bounded.length === MAX_TEMPLATE_WARNINGS) {
+      break;
+    }
+  }
+  return bounded;
+};

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -14,6 +14,7 @@ import {
   isFieldPath,
 } from "@stll/template-conditions";
 
+import type { TemplateWarning } from "@/api/lib/docx/template-warnings";
 import {
   fieldSourceSchema,
   fieldSourceToolInputSchema,
@@ -192,6 +193,14 @@ export type DiscoveredTemplate = {
   placeholders: DiscoveredPlaceholder[];
   fields: DiscoveredField[];
   structureErrors: TemplateStructureError[];
+  /** Marker mistakes that parse but almost certainly do not do what the author
+   *  meant. Never blocks a save; reported so it is fixed before the first
+   *  fill. */
+  warnings: TemplateWarning[];
+  /** Paths a `{{#if}}` / `{{#elseif}}` expression reads, sorted. Distinguishes
+   *  a condition driver from a value marker, which the field list alone
+   *  cannot: a path can be both. */
+  conditionPaths: string[];
 };
 
 // ── Custom XML Manifest ─────────────────────────────────

--- a/apps/api/src/lib/templates/template-fill-service.ts
+++ b/apps/api/src/lib/templates/template-fill-service.ts
@@ -41,9 +41,16 @@ import {
 } from "@/api/lib/docx/resolve-ai-fields";
 import { resolveClauseSlots } from "@/api/lib/docx/resolve-clause-slots";
 import { readManifest } from "@/api/lib/docx/template-manifest";
+import {
+  boundTemplateWarnings,
+  fieldOverlayWarnings,
+  type TemplateWarning,
+} from "@/api/lib/docx/template-warnings";
 import type {
   DiscoveredField,
+  DiscoveredTemplate,
   FieldDateFormat,
+  FieldMeta,
   FieldPart,
   InputType,
 } from "@/api/lib/docx/types";
@@ -250,8 +257,37 @@ export type DescribeTemplateResult =
       conditions: { name: string; expression: string }[];
       computed: { name: string; expression: string }[];
       arrays: DescribedArrayGroup[];
+      /** Marker authoring mistakes found in the stored DOCX plus the ones its
+       *  field configuration introduces. Advisory: the template is served
+       *  either way. */
+      warnings: TemplateWarning[];
     }
   | { error: string };
+
+/** Marker warnings from discovery, plus the ones only the configured fields
+ *  can reveal (a `condition` on a path the document also prints, a lookup
+ *  whose registry the organization has not enabled). */
+const describedWarnings = async ({
+  discovered,
+  fields,
+  organizationId,
+  scopedDb,
+}: {
+  discovered: DiscoveredTemplate;
+  fields: readonly FieldMeta[];
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+}): Promise<TemplateWarning[]> =>
+  boundTemplateWarnings([
+    ...discovered.warnings,
+    ...(await fieldOverlayWarnings({
+      conditionPaths: discovered.conditionPaths,
+      fields,
+      placeholderPaths: discovered.placeholders.map(({ name }) => name),
+      registryGate: async () =>
+        await buildIsRegistryEnabledForOrg({ organizationId, scopedDb }),
+    })),
+  ]);
 
 export const describeStoredTemplate = async ({
   templateId,
@@ -284,6 +320,12 @@ export const describeStoredTemplate = async ({
     return {
       name: loaded.name,
       arrays,
+      warnings: await describedWarnings({
+        discovered,
+        fields: manifest.fields,
+        organizationId,
+        scopedDb,
+      }),
       fields: manifest.fields
         .filter(isFillableTemplateInputField)
         .map((field) => ({
@@ -325,6 +367,12 @@ export const describeStoredTemplate = async ({
   return {
     name: loaded.name,
     arrays,
+    warnings: await describedWarnings({
+      discovered,
+      fields: [],
+      organizationId,
+      scopedDb,
+    }),
     fields: discovered.fields.map((field) => ({
       path: field.path,
       label: null,

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -742,7 +742,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "save_template",
     "scope": "stella:templates",
     "access": "write",
-    "description": "Create a document template from a DOCX, or configure an existing template's fields. To create, pass docx_base64 (base64-encoded .docx / Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} markers in the file become the template's fillable fields, and fields can configure them in the same call. To configure an existing template, pass template_id with fields and no docx_base64; only the manifest changes, the document's {{markers}} stay untouched. Read stella://reference/template-markers before authoring a DOCX and stella://reference/template-fields before configuring fields. Returns the template id and field count when creating, or the updated field list when configuring.",
+    "description": "Create a document template from a DOCX, or configure an existing template's fields. To create, pass docx_base64 (base64-encoded .docx / Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} markers in the file become the template's fillable fields, and fields can configure them in the same call. To configure an existing template, pass template_id with fields and no docx_base64; only the manifest changes, the document's {{markers}} stay untouched. Read stella://reference/template-markers before authoring a DOCX and stella://reference/template-fields before configuring fields. Returns the template id and field count when creating, or the updated field list when configuring, plus a warnings list of marker authoring mistakes to fix before filling.",
     "annotations": {
       "title": "Save template",
       "idempotentHint": false,

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -179,6 +179,9 @@ const createScopedDb = (
             },
           },
           templates: { findMany: async () => templates },
+          // No settings row: a brand-new org with no practice jurisdictions,
+          // which is exactly when a registry lookup is not enabled.
+          organizationSettings: { findFirst: async () => undefined },
         },
       });
     }),
@@ -243,12 +246,17 @@ const fakeTransaction = asTestRaw<Transaction>({});
 /** A real, minimal valid DOCX (well-formed word/document.xml) as base64, so
  *  save_template (create) exercises the real validateDocxBuffer — no module mock to
  *  leak across test files. */
-const makeValidDocxBase64 = async (): Promise<string> => {
+const makeValidDocxBase64 = async (
+  paragraphs: readonly string[] = ["{{name}}"],
+): Promise<string> => {
   const zip = new JSZip();
+  const body = paragraphs
+    .map((text) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`)
+    .join("");
   zip.file(
     "word/document.xml",
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-      `<w:document xmlns:w="${W_NS}"><w:body><w:p><w:r><w:t>{{name}}</w:t></w:r></w:p></w:body></w:document>`,
+      `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`,
   );
   const bytes = await zip.generateAsync({ type: "uint8array" });
   return Buffer.from(bytes).toString("base64");
@@ -1508,6 +1516,37 @@ describe("MCP template tools", () => {
       templateId: "tmpl_new",
       name: "NDA",
       fieldCount: 3,
+      warnings: [],
+    });
+  });
+
+  test("save_template (create) reports marker authoring warnings with the saved template", async () => {
+    createStoredTemplateMock.mockImplementation(async function* () {
+      yield* [];
+      return Result.ok({ id: "tmpl_new", name: "POA", fieldCount: 2 });
+    });
+
+    const result = await handleMcpToolCall({
+      args: {
+        name: "POA",
+        docx_base64: await makeValidDocxBase64([
+          "{{#each attorneys}}",
+          "{{name}}",
+          "{{#endeach}}",
+        ]),
+      },
+      context: createContext(),
+      toolName: "save_template",
+    });
+
+    // The save still happens: warnings advise, they never block.
+    expect(createStoredTemplateMock).toHaveBeenCalledTimes(1);
+    expect(parseToolPayload(result)).toMatchObject({
+      templateId: "tmpl_new",
+      warnings: [
+        { code: "unprefixed_item_path", path: "name" },
+        { code: "unknown_directive", path: "{{#endeach}}" },
+      ],
     });
   });
 
@@ -1593,6 +1632,45 @@ describe("MCP template tools", () => {
         },
       }),
     );
+  });
+
+  test("save_template (create) reports a lookup the org cannot resolve and a format with no marker", async () => {
+    createStoredTemplateMock.mockImplementation(async function* () {
+      yield* [];
+      return Result.ok({ id: "tmpl_new", name: "Company POA", fieldCount: 1 });
+    });
+
+    const result = await handleMcpToolCall({
+      args: {
+        name: "Company POA",
+        // {{company}} places the default format; nothing places `address`.
+        docx_base64: await makeValidDocxBase64(["{{company}}"]),
+        fields: [
+          {
+            path: "company",
+            input_type: "text",
+            lookup: {
+              registry: "krs",
+              formats: [
+                { key: "default", template: "[name], KRS [krs]" },
+                { key: "address", template: "[seat]" },
+              ],
+            },
+          },
+        ],
+      },
+      context: createContext(),
+      toolName: "save_template",
+    });
+
+    // The config is still saved: the org can enable the registry later.
+    expect(createStoredTemplateMock).toHaveBeenCalledTimes(1);
+    expect(parseToolPayload(result)).toMatchObject({
+      warnings: [
+        { code: "unmatched_lookup_format", path: "company.address" },
+        { code: "registry_disabled", path: "company" },
+      ],
+    });
   });
 
   test("save_template (create) rejects a malformed field config before inserting", async () => {

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -25,6 +25,17 @@ import {
   buildAiFieldGenerator,
   buildAiOccurrenceAdapter,
 } from "@/api/lib/docx/ai-field-generator";
+import { discoverTemplate } from "@/api/lib/docx/discover-template";
+import { buildIsRegistryEnabledForOrg } from "@/api/lib/docx/registry-org-gate";
+import {
+  mergeManifestWithDiscovery,
+  readManifest,
+} from "@/api/lib/docx/template-manifest";
+import {
+  boundTemplateWarnings,
+  fieldOverlayWarnings,
+  type TemplateWarning,
+} from "@/api/lib/docx/template-warnings";
 import type { FieldMeta, FieldPart } from "@/api/lib/docx/types";
 import { validateDocxBuffer } from "@/api/lib/entity-versions/validate-docx-buffer";
 import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
@@ -401,7 +412,8 @@ const SAVE_TEMPLATE_TOOL_DEFINITION = defineValibotMcpTool({
     `${TEMPLATE_MARKER_REFERENCE_URI} before authoring a DOCX and ` +
     `${TEMPLATE_FIELD_REFERENCE_URI} before configuring fields. Returns the ` +
     "template id and field count when creating, or the updated field list " +
-    "when configuring.",
+    "when configuring, plus a warnings list of marker authoring mistakes to " +
+    "fix before filling.",
   inputSchema: saveTemplateArgsSchema,
   jsonSchemaProjectionWaiver: {
     ignoreActions: ["check", "finite", "partial_check"],
@@ -1495,6 +1507,54 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
   return toolDataResult(persistence.value.value);
 };
 
+/** Marker mistakes in the uploaded DOCX plus the ones the field overlay
+ *  introduces, reported with the new template so the author fixes them before
+ *  the first fill. Never blocks the save. */
+const templateAuthoringWarnings = async ({
+  buffer,
+  context,
+  fields,
+}: {
+  buffer: Buffer;
+  context: McpRequestContext;
+  fields: FieldMeta[] | undefined;
+}): Promise<TemplateWarning[]> => {
+  const [discovered, embeddedManifest] = await Promise.all([
+    discoverTemplate(buffer),
+    readManifest(buffer),
+  ]);
+
+  // The saved manifest is what `createStoredTemplate` writes: any manifest the
+  // DOCX already embeds, merged with discovery, then the request overlay
+  // applied per path. Warning on the request overlay alone would let an
+  // embedded condition or lookup be persisted unreported, and the next
+  // list_templates describe would then disagree with this response.
+  const overlayByPath = new Map<string, FieldMeta>();
+  if (fields !== undefined) {
+    for (const field of fields) {
+      overlayByPath.set(field.path, field);
+    }
+  }
+  const savedFields = mergeManifestWithDiscovery(
+    embeddedManifest,
+    discovered,
+  ).map((field) => overlayByPath.get(field.path) ?? field);
+
+  return boundTemplateWarnings([
+    ...discovered.warnings,
+    ...(await fieldOverlayWarnings({
+      conditionPaths: discovered.conditionPaths,
+      fields: savedFields,
+      placeholderPaths: discovered.placeholders.map(({ name }) => name),
+      registryGate: async () =>
+        await buildIsRegistryEnabledForOrg({
+          organizationId: context.organizationId,
+          scopedDb: context.scopedDb,
+        }),
+    })),
+  ]);
+};
+
 // Create branch of save_template: a new template from an uploaded DOCX, with an
 // optional field-configuration overlay. Reused from the former create_template
 // tool.
@@ -1565,6 +1625,12 @@ const createTemplateFromDocx = async ({
     });
   }
 
+  // Discovery runs again here rather than riding out of `createStoredTemplate`:
+  // that recipe also serves the built-in report clones, which embed a
+  // pre-built manifest and never discover at all. One extra parse per template
+  // creation buys every create branch the same warning list.
+  const warnings = await templateAuthoringWarnings({ buffer, context, fields });
+
   const created = await Result.gen(() =>
     (context.testDependencies?.createStoredTemplate ?? createStoredTemplate)({
       safeDb: context.safeDb,
@@ -1585,6 +1651,7 @@ const createTemplateFromDocx = async ({
     templateId: created.value.id,
     name: created.value.name,
     fieldCount: created.value.fieldCount,
+    warnings,
   } satisfies v.InferInput<typeof SAVE_TEMPLATE_CREATE_PROJECTION>);
 };
 

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -783,7 +783,7 @@
       "scope": "templates"
     },
     "name": "save_template",
-    "description": "Create a document template from a DOCX, or configure an existing template's fields. To create, pass docx_base64 (base64-encoded .docx / Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} markers in the file become the template's fillable fields, and fields can configure them in the same call. To configure an existing template, pass template_id with fields and no docx_base64; only the manifest changes, the document's {{markers}} stay untouched. Read stella://reference/template-markers before authoring a DOCX and stella://reference/template-fields before configuring fields. Returns the template id and field count when creating, or the updated field list when configuring.",
+    "description": "Create a document template from a DOCX, or configure an existing template's fields. To create, pass docx_base64 (base64-encoded .docx / Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} markers in the file become the template's fillable fields, and fields can configure them in the same call. To configure an existing template, pass template_id with fields and no docx_base64; only the manifest changes, the document's {{markers}} stay untouched. Read stella://reference/template-markers before authoring a DOCX and stella://reference/template-fields before configuring fields. Returns the template id and field count when creating, or the updated field list when configuring, plus a warnings list of marker authoring mistakes to fix before filling.",
     "inputSchema": {
       "type": "object",
       "required": [],

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -210,6 +210,7 @@ export {
   BLOCK_DIRECTIVE_KINDS,
   blockDirectiveLinePattern,
   classifyMarker,
+  classifyMarkerDefect,
   clauseSlotPattern,
   countPattern,
   DIRECTIVE_KINDS,
@@ -220,6 +221,7 @@ export {
   isClauseSlotName,
   isFieldPath,
   isSafeFieldPath,
+  MARKER_DEFECT_KINDS,
   markerPattern,
   numPattern,
   placeholderPattern,
@@ -231,6 +233,7 @@ export type {
   BlockDirectiveKind,
   DirectiveKind,
   InvalidMarker,
+  MarkerDefectKind,
   MarkerMeta,
   ScannedMarker,
 } from "./markers.js";

--- a/packages/template-conditions/src/markers.test.ts
+++ b/packages/template-conditions/src/markers.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import {
   blockDirectiveLinePattern,
   classifyMarker,
+  classifyMarkerDefect,
+  DIRECTIVE_KINDS,
   isBlockDirectiveKind,
   isFieldPath,
   isSafeFieldPath,
@@ -163,5 +165,49 @@ describe("isBlockDirectiveKind", () => {
   test("distinguishes block directives from inline markers", () => {
     expect(isBlockDirectiveKind("if")).toBe(true);
     expect(isBlockDirectiveKind("placeholder")).toBe(false);
+  });
+});
+
+describe("classifyMarkerDefect", () => {
+  test("names the mistake behind a span the grammar rejects", () => {
+    expect(classifyMarkerDefect("#endeach")).toBe("unknown_directive");
+    expect(classifyMarkerDefect("/endif")).toBe("unknown_directive");
+    expect(classifyMarkerDefect("attorneys[0].name")).toBe("bracket_index");
+  });
+
+  // The grammar is the authority: anything classifyMarker accepts is not a
+  // defect, so a directive added there stops being reported with no list to
+  // update here.
+  test("every directive the grammar recognizes is not a defect", () => {
+    const recognized = [
+      "client.name",
+      "@clause:Indemnity",
+      "@num:scope",
+      "@ref:scope",
+      "@index",
+      "@count",
+      "#if signed",
+      "#elseif pending",
+      "#else",
+      "/if",
+      "#each attorneys",
+      "/each",
+    ];
+
+    expect(
+      new Set(
+        recognized.flatMap((inner) => {
+          const meta = classifyMarker(inner);
+          return meta ? [meta.kind] : [];
+        }),
+      ).size,
+    ).toBe(DIRECTIVE_KINDS.length);
+    expect(recognized.map(classifyMarkerDefect)).toEqual(
+      recognized.map(() => null),
+    );
+  });
+
+  test("a near-miss with no specific diagnosis stays unclassified", () => {
+    expect(classifyMarkerDefect("my field")).toBeNull();
   });
 });

--- a/packages/template-conditions/src/markers.ts
+++ b/packages/template-conditions/src/markers.ts
@@ -334,6 +334,58 @@ export const scanInvalidMarkers = (text: string): InvalidMarker[] => {
   return out;
 };
 
+// ── Defect classification ────────────────────────────────
+
+/**
+ * Why a `{{...}}` span misses the grammar in a way that names the authoring
+ * mistake rather than merely failing to classify. Consumers derive their own
+ * warning codes from {@link MARKER_DEFECT_KINDS} so the two never drift.
+ */
+export type MarkerDefectKind = "unknown_directive" | "bracket_index";
+
+const MARKER_DEFECT_KIND_VALUES = [
+  "unknown_directive",
+  "bracket_index",
+] as const satisfies readonly MarkerDefectKind[];
+
+type MissingMarkerDefectKind = Exclude<
+  MarkerDefectKind,
+  (typeof MARKER_DEFECT_KIND_VALUES)[number]
+>;
+
+true satisfies MissingMarkerDefectKind extends never ? true : never;
+
+export const MARKER_DEFECT_KINDS = MARKER_DEFECT_KIND_VALUES;
+
+/** A `{{#...}}` / `{{/...}}` shape: an author reaching for a block directive. */
+const DIRECTIVE_SHAPE_RE = /^[#/]/u;
+/** Bracket indexing (`items[0].name`), which no directive kind admits. */
+const BRACKET_INDEX_RE = /[[\]]/u;
+
+/**
+ * Name the authoring mistake behind one marker's inner text, or `null` when the
+ * text is a recognized directive ({@link classifyMarker} accepts it) or an
+ * unrecognizable span with no specific diagnosis (`{{my field}}`). The
+ * recognized-directive check is what makes `DIRECTIVE_KINDS` the single
+ * authority on which `{{#...}}` tokens exist: adding a directive to the grammar
+ * stops it being reported here, with no list to update.
+ */
+export const classifyMarkerDefect = (
+  innerRaw: string,
+): MarkerDefectKind | null => {
+  const inner = innerRaw.trim();
+  if (classifyMarker(inner) !== null) {
+    return null;
+  }
+  if (DIRECTIVE_SHAPE_RE.test(inner)) {
+    return "unknown_directive";
+  }
+  if (BRACKET_INDEX_RE.test(inner)) {
+    return "bracket_index";
+  }
+  return null;
+};
+
 /** Exhaustiveness guard — pass the discriminant in a `switch` default branch. */
 export const assertNever = (value: never): never =>
   panic(`Unhandled template directive: ${JSON.stringify(value)}`);


### PR DESCRIPTION
A DOCX whose markers parse but do not mean what the author wrote saves
silently. `save_template` (create) answered `{ templateId, name, fieldCount }`
and the describe payload said nothing, so a template written as
`{{#each attorneys}} {{name}} {{/each}}` was only discovered later, as a fill
with blank rows: discovery treats `name` as a top-level scalar because it does
not start with `attorneys.`.

Template discovery now also returns `warnings`, a list of
`{ code, path?, message, hint }` over a closed code union, and the field
configuration contributes the warnings only it can see. A warning never blocks
a save.

## Codes

| Code | Reported for |
| --- | --- |
| `unprefixed_item_path` | a placeholder inside `{{#each X}}` whose path does not start with `X.`; it fills from a top-level field, so every repeated row renders the same value |
| `this_prefix` | `{{this.name}}` — the grammar has no `this` scope, so it fills from a field literally named `this.name` |
| `unknown_directive` | a `{{#...}}` / `{{/...}}` token outside the grammar (`{{#endeach}}`, `{{/endif}}`) |
| `bracket_index` | `{{items[0].name}}` — bracket indexing is not in the marker charset, so it prints literally |
| `split_marker` | a `{{` or `}}` whose other half is in a different paragraph |
| `condition_removes_input` | a `condition` set on a path a `{{#if}}` reads that is also a value marker, so the path is derived and has no input |
| `registry_disabled` | a lookup against a registry the organization has not enabled, until now refused only at every fill |
| `unmatched_lookup_format` | a declared lookup format with no `{{path.key}}` marker, or a `{{path.key}}` marker naming no declared format |

## Where the checks live

`packages/template-conditions` gains `classifyMarkerDefect`, which names the
defect behind a `{{...}}` span `classifyMarker` rejects, plus
`MARKER_DEFECT_KINDS`. `TEMPLATE_WARNING_CODES` spreads that list rather than
repeating it, and the classifier's first step is `classifyMarker`, so
`DIRECTIVE_KINDS` stays the only authority on which directives exist: adding a
directive to the grammar stops it being reported, with no list to update.

The loop-scope and paragraph checks need document structure, so they live in
`apps/api/src/lib/docx/template-warnings.ts` and run from the pass
`discover-template.ts` already makes over the paragraphs, with the same loop
scopes discovery uses for item fields. Discovery also exposes
`conditionPaths` (the paths `{{#if}}` / `{{#elseif}}` expressions read), which
is what distinguishes a condition driver from a value marker — a path can be
both, and `condition_removes_input` is exactly that case.

Existing channels are reused, not duplicated: unbalanced block directives stay
`TemplateStructureError`s from `parseBlockTree`, and spans no recognizer sees
at all stay `invalidMarker` findings in the template check.

## Surfaces

- `save_template` create response and configure echo
- `list_templates` describe payload (`describeStoredTemplate`)
- chat projections: `TEMPLATE_DESCRIBE_PROJECTION` and
  `SAVE_TEMPLATE_CREATE_PROJECTION` declare `warnings`, so the projection tie
  stays a compile-time check with no cast
- the `save_template` description says the response lists authoring warnings
  to fix before filling (registry description budgets stay green; only the
  surface snapshot moved)

## Notes for review

- The registry-enablement predicate (`buildIsRegistryEnabledForOrg`, the same
  one the fill path uses) is resolved lazily: a template with no lookup field
  costs no settings read.
- The create branch runs discovery once more rather than threading it out of
  `createStoredTemplate`, which also serves report clones that embed a
  pre-built manifest and never discover at all.
- The list is deduplicated and capped (`MAX_TEMPLATE_WARNINGS`), so a
  pathological file cannot return an unbounded payload.
- Messages carry marker and field paths only; no document prose is echoed into
  a payload the anonymized surface serves.
- Overlap worth a decision later: `handlers/templates/check-template.ts`
  reports the same `{{#endeach}}` / `{{items[0].name}}` spans as a single
  `invalidMarker` finding on the REST check surface. Both now classify through
  the one grammar package, but the two finding shapes remain separate; folding
  the check's findings onto these codes is a bigger change than this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authoring warnings for DOCX templates, including invalid directives, bracket indexing, missing loop prefixes, split markers, and lookup configuration issues.
  - Template details and saved-template responses now include warning codes, messages, hints, and affected paths.
  - Templates can still be saved when warnings are detected.
  - Added condition-path information to improve warning accuracy.
  - Added marker-defect classification support for recognised warning categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->