### PR TITLE
feat(api): conditional blocks confined to a table row act on the whole row

### DIFF
--- a/apps/api/src/lib/docx/block-directives-tables.test.ts
+++ b/apps/api/src/lib/docx/block-directives-tables.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 import JSZip from "jszip";
 import * as slimdom from "slimdom";
+
+import {
+  propertyConfig,
+  propertySeed,
+  propertyTestTimeout,
+} from "@stll/property-testing";
 
 import { processBlockDirectives } from "./block-directives";
 import { paragraphText, W_NS } from "./ooxml";
@@ -35,6 +42,22 @@ const rowCount = (body: slimdom.Element): number =>
 
 const tableCount = (body: slimdom.Element): number =>
   body.getElementsByTagNameNS(W_NS, "tbl").length;
+
+/**
+ * Cells left without a `w:p`. OOXML requires every `w:tc` to carry at least one
+ * block-level child; Word reports a document that breaks this as corrupt, so
+ * the count must stay 0 after any directive pruning.
+ */
+const emptyCellCount = (body: slimdom.Element): number =>
+  [...body.getElementsByTagNameNS(W_NS, "tc")].filter(
+    (tc) => tc.getElementsByTagNameNS(W_NS, "p").length === 0,
+  ).length;
+
+/** Tables left without a `w:tr` — the same corruption one level up. */
+const emptyTableCount = (body: slimdom.Element): number =>
+  [...body.getElementsByTagNameNS(W_NS, "tbl")].filter(
+    (tbl) => tbl.getElementsByTagNameNS(W_NS, "tr").length === 0,
+  ).length;
 
 // A minimal DOCX ZIP for end-to-end fillTemplate coverage.
 const makeDocx = async (documentXml: string): Promise<Buffer> => {
@@ -189,6 +212,41 @@ describe("processBlockDirectives — malformed table placement", () => {
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0]?.message).toContain("table");
   });
+
+  test("{{#if}} opening in a row and closing outside the table → structure error", () => {
+    const xml = WRAP(
+      TBL(TR(TC(P("{{#if flag}}")))) + P("Body text") + P("{{/if}}"),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, { flag: true });
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.message).toContain("table");
+    expect(errors[0]?.directive).toBe("{{#if flag}}");
+    // Markers neutralized: nothing left for the scanner to re-open.
+    const texts = bodyTexts(body);
+    expect(texts).not.toContain("{{#if flag}}");
+    expect(texts).not.toContain("{{/if}}");
+    expect(emptyCellCount(body)).toBe(0);
+  });
+
+  test("{{#if}} spanning two rows → structure error, every branch marker cleared", () => {
+    const xml = WRAP(
+      TBL(
+        TR(TC(P("{{#if flag}}"), P("Yes"))),
+        TR(TC(P("{{#else}}"), P("No"), P("{{/if}}"))),
+      ),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, { flag: false });
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.message).toContain("table");
+    const texts = bodyTexts(body);
+    expect(texts).not.toContain("{{#if flag}}");
+    expect(texts).not.toContain("{{#else}}");
+    expect(texts).not.toContain("{{/if}}");
+  });
 });
 
 // ── Table cloning in body-level loops ────────────────────
@@ -284,6 +342,190 @@ describe("processBlockDirectives — if-branch table pruning", () => {
   });
 });
 
+// ── {{#if}} confined to a table row ──────────────────────
+
+// A bilingual scope table: one scope item per row, Polish cell | English cell,
+// the whole row wrapped in a conditional that opens in the first cell and
+// closes in the last.
+const bilingualScopeRow = TR(
+  TC(P("{{#if scope.analysis}}"), P("Analiza umowy")),
+  TC(P("Contract analysis"), P("{{/if}}")),
+);
+const bilingualScopeTable = TBL(
+  TR(TC(P("Zakres")), TC(P("Scope"))),
+  bilingualScopeRow,
+);
+
+describe("processBlockDirectives — table-row conditionals", () => {
+  test("a false condition removes the whole row", () => {
+    const body = parseBody(WRAP(bilingualScopeTable));
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: false },
+    });
+
+    expect(errors).toEqual([]);
+    expect(rowCount(body)).toBe(1);
+    expect(bodyTexts(body)).toEqual(["Zakres", "Scope"]);
+    expect(emptyCellCount(body)).toBe(0);
+  });
+
+  test("a true condition keeps the row and strips the marker paragraphs", () => {
+    const body = parseBody(WRAP(bilingualScopeTable));
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: true },
+    });
+
+    expect(errors).toEqual([]);
+    expect(rowCount(body)).toBe(2);
+    expect(bodyTexts(body)).toEqual([
+      "Zakres",
+      "Scope",
+      "Analiza umowy",
+      "Contract analysis",
+    ]);
+    expect(emptyCellCount(body)).toBe(0);
+  });
+
+  test("markers inside one cell still condition the whole row", () => {
+    const xml = WRAP(
+      TBL(
+        TR(TC(P("Zakres")), TC(P("Scope"))),
+        TR(
+          TC(P("Analiza umowy")),
+          TC(P("{{#if scope.analysis}}"), P("Contract analysis"), P("{{/if}}")),
+        ),
+      ),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: false },
+    });
+
+    expect(errors).toEqual([]);
+    // The row is the unit: the Polish cell goes with it.
+    expect(rowCount(body)).toBe(1);
+    expect(bodyTexts(body)).toEqual(["Zakres", "Scope"]);
+  });
+
+  test("an {{#else}} branch inside a row keeps the row and the else content", () => {
+    const xml = WRAP(
+      TBL(
+        TR(
+          TC(P("{{#if scope.analysis}}"), P("Analiza umowy")),
+          TC(P("Contract analysis"), P("{{#else}}")),
+          TC(P("Brak"), P("None"), P("{{/if}}")),
+        ),
+      ),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: false },
+    });
+
+    expect(errors).toEqual([]);
+    expect(rowCount(body)).toBe(1);
+    // The two cells the losing branch occupied are emptied but keep a
+    // paragraph each, so the row stays valid OOXML.
+    expect(bodyTexts(body)).toEqual(["", "", "Brak", "None"]);
+    expect(emptyCellCount(body)).toBe(0);
+  });
+
+  test("a cell left with no paragraph is backfilled with an empty one", () => {
+    const xml = WRAP(
+      TBL(
+        TR(
+          TC(P("{{#if scope.analysis}}")),
+          TC(P("Analiza umowy")),
+          TC(P("Contract analysis"), P("{{/if}}")),
+        ),
+      ),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: true },
+    });
+
+    expect(errors).toEqual([]);
+    expect(rowCount(body)).toBe(1);
+    // Three cells survive; the marker-only cell keeps an empty paragraph.
+    expect(body.getElementsByTagNameNS(W_NS, "tc").length).toBe(3);
+    expect(emptyCellCount(body)).toBe(0);
+    expect(bodyTexts(body)).toEqual(["", "Analiza umowy", "Contract analysis"]);
+  });
+
+  test("content in cells between the markers belongs to the block", () => {
+    const xml = WRAP(
+      TBL(
+        TR(
+          TC(P("{{#if scope.analysis}}")),
+          TC(P("Analiza umowy")),
+          TC(P("Contract analysis"), P("{{/if}}")),
+        ),
+      ),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: false },
+    });
+
+    expect(errors).toEqual([]);
+    // Row gone, and with it the table that had no other row.
+    expect(rowCount(body)).toBe(0);
+    expect(bodyTexts(body)).toEqual([]);
+  });
+
+  test("a false condition in a single-row table removes the table shell", () => {
+    const xml = WRAP(
+      P("Intro") +
+        TBL(TR(TC(P("{{#if scope.analysis}}"), P("Analiza"), P("{{/if}}")))) +
+        P("Outro"),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: false },
+    });
+
+    expect(errors).toEqual([]);
+    expect(tableCount(body)).toBe(0);
+    expect(emptyTableCount(body)).toBe(0);
+    expect(bodyTexts(body)).toEqual(["Intro", "Outro"]);
+  });
+
+  test("a nested row conditional inside a row-repeat drops only its own rows", () => {
+    const xml = WRAP(
+      TBL(
+        TR(TC(P("Zakres")), TC(P("Scope"))),
+        TR(
+          TC(
+            P("{{#each items}}"),
+            P("{{#if items.include}}"),
+            P("{{items.pl}}"),
+          ),
+          TC(P("{{items.en}}"), P("{{/if}}"), P("{{/each}}")),
+        ),
+      ),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      items: [
+        { include: true, pl: "Analiza", en: "Analysis" },
+        { include: false, pl: "Ukryte", en: "Hidden" },
+        { include: true, pl: "Doradztwo", en: "Advisory" },
+      ],
+    });
+
+    expect(errors).toEqual([]);
+    // Header + the two rows whose item passed the condition.
+    expect(rowCount(body)).toBe(3);
+    expect(emptyCellCount(body)).toBe(0);
+    const texts = bodyTexts(body);
+    expect(texts).toContain("{{__each_items_0_pl}}");
+    expect(texts).toContain("{{__each_items_2_en}}");
+    expect(texts).not.toContain("{{__each_items_1_pl}}");
+    expect(texts.join("|")).not.toContain("{{#if");
+  });
+});
+
 // ── Nested: contracts → fields (DD acceptance shape) ─────
 
 describe("processBlockDirectives — nested each (contracts → fields)", () => {
@@ -371,6 +613,47 @@ describe("fillTemplate — tables", () => {
     expect(reopened.file("word/document.xml")).not.toBeNull();
   });
 
+  test("a bilingual scope table keeps only the rows whose condition holds", async () => {
+    const docx = await makeDocx(
+      WRAP(
+        TBL(
+          TR(TC(P("Zakres")), TC(P("Scope"))),
+          TR(
+            TC(P("{{#if scope.analysis}}"), P("Analiza umowy")),
+            TC(P("Contract analysis"), P("{{/if}}")),
+          ),
+          TR(
+            TC(P("{{#if scope.litigation}}"), P("Spory sądowe")),
+            TC(P("Litigation"), P("{{/if}}")),
+          ),
+        ),
+      ),
+    );
+    const { buffer, unmatchedPlaceholders, structureErrors } =
+      await fillTemplate(docx, {
+        scope: { analysis: true, litigation: false },
+      });
+
+    expect(structureErrors).toEqual([]);
+    expect(unmatchedPlaceholders).toEqual([]);
+
+    const text = await documentText(buffer);
+    expect(text).toContain("Analiza umowy");
+    expect(text).toContain("Contract analysis");
+    expect(text).not.toContain("Spory sądowe");
+    expect(text).not.toContain("Litigation");
+    expect(text).not.toContain("{{");
+
+    // The filled package still parses, and no cell lost its paragraph.
+    const reopened = await JSZip.loadAsync(buffer);
+    const filledXml =
+      (await reopened.file("word/document.xml")?.async("string")) ?? "";
+    const filledBody = parseBody(filledXml);
+    expect(rowCount(filledBody)).toBe(2);
+    expect(emptyCellCount(filledBody)).toBe(0);
+    expect(emptyTableCount(filledBody)).toBe(0);
+  });
+
   test("nested contracts → fields fills end-to-end", async () => {
     const docx = await makeDocx(
       WRAP(
@@ -421,4 +704,81 @@ describe("fillTemplate — tables", () => {
     }
     expect(text).not.toContain("{{");
   });
+});
+
+// ── Property: a row conditional never corrupts the table ─
+
+describe("property: {{#if}} markers placed anywhere inside one row", () => {
+  test(
+    "no cell is left without a paragraph and no table without a row",
+    () => {
+      const placement = fc.record({
+        cellPicks: fc.array(fc.integer({ min: 0, max: 2 }), {
+          minLength: 7,
+          maxLength: 7,
+        }),
+        flag: fc.boolean(),
+        withElse: fc.boolean(),
+      });
+
+      fc.assert(
+        fc.property(placement, ({ cellPicks, flag, withElse }) => {
+          const tokens = withElse
+            ? [
+                "{{#if flag}}",
+                "PL",
+                "EN",
+                "{{#else}}",
+                "PL alt",
+                "EN alt",
+                "{{/if}}",
+              ]
+            : ["{{#if flag}}", "PL", "EN", "{{/if}}"];
+          // A non-decreasing cell index keeps each cell's paragraphs contiguous
+          // in document order, the only shape a real row can have.
+          const picks = cellPicks
+            .slice(0, tokens.length)
+            .toSorted((a, b) => a - b);
+          const byCell = new Map<number, string[]>();
+          for (const [i, token] of tokens.entries()) {
+            const cell = picks[i] ?? 0;
+            const paragraphs = byCell.get(cell);
+            if (paragraphs) {
+              paragraphs.push(token);
+            } else {
+              byCell.set(cell, [token]);
+            }
+          }
+          const cells = [...byCell.keys()]
+            .toSorted((a, b) => a - b)
+            .map((key) => TC(...(byCell.get(key) ?? []).map(P)));
+
+          // The label cell sits outside the marker span: the row is the unit,
+          // so it lives or dies with the conditional.
+          const body = parseBody(WRAP(TBL(TR(TC(P("Label")), ...cells))));
+          const { errors } = processBlockDirectives(body, { flag });
+
+          expect(errors).toEqual([]);
+          expect(emptyCellCount(body)).toBe(0);
+          expect(emptyTableCount(body)).toBe(0);
+
+          const texts = bodyTexts(body);
+          expect(texts.join("|")).not.toContain("{{");
+          if (flag) {
+            expect(texts).toContain("PL");
+            expect(texts).toContain("EN");
+            expect(texts).not.toContain("PL alt");
+          } else if (withElse) {
+            expect(texts).toContain("PL alt");
+            expect(texts).not.toContain("PL");
+          } else {
+            // The row was the block and the table's only row: both are gone.
+            expect(texts).toEqual([]);
+          }
+        }),
+        propertyConfig({ numRuns: 200, seed: propertySeed() }),
+      );
+    },
+    propertyTestTimeout(15_000),
+  );
 });

--- a/apps/api/src/lib/docx/block-directives-tables.test.ts
+++ b/apps/api/src/lib/docx/block-directives-tables.test.ts
@@ -247,6 +247,48 @@ describe("processBlockDirectives — malformed table placement", () => {
     expect(texts).not.toContain("{{#else}}");
     expect(texts).not.toContain("{{/if}}");
   });
+
+  test.each([
+    ["else", "{{#else}}"],
+    ["elseif", "{{#elseif fallback}}"],
+  ])(
+    "a nested-row %s marker rejects the outer-row conditional without pruning content",
+    (_kind, branchMarker) => {
+      const xml = WRAP(
+        TBL(
+          TR(
+            TC(
+              P("{{#if flag}}"),
+              P("Outer before"),
+              TBL(TR(TC(P(branchMarker), P("Nested content")))),
+              P("Outer after"),
+              P("{{/if}}"),
+            ),
+          ),
+        ),
+      );
+      const body = parseBody(xml);
+      const { errors } = processBlockDirectives(body, {
+        fallback: true,
+        flag: false,
+      });
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0]?.message).toContain("table");
+      expect(rowCount(body)).toBe(2);
+      expect(tableCount(body)).toBe(2);
+      expect(emptyCellCount(body)).toBe(0);
+      expect(emptyTableCount(body)).toBe(0);
+      expect(bodyTexts(body)).toEqual([
+        "",
+        "Outer before",
+        "",
+        "Nested content",
+        "Outer after",
+        "",
+      ]);
+    },
+  );
 });
 
 // ── Table cloning in body-level loops ────────────────────

--- a/apps/api/src/lib/docx/block-directives-tables.test.ts
+++ b/apps/api/src/lib/docx/block-directives-tables.test.ts
@@ -491,6 +491,33 @@ describe("processBlockDirectives — table-row conditionals", () => {
     expect(bodyTexts(body)).toEqual(["Intro", "Outro"]);
   });
 
+  test("markers Word split across runs still bind to the row", () => {
+    // Word splits a marker into several `w:r` runs after an edit or a
+    // spell-check pass. The scanner joins a paragraph's run text, so the block
+    // is recognized and the row is still the unit.
+    const splitOpener =
+      "<w:p><w:r><w:t>{{#if </w:t></w:r><w:r><w:t>scope.analysis}}</w:t></w:r></w:p>";
+    const splitCloser =
+      "<w:p><w:r><w:t>{{/</w:t></w:r><w:r><w:t>if}}</w:t></w:r></w:p>";
+    const xml = WRAP(
+      TBL(
+        TR(TC(P("Zakres")), TC(P("Scope"))),
+        TR(
+          TC(splitOpener, P("Analiza umowy")),
+          TC(P("Contract analysis"), splitCloser),
+        ),
+      ),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: false },
+    });
+
+    expect(errors).toEqual([]);
+    expect(rowCount(body)).toBe(1);
+    expect(bodyTexts(body)).toEqual(["Zakres", "Scope"]);
+  });
+
   test("a nested row conditional inside a row-repeat drops only its own rows", () => {
     const xml = WRAP(
       TBL(

--- a/apps/api/src/lib/docx/block-directives-tables.test.ts
+++ b/apps/api/src/lib/docx/block-directives-tables.test.ts
@@ -491,6 +491,64 @@ describe("processBlockDirectives — table-row conditionals", () => {
     expect(bodyTexts(body)).toEqual(["Intro", "Outro"]);
   });
 
+  test("a sibling block in a removed row never prunes content after the table", () => {
+    // Two sequential blocks share the row. The later one loses, so the row —
+    // and with it the earlier block's paragraphs — is removed. The earlier
+    // block is still queued for this pass: it must resolve to those removed
+    // paragraphs, not to whatever now occupies their old positions.
+    const xml = WRAP(
+      TBL(
+        TR(
+          TC(
+            P("{{#if scope.analysis}}"),
+            P("Analiza"),
+            P("{{/if}}"),
+            P("{{#if scope.litigation}}"),
+            P("Spory"),
+            P("{{/if}}"),
+          ),
+        ),
+      ) +
+        P("After 1") +
+        P("After 2") +
+        P("After 3"),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: true, litigation: false },
+    });
+
+    expect(errors).toEqual([]);
+    expect(tableCount(body)).toBe(0);
+    expect(bodyTexts(body)).toEqual(["After 1", "After 2", "After 3"]);
+  });
+
+  test("a row behind a content-control wrapper takes its table with it", () => {
+    // Word wraps a row-level content control as `w:tbl > w:sdt > w:sdtContent >
+    // w:tr`, so the emptied table is an ancestor of the removed row, not its
+    // parent.
+    const wrappedRow = (row: string) =>
+      `<w:sdt><w:sdtContent>${row}</w:sdtContent></w:sdt>`;
+    const xml = WRAP(
+      P("Intro") +
+        TBL(
+          wrappedRow(
+            TR(TC(P("{{#if scope.analysis}}"), P("Analiza"), P("{{/if}}"))),
+          ),
+        ) +
+        P("Outro"),
+    );
+    const body = parseBody(xml);
+    const { errors } = processBlockDirectives(body, {
+      scope: { analysis: false },
+    });
+
+    expect(errors).toEqual([]);
+    expect(tableCount(body)).toBe(0);
+    expect(emptyTableCount(body)).toBe(0);
+    expect(bodyTexts(body)).toEqual(["Intro", "Outro"]);
+  });
+
   test("markers Word split across runs still bind to the row", () => {
     // Word splits a marker into several `w:r` runs after an edit or a
     // spell-check pass. The scanner joins a paragraph's run text, so the block

--- a/apps/api/src/lib/docx/block-directives.ts
+++ b/apps/api/src/lib/docx/block-directives.ts
@@ -205,15 +205,28 @@ const KIND_MAP: Record<string, BlockDirectiveKind> = {
   "/each": "endeach",
 };
 
+/** A body's paragraphs, in document order, as a stable snapshot. */
+const bodyParagraphs = (body: slimdom.Element): slimdom.Element[] => [
+  ...body.getElementsByTagNameNS(W_NS, "p"),
+];
+
 /**
  * Extract block directives from body paragraphs.
  * Returns directives in document order.
  */
-export const scanBlockDirectives = (
-  body: slimdom.Element,
+export const scanBlockDirectives = (body: slimdom.Element): BlockDirective[] =>
+  scanDirectivesInParagraphs(bodyParagraphs(body));
+
+/**
+ * Extract block directives from an ordered paragraph list. Every
+ * `paragraphIndex` addresses THAT list, so a caller resolving indices must hold
+ * the same array for the whole pass: a block that deletes a table row shifts
+ * document positions, while the snapshot's element references stay valid.
+ */
+const scanDirectivesInParagraphs = (
+  paragraphs: readonly slimdom.Element[],
 ): BlockDirective[] => {
   const directives: BlockDirective[] = [];
-  const paragraphs = body.getElementsByTagNameNS(W_NS, "p");
 
   for (const [i, p] of paragraphs.entries()) {
     const text = paragraphText(p);
@@ -555,18 +568,18 @@ const removeBlockUnit = (unit: slimdom.Node): void => {
   if (!parent) {
     return;
   }
-  const cell = ancestorByLocalName(unit, TAG.cell);
+  // Resolve the containers to repair from the PARENT, not the direct
+  // parent-child relation: a row-level content control wraps its `w:tr` in
+  // `w:sdt`/`w:sdtContent`, so the enclosing table is an ancestor rather than
+  // the row's parent, and a table-shell check on `parent` alone would miss it.
+  const cell = ancestorByLocalName(parent, TAG.cell);
+  const table = ancestorByLocalName(parent, TAG.table);
   parent.removeChild(unit);
 
   // The last row left the table: drop the shell, then repair whatever cell the
   // table itself lived in.
-  if (
-    isElement(parent) &&
-    parent.localName === TAG.table &&
-    parent.namespaceURI === W_NS &&
-    parent.getElementsByTagNameNS(W_NS, TAG.row).length === 0
-  ) {
-    removeBlockUnit(parent);
+  if (table && table.getElementsByTagNameNS(W_NS, TAG.row).length === 0) {
+    removeBlockUnit(table);
     return;
   }
 
@@ -762,7 +775,17 @@ export const processBlockDirectives = (
     // inside a kept branch become top-level in the next pass.
     const MAX_PASSES = 20;
     for (let pass = 0; pass < MAX_PASSES; pass++) {
-      const directives = scanBlockDirectives(bodyEl);
+      // One snapshot per pass, shared by the scan and every block parsed from
+      // it. Re-fetching per block would resolve a block's indices against a
+      // list a SIBLING block already mutated: a row-confined block removes a
+      // whole row (a false `{{#if}}`, a zero-item row repeat), which deletes
+      // paragraphs the pass had already indexed and shifts every later
+      // position, so the next block's stale indices would land on unrelated
+      // content after the table. Element references survive that: a sibling
+      // whose paragraphs went with the row resolves to detached nodes, where
+      // its removals change nothing.
+      const paragraphs = bodyParagraphs(bodyEl);
+      const directives = scanDirectivesInParagraphs(paragraphs);
       if (directives.length === 0) {
         return;
       }
@@ -774,8 +797,8 @@ export const processBlockDirectives = (
         return;
       }
 
-      // Process blocks in reverse order to preserve paragraph
-      // indices
+      // Process blocks in reverse document order so an expansion's inserted
+      // paragraphs never sit between an earlier block's markers.
       const sortedBlocks = [...blocks].toSorted((a, b) => {
         const aStart = a.directiveParagraphs[0] ?? 0;
         const bStart = b.directiveParagraphs[0] ?? 0;
@@ -783,13 +806,10 @@ export const processBlockDirectives = (
       });
 
       for (const block of sortedBlocks) {
-        // Re-fetch paragraphs after each mutation
-        const ps = bodyEl.getElementsByTagNameNS(W_NS, "p");
-
         if (block.kind === "if") {
-          processIfBlock(ps, block, contextData, namedConditions);
+          processIfBlock(paragraphs, block, contextData, namedConditions);
         } else {
-          processEachBlock(bodyEl, ps, block, contextData);
+          processEachBlock(bodyEl, paragraphs, block, contextData);
         }
       }
     }
@@ -809,7 +829,7 @@ export const processBlockDirectives = (
   };
 
   const processIfBlock = (
-    paragraphs: slimdom.Element[],
+    paragraphs: readonly slimdom.Element[],
     block: IfBlock,
     contextData: Record<string, unknown>,
     conditions?: NamedCondition[],
@@ -1351,7 +1371,7 @@ export const processBlockDirectives = (
 
   const processEachBlock = (
     bodyEl: slimdom.Element,
-    paragraphs: slimdom.Element[],
+    paragraphs: readonly slimdom.Element[],
     block: EachBlock,
     contextData: Record<string, unknown>,
   ): void => {

--- a/apps/api/src/lib/docx/block-directives.ts
+++ b/apps/api/src/lib/docx/block-directives.ts
@@ -9,22 +9,35 @@
  * Templates without block directives skip all processing
  * (fast-path check via regex on raw XML).
  *
- * `{{#each}}` loop bodies clone block-level units, not just
- * paragraphs. Placement decides what a loop repeats:
+ * Placement decides what a block directive acts on. Both families
+ * ({{#if}} and {{#each}}) read a table row as one unit:
  *   - ROW REPEAT: when the opener `{{#each}}` and its matching
  *     `{{/each}}` are paragraphs confined to the SAME table row
  *     (`w:tr`), the whole row is cloned once per item and the two
- *     marker paragraphs are stripped from the output rows (a cell
- *     left with no paragraph is backfilled with an empty one so
- *     the row stays valid OOXML). Zero items removes the row.
- *   - BLOCK REPEAT: when the opener and closer are block-level
- *     siblings (typically direct children of `w:body`), every
- *     block child between them — paragraphs AND whole tables
- *     (`w:tbl`) — is cloned as a unit per item.
+ *     marker paragraphs are stripped from the output rows. Zero
+ *     items removes the row.
+ *   - ROW CONDITION: when an `{{#if}}` block's directive paragraphs
+ *     (including its `{{#elseif}}`/`{{#else}}` branches) are
+ *     confined to one `w:tr`, the row is the unit: no winning
+ *     branch removes the whole row, and a winning branch keeps the
+ *     row with the directive and losing-branch paragraphs removed.
+ *     A block spanning several cells of the row (opener in the
+ *     first cell, closer in the last) therefore conditions the
+ *     row's whole content, which is what a bilingual
+ *     "Polish | English" row needs.
+ *   - BLOCK REPEAT / BLOCK CONDITION: when the opener and closer
+ *     are block-level siblings (typically direct children of
+ *     `w:body`), every block child between them — paragraphs AND
+ *     whole tables (`w:tbl`) — is cloned or pruned as a unit.
  * A marker pair that straddles a table boundary (opener in a row,
  * closer outside it, or the two in different rows) is ambiguous:
  * it is reported as a {@link TemplateStructureError} and its
  * markers are neutralized rather than producing corrupt XML.
+ *
+ * Every removal goes through {@link removeBlockUnit}, which repairs
+ * the containers a removal can invalidate: a `w:tc` must keep at
+ * least one `w:p` and a `w:tbl` at least one `w:tr`, or Word
+ * reports the file as corrupt.
  *
  * Nested loops resolve through per-item recursion: an inner
  * `{{#each outer.sub}}` keeps its path and is expanded against the
@@ -530,17 +543,39 @@ const paragraphsInUnits = (
 ): slimdom.Element[] => units.flatMap(paragraphsInUnit);
 
 /**
- * Remove a stripped `{{#each}}`/`{{/each}}` marker paragraph from a cloned row,
- * backfilling an empty paragraph when its cell would otherwise be left without
- * one (a `w:tc` must contain at least one block-level child).
+ * Remove one block-level unit (a paragraph, a row, or a whole table) and repair
+ * the containers the removal would leave invalid: a `w:tc` must keep at least
+ * one `w:p`, and a `w:tbl` at least one `w:tr` — Word reports a document
+ * violating either as corrupt. Every directive removal path routes through
+ * here (marker stripping, branch pruning, row removal, and the paragraph-index
+ * fallback), so no path can invent a new way to empty a cell.
  */
-const stripRowMarkerParagraph = (
-  paragraph: slimdom.Element,
-  doc: slimdom.Document,
-): void => {
-  const cell = ancestorByLocalName(paragraph, TAG.cell);
-  paragraph.parentNode?.removeChild(paragraph);
-  if (cell?.getElementsByTagNameNS(W_NS, TAG.paragraph).length === 0) {
+const removeBlockUnit = (unit: slimdom.Node): void => {
+  const parent = unit.parentNode;
+  if (!parent) {
+    return;
+  }
+  const cell = ancestorByLocalName(unit, TAG.cell);
+  parent.removeChild(unit);
+
+  // The last row left the table: drop the shell, then repair whatever cell the
+  // table itself lived in.
+  if (
+    isElement(parent) &&
+    parent.localName === TAG.table &&
+    parent.namespaceURI === W_NS &&
+    parent.getElementsByTagNameNS(W_NS, TAG.row).length === 0
+  ) {
+    removeBlockUnit(parent);
+    return;
+  }
+
+  const doc = cell?.ownerDocument;
+  if (
+    cell &&
+    doc &&
+    cell.getElementsByTagNameNS(W_NS, TAG.paragraph).length === 0
+  ) {
     cell.append(doc.createElementNS(W_NS, "w:p"));
   }
 };
@@ -601,9 +636,54 @@ const pruneIfBlockUnits = (
     }
   }
   for (const n of toRemove) {
-    parent.removeChild(n);
+    removeBlockUnit(n);
   }
   return true;
+};
+
+type PruneIfRowOptions = {
+  firstDirective: number;
+  lastDirective: number;
+  paragraphs: readonly slimdom.Element[];
+  row: slimdom.Element;
+  winningBranch: IfBranch | null;
+};
+
+/**
+ * Prune an `{{#if}}` block whose directive paragraphs are confined to one
+ * `w:tr`, mirroring the each row-repeat: the ROW is the unit. With no winning
+ * branch the whole row goes, including cells the markers do not span — an
+ * author who conditions a row conditions the row, not a fragment of it, which
+ * is what a bilingual row (one scope item per row, one language per cell)
+ * means. A winning branch keeps the row and removes every paragraph of the
+ * block that is not its content, wherever in the row it sits: the directive
+ * paragraphs and the losing branches. Paragraphs between the opener's cell and
+ * the closer's cell belong to the block by document order, so an opener in the
+ * first cell and a closer in the last condition the row's whole content.
+ */
+const pruneIfRow = ({
+  firstDirective,
+  lastDirective,
+  paragraphs,
+  row,
+  winningBranch,
+}: PruneIfRowOptions): void => {
+  if (!winningBranch) {
+    removeBlockUnit(row);
+    return;
+  }
+  // `contentStart` is the first paragraph after the winning branch's opening
+  // directive; `contentEnd` is its closing directive (the next
+  // elseif/else/endif), so the kept range is half-open.
+  for (let j = lastDirective; j >= firstDirective; j--) {
+    if (j >= winningBranch.contentStart && j < winningBranch.contentEnd) {
+      continue;
+    }
+    const p = paragraphs[j];
+    if (p) {
+      removeBlockUnit(p);
+    }
+  }
 };
 
 // ── Main processor ───────────────────────────────────────
@@ -753,22 +833,53 @@ export const processBlockDirectives = (
     // directiveParagraphs always has opening + closing entries
     const lastDirective = block.directiveParagraphs.at(-1) ?? 0;
 
-    // Preferred path: when the block's directive paragraphs are block-level
-    // siblings (share one parent), prune by block-level UNIT so a losing
-    // branch's whole tables (`w:tbl`) are removed too, not just its paragraphs.
-    // This mirrors the each-loop's block-unit treatment (see expandBlock);
-    // without it a two-table `{{#if}}/{{#else}}` variant would leave the losing
-    // branch's empty table shell behind. Falls through to the paragraph-index
-    // removal below for a degenerate placement where the directive paragraphs do
-    // not share a block-level parent (e.g. straddling a table boundary).
     const firstP = paragraphs[firstDirective];
     const lastP = paragraphs[lastDirective];
-    if (
-      firstP &&
-      lastP &&
-      pruneIfBlockUnits(paragraphs, firstP, lastP, winningBranch)
-    ) {
-      return;
+
+    if (firstP && lastP) {
+      const openerRow = ancestorByLocalName(firstP, TAG.row);
+      const closerRow = ancestorByLocalName(lastP, TAG.row);
+
+      // Row condition: every directive paragraph sits in one `w:tr` (the
+      // paragraphs between opener and closer are inside that row by document
+      // order), so the row is the unit.
+      if (openerRow && openerRow === closerRow) {
+        pruneIfRow({
+          firstDirective,
+          lastDirective,
+          paragraphs,
+          row: openerRow,
+          winningBranch,
+        });
+        return;
+      }
+
+      // Ambiguous: one marker inside a row and the other outside it, or the two
+      // in different rows. Reject rather than emit corrupt XML, exactly as the
+      // each family does.
+      if (openerRow || closerRow) {
+        reportAmbiguousPlacement({
+          directive: `{{#if ${block.branches[0]?.condition ?? ""}}}`,
+          markerParagraphs: block.directiveParagraphs.flatMap(
+            (index) => paragraphs[index] ?? [],
+          ),
+          markers: "{{#if}} and {{/if}}",
+          paragraphIndex: firstDirective,
+        });
+        return;
+      }
+
+      // Preferred path outside tables: when the block's directive paragraphs are
+      // block-level siblings (share one parent), prune by block-level UNIT so a
+      // losing branch's whole tables (`w:tbl`) are removed too, not just its
+      // paragraphs. This mirrors the each-loop's block-unit treatment (see
+      // expandBlock); without it a two-table `{{#if}}/{{#else}}` variant would
+      // leave the losing branch's empty table shell behind. Falls through to the
+      // paragraph-index removal below for a degenerate placement where the
+      // directive paragraphs do not share a block-level parent.
+      if (pruneIfBlockUnits(paragraphs, firstP, lastP, winningBranch)) {
+        return;
+      }
     }
 
     // We need to remove everything from firstDirective to
@@ -783,7 +894,7 @@ export const processBlockDirectives = (
       for (let j = lastDirective; j >= keepEnd; j--) {
         const p = paragraphs[j];
         if (p) {
-          p.parentNode?.removeChild(p);
+          removeBlockUnit(p);
         }
       }
 
@@ -791,7 +902,7 @@ export const processBlockDirectives = (
       for (let j = keepStart - 1; j >= firstDirective; j--) {
         const p = paragraphs[j];
         if (p) {
-          p.parentNode?.removeChild(p);
+          removeBlockUnit(p);
         }
       }
     } else {
@@ -799,7 +910,7 @@ export const processBlockDirectives = (
       for (let j = lastDirective; j >= firstDirective; j--) {
         const p = paragraphs[j];
         if (p) {
-          p.parentNode?.removeChild(p);
+          removeBlockUnit(p);
         }
       }
     }
@@ -973,21 +1084,31 @@ export const processBlockDirectives = (
     }
   };
 
-  // Clear a straddling marker's text so the scanner stops treating it as a
+  type ReportAmbiguousPlacementOptions = {
+    /** The opening directive, verbatim, for the error record. */
+    directive: string;
+    /** Every marker paragraph of the block, including inner branches. */
+    markerParagraphs: readonly slimdom.Element[];
+    /** The marker pair named in the message, e.g. `{{#if}} and {{/if}}`. */
+    markers: string;
+    paragraphIndex: number;
+  };
+
+  // Clear a straddling block's marker text so the scanner stops treating it as a
   // directive (avoids an unresolved-directive loop), then report the error.
-  const reportAmbiguousPlacement = (
-    openerP: slimdom.Element,
-    closerP: slimdom.Element,
-    block: EachBlock,
-    openingIdx: number,
-  ): void => {
-    rewriteTextNodes(openerP, () => "");
-    rewriteTextNodes(closerP, () => "");
+  const reportAmbiguousPlacement = ({
+    directive,
+    markerParagraphs,
+    markers,
+    paragraphIndex,
+  }: ReportAmbiguousPlacementOptions): void => {
+    for (const marker of markerParagraphs) {
+      rewriteTextNodes(marker, () => "");
+    }
     allErrors.push({
-      message:
-        "{{#each}} and {{/each}} must sit in the same table row or share a block-level parent; a marker pair that straddles a table boundary is not supported",
-      paragraphIndex: openingIdx,
-      directive: `{{#each ${block.arrayPath}}}`,
+      message: `${markers} must sit in the same table row or share a block-level parent; a marker pair that straddles a table boundary is not supported`,
+      paragraphIndex,
+      directive,
     });
   };
 
@@ -1043,10 +1164,10 @@ export const processBlockDirectives = (
       const openerClone = clonedParas[openerOrdinal];
       const closerClone = clonedParas[closerOrdinal];
       if (openerClone) {
-        stripRowMarkerParagraph(openerClone, doc);
+        removeBlockUnit(openerClone);
       }
       if (closerClone && closerClone !== openerClone) {
-        stripRowMarkerParagraph(closerClone, doc);
+        removeBlockUnit(closerClone);
       }
 
       rewriteEachPlaceholders(clonedRow, {
@@ -1099,15 +1220,13 @@ export const processBlockDirectives = (
       }
     }
 
-    const insertionRef = row.nextSibling;
-    tbl.removeChild(row);
+    // Insert before the template row, then drop it through the shared removal:
+    // zero items leaves the table without rows, and a `w:tbl` with no `w:tr` is
+    // as invalid as an empty `w:tc`.
     for (const r of finalRows) {
-      if (insertionRef) {
-        tbl.insertBefore(r, insertionRef);
-      } else {
-        tbl.append(r);
-      }
+      tbl.insertBefore(r, row);
     }
+    removeBlockUnit(row);
   };
 
   // Block repeat: opener/closer are block-level siblings. Clone every block
@@ -1277,7 +1396,12 @@ export const processBlockDirectives = (
     // different rows, or non-sibling block-level markers. Reject rather than
     // emit corrupt XML.
     if (openerRow || closerRow || openerP.parentNode !== closerP.parentNode) {
-      reportAmbiguousPlacement(openerP, closerP, block, openingIdx);
+      reportAmbiguousPlacement({
+        directive: `{{#each ${block.arrayPath}}}`,
+        markerParagraphs: [openerP, closerP],
+        markers: "{{#each}} and {{/each}}",
+        paragraphIndex: openingIdx,
+      });
       return;
     }
 

--- a/apps/api/src/lib/docx/block-directives.ts
+++ b/apps/api/src/lib/docx/block-directives.ts
@@ -858,11 +858,16 @@ export const processBlockDirectives = (
       // in different rows. Reject rather than emit corrupt XML, exactly as the
       // each family does.
       if (openerRow || closerRow) {
+        const markerParagraphs: slimdom.Element[] = [];
+        for (const index of block.directiveParagraphs) {
+          const marker = paragraphs[index];
+          if (marker) {
+            markerParagraphs.push(marker);
+          }
+        }
         reportAmbiguousPlacement({
           directive: `{{#if ${block.branches[0]?.condition ?? ""}}}`,
-          markerParagraphs: block.directiveParagraphs.flatMap(
-            (index) => paragraphs[index] ?? [],
-          ),
+          markerParagraphs,
           markers: "{{#if}} and {{/if}}",
           paragraphIndex: firstDirective,
         });

--- a/apps/api/src/lib/docx/block-directives.ts
+++ b/apps/api/src/lib/docx/block-directives.ts
@@ -578,7 +578,7 @@ const removeBlockUnit = (unit: slimdom.Node): void => {
 
   // The last row left the table: drop the shell, then repair whatever cell the
   // table itself lived in.
-  if (table && table.getElementsByTagNameNS(W_NS, TAG.row).length === 0) {
+  if (table?.getElementsByTagNameNS(W_NS, TAG.row).length === 0) {
     removeBlockUnit(table);
     return;
   }

--- a/apps/api/src/lib/docx/block-directives.ts
+++ b/apps/api/src/lib/docx/block-directives.ts
@@ -859,11 +859,23 @@ export const processBlockDirectives = (
     if (firstP && lastP) {
       const openerRow = ancestorByLocalName(firstP, TAG.row);
       const closerRow = ancestorByLocalName(lastP, TAG.row);
+      const markerParagraphs: slimdom.Element[] = [];
+      for (const index of block.directiveParagraphs) {
+        const marker = paragraphs[index];
+        if (marker) {
+          markerParagraphs.push(marker);
+        }
+      }
+      const allMarkersShareOpenerRow =
+        markerParagraphs.length === block.directiveParagraphs.length &&
+        markerParagraphs.every(
+          (marker) => ancestorByLocalName(marker, TAG.row) === openerRow,
+        );
 
-      // Row condition: every directive paragraph sits in one `w:tr` (the
-      // paragraphs between opener and closer are inside that row by document
-      // order), so the row is the unit.
-      if (openerRow && openerRow === closerRow) {
+      // Row condition: every directive paragraph sits in one `w:tr`, so the
+      // row is the unit. A nested table may place a branch marker between the
+      // opener and closer in document order while its nearest row differs.
+      if (openerRow && openerRow === closerRow && allMarkersShareOpenerRow) {
         pruneIfRow({
           firstDirective,
           lastDirective,
@@ -878,13 +890,6 @@ export const processBlockDirectives = (
       // in different rows. Reject rather than emit corrupt XML, exactly as the
       // each family does.
       if (openerRow || closerRow) {
-        const markerParagraphs: slimdom.Element[] = [];
-        for (const index of block.directiveParagraphs) {
-          const marker = paragraphs[index];
-          if (marker) {
-            markerParagraphs.push(marker);
-          }
-        }
         reportAmbiguousPlacement({
           directive: `{{#if ${block.branches[0]?.condition ?? ""}}}`,
           markerParagraphs,

--- a/apps/api/src/mcp/template-marker-reference.ts
+++ b/apps/api/src/mcp/template-marker-reference.ts
@@ -118,6 +118,14 @@ const NON_DIRECTIVE_RULES = [
       "rendering (`{{company.address}}`).",
   },
   {
+    title: "Block markers in a table",
+    detail:
+      "A block marker pair (`#if` or `#each` family) confined to ONE table row " +
+      "acts on the whole row: the row repeats per item, or is dropped when no " +
+      "branch wins. Opening and closing markers must not straddle a row " +
+      "boundary.",
+  },
+  {
     title: "Bilingual / multi-column documents",
     detail:
       "Mark every language or column occurrence of the same value with the " +

--- a/apps/api/src/mcp/template-marker-reference.ts
+++ b/apps/api/src/mcp/template-marker-reference.ts
@@ -126,6 +126,14 @@ const NON_DIRECTIVE_RULES = [
       "boundary.",
   },
   {
+    title: "Markers Word splits into runs",
+    detail:
+      "Word often splits a marker across several runs (`w:r`) inside one " +
+      "paragraph; discovery and fill join a paragraph's run text before " +
+      "scanning, so a split marker still resolves. A marker must never span " +
+      "two paragraphs or two table cells.",
+  },
+  {
     title: "Bilingual / multi-column documents",
     detail:
       "Mark every language or column occurrence of the same value with the " +


### PR DESCRIPTION
`{{#each}}` has a row-repeat mode: markers confined to one `w:tr` repeat the
whole row. `{{#if}}` had no equivalent. `pruneIfBlockUnits` only handles
block-level siblings, so a conditional whose markers sit in a table row fell
through to paragraph-index removal: a false condition left an empty row shell,
and a cell whose every paragraph was removed was left with no `w:p` — invalid
OOXML that Word reports as a corrupt file.

## Row mode for `{{#if}}`

When a block's directive paragraphs (`{{#if}}`, `{{#elseif}}`, `{{#else}}`,
`{{/if}}`) are confined to one `w:tr`, the row is the unit:

- no winning branch removes the whole row, including cells the markers do not
  span;
- a winning branch keeps the row, strips the directive paragraphs and removes
  the losing branches' paragraphs.

Opener and closer in different cells of the same row is the supported bilingual
shape (`{{#if scope.item}}` in the Polish cell, `{{/if}}` in the English one):
paragraphs between them belong to the block by document order, so the whole row
is conditioned as one scope item.

## Straddling markers

An `{{#if}}` whose opener sits in a row and whose closer sits outside the table,
or in a different row, now reports the `TemplateStructureError` the `{{#each}}`
family already reported, and every branch marker is cleared so the scanner
cannot re-open the block on the next pass.

## One removal path

`removeBlockUnit` replaces the ad hoc `removeChild` calls on every directive
path (marker stripping, branch pruning, row removal, the paragraph-index
fallback). It backfills an emptied `w:tc` with a `w:p` and drops a `w:tbl` left
without a `w:tr`; the latter also fixes a pre-existing case where a zero-item
row repeat on a single-row table left an empty table behind.

## One paragraph snapshot per pass

A pass parsed its block tree from one paragraph list, then re-fetched the list
per block. That held while every block removed only paragraphs, and stops
holding once a block removes a whole row: the removal deletes paragraphs the
pass had already indexed and shifts every later position, so a sibling block
queued in the same pass resolved stale indices against content following the
table and pruned it. The pass now holds one snapshot, shared by the scan and
every block parsed from it. Element references survive a sibling's row deletion:
a block whose paragraphs went with the row acts on detached nodes, where its
removals change nothing. The same hazard applied to a zero-item row repeat.

`removeBlockUnit` resolves the containers to repair as ancestors rather than as
the removed node's direct parent, so a row-level content control (`w:tbl >
w:sdt > w:sdtContent > w:tr`) cannot hide the emptied table.

## Reference

`stella://reference/template-markers` states the rule for both block families:
a marker pair confined to one table row acts on the whole row, and markers must
not straddle a row boundary.

It also records the run-splitting rule, verified against the code rather than
assumed: `discover-placeholders`, `scanBlockDirectives`, the numbering pass in
`patch-template`, and `rich-patch` all join a paragraph's run text before
scanning, so a marker Word split across `w:r` runs resolves at discovery and at
fill. Two paragraphs, or two cells, never join.

## Tests

`block-directives-tables.test.ts` covers row removed when false, row kept and
markers stripped when true, an `{{#else}}` branch inside a row, a cell emptied
by stripping keeping a paragraph, both straddling placements, a nested row
conditional inside a row repeat, a row block whose markers Word split across
runs, a sibling block in a removed row leaving content after the table alone, a
row behind a content-control wrapper taking its table with it, and a
`fillTemplate` end-to-end bilingual scope table. A property test
places the markers at every position across the cells of one row and asserts no
`w:tc` is left without a `w:p` and no `w:tbl` without a `w:tr`. Every new test
was run against the previous behaviour first; eleven of them failed there.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for conditional blocks confined to a table row, allowing rows to be removed or reduced to the matching branch.
  * Improved handling of markers split across Word text runs.
  * Added support for nested row conditionals within repeated rows.

* **Bug Fixes**
  * Prevented empty cells and tables after conditional or repeated-row processing.
  * Added clearer validation for markers crossing table rows, paragraphs, or cells.
  * Improved handling of zero-item repeated rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->