### PR TITLE
fix(api): every MCP id input is validated as a UUID before reaching SQL

### DIFF
--- a/.changeset/mcp-uuid-id-inputs.md
+++ b/.changeset/mcp-uuid-id-inputs.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": patch
+---
+
+Every id a tool accepts that names a persisted record is now advertised as a UUID, so a malformed id is rejected before it is sent instead of failing on the server.

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -53,7 +53,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document/entity ID"
         },
         "cursor": {
@@ -82,7 +82,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to return a single matter's overview; omit to list matters"
         },
         "status": {
@@ -203,7 +203,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "source_id": {
           "type": "string",
-          "maxLength": 36,
+          "format": "uuid",
           "description": "Filter by source ID"
         },
         "date_from": {
@@ -270,7 +270,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "decision_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Case-law decision ID"
         },
         "cursor": {
@@ -301,7 +301,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID"
         }
       }
@@ -618,6 +618,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "template_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Template id to describe its fields in detail; omit to list templates"
         },
         "cursor": {
@@ -644,6 +645,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "template_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Template id, as returned by list_templates"
         },
         "values": {
@@ -698,18 +700,22 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "template_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Template id, as returned by list_templates"
         },
         "matter_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Matter receiving the filled DOCX."
         },
         "entity_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Existing document entity id; required only for create_version"
         },
         "parent_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Folder entity id for a new document; valid only for create_document"
         },
         "name": {
@@ -755,7 +761,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "template_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Template to configure; omit when creating"
         },
         "name": {
@@ -1200,7 +1206,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list documents in."
         },
         "mode": {
@@ -1213,7 +1219,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "parent_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Folder entity ID whose direct children to list. Only valid in children mode; supplying it selects children mode when mode is omitted and is rejected together with mode 'flat'."
         },
         "limit": {
@@ -1254,12 +1260,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Return this version's metadata and field values instead of the current version"
         },
         "compare_with_version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "With version_id, return a plain-text line diff of this version (base) against version_id (target)"
         },
         "include_versions": {
@@ -1291,12 +1297,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "entity_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document entity ID to update; omit to create"
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to create the entity in; required when creating."
         },
         "name": {
@@ -1307,7 +1313,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "parent_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Folder entity ID: to place the new entity inside when creating, or to move the document into when updating"
         },
         "kind": {
@@ -1324,7 +1330,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Version ID to annotate; required when setting label or description. Only valid when updating."
         },
         "label": {
@@ -1459,7 +1465,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Delete only this version instead of the whole document"
         },
         "confirm": {
@@ -1488,7 +1494,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list properties for."
         },
         "limit": {
@@ -1531,7 +1537,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "property_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Property ID, as returned by list_properties"
         },
         "content": {
@@ -1696,7 +1702,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to update; omit to create a new matter"
         },
         "name": {
@@ -1707,7 +1713,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "client_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID to attach in the client role. Only valid when creating a matter."
         },
         "reference": {
@@ -1759,7 +1765,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to delete"
         },
         "confirm": {
@@ -1827,7 +1833,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID to update; omit to create"
         },
         "type": {
@@ -1914,7 +1920,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID to delete"
         },
         "confirm": {
@@ -1985,12 +1991,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list tasks in; required unless task_id is given."
         },
         "task_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Task entity ID to read in detail"
         },
         "date_from": {
@@ -2042,12 +2048,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "task_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Task entity ID to update; omit to create"
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to create the task in; required when creating."
         },
         "name": {
@@ -2142,12 +2148,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "link_entity_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Entity ID to link to the task (document, folder, or another task)"
         },
         "unlink_link_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Entity-link ID to remove"
         }
       }
@@ -2202,12 +2208,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID"
         },
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID: with role to link the contact, or alone to unlink it from the matter"
         },
         "role": {
@@ -2227,7 +2233,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "matter_contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Existing matter-contact link ID to remove, from list_matters"
         }
       }
@@ -2250,17 +2256,17 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "clause_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Clause id to read in detail; omit to list"
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "With clause_id, return this version's body instead of the current clause"
         },
         "category_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "List only clauses filed under this category (list mode)"
         },
         "query": {
@@ -2303,7 +2309,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "clause_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Clause id to update; omit to create"
         },
         "title": {
@@ -2399,7 +2405,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "anyOf": [
             {
               "type": "string",
-              "minLength": 1
+              "format": "uuid"
             },
             {
               "type": "null"
@@ -2483,7 +2489,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "clause_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Clause id to delete"
         },
         "confirm": {
@@ -2510,7 +2516,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "playbook_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Playbook id to read in detail; omit to list playbooks"
         },
         "limit": {
@@ -2547,12 +2553,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to run the playbook over."
         },
         "playbook_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Playbook id to run"
         }
       }
@@ -2576,12 +2582,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list time entries in; required unless time_entry_id is given."
         },
         "time_entry_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Time entry ID to read in detail"
         },
         "entity_id": {
@@ -2648,12 +2654,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "time_entry_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Time entry ID to update; omit to create"
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to create the entry in; required when creating."
         },
         "entity_id": {
@@ -2759,7 +2765,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "time_entry_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Time entry ID to delete or write off"
         },
         "confirm": {
@@ -2791,7 +2797,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to resolve the rate in."
         },
         "user_id": {
@@ -2826,12 +2832,12 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list invoices in; required unless invoice_id is given."
         },
         "invoice_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Invoice ID to read in detail"
         },
         "limit": {
@@ -2978,7 +2984,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Only entries scoped to this matter."
         },
         "action": {
@@ -3054,7 +3060,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID for add_member and remove_member."
         },
         "user_id": {
@@ -3319,7 +3325,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document/entity ID"
         },
         "cursor": {
@@ -3348,7 +3354,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to return a single matter's overview; omit to list matters"
         },
         "status": {
@@ -3469,7 +3475,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
         },
         "source_id": {
           "type": "string",
-          "maxLength": 36,
+          "format": "uuid",
           "description": "Filter by source ID"
         },
         "date_from": {
@@ -3536,7 +3542,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "decision_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Case-law decision ID"
         },
         "cursor": {
@@ -3567,7 +3573,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID"
         }
       }
@@ -3588,6 +3594,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "template_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Template id to describe its fields in detail; omit to list templates"
         },
         "cursor": {
@@ -3618,7 +3625,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list documents in."
         },
         "mode": {
@@ -3631,7 +3638,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
         },
         "parent_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Folder entity ID whose direct children to list. Only valid in children mode; supplying it selects children mode when mode is omitted and is rejected together with mode 'flat'."
         },
         "limit": {
@@ -3672,12 +3679,12 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Return this version's metadata and field values instead of the current version"
         },
         "compare_with_version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "With version_id, return a plain-text line diff of this version (base) against version_id (target)"
         },
         "include_versions": {
@@ -3711,7 +3718,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list properties for."
         },
         "limit": {
@@ -3789,12 +3796,12 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list tasks in; required unless task_id is given."
         },
         "task_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Task entity ID to read in detail"
         },
         "date_from": {
@@ -3846,17 +3853,17 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "clause_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Clause id to read in detail; omit to list"
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "With clause_id, return this version's body instead of the current clause"
         },
         "category_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "List only clauses filed under this category (list mode)"
         },
         "query": {
@@ -3899,7 +3906,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "playbook_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Playbook id to read in detail; omit to list playbooks"
         },
         "limit": {
@@ -3934,12 +3941,12 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list time entries in; required unless time_entry_id is given."
         },
         "time_entry_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Time entry ID to read in detail"
         },
         "entity_id": {
@@ -4010,7 +4017,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to resolve the rate in."
         },
         "user_id": {
@@ -4045,12 +4052,12 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list invoices in; required unless invoice_id is given."
         },
         "invoice_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Invoice ID to read in detail"
         },
         "limit": {

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -67,6 +67,7 @@ import {
   notFoundResult,
   structuredErrorResult,
   toolDataResult,
+  uuidInputSchema,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
@@ -370,21 +371,13 @@ const loadUserNames = async ({
 const listTimeEntriesArgsSchema = v.pipe(
   v.strictObject({
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Matter ID to list time entries in; required unless " +
-            "time_entry_id is given.",
-        ),
+      uuidInputSchema(
+        "Matter ID to list time entries in; required unless " +
+          "time_entry_id is given.",
       ),
     ),
     time_entry_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Time entry ID to read in detail"),
-      ),
+      uuidInputSchema("Time entry ID to read in detail"),
     ),
     entity_id: v.optional(
       v.pipe(
@@ -704,19 +697,11 @@ const handleListTimeEntriesTool: TypedMcpToolHandler<
 const saveTimeEntryArgsSchema = v.pipe(
   v.strictObject({
     time_entry_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Time entry ID to update; omit to create"),
-      ),
+      uuidInputSchema("Time entry ID to update; omit to create"),
     ),
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Matter ID to create the entry in; required when creating.",
-        ),
+      uuidInputSchema(
+        "Matter ID to create the entry in; required when creating.",
       ),
     ),
     entity_id: v.optional(
@@ -1008,11 +993,7 @@ const handleSaveTimeEntryTool: TypedMcpToolHandler<
 // --- delete_time_entry --------------------------------------------------
 
 const deleteTimeEntryArgsSchema = v.strictObject({
-  time_entry_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Time entry ID to delete or write off"),
-  ),
+  time_entry_id: uuidInputSchema("Time entry ID to delete or write off"),
   confirm: v.optional(
     v.pipe(
       v.boolean(),
@@ -1069,11 +1050,7 @@ const handleDeleteTimeEntryTool: TypedMcpToolHandler<
 // --- resolve_rate -------------------------------------------------------
 
 const resolveRateArgsSchema = v.strictObject({
-  matter_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Matter ID to resolve the rate in."),
-  ),
+  matter_id: uuidInputSchema("Matter ID to resolve the rate in."),
   user_id: v.pipe(
     v.string(),
     v.minLength(1),
@@ -1148,22 +1125,12 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
 const listInvoicesArgsSchema = v.pipe(
   v.strictObject({
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Matter ID to list invoices in; required unless invoice_id is " +
-            "given.",
-        ),
+      uuidInputSchema(
+        "Matter ID to list invoices in; required unless invoice_id is " +
+          "given.",
       ),
     ),
-    invoice_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Invoice ID to read in detail"),
-      ),
-    ),
+    invoice_id: v.optional(uuidInputSchema("Invoice ID to read in detail")),
     limit: v.optional(
       v.pipe(
         v.number(),

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -25,6 +25,7 @@ import {
   MAX_CURSOR_LENGTH,
   notFoundResult,
   structuredErrorResult,
+  uuidInputSchema,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
@@ -248,7 +249,7 @@ const compatSearchArgsSchema = v.strictObject({
 });
 
 const compatFetchArgsSchema = v.strictObject({
-  id: v.pipe(v.string(), v.minLength(1), v.description("Document/entity ID")),
+  id: uuidInputSchema("Document/entity ID"),
   cursor: v.optional(
     v.pipe(
       v.string(),
@@ -362,7 +363,10 @@ const handleCompatSearchTool: McpToolHandler = async ({ args, context }) => {
 const handleCompatFetchTool: McpToolHandler = async ({ args, context }) => {
   const parsed = v.safeParse(compatFetchArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult(parsed.issues);
+    return validationErrorResult(
+      parsed.issues,
+      "Pass an 'id' from a search result verbatim; it is a document UUID. A stella:// resource URI is read with resources/read, not this tool.",
+    );
   }
   const { cursor, id: rawEntityId } = parsed.output;
   const entityId = brandPersistedEntityId(rawEntityId);

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -40,7 +40,6 @@ import type {
   SAVE_DOCUMENT_UPDATE_PROJECTION,
   SET_FIELD_VALUE_PROJECTION,
 } from "@/api/lib/chat/projections";
-import { isUuid } from "@/api/lib/custom-schema";
 import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { selectCurrentExtractedContent } from "@/api/lib/document-content-provenance";
 import {
@@ -611,11 +610,7 @@ const decodeEntityPageCursor = (
 
 const listDocumentsArgsSchema = v.pipe(
   v.strictObject({
-    matter_id: v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.description("Matter ID to list documents in."),
-    ),
+    matter_id: uuidInputSchema("Matter ID to list documents in."),
     mode: v.optional(
       v.pipe(
         v.picklist(["flat", "children"]),
@@ -629,14 +624,10 @@ const listDocumentsArgsSchema = v.pipe(
       ),
     ),
     parent_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Folder entity ID whose direct children to list. Only valid in " +
-            "children mode; supplying it selects children mode when mode is " +
-            "omitted and is rejected together with mode 'flat'.",
-        ),
+      uuidInputSchema(
+        "Folder entity ID whose direct children to list. Only valid in " +
+          "children mode; supplying it selects children mode when mode is " +
+          "omitted and is rejected together with mode 'flat'.",
       ),
     ),
     limit: v.optional(
@@ -805,21 +796,13 @@ const readDocumentArgsSchema = v.pipe(
   v.strictObject({
     entity_id: uuidInputSchema("Document entity ID"),
     version_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Return this version's metadata and field values instead of the current version",
-        ),
+      uuidInputSchema(
+        "Return this version's metadata and field values instead of the current version",
       ),
     ),
     compare_with_version_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "With version_id, return a plain-text line diff of this version (base) against version_id (target)",
-        ),
+      uuidInputSchema(
+        "With version_id, return a plain-text line diff of this version (base) against version_id (target)",
       ),
     ),
     include_versions: v.optional(
@@ -1591,19 +1574,11 @@ const handleReadDocumentTool: TypedMcpToolHandler<
 const saveDocumentArgsSchema = v.pipe(
   v.strictObject({
     entity_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Document entity ID to update; omit to create"),
-      ),
+      uuidInputSchema("Document entity ID to update; omit to create"),
     ),
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Matter ID to create the entity in; required when creating.",
-        ),
+      uuidInputSchema(
+        "Matter ID to create the entity in; required when creating.",
       ),
     ),
     name: v.optional(
@@ -1617,13 +1592,9 @@ const saveDocumentArgsSchema = v.pipe(
       ),
     ),
     parent_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Folder entity ID: to place the new entity inside when creating, or to " +
-            "move the document into when updating",
-        ),
+      uuidInputSchema(
+        "Folder entity ID: to place the new entity inside when creating, or to " +
+          "move the document into when updating",
       ),
     ),
     kind: v.optional(
@@ -1643,12 +1614,8 @@ const saveDocumentArgsSchema = v.pipe(
       ),
     ),
     version_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Version ID to annotate; required when setting label or description. Only valid when updating.",
-        ),
+      uuidInputSchema(
+        "Version ID to annotate; required when setting label or description. Only valid when updating.",
       ),
     ),
     label: v.optional(
@@ -2150,11 +2117,7 @@ const handleOpenDocumentVersionUploadTool: McpToolHandler = async ({
 const deleteDocumentArgsSchema = v.strictObject({
   entity_id: uuidInputSchema("Document entity ID to delete"),
   version_id: v.optional(
-    v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.description("Delete only this version instead of the whole document"),
-    ),
+    uuidInputSchema("Delete only this version instead of the whole document"),
   ),
   confirm: v.optional(
     v.pipe(
@@ -2235,11 +2198,7 @@ const handleDeleteDocumentTool: TypedMcpToolHandler<
 };
 
 const listPropertiesArgsSchema = v.strictObject({
-  matter_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Matter ID to list properties for."),
-  ),
+  matter_id: uuidInputSchema("Matter ID to list properties for."),
   limit: v.optional(
     v.pipe(
       v.number(),
@@ -2420,11 +2379,7 @@ const setFieldValueContentSchema = v.variant("type", [
 
 const setFieldValueArgsSchema = v.strictObject({
   entity_id: uuidInputSchema("Document entity ID whose cell to set"),
-  property_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Property ID, as returned by list_properties"),
-  ),
+  property_id: uuidInputSchema("Property ID, as returned by list_properties"),
   content: v.pipe(
     setFieldValueContentSchema,
     v.description("The value to set; 'type' must match the property."),
@@ -2487,13 +2442,6 @@ const handleSetFieldValueTool: TypedMcpToolHandler<
   const parsed = v.safeParse(setFieldValueArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult(parsed.issues);
-  }
-  if (!isUuid(parsed.output.property_id)) {
-    return structuredErrorResult({
-      code: "validation_error",
-      issues: [{ path: "property_id", message: "property_id must be a UUID" }],
-      message: "Invalid input: property_id must be a UUID",
-    });
   }
 
   const entityId = brandPersistedEntityId(parsed.output.entity_id);

--- a/apps/api/src/mcp/egress-canary.test.ts
+++ b/apps/api/src/mcp/egress-canary.test.ts
@@ -221,7 +221,7 @@ const buildContext = ({
   memberRole = "owner",
   organizationId = CANARY_ORGANIZATION_ID,
   tx = {},
-  workspaceIds = ["ws_1"],
+  workspaceIds = ["00000000-0000-4000-8000-0000000a0001"],
 }: {
   memberRole?: McpRequestContext["memberRole"];
   organizationId?: string;
@@ -365,7 +365,7 @@ describe("MCP anonymization canary corpus", () => {
       hits: [
         {
           entityId: "00000000-0000-4000-8000-0000000e0001",
-          workspaceId: "ws_1",
+          workspaceId: "00000000-0000-4000-8000-0000000a0001",
           title: titleSeed,
         },
       ],
@@ -377,7 +377,7 @@ describe("MCP anonymization canary corpus", () => {
         chainableJoinRows([
           {
             entityId: "00000000-0000-4000-8000-0000000e0001",
-            workspaceId: "ws_1",
+            workspaceId: "00000000-0000-4000-8000-0000000a0001",
             fieldId: "field_1",
           },
         ]),
@@ -408,7 +408,10 @@ describe("MCP anonymization canary corpus", () => {
             charCount: textSeed.length,
             ciphertext: extracted.ciphertext,
             iv: extracted.iv,
-            entity: { name: titleSeed, workspaceId: "ws_1" },
+            entity: {
+              name: titleSeed,
+              workspaceId: "00000000-0000-4000-8000-0000000a0001",
+            },
           }),
         },
       },
@@ -437,7 +440,7 @@ describe("MCP anonymization canary corpus", () => {
         select: () =>
           chainableRows([
             {
-              id: "ws_1",
+              id: "00000000-0000-4000-8000-0000000a0001",
               name: nameSeed,
               reference: "REF-1",
               status: "active",
@@ -463,7 +466,7 @@ describe("MCP anonymization canary corpus", () => {
       expect(JSON.parse(parseResultText(result))).toEqual({
         matters: [
           {
-            id: "ws_1",
+            id: "00000000-0000-4000-8000-0000000a0001",
             name: "[ANON_0]",
             reference: "[ANON_1]",
             status: "active",
@@ -488,7 +491,7 @@ describe("MCP anonymization canary corpus", () => {
       const memberNameSeed = mkSeed(tool, 7);
 
       readWorkspaceHandlerMock.mockResolvedValue({
-        id: "ws_1",
+        id: "00000000-0000-4000-8000-0000000a0001",
         name: matterNameSeed,
         reference: "REF-1",
         status: "active",
@@ -527,7 +530,7 @@ describe("MCP anonymization canary corpus", () => {
           id: "wc_1",
           role: "client",
           contact: {
-            id: "contact_1",
+            id: "00000000-0000-4000-8000-0000000c0001",
             type: "person",
             displayName: contactDisplayNameSeed,
           },
@@ -549,7 +552,7 @@ describe("MCP anonymization canary corpus", () => {
 
       const context = buildContext();
       const response = await STELLA_TOOL_HANDLERS.list_matters({
-        args: { matter_id: "ws_1" },
+        args: { matter_id: "00000000-0000-4000-8000-0000000a0001" },
         context,
       });
       const result = await finalize(context, response);
@@ -580,7 +583,7 @@ describe("MCP anonymization canary corpus", () => {
         hits: [
           {
             entityId: "00000000-0000-4000-8000-0000000e0001",
-            workspaceId: "ws_1",
+            workspaceId: "00000000-0000-4000-8000-0000000a0001",
             title: nameSeed,
             headline: headlineSeed,
             workspaceName: workspaceNameSeed,
@@ -618,7 +621,7 @@ describe("MCP anonymization canary corpus", () => {
             findFirst: async () => ({
               kind: "document",
               name: nameSeed,
-              workspaceId: "ws_1",
+              workspaceId: "00000000-0000-4000-8000-0000000a0001",
               extractedContent: {
                 sourceEntityVersionId: "ver_current",
                 sourceFieldId: "field_current",
@@ -686,7 +689,7 @@ describe("MCP anonymization canary corpus", () => {
         query: {
           contacts: {
             findFirst: async () => ({
-              id: "contact_1",
+              id: "00000000-0000-4000-8000-0000000c0001",
               type: "person",
               displayName: displayNameSeed,
               firstName: firstNameSeed,
@@ -701,7 +704,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await STELLA_TOOL_HANDLERS.read_contact({
-        args: { contact_id: "contact_1" },
+        args: { contact_id: "00000000-0000-4000-8000-0000000c0001" },
         context,
       });
       const result = await finalize(context, response);
@@ -740,7 +743,7 @@ describe("MCP anonymization canary corpus", () => {
     const context = buildContext({ tx });
 
     const response = await DOCUMENT_TOOL_HANDLERS.list_documents({
-      args: { matter_id: "ws_1" },
+      args: { matter_id: "00000000-0000-4000-8000-0000000a0001" },
       context,
     });
     const result = await finalize(context, response);
@@ -763,7 +766,7 @@ describe("MCP anonymization canary corpus", () => {
           entities: {
             findFirst: async () => ({
               createdAt: new Date("2025-12-01T00:00:00.000Z"),
-              workspaceId: "ws_1",
+              workspaceId: "00000000-0000-4000-8000-0000000a0001",
               kind: "document",
               name: nameSeed,
               updatedAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -844,7 +847,7 @@ describe("MCP anonymization canary corpus", () => {
         query: {
           entities: {
             findFirst: async () => ({
-              workspaceId: "ws_1",
+              workspaceId: "00000000-0000-4000-8000-0000000a0001",
               kind: "document",
               name: "Doc",
             }),
@@ -853,7 +856,7 @@ describe("MCP anonymization canary corpus", () => {
             // The version_id branch folds the version's fields into the
             // tombstone-checked version query via the `fields` relation.
             findFirst: async () => ({
-              id: "ver_1",
+              id: "00000000-0000-4000-8000-000000030001",
               versionNumber: 1,
               stamp: null,
               label: null,
@@ -879,7 +882,7 @@ describe("MCP anonymization canary corpus", () => {
       const response = await DOCUMENT_TOOL_HANDLERS.read_document({
         args: {
           entity_id: "00000000-0000-4000-8000-0000000e0001",
-          version_id: "ver_1",
+          version_id: "00000000-0000-4000-8000-000000030001",
         },
         context,
       });
@@ -920,7 +923,7 @@ describe("MCP anonymization canary corpus", () => {
               diffSegment.text = value;
             },
             value: diffSeed,
-            workspaceId: "ws_1",
+            workspaceId: "00000000-0000-4000-8000-0000000a0001",
           },
         ],
       };
@@ -958,7 +961,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await DOCUMENT_TOOL_HANDLERS.list_properties({
-        args: { matter_id: "ws_1" },
+        args: { matter_id: "00000000-0000-4000-8000-0000000a0001" },
         context,
       });
       const result = await finalize(context, response);
@@ -979,7 +982,7 @@ describe("MCP anonymization canary corpus", () => {
         chainableRows([
           {
             createdAt: "2026-01-01T00:00:00.000000",
-            id: "task_1",
+            id: "00000000-0000-4000-8000-0000000b0001",
             name: nameSeed,
             status: "open",
             priority: "high",
@@ -990,7 +993,7 @@ describe("MCP anonymization canary corpus", () => {
     const context = buildContext({ tx });
 
     const response = await MATTER_TOOL_HANDLERS.list_tasks({
-      args: { matter_id: "ws_1" },
+      args: { matter_id: "00000000-0000-4000-8000-0000000a0001" },
       context,
     });
     const result = await finalize(context, response);
@@ -1010,8 +1013,8 @@ describe("MCP anonymization canary corpus", () => {
         query: {
           entities: {
             findFirst: async () => ({
-              id: "task_1",
-              workspaceId: "ws_1",
+              id: "00000000-0000-4000-8000-0000000b0001",
+              workspaceId: "00000000-0000-4000-8000-0000000a0001",
               kind: "task",
               name: nameSeed,
               status: "open",
@@ -1041,10 +1044,10 @@ describe("MCP anonymization canary corpus", () => {
                     {
                       id: "link_1",
                       linkType: "related",
-                      sourceEntityId: "task_1",
+                      sourceEntityId: "00000000-0000-4000-8000-0000000b0001",
                       targetEntityId: "doc_1",
                       sourceEntity: {
-                        id: "task_1",
+                        id: "00000000-0000-4000-8000-0000000b0001",
                         name: nameSeed,
                         kind: "task",
                       },
@@ -1061,7 +1064,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await MATTER_TOOL_HANDLERS.list_tasks({
-        args: { task_id: "task_1" },
+        args: { task_id: "00000000-0000-4000-8000-0000000b0001" },
         context,
       });
       const result = await finalize(context, response);
@@ -1091,7 +1094,7 @@ describe("MCP anonymization canary corpus", () => {
         select: () =>
           chainableRows([
             {
-              id: "tpl_1",
+              id: "00000000-0000-4000-8000-0000000d0001",
               name: nameSeed,
               fieldCount: 2,
               tags: [],
@@ -1146,7 +1149,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext();
 
       const response = await TEMPLATE_TOOL_HANDLERS.list_templates({
-        args: { template_id: "tpl_1" },
+        args: { template_id: "00000000-0000-4000-8000-0000000d0001" },
         context,
       });
       const result = await finalize(context, response);
@@ -1192,7 +1195,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await BILLING_TOOL_HANDLERS.list_time_entries({
-        args: { matter_id: "ws_1" },
+        args: { matter_id: "00000000-0000-4000-8000-0000000a0001" },
         context,
       });
       const result = await finalize(context, response);
@@ -1212,13 +1215,15 @@ describe("MCP anonymization canary corpus", () => {
       const tx = {
         query: {
           timeEntries: {
-            findFirst: async () => ({ workspaceId: "ws_1" }),
+            findFirst: async () => ({
+              workspaceId: "00000000-0000-4000-8000-0000000a0001",
+            }),
           },
         },
         select: createEntriesAndUserNamesSelect({
           entryRows: [
             {
-              id: "te_2",
+              id: "00000000-0000-4000-8000-0000000f0002",
               entityId: "00000000-0000-4000-8000-0000000e0001",
               userId: "user_3",
               dateWorked: "2026-01-01",
@@ -1239,7 +1244,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await BILLING_TOOL_HANDLERS.list_time_entries({
-        args: { time_entry_id: "te_2" },
+        args: { time_entry_id: "00000000-0000-4000-8000-0000000f0002" },
         context,
       });
       const result = await finalize(context, response);
@@ -1275,7 +1280,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await BILLING_TOOL_HANDLERS.list_invoices({
-        args: { matter_id: "ws_1" },
+        args: { matter_id: "00000000-0000-4000-8000-0000000a0001" },
         context,
       });
       const result = await finalize(context, response);
@@ -1300,8 +1305,8 @@ describe("MCP anonymization canary corpus", () => {
         query: {
           invoices: {
             findFirst: async () => ({
-              id: "inv_2",
-              workspaceId: "ws_1",
+              id: "00000000-0000-4000-8000-000000020002",
+              workspaceId: "00000000-0000-4000-8000-0000000a0001",
               invoiceNumber: "INV-2",
               reference: referenceSeed,
               status: "draft",
@@ -1352,7 +1357,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await BILLING_TOOL_HANDLERS.list_invoices({
-        args: { invoice_id: "inv_2" },
+        args: { invoice_id: "00000000-0000-4000-8000-000000020002" },
         context,
       });
       const result = await finalize(context, response);
@@ -1446,7 +1451,7 @@ describe("MCP anonymization canary corpus", () => {
         query: {
           clauses: {
             findFirst: async () => ({
-              id: "c2",
+              id: "00000000-0000-4000-8000-0000000000c2",
               title: titleSeed,
               categoryId: null,
               description: descriptionSeed,
@@ -1475,7 +1480,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
-        args: { clause_id: "c2" },
+        args: { clause_id: "00000000-0000-4000-8000-0000000000c2" },
         context,
       });
       const result = await finalize(context, response);
@@ -1500,10 +1505,14 @@ describe("MCP anonymization canary corpus", () => {
       const versionBodySeed = mkSeed(tool, 10);
       const tx = {
         query: {
-          clauses: { findFirst: async () => ({ id: "c2" }) },
+          clauses: {
+            findFirst: async () => ({
+              id: "00000000-0000-4000-8000-0000000000c2",
+            }),
+          },
           clauseVersions: {
             findFirst: async () => ({
-              id: "cv_1",
+              id: "00000000-0000-4000-8000-000000040001",
               version: 1,
               body: [{ text: versionBodySeed }],
               createdAt: new Date("2026-01-01"),
@@ -1514,7 +1523,10 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
-        args: { clause_id: "c2", version_id: "cv_1" },
+        args: {
+          clause_id: "00000000-0000-4000-8000-0000000000c2",
+          version_id: "00000000-0000-4000-8000-000000040001",
+        },
         context,
       });
       const result = await finalize(context, response);
@@ -1534,7 +1546,7 @@ describe("MCP anonymization canary corpus", () => {
       query: {
         clauses: {
           findFirst: async () => ({
-            id: "c3",
+            id: "00000000-0000-4000-8000-0000000000c3",
             title: titleSeed,
             categoryId: null,
             description: null,
@@ -1555,7 +1567,7 @@ describe("MCP anonymization canary corpus", () => {
     const context = buildContext({ tx });
 
     const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
-      args: { clause_id: "c3" },
+      args: { clause_id: "00000000-0000-4000-8000-0000000000c3" },
       context,
     });
 
@@ -1633,7 +1645,7 @@ describe("MCP anonymization canary corpus", () => {
         query: {
           playbookDefinitions: {
             findFirst: async () => ({
-              id: "pb_2",
+              id: "00000000-0000-4000-8000-000000050002",
               name: nameSeed,
               description: descriptionSeed,
               scope: "organization",
@@ -1728,7 +1740,7 @@ describe("MCP anonymization canary corpus", () => {
       const context = buildContext({ tx });
 
       const response = await KNOWLEDGE_TOOL_HANDLERS.list_playbooks({
-        args: { playbook_id: "pb_2" },
+        args: { playbook_id: "00000000-0000-4000-8000-000000050002" },
         context,
       });
       const result = await finalize(context, response);

--- a/apps/api/src/mcp/internal-failure-envelope.test.ts
+++ b/apps/api/src/mcp/internal-failure-envelope.test.ts
@@ -37,6 +37,10 @@ const { internalFailureResult, MCP_INTERNAL_ERROR_HINT, serializeToolResult } =
 // checks it is absent from the serialized tool result.
 const DB_INTERNAL_LEAK_TOKEN = "PGDRIVER_INTERNAL_DETAIL_9f3a";
 
+// Matter ids are advertised and validated as uuids, so a placeholder would be
+// rejected before the handler reaches the DB seam these assertions exercise.
+const WORKSPACE_ID = "00000000-0000-4000-8000-0000000a0001";
+
 // Every DB seam throws, standing in for a driver/ORM failure. `toSafeDbMock`
 // funnels the throw into a `Result.err`, so the backing handler returns a
 // failed `Result` exactly as it would on a real outage; the tool site then
@@ -52,9 +56,9 @@ const createRecordAuditEventMock = () =>
 // workspace-access pre-checks pass and each handler advances to its first DB
 // call (the only thing that fails here).
 const createFailingDbContext = (): McpRequestContext => ({
-  accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
-  accessibleWorkspaceIdSet: new Set(["ws_1"]),
-  accessibleWorkspaceStatusById: new Map([["ws_1", "active"]]),
+  accessibleWorkspaceIds: [toSafeId<"workspace">(WORKSPACE_ID)],
+  accessibleWorkspaceIdSet: new Set([WORKSPACE_ID]),
+  accessibleWorkspaceStatusById: new Map([[WORKSPACE_ID, "active"]]),
   accessibleWorkspaces: [],
   grantedScopes: [],
   memberRole: "owner",
@@ -124,12 +128,12 @@ const REPRESENTATIVE_DB_FAILURES: {
   {
     file: "billing-tools.ts",
     handler: BILLING_TOOL_HANDLERS.resolve_rate,
-    args: { matter_id: "ws_1", user_id: "user_2", date: "2024-01-01" },
+    args: { matter_id: WORKSPACE_ID, user_id: "user_2", date: "2024-01-01" },
   },
   {
     file: "document-tools.ts",
     handler: DOCUMENT_TOOL_HANDLERS.save_document,
-    args: { matter_id: "ws_1", kind: "document", name: "Doc" },
+    args: { matter_id: WORKSPACE_ID, kind: "document", name: "Doc" },
   },
   {
     file: "knowledge-tools.ts",
@@ -142,7 +146,7 @@ const REPRESENTATIVE_DB_FAILURES: {
   {
     file: "research-admin-tools.ts",
     handler: RESEARCH_ADMIN_TOOL_HANDLERS.manage_organization,
-    args: { action: "add_member", matter_id: "ws_1", user_id: "user_2" },
+    args: { action: "add_member", matter_id: WORKSPACE_ID, user_id: "user_2" },
   },
 ];
 
@@ -279,7 +283,7 @@ describe("internalFailureResult preserves expected handler errors", () => {
 // 5xx must not.
 describe("save_time_entry threads backing handler errors correctly", () => {
   const TIME_ENTRY_CREATE_ARGS = {
-    matter_id: "ws_1",
+    matter_id: WORKSPACE_ID,
     entity_id: "00000000-0000-4000-8000-0000000e0001",
     date_worked: "2024-01-01",
     timezone_id: "Europe/Prague",

--- a/apps/api/src/mcp/knowledge-tools.test.ts
+++ b/apps/api/src/mcp/knowledge-tools.test.ts
@@ -28,6 +28,18 @@ const parseToolPayload = (
   return JSON.parse(item.text) as unknown;
 };
 
+// Ids that reach `uuid` columns are validated as UUIDs by the tool input
+// schemas, so the fixtures use well-formed ones. Each id has one value shared by
+// the tool input, the mocked row, and the assertion.
+const MATTER_ID = "00000000-0000-4000-8000-000000000001";
+const CLAUSE_ID = "00000000-0000-4000-8000-000000000002";
+const PLAYBOOK_ID = toSafeId<"playbookDefinition">(
+  "00000000-0000-4000-8000-000000000003",
+);
+const APPROVED_VERSION_ID = toSafeId<"playbookDefinitionVersion">(
+  "00000000-0000-4000-8000-000000000004",
+);
+
 /** A scopedDb whose select chain resolves to the seeded clause rows. */
 const createClauseScopedDb = (rows: unknown[]) =>
   asTestRaw<McpRequestContext["scopedDb"] & ReturnType<typeof mock>>(
@@ -42,9 +54,6 @@ const createClauseScopedDb = (rows: unknown[]) =>
       return await run(builder);
     }),
   );
-
-const PLAYBOOK_ID = toSafeId<"playbookDefinition">("pb_1");
-const APPROVED_VERSION_ID = toSafeId<"playbookDefinitionVersion">("pbv_1");
 
 /**
  * A playbook's positions, tagged by the issue text so the approved snapshot and
@@ -101,7 +110,7 @@ const createClauseWriteScopedDb = () => {
             if (row.body !== undefined) {
               insertedBodies.push(row.body);
             }
-            return { returning: async () => [{ id: "c1" }] };
+            return { returning: async () => [{ id: CLAUSE_ID }] };
           },
         }),
         update: () => ({ set: () => ({ where: async () => undefined }) }),
@@ -132,9 +141,9 @@ const createContext = ({
   memberRole?: McpRequestContext["memberRole"];
   scopedDb?: McpRequestContext["scopedDb"];
 } = {}): McpRequestContext => ({
-  accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
-  accessibleWorkspaceIdSet: new Set(["ws_1"]),
-  accessibleWorkspaceStatusById: new Map([["ws_1", "active"]]),
+  accessibleWorkspaceIds: [toSafeId<"workspace">(MATTER_ID)],
+  accessibleWorkspaceIdSet: new Set([MATTER_ID]),
+  accessibleWorkspaceStatusById: new Map([[MATTER_ID, "active"]]),
   accessibleWorkspaces: [],
   grantedScopes: [],
   memberRole,
@@ -175,7 +184,7 @@ describe("MCP knowledge tools", () => {
   test("list_clauses declares tenant text fields that redact the payload in place", async () => {
     const rows = [
       {
-        id: "c1",
+        id: CLAUSE_ID,
         title: "Governing Law",
         categoryId: null,
         language: "en",
@@ -217,7 +226,7 @@ describe("MCP knowledge tools", () => {
 
   test("list_clauses fails closed when a clause body is unrecognized, leaking nothing", async () => {
     const clause = {
-      id: "c1",
+      id: CLAUSE_ID,
       title: "Governing Law",
       categoryId: null,
       description: null,
@@ -236,7 +245,7 @@ describe("MCP knowledge tools", () => {
     };
 
     const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
-      args: { clause_id: "c1" },
+      args: { clause_id: CLAUSE_ID },
       context: createContext({
         scopedDb: createClauseDetailScopedDb(clause),
       }),
@@ -323,7 +332,7 @@ describe("MCP knowledge tools", () => {
 
   test("save_clause rejects an update that changes nothing", async () => {
     const result = await handleMcpToolCall({
-      args: { clause_id: "c1" },
+      args: { clause_id: CLAUSE_ID },
       context: createContext(),
       toolName: "save_clause",
     });
@@ -361,7 +370,7 @@ describe("MCP knowledge tools", () => {
     startWorkflowMock.mockResolvedValue({ status: "started" });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", playbook_id: "pb_1" },
+      args: { matter_id: MATTER_ID, playbook_id: PLAYBOOK_ID },
       context: createContext({
         scopedDb: createPlaybookScopedDb({
           id: PLAYBOOK_ID,
@@ -389,7 +398,7 @@ describe("MCP knowledge tools", () => {
     // against, projected onto the table the tool materialized into.
     expect(createPlaybookTableRunsMock).toHaveBeenCalledTimes(1);
     expect(createPlaybookTableRunsMock.mock.calls.at(0)?.[0]).toMatchObject({
-      workspaceId: "ws_1",
+      workspaceId: MATTER_ID,
       userId: "user_1",
       projection: "columns",
       docTypeGate: null,
@@ -407,7 +416,7 @@ describe("MCP knowledge tools", () => {
     expect(startWorkflowMock).toHaveBeenCalledTimes(1);
     expect(startWorkflowMock.mock.calls.at(0)?.[0]).toMatchObject({
       propertyIds: [toSafeId<"property">("p1"), toSafeId<"property">("p2")],
-      workspaceId: "ws_1",
+      workspaceId: MATTER_ID,
     });
   });
 
@@ -427,7 +436,7 @@ describe("MCP knowledge tools", () => {
     startWorkflowMock.mockResolvedValue({ status: "failed" });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", playbook_id: "pb_1" },
+      args: { matter_id: MATTER_ID, playbook_id: PLAYBOOK_ID },
       context: createContext({
         scopedDb: createPlaybookScopedDb({
           id: PLAYBOOK_ID,

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -79,6 +79,7 @@ import {
   MCP_INTERNAL_ERROR_HINT,
   structuredErrorResult,
   toolDataResult,
+  uuidInputSchema,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
@@ -592,28 +593,16 @@ const playbookDetailTextFieldSpecs = (
 const listClausesArgsSchema = v.pipe(
   v.strictObject({
     clause_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Clause id to read in detail; omit to list"),
-      ),
+      uuidInputSchema("Clause id to read in detail; omit to list"),
     ),
     version_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "With clause_id, return this version's body instead of the current clause",
-        ),
+      uuidInputSchema(
+        "With clause_id, return this version's body instead of the current clause",
       ),
     ),
     category_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "List only clauses filed under this category (list mode)",
-        ),
+      uuidInputSchema(
+        "List only clauses filed under this category (list mode)",
       ),
     ),
     query: v.optional(
@@ -1023,11 +1012,7 @@ const clauseBodyArgSchema = v.pipe(
 const saveClauseArgsSchema = v.pipe(
   v.strictObject({
     clause_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Clause id to update; omit to create"),
-      ),
+      uuidInputSchema("Clause id to update; omit to create"),
     ),
     title: v.optional(
       v.pipe(
@@ -1040,7 +1025,7 @@ const saveClauseArgsSchema = v.pipe(
     body: v.optional(clauseBodyArgSchema),
     category_id: v.optional(
       v.pipe(
-        v.nullable(v.pipe(v.string(), v.minLength(1))),
+        v.nullable(v.pipe(v.string(), v.uuid())),
         v.description(
           "Category id to file the clause under; pass null to clear",
         ),
@@ -1255,11 +1240,7 @@ const handleSaveClauseTool: TypedMcpToolHandler<
 // --- delete_clause ------------------------------------------------------
 
 const deleteClauseArgsSchema = v.strictObject({
-  clause_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Clause id to delete"),
-  ),
+  clause_id: uuidInputSchema("Clause id to delete"),
   confirm: v.optional(
     v.pipe(
       v.boolean(),
@@ -1304,11 +1285,7 @@ const handleDeleteClauseTool: TypedMcpToolHandler<
 const listPlaybooksArgsSchema = v.pipe(
   v.strictObject({
     playbook_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Playbook id to read in detail; omit to list playbooks"),
-      ),
+      uuidInputSchema("Playbook id to read in detail; omit to list playbooks"),
     ),
     limit: v.optional(
       v.pipe(
@@ -1424,16 +1401,8 @@ const handleListPlaybooksTool: TypedMcpToolHandler<
 // --- run_playbook -------------------------------------------------------
 
 const runPlaybookArgsSchema = v.strictObject({
-  matter_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Matter ID to run the playbook over."),
-  ),
-  playbook_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Playbook id to run"),
-  ),
+  matter_id: uuidInputSchema("Matter ID to run the playbook over."),
+  playbook_id: uuidInputSchema("Playbook id to run"),
 });
 
 /**

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -218,11 +218,7 @@ const TASK_DETAIL_TEXT_FIELD_PATHS = deriveTextFieldPaths(
 const saveMatterArgsSchema = v.pipe(
   v.strictObject({
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Matter ID to update; omit to create a new matter"),
-      ),
+      uuidInputSchema("Matter ID to update; omit to create a new matter"),
     ),
     name: v.optional(
       v.pipe(
@@ -233,12 +229,8 @@ const saveMatterArgsSchema = v.pipe(
       ),
     ),
     client_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Contact ID to attach in the client role. Only valid when creating a matter.",
-        ),
+      uuidInputSchema(
+        "Contact ID to attach in the client role. Only valid when creating a matter.",
       ),
     ),
     reference: v.optional(
@@ -461,11 +453,7 @@ const handleSaveMatterTool: TypedMcpToolHandler<
 // --- delete_matter ------------------------------------------------------
 
 const deleteMatterArgsSchema = v.strictObject({
-  matter_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Matter ID to delete"),
-  ),
+  matter_id: uuidInputSchema("Matter ID to delete"),
   confirm: v.optional(
     v.pipe(
       v.boolean(),
@@ -625,11 +613,7 @@ export const deriveContactDisplayName = ({
 const saveContactArgsSchema = v.pipe(
   v.strictObject({
     contact_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Contact ID to update; omit to create"),
-      ),
+      uuidInputSchema("Contact ID to update; omit to create"),
     ),
     type: v.optional(
       v.pipe(
@@ -814,11 +798,7 @@ const handleSaveContactTool: TypedMcpToolHandler<
 // --- delete_contact -----------------------------------------------------
 
 const deleteContactArgsSchema = v.strictObject({
-  contact_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Contact ID to delete"),
-  ),
+  contact_id: uuidInputSchema("Contact ID to delete"),
   confirm: v.optional(
     v.pipe(
       v.boolean(),
@@ -945,21 +925,11 @@ const resolveTaskWorkspace = async ({
 const listTasksArgsSchema = v.pipe(
   v.strictObject({
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Matter ID to list tasks in; required unless task_id is given.",
-        ),
+      uuidInputSchema(
+        "Matter ID to list tasks in; required unless task_id is given.",
       ),
     ),
-    task_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Task entity ID to read in detail"),
-      ),
-    ),
+    task_id: v.optional(uuidInputSchema("Task entity ID to read in detail")),
     date_from: v.optional(
       v.pipe(
         ISO_DATE_SCHEMA,
@@ -1293,19 +1263,11 @@ const handleListTasksTool: TypedMcpToolHandler<
 const saveTaskArgsSchema = v.pipe(
   v.strictObject({
     task_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Task entity ID to update; omit to create"),
-      ),
+      uuidInputSchema("Task entity ID to update; omit to create"),
     ),
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Matter ID to create the task in; required when creating.",
-        ),
+      uuidInputSchema(
+        "Matter ID to create the task in; required when creating.",
       ),
     ),
     name: v.optional(
@@ -1329,19 +1291,11 @@ const saveTaskArgsSchema = v.pipe(
       ),
     ),
     list_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.uuid(),
-        v.description("List ID to create the item in (creating only)"),
-      ),
+      uuidInputSchema("List ID to create the item in (creating only)"),
     ),
     list_section_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.uuid(),
-        v.description(
-          "Section of list_id to create the item under (creating only)",
-        ),
+      uuidInputSchema(
+        "Section of list_id to create the item under (creating only)",
       ),
     ),
     list_description: v.optional(
@@ -1382,21 +1336,11 @@ const saveTaskArgsSchema = v.pipe(
       ),
     ),
     link_entity_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Entity ID to link to the task (document, folder, or another task)",
-        ),
+      uuidInputSchema(
+        "Entity ID to link to the task (document, folder, or another task)",
       ),
     ),
-    unlink_link_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Entity-link ID to remove"),
-      ),
-    ),
+    unlink_link_id: v.optional(uuidInputSchema("Entity-link ID to remove")),
   }),
   // Creating (no task_id) requires matter_id and name.
   v.forward(
@@ -1925,15 +1869,11 @@ const handleDeleteTaskTool: TypedMcpToolHandler<
 
 const linkMatterContactArgsSchema = v.pipe(
   v.strictObject({
-    matter_id: v.pipe(v.string(), v.minLength(1), v.description("Matter ID")),
+    matter_id: uuidInputSchema("Matter ID"),
     contact_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Contact ID: with role to link the contact, or alone to unlink it " +
-            "from the matter",
-        ),
+      uuidInputSchema(
+        "Contact ID: with role to link the contact, or alone to unlink it " +
+          "from the matter",
       ),
     ),
     role: v.optional(
@@ -1945,12 +1885,8 @@ const linkMatterContactArgsSchema = v.pipe(
       ),
     ),
     matter_contact_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Existing matter-contact link ID to remove, from list_matters",
-        ),
+      uuidInputSchema(
+        "Existing matter-contact link ID to remove, from list_matters",
       ),
     ),
   }),

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -16,6 +16,8 @@ import { listMcpTools } from "@/api/mcp/tools";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
+const WORKSPACE_ID = "00000000-0000-4000-8000-000000000001";
+
 // A DB accessor that fails the test if any handler reaches it. Every assertion
 // here exercises authorization or input validation, which must reject before
 // the tool touches the database.
@@ -214,7 +216,7 @@ describe("manage_organization per-action validation", () => {
   test("requires user_id for a member action", async () => {
     expect(
       errorMessage(
-        await runManageOrg({ action: "add_member", matter_id: "ws_1" }),
+        await runManageOrg({ action: "add_member", matter_id: WORKSPACE_ID }),
       ),
     ).toBe("user_id is required for add_member and remove_member");
   });
@@ -223,7 +225,7 @@ describe("manage_organization per-action validation", () => {
     const message = errorMessage(
       await runManageOrg({
         action: "remove_member",
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         user_id: "user_2",
         prompt_caching_enabled: false,
         document_processing_mode: "searchable-text",
@@ -306,7 +308,7 @@ describe("manage_organization remove_member confirm gate", () => {
       errorText(
         await runManageOrg({
           action: "remove_member",
-          matter_id: "ws_1",
+          matter_id: WORKSPACE_ID,
           user_id: "user_2",
         }),
       ),
@@ -321,7 +323,7 @@ describe("manage_organization remove_member confirm gate", () => {
     const text = errorText(
       await runManageOrg({
         action: "remove_member",
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         user_id: "user_2",
         confirm: true,
       }),

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -51,6 +51,7 @@ import {
   internalFailureResult,
   structuredErrorResult,
   toolDataResult,
+  uuidInputSchema,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
@@ -125,11 +126,7 @@ const widenDateOnlyBound = (bound: string, edge: "start" | "end"): string =>
 const listAuditLogArgsSchema = v.pipe(
   v.strictObject({
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Only entries scoped to this matter."),
-      ),
+      uuidInputSchema("Only entries scoped to this matter."),
     ),
     action: v.optional(
       v.pipe(
@@ -653,11 +650,7 @@ const manageOrganizationArgsSchema = v.pipe(
       v.description("Administrative action to perform"),
     ),
     matter_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Matter ID for add_member and remove_member."),
-      ),
+      uuidInputSchema("Matter ID for add_member and remove_member."),
     ),
     user_id: v.optional(
       v.pipe(

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -41,7 +41,6 @@ import type {
   SET_PRACTICE_JURISDICTIONS_PROJECTION,
 } from "@/api/lib/chat/projections";
 import { decryptContent } from "@/api/lib/content-encryption";
-import { isUuid } from "@/api/lib/custom-schema";
 import {
   resolveCurrentFileSourceField,
   selectCurrentExtractedContent,
@@ -499,12 +498,8 @@ const buildContactTextFieldSpecs = (
 
 const listMattersArgsSchema = v.strictObject({
   matter_id: v.optional(
-    v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.description(
-        "Matter ID to return a single matter's overview; omit to list matters",
-      ),
+    uuidInputSchema(
+      "Matter ID to return a single matter's overview; omit to list matters",
     ),
   ),
   status: v.optional(
@@ -605,9 +600,7 @@ const searchCaseLawArgsSchema = v.strictObject({
       v.description("Filter by decision type"),
     ),
   ),
-  source_id: v.optional(
-    v.pipe(v.string(), v.maxLength(36), v.description("Filter by source ID")),
-  ),
+  source_id: v.optional(uuidInputSchema("Filter by source ID")),
   date_from: v.optional(
     v.pipe(
       v.string(),
@@ -639,11 +632,7 @@ const readContentAcrossMattersArgsSchema = v.strictObject({
 });
 
 const readCaseLawDecisionArgsSchema = v.strictObject({
-  decision_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("Case-law decision ID"),
-  ),
+  decision_id: uuidInputSchema("Case-law decision ID"),
   cursor: v.optional(
     v.pipe(
       v.string(),
@@ -657,7 +646,7 @@ const readCaseLawDecisionArgsSchema = v.strictObject({
 });
 
 const readContactArgsSchema = v.strictObject({
-  contact_id: v.pipe(v.string(), v.minLength(1), v.description("Contact ID")),
+  contact_id: uuidInputSchema("Contact ID"),
 });
 
 const practiceJurisdictionInputSchema = v.strictObject({
@@ -1657,18 +1646,6 @@ const handleSearchCaseLawTool: TypedMcpToolHandler<
   } = parsed.output;
   const limit = parsed.output.limit ?? DEFAULT_SEARCH_LIMIT;
 
-  if (sourceId !== undefined && !isUuid(sourceId)) {
-    return structuredErrorResult({
-      code: "validation_error",
-      message: "Invalid parameter: source_id. Expected a UUID",
-      issues: [
-        {
-          path: "source_id",
-          message: "Invalid parameter: source_id. Expected a UUID",
-        },
-      ],
-    });
-  }
   const dateFromIssue = isoDateIssue("date_from", dateFrom);
   if (dateFromIssue) {
     return dateFromIssue;

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -193,9 +193,9 @@ const createContext = ({
   scopedDb?: McpRequestContext["scopedDb"];
   workspaceStatus?: "active" | "archived";
 } = {}): McpRequestContext => ({
-  accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
-  accessibleWorkspaceIdSet: new Set(["ws_1"]),
-  accessibleWorkspaceStatusById: new Map([["ws_1", workspaceStatus]]),
+  accessibleWorkspaceIds: [toSafeId<"workspace">(WORKSPACE_ID)],
+  accessibleWorkspaceIdSet: new Set([WORKSPACE_ID]),
+  accessibleWorkspaceStatusById: new Map([[WORKSPACE_ID, workspaceStatus]]),
   accessibleWorkspaces: [],
   grantedScopes: [],
   memberRole,
@@ -238,6 +238,8 @@ const NON_FOLDER_ID = "00000000-0000-4000-8000-000000000004";
 const MISSING_VERSION_ID = "00000000-0000-4000-8000-000000000005";
 const READ_ONLY_VERSION_ID = "00000000-0000-4000-8000-000000000006";
 const NON_FILE_VERSION_ID = "00000000-0000-4000-8000-000000000007";
+const MISSING_TEMPLATE_ID = "00000000-0000-4000-8000-000000000008";
+const WORKSPACE_ID = "00000000-0000-4000-8000-000000000009";
 const fakeTransaction = asTestRaw<Transaction>({});
 
 /** A real, minimal valid DOCX (well-formed word/document.xml) as base64, so
@@ -415,7 +417,7 @@ describe("MCP template tools", () => {
   test("list_templates returns the org's templates", async () => {
     const rows = [
       {
-        id: "t1",
+        id: TEMPLATE_ID,
         name: "NDA",
         fieldCount: 4,
         tags: ["nda"],
@@ -437,7 +439,7 @@ describe("MCP template tools", () => {
   test("list_templates anonymizes template tags in anonymized mode", async () => {
     const rows = [
       {
-        id: "t1",
+        id: TEMPLATE_ID,
         name: "Smith NDA",
         fieldCount: 4,
         tags: ["Smith acquisition"],
@@ -530,13 +532,13 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1" },
+      args: { template_id: TEMPLATE_ID },
       context: createContext(),
       toolName: "list_templates",
     });
 
     expect(describeStoredTemplateMock).toHaveBeenCalledWith(
-      expect.objectContaining({ templateId: "t1" }),
+      expect.objectContaining({ templateId: TEMPLATE_ID }),
     );
     expect(parseToolPayload(result)).toMatchObject({
       name: "Company POA",
@@ -598,7 +600,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1" },
+      args: { template_id: TEMPLATE_ID },
       context: createContext(),
       mode: "anonymized",
       toolName: "list_templates",
@@ -643,7 +645,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "missing" },
+      args: { template_id: MISSING_TEMPLATE_ID },
       context: createContext(),
       toolName: "list_templates",
     });
@@ -676,14 +678,14 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", values: { "tenant.name": "ACME" } },
+      args: { template_id: TEMPLATE_ID, values: { "tenant.name": "ACME" } },
       context: createContext(),
       toolName: "fill_template",
     });
 
     expect(fillStoredTemplateWithTextStrictMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        templateId: "t1",
+        templateId: TEMPLATE_ID,
         values: { "tenant.name": "ACME" },
         organizationId: toSafeId<"organization">("org_1"),
       }),
@@ -701,7 +703,7 @@ describe("MCP template tools", () => {
     // The execution is recorded (fill row + audit) so agent fills are audited.
     expect(recordTemplateFillMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        templateId: "t1",
+        templateId: TEMPLATE_ID,
         organizationId: toSafeId<"organization">("org_1"),
         format: "docx",
         unmatchedCount: 0,
@@ -728,7 +730,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", values: { "tenant.name": "ACME" } },
+      args: { template_id: TEMPLATE_ID, values: { "tenant.name": "ACME" } },
       context: createContext(),
       toolName: "fill_template",
     });
@@ -761,7 +763,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", values: {} },
+      args: { template_id: TEMPLATE_ID, values: {} },
       context: createContext(),
       toolName: "fill_template",
     });
@@ -791,7 +793,7 @@ describe("MCP template tools", () => {
 
     const result = await handleMcpToolCall({
       args: {
-        template_id: "t1",
+        template_id: TEMPLATE_ID,
         values: { "tenant.name": "ACME" },
         completion_mode: "allow_partial",
       },
@@ -817,7 +819,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", values: { first: "value" } },
+      args: { template_id: TEMPLATE_ID, values: { first: "value" } },
       context: createContext(),
       toolName: "fill_template",
     });
@@ -845,7 +847,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", values: { "tenant.name": "ACME" } },
+      args: { template_id: TEMPLATE_ID, values: { "tenant.name": "ACME" } },
       context: createContext(),
       toolName: "fill_template",
     });
@@ -875,7 +877,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", values: {} },
+      args: { template_id: TEMPLATE_ID, values: {} },
       context: createContext(),
       toolName: "fill_template",
     });
@@ -908,7 +910,7 @@ describe("MCP template tools", () => {
 
     const result = await handleMcpToolCall({
       args: {
-        template_id: "t1",
+        template_id: TEMPLATE_ID,
         values: { intentional: "value" },
         allow_unused_values: true,
       },
@@ -936,7 +938,7 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", values: { "tenant.name": "ACME" } },
+      args: { template_id: TEMPLATE_ID, values: { "tenant.name": "ACME" } },
       context: createContext(),
       toolName: "fill_template",
     });
@@ -969,7 +971,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "create-document-1",
         parent_id: FOLDER_ID,
         name: "Example Lease",
@@ -981,7 +983,7 @@ describe("MCP template tools", () => {
 
     expect(createEntityFromBufferMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspaceId: "ws_1",
+        workspaceId: WORKSPACE_ID,
         parentId: FOLDER_ID,
         fileName: "Example Lease.docx",
         afterCreate: expect.any(Function),
@@ -1039,7 +1041,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "create-document-missing-required",
         values: { "tenant.name": "ACME" },
       },
@@ -1077,7 +1079,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "disconnect-1",
         values: { "tenant.name": "ACME" },
       },
@@ -1118,7 +1120,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "create-document-retry",
         values: { "tenant.name": "ACME" },
       },
@@ -1147,7 +1149,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "concurrent-retry",
         values: { "tenant.name": "ACME" },
       },
@@ -1175,7 +1177,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "reused-key",
         values: { "tenant.name": "Different" },
       },
@@ -1221,7 +1223,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "create-version-1",
         entity_id: ENTITY_ID,
         values: { "tenant.name": "ACME" },
@@ -1232,7 +1234,7 @@ describe("MCP template tools", () => {
 
     expect(createEntityVersionFromBufferMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspaceId: "ws_1",
+        workspaceId: WORKSPACE_ID,
         entityId: ENTITY_ID,
         fileName: "lease.docx",
         source: null,
@@ -1251,7 +1253,7 @@ describe("MCP template tools", () => {
         ],
         entityId: ENTITY_ID,
         entityVersionId: "version_2",
-        workspaceId: "ws_1",
+        workspaceId: WORKSPACE_ID,
       }),
     );
     expect(parseToolPayload(result)).toEqual({
@@ -1270,7 +1272,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "missing-entity-1",
         values: {},
       },
@@ -1281,7 +1283,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "archived-1",
         values: {},
       },
@@ -1292,7 +1294,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "forbidden-1",
         values: {},
       },
@@ -1303,7 +1305,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: "not-a-uuid",
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "malformed-template-1",
         values: {},
       },
@@ -1314,7 +1316,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "malformed-parent-1",
         parent_id: "not-a-uuid",
         values: {},
@@ -1326,7 +1328,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "malformed-entity-1",
         entity_id: "not-a-uuid",
         values: {},
@@ -1383,7 +1385,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "missing-parent-1",
         parent_id: MISSING_FOLDER_ID,
         values: {},
@@ -1395,7 +1397,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "non-folder-1",
         parent_id: NON_FOLDER_ID,
         values: {},
@@ -1407,7 +1409,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "missing-version-1",
         entity_id: MISSING_VERSION_ID,
         values: {},
@@ -1419,7 +1421,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "read-only-1",
         entity_id: READ_ONLY_VERSION_ID,
         values: {},
@@ -1431,7 +1433,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_version",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "non-file-1",
         entity_id: NON_FILE_VERSION_ID,
         values: {},
@@ -1465,7 +1467,7 @@ describe("MCP template tools", () => {
       args: {
         action: "create_document",
         template_id: TEMPLATE_ID,
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         idempotency_key: "full-workspace-1",
         values: {},
       },
@@ -1716,7 +1718,7 @@ describe("MCP template tools", () => {
 
     const result = await handleMcpToolCall({
       args: {
-        template_id: "t1",
+        template_id: TEMPLATE_ID,
         fields: [
           {
             path: "company",
@@ -1734,7 +1736,7 @@ describe("MCP template tools", () => {
     expect(result.isError).toBeFalsy();
     expect(configureTemplateFieldsMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        templateId: "t1",
+        templateId: TEMPLATE_ID,
         organizationId: toSafeId<"organization">("org_1"),
         fields: [
           expect.objectContaining({
@@ -1755,7 +1757,7 @@ describe("MCP template tools", () => {
       ],
     });
     expect(describeStoredTemplateMock).toHaveBeenCalledWith(
-      expect.objectContaining({ templateId: "t1" }),
+      expect.objectContaining({ templateId: TEMPLATE_ID }),
     );
   });
 
@@ -1768,7 +1770,10 @@ describe("MCP template tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", fields: [{ path: "ghost", label: "Ghost" }] },
+      args: {
+        template_id: TEMPLATE_ID,
+        fields: [{ path: "ghost", label: "Ghost" }],
+      },
       context: createContext(),
       toolName: "save_template",
     });
@@ -1781,7 +1786,7 @@ describe("MCP template tools", () => {
 
   test("save_template (configure) forbids members without template:create permission", async () => {
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", fields: [{ path: "company" }] },
+      args: { template_id: TEMPLATE_ID, fields: [{ path: "company" }] },
       context: createContext({ memberRole: "intern" }),
       toolName: "save_template",
     });
@@ -1793,7 +1798,7 @@ describe("MCP template tools", () => {
 
   test("list_templates (detail) rejects template_id combined with a cursor", async () => {
     const result = await handleMcpToolCall({
-      args: { template_id: "t1", cursor: "abc" },
+      args: { template_id: TEMPLATE_ID, cursor: "abc" },
       context: createContext(),
       toolName: "list_templates",
     });

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -699,7 +699,15 @@ const handleListTemplatesTool: TypedMcpToolHandler<
   return { egress: "structured", payload, textFields };
 };
 
-const describeTemplateArgsSchema = v.strictObject({
+/**
+ * Exported, with the two validators below, only so `uuid-id-inputs.test.ts` can
+ * bind it to the hand-written `inputSchema` these three tools still advertise:
+ * a one-sided edit to either representation fails there instead of shipping a
+ * `tools/list` contract the handler does not enforce. The binding retires with
+ * the schema, once the tool moves to `defineValibotMcpTool` and its advertised
+ * schema is projected from this one.
+ */
+export const describeTemplateArgsSchema = v.strictObject({
   template_id: v.pipe(v.string(), v.uuid()),
 });
 
@@ -831,7 +839,7 @@ const assertTemplateFillUsage = async ({
   });
 };
 
-const fillTemplateArgsSchema = v.strictObject({
+export const fillTemplateArgsSchema = v.strictObject({
   template_id: v.pipe(v.string(), v.uuid()),
   values: v.record(v.string(), v.unknown()),
   allow_unused_values: v.optional(v.boolean()),
@@ -997,7 +1005,7 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
   });
 };
 
-const saveFilledTemplateArgsSchema = v.strictObject({
+export const saveFilledTemplateArgsSchema = v.strictObject({
   action: v.picklist(["create_document", "create_version"]),
   template_id: v.pipe(v.string(), v.uuid()),
   matter_id: v.pipe(v.string(), v.uuid()),

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -104,6 +104,8 @@ import {
   stringProp,
   structuredErrorResult,
   toolDataResult,
+  uuidInputSchema,
+  uuidProp,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
@@ -128,11 +130,7 @@ const MAX_DOCX_BASE64_LENGTH =
 const saveTemplateArgsSchema = v.pipe(
   v.strictObject({
     template_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Template to configure; omit when creating"),
-      ),
+      uuidInputSchema("Template to configure; omit when creating"),
     ),
     name: v.optional(
       v.pipe(
@@ -442,7 +440,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
     inputSchema: {
       type: "object",
       properties: {
-        template_id: stringProp(
+        template_id: uuidProp(
           "Template id to describe its fields in detail; omit to list templates",
         ),
         cursor: stringProp(
@@ -480,7 +478,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
     inputSchema: {
       type: "object",
       properties: {
-        template_id: stringProp("Template id, as returned by list_templates"),
+        template_id: uuidProp("Template id, as returned by list_templates"),
         values: {
           type: "object",
           description: "Map of field path to value.",
@@ -537,12 +535,12 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
           "create_document",
           "create_version",
         ]),
-        template_id: stringProp("Template id, as returned by list_templates"),
-        matter_id: stringProp("Matter receiving the filled DOCX."),
-        entity_id: stringProp(
+        template_id: uuidProp("Template id, as returned by list_templates"),
+        matter_id: uuidProp("Matter receiving the filled DOCX."),
+        entity_id: uuidProp(
           "Existing document entity id; required only for create_version",
         ),
-        parent_id: stringProp(
+        parent_id: uuidProp(
           "Folder entity id for a new document; valid only for create_document",
         ),
         name: stringProp(
@@ -702,7 +700,7 @@ const handleListTemplatesTool: TypedMcpToolHandler<
 };
 
 const describeTemplateArgsSchema = v.strictObject({
-  template_id: v.pipe(v.string(), v.minLength(1)),
+  template_id: v.pipe(v.string(), v.uuid()),
 });
 
 // Detail branch of list_templates: one template's field configuration. Reused
@@ -834,7 +832,7 @@ const assertTemplateFillUsage = async ({
 };
 
 const fillTemplateArgsSchema = v.strictObject({
-  template_id: v.pipe(v.string(), v.minLength(1)),
+  template_id: v.pipe(v.string(), v.uuid()),
   values: v.record(v.string(), v.unknown()),
   allow_unused_values: v.optional(v.boolean()),
   completion_mode: v.optional(
@@ -1002,7 +1000,7 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
 const saveFilledTemplateArgsSchema = v.strictObject({
   action: v.picklist(["create_document", "create_version"]),
   template_id: v.pipe(v.string(), v.uuid()),
-  matter_id: v.pipe(v.string(), v.minLength(1)),
+  matter_id: v.pipe(v.string(), v.uuid()),
   entity_id: v.optional(v.pipe(v.string(), v.uuid())),
   parent_id: v.optional(v.pipe(v.string(), v.uuid())),
   name: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(255))),

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -100,6 +100,19 @@ export const stringProp = (
   }) as const;
 
 /**
+ * `uuidInputSchema` as a hand-written JSON Schema property, for the tools whose
+ * advertised schema is still maintained alongside their validator rather than
+ * projected from it. Both sides must move together until the tool migrates to
+ * `defineValibotMcpTool`.
+ */
+export const uuidProp = (description: string) =>
+  ({
+    type: "string",
+    format: "uuid",
+    description,
+  }) as const;
+
+/**
  * A nullable string parameter. Advertises `type: ["string", "null"]` so the MCP
  * JSON schema matches a Valibot field that accepts null (the "pass null to
  * clear" convention); a plain string type would mislead callers into believing

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -88,6 +88,26 @@ const makeDocxBytes = async () => {
 const ORGANIZATION_ID = toSafeId<"organization">("org_1");
 
 /**
+ * Id fixtures. Every id that reaches a Postgres `uuid` column is validated as
+ * a UUID by the tool input schemas, so the fixtures are uuid-shaped and each
+ * one is spelled once: the mocked context, the mocked rows, the tool arguments
+ * and the expectations all read the same constant.
+ */
+const WORKSPACE_ID = "00000000-0000-4000-8000-0000000a0001";
+const WORKSPACE_ID_2 = "00000000-0000-4000-8000-0000000a0002";
+const WORKSPACE_ID_3 = "00000000-0000-4000-8000-0000000a0003";
+const CONTACT_ID = "00000000-0000-4000-8000-0000000c0001";
+const DECISION_ID = "00000000-0000-4000-8000-0000000d0001";
+/** A document entity, used where a tool is handed one in place of a task. */
+const DOCUMENT_ENTITY_ID = "00000000-0000-4000-8000-0000000e0d01";
+const FOLDER_ENTITY_ID = "00000000-0000-4000-8000-0000000e0f01";
+const ENTITY_LINK_ID = "00000000-0000-4000-8000-0000000b0001";
+const FILE_PROPERTY_ID = "00000000-0000-4000-8000-0000000f0001";
+const TEXT_PROPERTY_ID = "00000000-0000-4000-8000-0000000f0002";
+const TIME_ENTRY_ID = "00000000-0000-4000-8000-000000010001";
+const BASE_VERSION_ID = "00000000-0000-4000-8000-000000090001";
+
+/**
  * The object store the tools really read through: `startFakeS3` points
  * `lib/s3` at an in-process S3, so the key derivation, the presigned read and
  * the DOCX conversion are all part of what these tests prove. A DOCX branch
@@ -100,7 +120,7 @@ let fake: FakeS3;
 const objectReadKeys = (): string[] =>
   fake.requests.filter(({ method }) => method === "GET").map(({ key }) => key);
 
-const docxKey = (fileId: string, workspaceId = "ws_1"): string =>
+const docxKey = (fileId: string, workspaceId = WORKSPACE_ID): string =>
   createFileKey({
     organizationId: ORGANIZATION_ID,
     workspaceId: toSafeId<"workspace">(workspaceId),
@@ -109,7 +129,7 @@ const docxKey = (fileId: string, workspaceId = "ws_1"): string =>
   });
 
 /** Put the DOCX fixture where the tool will look for that file's bytes. */
-const seedDocxFile = async (fileId: string, workspaceId = "ws_1") => {
+const seedDocxFile = async (fileId: string, workspaceId = WORKSPACE_ID) => {
   fake.put(
     envBase.S3_BUCKET,
     docxKey(fileId, workspaceId),
@@ -312,7 +332,7 @@ const createReadDecisionResult = () => ({
   documentUrl: "https://example.test/document.pdf",
   ecli: null,
   fulltext: null,
-  id: "dec_123",
+  id: DECISION_ID,
   language: "cs",
   metadata: { panel: "29 Cdo" },
   slug: "stable-official-slug",
@@ -460,7 +480,7 @@ const createExtractedContentRow = ({
   encrypted = DEFAULT_EXTRACTED_CONTENT,
   entityId = "00000000-0000-4000-8000-0000000e0001",
   name = "Share Purchase Agreement",
-  workspaceId = "ws_1",
+  workspaceId = WORKSPACE_ID,
   sourceEntityVersionId = null,
   sourceFieldId = null,
   sourceFileId = null,
@@ -655,7 +675,7 @@ const createRecordAuditEventMock = () =>
   );
 
 const createContext = ({
-  accessibleWorkspaceIds = ["ws_1"],
+  accessibleWorkspaceIds = [WORKSPACE_ID],
   archivedWorkspaceIds = [],
   recordAuditEvent = createRecordAuditEventMock(),
   scopedDb = createScopedDb(),
@@ -820,8 +840,8 @@ describe("OpenAI-compatible MCP tools", () => {
         },
         source_id: {
           type: "string",
+          format: "uuid",
           description: "Filter by source ID",
-          maxLength: 36,
         },
         date_from: {
           type: "string",
@@ -1006,12 +1026,12 @@ describe("OpenAI-compatible MCP tools", () => {
       hits: [
         {
           entityId: "00000000-0000-4000-8000-0000000e0001",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
           name: "Share Purchase Agreement",
         },
         {
           entityId: "00000000-0000-4000-8000-0000000e0002",
-          workspaceId: "ws_2",
+          workspaceId: WORKSPACE_ID_2,
           name: "Not Fetchable",
         },
       ],
@@ -1024,7 +1044,7 @@ describe("OpenAI-compatible MCP tools", () => {
           {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             fieldId: "field_1",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
         ]),
       }),
@@ -1048,7 +1068,7 @@ describe("OpenAI-compatible MCP tools", () => {
         {
           id: "00000000-0000-4000-8000-0000000e0001",
           title: "Share Purchase Agreement",
-          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+          url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
         },
       ],
     });
@@ -1071,15 +1091,41 @@ describe("OpenAI-compatible MCP tools", () => {
       id: "00000000-0000-4000-8000-0000000e0001",
       title: "Share Purchase Agreement",
       text: "Full document text",
-      url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+      url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
       nextCursor: null,
       metadata: {
         charCount: "Full document text".length,
         source: "stella",
         truncated: false,
-        workspaceId: "ws_1",
+        workspaceId: WORKSPACE_ID,
       },
     });
+  });
+
+  test("fetch rejects a resource URI passed as an id", async () => {
+    // A client that hands the fetch tool a `stella://` resource URI must get a
+    // validation_error naming `id` and pointing at resources/read. The id is
+    // matched against a uuid column, so reaching the query at all is the
+    // Postgres cast failure this once surfaced as internal_error.
+    const result = await handleMcpToolCall({
+      args: { id: "stella://reference/template-markers" },
+      context: createContext({
+        scopedDb: asTestRaw<McpRequestContext["scopedDb"]>(() => {
+          throw new Error("the malformed id must never reach the database");
+        }),
+      }),
+      toolName: "fetch",
+    });
+
+    const error = validationEnvelope(result);
+    expect(error["code"]).toBe("validation_error");
+    expect(error["issues"]).toEqual([
+      {
+        path: "id",
+        message: 'Invalid UUID: Received "stella://reference/template-markers"',
+      },
+    ]);
+    expect(error["hint"]).toContain("resources/read");
   });
 
   test("fetch pages long document text via the returned cursor", async () => {
@@ -1146,7 +1192,7 @@ describe("OpenAI-compatible MCP tools", () => {
           country: "CZE",
           court: "Nejvyšší soud",
           decisionDate: "2024-02-01",
-          decisionId: "dec_123",
+          decisionId: DECISION_ID,
           decisionType: "judgment",
           ecli: "ECLI:CZ:NS:2024:29.CDO.123.2024.1",
           // The handler builds the headline for the web UI; the MCP snippet
@@ -1159,7 +1205,7 @@ describe("OpenAI-compatible MCP tools", () => {
               country: "CZE",
               court: "Nejvyšší soud",
               decisionDate: "2024-02-01",
-              id: "dec_123",
+              id: DECISION_ID,
               language: "cs",
               slug: "stable-official-slug",
             },
@@ -1224,8 +1270,8 @@ describe("OpenAI-compatible MCP tools", () => {
           country: "CZE",
           court: "Nejvyšší soud",
           decisionDate: "2024-02-01",
-          decisionId: "dec_123",
-          resourceName: "stella://resource/case_law_decision/id=dec_123",
+          decisionId: DECISION_ID,
+          resourceName: `stella://resource/case_law_decision/id=${DECISION_ID}`,
           decisionType: "judgment",
           ecli: "ECLI:CZ:NS:2024:29.CDO.123.2024.1",
           language: "cs",
@@ -1249,7 +1295,7 @@ describe("OpenAI-compatible MCP tools", () => {
           country: "CZE",
           court: "Nejvyšší soud",
           decisionDate: "2024-02-01",
-          decisionId: "dec_123",
+          decisionId: DECISION_ID,
           decisionType: "judgment",
           ecli: "ECLI:CZ:NS:2024:29.CDO.123.2024.1",
           headline: "Relevant <mark>holding</mark>",
@@ -1282,8 +1328,8 @@ describe("OpenAI-compatible MCP tools", () => {
           country: "CZE",
           court: "Nejvyšší soud",
           decisionDate: "2024-02-01",
-          decisionId: "dec_123",
-          resourceName: "stella://resource/case_law_decision/id=dec_123",
+          decisionId: DECISION_ID,
+          resourceName: `stella://resource/case_law_decision/id=${DECISION_ID}`,
           decisionType: "judgment",
           ecli: "ECLI:CZ:NS:2024:29.CDO.123.2024.1",
           language: "cs",
@@ -1383,7 +1429,7 @@ describe("OpenAI-compatible MCP tools", () => {
             country: "CZE",
             court: "Nejvyšší soud",
             decisionDate: "2024-02-01",
-            decisionId: "dec_123",
+            decisionId: DECISION_ID,
             decisionType: "judgment",
             ecli: null,
             headline: null,
@@ -1410,8 +1456,8 @@ describe("OpenAI-compatible MCP tools", () => {
         results: [
           {
             appUrl: `${APP_BASE_URL}/law/cze/cases/nejvyssi-soud/stable-official-slug`,
-            decisionId: "dec_123",
-            resourceName: "stella://resource/case_law_decision/id=dec_123",
+            decisionId: DECISION_ID,
+            resourceName: `stella://resource/case_law_decision/id=${DECISION_ID}`,
           },
         ],
         totalCount: 1,
@@ -1456,13 +1502,10 @@ describe("OpenAI-compatible MCP tools", () => {
 
     const error = validationEnvelope(result);
     expect(error["code"]).toBe("validation_error");
-    expect(error["message"]).toBe(
-      "Invalid parameter: source_id. Expected a UUID",
-    );
     expect(error["issues"]).toEqual([
       {
         path: "source_id",
-        message: "Invalid parameter: source_id. Expected a UUID",
+        message: 'Invalid UUID: Received "not-a-uuid"',
       },
     ]);
     expect(searchDecisionsHandlerMock).not.toHaveBeenCalled();
@@ -1473,7 +1516,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     const context = createContext();
     const result = await handleMcpToolCall({
-      args: { decision_id: "dec_123" },
+      args: { decision_id: DECISION_ID },
       context,
       toolName: "read_case_law_decision",
     });
@@ -1483,7 +1526,7 @@ describe("OpenAI-compatible MCP tools", () => {
     // The gate and the read are one call, so the tool names the decision
     // by locator and never holds an ungated id.
     expect(readGatedDecisionMock).toHaveBeenCalledWith({
-      locator: { kind: "id", id: "dec_123" },
+      locator: { kind: "id", id: DECISION_ID },
       caseLawDb: caseLawPublicReadDb,
       caller: "attributed",
       citationsCursor: undefined,
@@ -1499,8 +1542,8 @@ describe("OpenAI-compatible MCP tools", () => {
         country: "CZE",
         court: "Nejvyšší soud",
         decisionDate: "2024-02-01",
-        decisionId: "dec_123",
-        resourceName: "stella://resource/case_law_decision/id=dec_123",
+        decisionId: DECISION_ID,
+        resourceName: `stella://resource/case_law_decision/id=${DECISION_ID}`,
         decisionType: "judgment",
         documentUrl: "https://example.test/document.pdf",
         ecli: null,
@@ -1542,7 +1585,7 @@ describe("OpenAI-compatible MCP tools", () => {
     withRedistributableSubjectMock.mockResolvedValue(null);
 
     const result = await handleMcpToolCall({
-      args: { decision_id: "dec_123" },
+      args: { decision_id: DECISION_ID },
       context: createContext(),
       toolName: "read_case_law_decision",
     });
@@ -1562,7 +1605,7 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { decision_id: "dec_123" },
+      args: { decision_id: DECISION_ID },
       context: createContext(),
       toolName: "read_case_law_decision",
     });
@@ -1580,7 +1623,7 @@ describe("OpenAI-compatible MCP tools", () => {
     readDecisionHandlerMock.mockResolvedValue(createReadDecisionResult());
 
     const result = await handleMcpToolCall({
-      args: { decision_id: "dec_123" },
+      args: { decision_id: DECISION_ID },
       context: createContext(),
       mode: "anonymized",
       toolName: "read_case_law_decision",
@@ -1596,8 +1639,8 @@ describe("OpenAI-compatible MCP tools", () => {
         country: "CZE",
         court: "Nejvyšší soud",
         decisionDate: "2024-02-01",
-        decisionId: "dec_123",
-        resourceName: "stella://resource/case_law_decision/id=dec_123",
+        decisionId: DECISION_ID,
+        resourceName: `stella://resource/case_law_decision/id=${DECISION_ID}`,
         decisionType: "judgment",
         documentUrl: "https://example.test/document.pdf",
         ecli: null,
@@ -1658,7 +1701,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const page1 = asTestRaw<DecisionPage>(
       parseToolPayload(
         await handleMcpToolCall({
-          args: { decision_id: "dec_123" },
+          args: { decision_id: DECISION_ID },
           context: createContext(),
           toolName: "read_case_law_decision",
         }),
@@ -1671,7 +1714,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const page2 = asTestRaw<DecisionPage>(
       parseToolPayload(
         await handleMcpToolCall({
-          args: { decision_id: "dec_123", cursor: page1.nextCursor },
+          args: { decision_id: DECISION_ID, cursor: page1.nextCursor },
           context: createContext(),
           toolName: "read_case_law_decision",
         }),
@@ -1684,7 +1727,7 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(page2.decision.text).toBeNull();
     expect(page2.nextCursor).toBeNull();
     expect(readGatedDecisionMock).toHaveBeenLastCalledWith({
-      locator: { kind: "id", id: "dec_123" },
+      locator: { kind: "id", id: DECISION_ID },
       caseLawDb: caseLawPublicReadDb,
       caller: "attributed",
       citationsCursor: "citations-next",
@@ -1695,11 +1738,11 @@ describe("OpenAI-compatible MCP tools", () => {
     const result = await handleMcpToolCall({
       args: { id: "00000000-0000-4000-8000-0000000e0001" },
       context: createContext({
-        accessibleWorkspaceIds: ["ws_1"],
+        accessibleWorkspaceIds: [WORKSPACE_ID],
         scopedDb: createScopedDb(
           [],
           createExtractedContentRow({
-            workspaceId: "ws_2",
+            workspaceId: WORKSPACE_ID_2,
           }),
         ),
       }),
@@ -1719,7 +1762,7 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
     });
     await handleMcpToolCall({
       args: { query: "share purchase" },
@@ -1732,8 +1775,8 @@ describe("OpenAI-compatible MCP tools", () => {
       organizationId: toSafeId<"organization">("org_1"),
       query: "share purchase",
       workspaceIds: [
-        toSafeId<"workspace">("ws_1"),
-        toSafeId<"workspace">("ws_3"),
+        toSafeId<"workspace">(WORKSPACE_ID),
+        toSafeId<"workspace">(WORKSPACE_ID_3),
       ],
     });
   });
@@ -1752,7 +1795,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("read_content_across_matters returns content from allowed workspaces", async () => {
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb([], createExtractedContentRow()),
     });
     const result = await handleMcpToolCall({
@@ -1769,14 +1812,14 @@ describe("OpenAI-compatible MCP tools", () => {
       text: "Full document text",
       truncated: false,
       nextCursor: null,
-      workspaceId: "ws_1",
+      workspaceId: WORKSPACE_ID,
     });
   });
 
   test("read_content_across_matters returns folio Markdown when the current version holds a DOCX file", async () => {
     await seedDocxFile("file_1");
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb([], createExtractedContentRow(), [
         {
           type: "file",
@@ -1797,7 +1840,7 @@ describe("OpenAI-compatible MCP tools", () => {
       entityId: "00000000-0000-4000-8000-0000000e0001",
       kind: "document",
       name: "Share Purchase Agreement",
-      workspaceId: "ws_1",
+      workspaceId: WORKSPACE_ID,
     });
     if (!isRecord(payload) || typeof payload["text"] !== "string") {
       throw new Error("Expected payload.text to be a string");
@@ -1818,7 +1861,7 @@ describe("OpenAI-compatible MCP tools", () => {
   test("read_content_across_matters reads a fresh DOCX before asynchronous extraction exists", async () => {
     await seedDocxFile("file_1");
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb(
         [],
         null,
@@ -1834,7 +1877,7 @@ describe("OpenAI-compatible MCP tools", () => {
           entityId: "00000000-0000-4000-8000-0000000e0001",
           kind: "document",
           name: "Fresh Agreement",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
         },
       ),
     });
@@ -1981,7 +2024,7 @@ describe("OpenAI-compatible MCP tools", () => {
           entityId: "00000000-0000-4000-8000-0000000e0001",
           kind: "document",
           name: "Promoted Version",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
         },
         { latestVersionId: "entity_version_deleted_newer" },
       ),
@@ -2009,7 +2052,7 @@ describe("OpenAI-compatible MCP tools", () => {
     // leaves it alone by choice, not because the store lacks it.
     await seedDocxFile("file_auxiliary");
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb(
         [],
         createExtractedContentRow({
@@ -2055,7 +2098,7 @@ describe("OpenAI-compatible MCP tools", () => {
   test("read_content_across_matters follows a persisted non-first DOCX source", async () => {
     await seedDocxFile("file_selected");
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb(
         [],
         createExtractedContentRow({
@@ -2101,7 +2144,7 @@ describe("OpenAI-compatible MCP tools", () => {
     await seedDocxFile("file_1");
     fake.failNext({ method: "GET", code: "InternalError", status: 500 });
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb([], createExtractedContentRow(), [
         {
           type: "file",
@@ -2126,7 +2169,7 @@ describe("OpenAI-compatible MCP tools", () => {
     await seedDocxFile("file_1");
     fake.failNext({ method: "GET", code: "InternalError", status: 500 });
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb([], createExtractedContentRow(), [
         {
           type: "file",
@@ -2170,7 +2213,7 @@ describe("OpenAI-compatible MCP tools", () => {
       });
     });
     const context = createContext({
-      accessibleWorkspaceIds: ["ws_1", "ws_3"],
+      accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_3],
       scopedDb: createScopedDb([], createExtractedContentRow(), [
         {
           type: "file",
@@ -2205,7 +2248,7 @@ describe("OpenAI-compatible MCP tools", () => {
       hits: [
         {
           entityId: "00000000-0000-4000-8000-0000000e0001",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
           name: "John Smith SPA",
         },
       ],
@@ -2222,7 +2265,7 @@ describe("OpenAI-compatible MCP tools", () => {
           {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             fieldId: "field_1",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
         ]),
       }),
@@ -2236,7 +2279,7 @@ describe("OpenAI-compatible MCP tools", () => {
         {
           id: "00000000-0000-4000-8000-0000000e0001",
           title: "[PERSON_1] SPA",
-          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+          url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
         },
       ],
     });
@@ -2244,7 +2287,7 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(anonymizeInput).toMatchObject({
       fields: ["John Smith SPA"],
       organizationId: toSafeId<"organization">("org_1"),
-      workspaceId: "ws_1",
+      workspaceId: WORKSPACE_ID,
     });
     // The egress pipeline resolves both catalogs for the workspaces its
     // payload names and hands them over pre-resolved, so the redactor holds
@@ -2256,7 +2299,7 @@ describe("OpenAI-compatible MCP tools", () => {
     });
     expect(loadGazetteerByWorkspaceMock).toHaveBeenCalledTimes(1);
     expect(loadGazetteerByWorkspaceMock.mock.calls.at(0)?.[0]).toMatchObject({
-      workspaceIds: ["ws_1"],
+      workspaceIds: [WORKSPACE_ID],
     });
   });
 
@@ -2265,12 +2308,12 @@ describe("OpenAI-compatible MCP tools", () => {
       hits: [
         {
           entityId: "00000000-0000-4000-8000-0000000e0001",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
           name: "John Smith SPA",
         },
         {
           entityId: "00000000-0000-4000-8000-0000000e0002",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
           name: "Jane Doe NDA",
         },
       ],
@@ -2287,12 +2330,12 @@ describe("OpenAI-compatible MCP tools", () => {
           {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             fieldId: "field_1",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
           {
             entityId: "00000000-0000-4000-8000-0000000e0002",
             fieldId: "field_2",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
         ]),
       }),
@@ -2306,19 +2349,19 @@ describe("OpenAI-compatible MCP tools", () => {
         {
           id: "00000000-0000-4000-8000-0000000e0001",
           title: "[PERSON_1] SPA",
-          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+          url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
         },
         {
           id: "00000000-0000-4000-8000-0000000e0002",
           title: "[PERSON_2] NDA",
-          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0002&field=field_2`,
+          url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0002&field=field_2`,
         },
       ],
     });
     expect(anonymizeTextFieldsMock).toHaveBeenCalledTimes(1);
     expect(anonymizeTextFieldsMock.mock.calls.at(0)?.[0]).toMatchObject({
       fields: ["John Smith SPA", "Jane Doe NDA"],
-      workspaceId: "ws_1",
+      workspaceId: WORKSPACE_ID,
     });
   });
 
@@ -2327,7 +2370,7 @@ describe("OpenAI-compatible MCP tools", () => {
       hits: [
         {
           entityId: "00000000-0000-4000-8000-0000000e0001",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
           name: "John Smith",
         },
       ],
@@ -2344,7 +2387,7 @@ describe("OpenAI-compatible MCP tools", () => {
           {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             fieldId: "field_1",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
         ]),
       }),
@@ -2358,7 +2401,7 @@ describe("OpenAI-compatible MCP tools", () => {
         {
           id: "00000000-0000-4000-8000-0000000e0001",
           title: "",
-          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+          url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
         },
       ],
     });
@@ -2369,7 +2412,7 @@ describe("OpenAI-compatible MCP tools", () => {
       hits: [
         {
           entityId: "00000000-0000-4000-8000-0000000e0001",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
           name: "John Smith",
         },
       ],
@@ -2386,7 +2429,7 @@ describe("OpenAI-compatible MCP tools", () => {
           {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             fieldId: "field_1",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
         ]),
       }),
@@ -2400,7 +2443,7 @@ describe("OpenAI-compatible MCP tools", () => {
         {
           id: "00000000-0000-4000-8000-0000000e0001",
           title: "[REDACTED]",
-          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+          url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
         },
       ],
     });
@@ -2434,7 +2477,7 @@ describe("OpenAI-compatible MCP tools", () => {
       id: "00000000-0000-4000-8000-0000000e0001",
       title: "[PERSON_1] SPA",
       text: "[PERSON_1] signed the agreement",
-      url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+      url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
       nextCursor: null,
       metadata: {
         anonymized: true,
@@ -2442,7 +2485,7 @@ describe("OpenAI-compatible MCP tools", () => {
         charCount: "[PERSON_1] signed the agreement".length,
         source: "stella",
         truncated: false,
-        workspaceId: "ws_1",
+        workspaceId: WORKSPACE_ID,
       },
     });
   });
@@ -2473,7 +2516,7 @@ describe("OpenAI-compatible MCP tools", () => {
       id: "00000000-0000-4000-8000-0000000e0001",
       title: "",
       text: "",
-      url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+      url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
       nextCursor: null,
       metadata: {
         anonymized: true,
@@ -2481,7 +2524,7 @@ describe("OpenAI-compatible MCP tools", () => {
         charCount: 0,
         source: "stella",
         truncated: false,
-        workspaceId: "ws_1",
+        workspaceId: WORKSPACE_ID,
       },
     });
   });
@@ -2512,7 +2555,7 @@ describe("OpenAI-compatible MCP tools", () => {
       id: "00000000-0000-4000-8000-0000000e0001",
       title: "[REDACTED]",
       text: "[REDACTED]",
-      url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
+      url: `${APP_BASE_URL}/workspaces/${WORKSPACE_ID}/all/pdf?entity=00000000-0000-4000-8000-0000000e0001&field=field_1`,
       nextCursor: null,
       metadata: {
         anonymized: true,
@@ -2520,7 +2563,7 @@ describe("OpenAI-compatible MCP tools", () => {
         charCount: "[REDACTED]".length,
         source: "stella",
         truncated: false,
-        workspaceId: "ws_1",
+        workspaceId: WORKSPACE_ID,
       },
     });
   });
@@ -2577,7 +2620,7 @@ describe("OpenAI-compatible MCP tools", () => {
                 findFirst: async () => ({
                   kind,
                   name: "Weekly sync",
-                  workspaceId: "ws_1",
+                  workspaceId: WORKSPACE_ID,
                 }),
               },
             },
@@ -2620,7 +2663,11 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_documents rejects flat mode combined with parent_id", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", mode: "flat", parent_id: "entity_folder" },
+      args: {
+        matter_id: WORKSPACE_ID,
+        mode: "flat",
+        parent_id: FOLDER_ENTITY_ID,
+      },
       context: createContext(),
       toolName: "list_documents",
     });
@@ -2648,7 +2695,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const result = await handleMcpToolCall({
       args: {
         entity_id: "00000000-0000-4000-8000-0000000e0001",
-        compare_with_version_id: "ver_base",
+        compare_with_version_id: BASE_VERSION_ID,
       },
       context: createContext(),
       toolName: "read_document",
@@ -2679,7 +2726,7 @@ describe("OpenAI-compatible MCP tools", () => {
           entityId: "00000000-0000-4000-8000-0000000e0001",
           kind: "document",
           name: "Fresh Agreement",
-          workspaceId: "ws_1",
+          workspaceId: WORKSPACE_ID,
         }),
       }),
       toolName: "read_document",
@@ -2722,7 +2769,7 @@ describe("OpenAI-compatible MCP tools", () => {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             kind: "document",
             name: "Corrupt Agreement",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
           {
             runs: [
@@ -2789,7 +2836,7 @@ describe("OpenAI-compatible MCP tools", () => {
             capability: "entities.ocr.create",
             input: {
               params: {
-                matterId: "ws_1",
+                matterId: WORKSPACE_ID,
                 entityId: "00000000-0000-4000-8000-0000000e0001",
               },
               body: { fieldId: "field_1" },
@@ -2972,7 +3019,7 @@ describe("OpenAI-compatible MCP tools", () => {
               entityId: "00000000-0000-4000-8000-0000000e0001",
               kind: "document",
               name: "Scan",
-              workspaceId: "ws_1",
+              workspaceId: WORKSPACE_ID,
             },
             {
               runs: [
@@ -3080,7 +3127,7 @@ describe("OpenAI-compatible MCP tools", () => {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             kind: "document",
             name: "Scan",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
           {
             runs: [
@@ -3145,7 +3192,7 @@ describe("OpenAI-compatible MCP tools", () => {
               entityId: "00000000-0000-4000-8000-0000000e0001",
               kind: "document",
               name: "Scan",
-              workspaceId: "ws_1",
+              workspaceId: WORKSPACE_ID,
             },
             {
               documentProcessingMode: "off",
@@ -3225,7 +3272,7 @@ describe("OpenAI-compatible MCP tools", () => {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             kind: "document",
             name: "Current PDF",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
           {
             runs: [
@@ -3290,7 +3337,7 @@ describe("OpenAI-compatible MCP tools", () => {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             kind: "document",
             name: "Current PDF",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
           {
             runs: [
@@ -3353,7 +3400,7 @@ describe("OpenAI-compatible MCP tools", () => {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             kind: "document",
             name: "Searchable PDF",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
           {
             runs: [
@@ -3408,7 +3455,7 @@ describe("OpenAI-compatible MCP tools", () => {
             entityId: "00000000-0000-4000-8000-0000000e0001",
             kind: "document",
             name: "Binary payload",
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           },
           {
             searchUpdatedAt: new Date("2026-01-02T00:00:00.000Z"),
@@ -3430,20 +3477,21 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_properties declares how file and scalar properties are written", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1" },
+      args: { matter_id: WORKSPACE_ID },
       context: createContext({
+        accessibleWorkspaceIds: [WORKSPACE_ID],
         scopedDb: createScopedDb([
           {
             content: { type: "file", version: 1 },
             createdAt: "2026-01-01T00:00:00.000000",
-            id: "property_file",
+            id: FILE_PROPERTY_ID,
             name: "Documents",
             status: "fresh",
           },
           {
             content: { type: "text", version: 1 },
             createdAt: "2026-01-02T00:00:00.000000",
-            id: "property_text",
+            id: TEXT_PROPERTY_ID,
             name: "Summary",
             status: "fresh",
           },
@@ -3455,12 +3503,12 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(parseToolPayload(result)).toMatchObject({
       properties: [
         {
-          id: "property_file",
+          id: FILE_PROPERTY_ID,
           valueType: "file",
           writeMethod: "unsupported",
         },
         {
-          id: "property_text",
+          id: TEXT_PROPERTY_ID,
           valueType: "text",
           writeMethod: "set_field_value",
         },
@@ -3472,7 +3520,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const result = await handleMcpToolCall({
       args: {
         entity_id: "00000000-0000-4000-8000-0000000e0001",
-        property_id: "property_file",
+        property_id: FILE_PROPERTY_ID,
         content: { type: "file", value: "not-supported" },
       },
       context: createContext(),
@@ -3511,7 +3559,7 @@ describe("OpenAI-compatible MCP tools", () => {
       args: {
         entity_id: "00000000-0000-4000-8000-0000000e0001",
         move_to_root: true,
-        parent_id: "entity_folder",
+        parent_id: FOLDER_ENTITY_ID,
       },
       context: createContext(),
       toolName: "save_document",
@@ -3543,7 +3591,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const result = await handleMcpToolCall({
       args: {
         entity_id: "00000000-0000-4000-8000-0000000e0001",
-        matter_id: "ws_1",
+        matter_id: WORKSPACE_ID,
         name: "Renamed",
       },
       context: createContext(),
@@ -3558,7 +3606,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_matters rejects matter_id combined with a list filter", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", limit: 10 },
+      args: { matter_id: WORKSPACE_ID, limit: 10 },
       context: createContext(),
       toolName: "list_matters",
     });
@@ -3606,7 +3654,7 @@ describe("OpenAI-compatible MCP tools", () => {
                 kind: "document",
                 name: "Secret Doc for John Smith",
                 updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-                workspaceId: "ws_1",
+                workspaceId: WORKSPACE_ID,
                 extractedContent: null,
                 currentVersion: {
                   createdAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -3674,7 +3722,7 @@ describe("OpenAI-compatible MCP tools", () => {
         "Draft by John Smith",
         "Note authored by John Smith",
       ],
-      workspaceId: "ws_1",
+      workspaceId: WORKSPACE_ID,
     });
 
     expect(parseToolPayload(result)).toMatchObject({
@@ -3708,8 +3756,8 @@ describe("OpenAI-compatible MCP tools", () => {
   // rejected before any backing handler runs.
   test("save_matter rejects a write to an archived matter", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", name: "Renamed" },
-      context: createContext({ archivedWorkspaceIds: ["ws_1"] }),
+      args: { matter_id: WORKSPACE_ID, name: "Renamed" },
+      context: createContext({ archivedWorkspaceIds: [WORKSPACE_ID] }),
       toolName: "save_matter",
     });
 
@@ -3729,7 +3777,7 @@ describe("OpenAI-compatible MCP tools", () => {
         const builder = {
           set: () => builder,
           where: () => builder,
-          returning: async () => [{ id: "ws_1" }],
+          returning: async () => [{ id: WORKSPACE_ID }],
         };
         return await callback({ update: () => builder });
       }),
@@ -3737,9 +3785,9 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("save_matter allows unarchiving an archived matter", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", status: "active" },
+      args: { matter_id: WORKSPACE_ID, status: "active" },
       context: createContext({
-        archivedWorkspaceIds: ["ws_1"],
+        archivedWorkspaceIds: [WORKSPACE_ID],
         scopedDb: createWorkspaceUnarchiveScopedDb(),
       }),
       toolName: "save_matter",
@@ -3747,7 +3795,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     expect(result.isError).toBeUndefined();
     expect(parseToolPayload(result)).toEqual({
-      matterId: "ws_1",
+      matterId: WORKSPACE_ID,
       updated: true,
     });
   });
@@ -3833,7 +3881,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_contacts returns internal directory IDs from the shared query", async () => {
     const contact = {
-      id: "contact_1",
+      id: CONTACT_ID,
       type: "organization",
       displayName: "Acme Corp",
       firstName: null,
@@ -3854,7 +3902,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     expect(result.isError).toBeUndefined();
     expect(parseToolPayload(result)).toMatchObject({
-      items: [{ id: "contact_1" }],
+      items: [{ id: CONTACT_ID }],
     });
   });
 
@@ -3903,7 +3951,7 @@ describe("OpenAI-compatible MCP tools", () => {
           await callback({
             query: {
               entities: {
-                findFirst: async () => ({ kind, workspaceId: "ws_1" }),
+                findFirst: async () => ({ kind, workspaceId: WORKSPACE_ID }),
               },
             },
           }),
@@ -3912,7 +3960,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("list_tasks rejects a task_id that is not a task", async () => {
     const result = await handleMcpToolCall({
-      args: { task_id: "entity_doc" },
+      args: { task_id: DOCUMENT_ENTITY_ID },
       context: createContext({ scopedDb: createTaskKindScopedDb("document") }),
       toolName: "list_tasks",
     });
@@ -3925,7 +3973,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("save_task rejects a task_id that is not a task", async () => {
     const result = await handleMcpToolCall({
-      args: { task_id: "entity_doc", name: "Renamed" },
+      args: { task_id: DOCUMENT_ENTITY_ID, name: "Renamed" },
       context: createContext({ scopedDb: createTaskKindScopedDb("document") }),
       toolName: "save_task",
     });
@@ -3942,7 +3990,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const result = await handleMcpToolCall({
       args: {
         task_id: "00000000-0000-4000-8000-00000007a001",
-        matter_id: "ws_2",
+        matter_id: WORKSPACE_ID_2,
         name: "Renamed",
       },
       context: createContext({ scopedDb: createTaskKindScopedDb("task") }),
@@ -3962,10 +4010,10 @@ describe("OpenAI-compatible MCP tools", () => {
     const result = await handleMcpToolCall({
       args: {
         task_id: "00000000-0000-4000-8000-00000007a001",
-        matter_id: "ws_2",
+        matter_id: WORKSPACE_ID_2,
       },
       context: createContext({
-        accessibleWorkspaceIds: ["ws_1", "ws_2"],
+        accessibleWorkspaceIds: [WORKSPACE_ID, WORKSPACE_ID_2],
         scopedDb: createTaskKindScopedDb("task"),
       }),
       toolName: "list_tasks",
@@ -4003,7 +4051,10 @@ describe("OpenAI-compatible MCP tools", () => {
           await callback({
             query: {
               entities: {
-                findFirst: async () => ({ kind: "task", workspaceId: "ws_1" }),
+                findFirst: async () => ({
+                  kind: "task",
+                  workspaceId: WORKSPACE_ID,
+                }),
               },
               entityLinks: {
                 findFirst: async () => ({
@@ -4020,7 +4071,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const result = await handleMcpToolCall({
       args: {
         task_id: "00000000-0000-4000-8000-00000007a001",
-        unlink_link_id: "link_1",
+        unlink_link_id: ENTITY_LINK_ID,
       },
       context: createContext({ scopedDb: createUnlinkMismatchScopedDb() }),
       toolName: "save_task",
@@ -4069,7 +4120,7 @@ describe("OpenAI-compatible MCP tools", () => {
                 findFirst: async () => ({
                   kind: "task",
                   readOnly: false,
-                  workspaceId: "ws_1",
+                  workspaceId: WORKSPACE_ID,
                 }),
               },
               entityLinks: {
@@ -4146,7 +4197,7 @@ describe("OpenAI-compatible MCP tools", () => {
           findFirst: async () => ({
             kind: "task",
             readOnly: false,
-            workspaceId: "ws_1",
+            workspaceId: WORKSPACE_ID,
           }),
         },
       },
@@ -4157,7 +4208,7 @@ describe("OpenAI-compatible MCP tools", () => {
               for: async () => [
                 {
                   entityId: "00000000-0000-4000-8000-00000007a001",
-                  workspaceId: "ws_1",
+                  workspaceId: WORKSPACE_ID,
                   type: "task",
                   status: WORK_OBLIGATION_STATUS.CANCELLED,
                   ownerUserId: null,
@@ -4246,7 +4297,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("link_matter_contact rejects an ambiguous contact_id unlink", async () => {
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1", contact_id: "contact_1" },
+      args: { matter_id: WORKSPACE_ID, contact_id: CONTACT_ID },
       context: createContext({ scopedDb: createMultiRoleContactScopedDb() }),
       toolName: "link_matter_contact",
     });
@@ -4286,7 +4337,7 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1" },
+      args: { matter_id: WORKSPACE_ID },
       context: createContext({
         scopedDb: createSelectListScopedDb([
           {
@@ -4306,7 +4357,7 @@ describe("OpenAI-compatible MCP tools", () => {
     const anonymizeInput = anonymizeTextFieldsMock.mock.calls.at(-1)?.[0];
     expect(anonymizeInput).toMatchObject({
       fields: ["John Smith deposition"],
-      workspaceId: "ws_1",
+      workspaceId: WORKSPACE_ID,
     });
 
     expect(parseToolPayload(result)).toEqual({
@@ -4335,11 +4386,11 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     const result = await handleMcpToolCall({
-      args: { matter_id: "ws_1" },
+      args: { matter_id: WORKSPACE_ID },
       context: createContext({
         scopedDb: createSelectListScopedDb([
           {
-            id: "te_1",
+            id: TIME_ENTRY_ID,
             entityId: "00000000-0000-4000-8000-0000000e0001",
             userId: null,
             dateWorked: "2026-02-01",
@@ -4362,14 +4413,14 @@ describe("OpenAI-compatible MCP tools", () => {
     const anonymizeInput = anonymizeTextFieldsMock.mock.calls.at(-1)?.[0];
     expect(anonymizeInput).toMatchObject({
       fields: ["Call with John Smith"],
-      workspaceId: "ws_1",
+      workspaceId: WORKSPACE_ID,
     });
 
     expect(parseToolPayload(result)).toEqual({
       visibility: "all_entries",
       entries: [
         {
-          id: "te_1",
+          id: TIME_ENTRY_ID,
           entityId: "00000000-0000-4000-8000-0000000e0001",
           userId: null,
           userName: null,
@@ -4394,7 +4445,7 @@ describe("OpenAI-compatible MCP tools", () => {
   // the cross-field schema rejects it before touching the database.
   test("save_time_entry rejects an update with no changes", async () => {
     const result = await handleMcpToolCall({
-      args: { time_entry_id: "te_1" },
+      args: { time_entry_id: TIME_ENTRY_ID },
       context: createContext(),
       toolName: "save_time_entry",
     });
@@ -4470,7 +4521,7 @@ describe("OpenAI-compatible MCP tools", () => {
         const recordAuditEvent = createRecordAuditEventMock();
         const result = await handleMcpToolCall({
           args: {
-            matter_id: "ws_1",
+            matter_id: WORKSPACE_ID,
             entity_id: "00000000-0000-4000-8000-0000000e0001",
             date_worked: "2026-02-01",
             timezone_id: "Europe/Prague",
@@ -4634,7 +4685,7 @@ describe("undeclared-argument backstop", () => {
   test("accepts exactly the declared keys", () => {
     expect(
       findUndeclaredArguments({
-        args: { matter_id: "ws_1", limit: 10 },
+        args: { matter_id: WORKSPACE_ID, limit: 10 },
         inputSchema: fakeToolSchema,
       }),
     ).toBeUndefined();
@@ -4643,7 +4694,7 @@ describe("undeclared-argument backstop", () => {
   test("names every undeclared key, with a did-you-mean for case/underscore slips", () => {
     expect(
       findUndeclaredArguments({
-        args: { matter_id: "ws_1", matterId: "ws_1", bogus: 1 },
+        args: { matter_id: WORKSPACE_ID, matterId: WORKSPACE_ID, bogus: 1 },
         inputSchema: fakeToolSchema,
       }),
     ).toEqual({
@@ -4678,7 +4729,7 @@ describe("undeclared-argument backstop", () => {
 
   test("dispatch rejects an undeclared key before the handler runs", async () => {
     const result = await handleMcpToolCall({
-      args: { matterId: "ws_1" },
+      args: { matterId: WORKSPACE_ID },
       context: createContext(),
       toolName: "list_matters",
     });

--- a/apps/api/src/mcp/uuid-id-inputs.test.ts
+++ b/apps/api/src/mcp/uuid-id-inputs.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions";
+import {
+  describeTemplateArgsSchema,
+  fillTemplateArgsSchema,
+  saveFilledTemplateArgsSchema,
+} from "@/api/mcp/template-tools";
 
 /**
  * Every id a tool accepts is either a UUID this codebase mints or one of the
@@ -15,9 +20,12 @@ import { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions"
  * property named `id` or ending in `_id`. For a `defineValibotMcpTool` tool
  * the advertised schema is projected from the `v.strictObject` its handler
  * parses, so the assertion binds the runtime validator, not a mirror of it.
- * The remaining hand-written schemas (the decreasing legacy list in
- * `static-tool-definitions.ts`) must keep their validator in step by hand
- * until they migrate.
+ *
+ * The tools on the decreasing legacy list in `static-tool-definitions.ts` still
+ * advertise a hand-written schema alongside that validator, so the advertised
+ * side alone would let a one-sided edit ship a contract the handler does not
+ * enforce. `LEGACY_MANUAL_INPUT_VALIDATORS` binds the two, in both directions,
+ * until those tools migrate.
  */
 const NON_UUID_ID_INPUTS: Record<string, string> = {
   // Auth-provider (better-auth) user ids are alphanumeric text, and the
@@ -80,6 +88,36 @@ const declaresUuid = (schema: unknown): boolean => {
   return false;
 };
 
+/**
+ * The validator each legacy tool's handler actually parses, keyed by tool name.
+ * `list_templates` reaches its detail branch through `describeTemplateArgsSchema`.
+ */
+const LEGACY_MANUAL_INPUT_VALIDATORS = {
+  list_templates: describeTemplateArgsSchema,
+  fill_template: fillTemplateArgsSchema,
+  save_filled_template: saveFilledTemplateArgsSchema,
+};
+
+/**
+ * True when a Valibot schema enforces a uuid on the value it accepts: a `uuid`
+ * action anywhere in its pipe, through any `optional`/`nullable` wrapper. This
+ * reads the schema the handler runs, so it is evidence of enforcement rather
+ * than of what the tool advertises.
+ */
+const validatorEnforcesUuid = (schema: unknown): boolean => {
+  if (!isRecord(schema)) {
+    return false;
+  }
+  if (schema["kind"] === "validation" && schema["type"] === "uuid") {
+    return true;
+  }
+  const pipe = schema["pipe"];
+  if (Array.isArray(pipe) && pipe.some(validatorEnforcesUuid)) {
+    return true;
+  }
+  return validatorEnforcesUuid(schema["wrapped"]);
+};
+
 /** Every id-named property in an advertised schema, at any nesting depth. */
 const collectIdProperties = (
   schema: unknown,
@@ -140,6 +178,47 @@ describe("MCP id inputs are validated as UUIDs", () => {
     expect(
       stale,
       `These NON_UUID_ID_INPUTS entries name inputs the registry no longer advertises: ${stale.join(", ")}. Remove them so the exception list cannot outlive its reason.`,
+    ).toEqual([]);
+  });
+
+  test("a hand-written schema cannot advertise a uuid its validator omits", () => {
+    const mismatches: string[] = [];
+    for (const [toolName, validator] of Object.entries(
+      LEGACY_MANUAL_INPUT_VALIDATORS,
+    )) {
+      const tool = DEFAULT_MCP_TOOL_DEFINITIONS.find(
+        ({ name }) => name === toolName,
+      );
+      if (tool === undefined) {
+        throw new Error(`${toolName} is no longer a registered tool`);
+      }
+      const advertised: { path: string; schema: unknown }[] = [];
+      collectIdProperties(tool.inputSchema, toolName, advertised);
+      for (const { path, schema } of advertised) {
+        const key = path.slice(`${toolName}.`.length);
+        if (declaresUuid(schema) !== validatorEnforcesUuid(validator.entries[key])) {
+          mismatches.push(path);
+        }
+      }
+    }
+
+    expect(
+      mismatches,
+      `The advertised schema and the validator its handler parses disagree on whether these ids are uuids: ${mismatches.join(", ")}. Both sides are hand-written for these tools, so change them together, or move the tool to defineValibotMcpTool so the advertised schema is projected from the validator.`,
+    ).toEqual([]);
+  });
+
+  test("every hand-written schema carrying an id is bound to its validator", () => {
+    const unbound = DEFAULT_MCP_TOOL_DEFINITIONS.filter(
+      (tool) =>
+        !("inputSchemaSource" in tool) &&
+        !(tool.name in LEGACY_MANUAL_INPUT_VALIDATORS) &&
+        idProperties.some(({ path }) => path.startsWith(`${tool.name}.`)),
+    ).map(({ name }) => name);
+
+    expect(
+      unbound,
+      `These tools advertise a hand-written schema with an id input but no validator to bind it to: ${unbound.join(", ")}. Add the validator to LEGACY_MANUAL_INPUT_VALIDATORS, or define the tool with defineValibotMcpTool.`,
     ).toEqual([]);
   });
 

--- a/apps/api/src/mcp/uuid-id-inputs.test.ts
+++ b/apps/api/src/mcp/uuid-id-inputs.test.ts
@@ -196,7 +196,10 @@ describe("MCP id inputs are validated as UUIDs", () => {
       collectIdProperties(tool.inputSchema, toolName, advertised);
       for (const { path, schema } of advertised) {
         const key = path.slice(`${toolName}.`.length);
-        if (declaresUuid(schema) !== validatorEnforcesUuid(validator.entries[key])) {
+        const validatorEntry = Object.entries(validator.entries)
+          .find(([name]) => name === key)
+          ?.at(1);
+        if (declaresUuid(schema) !== validatorEnforcesUuid(validatorEntry)) {
           mismatches.push(path);
         }
       }

--- a/apps/api/src/mcp/uuid-id-inputs.test.ts
+++ b/apps/api/src/mcp/uuid-id-inputs.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions";
+
+/**
+ * Every id a tool accepts is either a UUID this codebase mints or one of the
+ * few identifiers that are deliberately not. The first kind reaches SQL as a
+ * `uuid` column, so an unvalidated one fails in Postgres (22P02) and surfaces
+ * as `internal_error` with a captured DrizzleQueryError, instead of the
+ * `validation_error` naming the field that the caller can act on. Declaring
+ * the format also tells a client what shape to send before it sends it.
+ *
+ * This walks the advertised input schema of every registered tool -- the same
+ * definitions `tools/list` serializes -- and requires a uuid check on every
+ * property named `id` or ending in `_id`. For a `defineValibotMcpTool` tool
+ * the advertised schema is projected from the `v.strictObject` its handler
+ * parses, so the assertion binds the runtime validator, not a mirror of it.
+ * The remaining hand-written schemas (the decreasing legacy list in
+ * `static-tool-definitions.ts`) must keep their validator in step by hand
+ * until they migrate.
+ */
+const NON_UUID_ID_INPUTS: Record<string, string> = {
+  // Auth-provider (better-auth) user ids are alphanumeric text, and the
+  // columns that hold them are `text`/`varchar`, never `uuid`.
+  "list_time_entries.user_id": "better-auth user id (text column)",
+  "resolve_rate.user_id": "better-auth user id (text column)",
+  "save_task.add_assignee_user_id": "better-auth user id (text column)",
+  "save_task.remove_assignee_user_id": "better-auth user id (text column)",
+  "list_audit_log.user_id": "better-auth user id (text column)",
+  "manage_organization.user_id": "better-auth user id (text column)",
+  // The audit log records one text `resource_id` for every resource type it
+  // audits, including the text user ids above.
+  "list_audit_log.resource_id":
+    "audit-log resource id of any type (text column)",
+  // An IANA time zone name (`Europe/Prague`), not an id this codebase mints.
+  "save_time_entry.timezone_id": "IANA time zone name",
+  // External statute-corpus identifiers, fetched over HTTP and never stored:
+  // already shape-checked by their own regexes (e.g. `BOE-A-1889-4763`).
+  "search_legislation.law_id": "external statute corpus identifier",
+  "search_legislation.block_id": "external statute text-block identifier",
+  // A host-assigned reference from the MCP client's file payload, used only
+  // as a display-name fallback.
+  "upload_document_version.file.file_id": "host-assigned client file reference",
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isIdProperty = (name: string): boolean =>
+  name === "id" || name.endsWith("_id");
+
+/**
+ * True when a property schema constrains its string to a UUID. A nullable or
+ * unioned id (`anyOf: [{ format: "uuid" }, { type: "null" }]`) counts only if
+ * every branch that can hold a string is itself uuid-constrained, so one
+ * unconstrained branch cannot smuggle a raw string through.
+ */
+const declaresUuid = (schema: unknown): boolean => {
+  if (!isRecord(schema)) {
+    return false;
+  }
+  if (schema["format"] === "uuid") {
+    return true;
+  }
+  for (const keyword of ["anyOf", "allOf", "oneOf"] as const) {
+    const branches = schema[keyword];
+    if (!Array.isArray(branches) || branches.length === 0) {
+      continue;
+    }
+    const stringBranches = branches.filter(
+      (branch) => !(isRecord(branch) && branch["type"] === "null"),
+    );
+    if (
+      stringBranches.length > 0 &&
+      stringBranches.every((branch) => declaresUuid(branch))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/** Every id-named property in an advertised schema, at any nesting depth. */
+const collectIdProperties = (
+  schema: unknown,
+  path: string,
+  found: { path: string; schema: unknown }[],
+): void => {
+  if (!isRecord(schema)) {
+    return;
+  }
+  if (isRecord(schema["properties"])) {
+    for (const [key, property] of Object.entries(schema["properties"])) {
+      const propertyPath = `${path}.${key}`;
+      if (isIdProperty(key)) {
+        found.push({ path: propertyPath, schema: property });
+      }
+      collectIdProperties(property, propertyPath, found);
+    }
+  }
+  collectIdProperties(schema["items"], `${path}[]`, found);
+  for (const keyword of ["anyOf", "allOf", "oneOf"] as const) {
+    const branches = schema[keyword];
+    if (!Array.isArray(branches)) {
+      continue;
+    }
+    for (const branch of branches) {
+      collectIdProperties(branch, path, found);
+    }
+  }
+};
+
+const idProperties = DEFAULT_MCP_TOOL_DEFINITIONS.flatMap((tool) => {
+  const found: { path: string; schema: unknown }[] = [];
+  collectIdProperties(tool.inputSchema, tool.name, found);
+  return found;
+});
+
+describe("MCP id inputs are validated as UUIDs", () => {
+  test("every id input either validates as a uuid or is a declared exception", () => {
+    const unvalidated = idProperties
+      .filter(
+        ({ path, schema }) =>
+          NON_UUID_ID_INPUTS[path] === undefined && !declaresUuid(schema),
+      )
+      .map(({ path }) => path);
+
+    expect(
+      unvalidated,
+      `These id inputs reach SQL without a uuid check, so a malformed value fails as a Postgres cast error reported as internal_error: ${unvalidated.join(", ")}. Declare each with uuidInputSchema(...) from tool-utils, or add it to NON_UUID_ID_INPUTS with the reason it is not a uuid.`,
+    ).toEqual([]);
+  });
+
+  test("no declared exception outlives the input it exempts", () => {
+    const advertised = new Set(idProperties.map(({ path }) => path));
+    const stale = Object.keys(NON_UUID_ID_INPUTS).filter(
+      (path) => !advertised.has(path),
+    );
+
+    expect(
+      stale,
+      `These NON_UUID_ID_INPUTS entries name inputs the registry no longer advertises: ${stale.join(", ")}. Remove them so the exception list cannot outlive its reason.`,
+    ).toEqual([]);
+  });
+
+  test("the registry advertises id inputs at all", () => {
+    // Guards the walk itself: a projection change that stopped exposing
+    // properties would make both checks above pass vacuously.
+    expect(idProperties.length).toBeGreaterThan(30);
+  });
+});

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -909,7 +909,7 @@ describe("help surfaces --input for inputOnly tools", () => {
     expect(result.stdout).toContain("require_complete");
     expect(result.stdout).toContain("allow_partial");
     expect(result.stdout).toContain(
-      `--input '{"template_id":"xxxxx","values":{"key":"value"}}'`,
+      `--input '{"template_id":"00000000-0000-4000-8000-000000000000","values":{"key":"value"}}'`,
     );
   });
 
@@ -993,7 +993,7 @@ describe("template fill strictness policies", () => {
         "template",
         "fill",
         "--template-id",
-        "template-1",
+        "11111111-1111-4111-8111-111111111111",
         "--input",
         '{"values":{"typo":"value"}}',
       ],
@@ -1019,7 +1019,7 @@ describe("template fill strictness policies", () => {
         "template",
         "fill",
         "--template-id",
-        "template-1",
+        "11111111-1111-4111-8111-111111111111",
         "--input",
         '{"values":{"intentional":"value"}}',
         "--allow-unused-values",
@@ -1032,7 +1032,7 @@ describe("template fill strictness policies", () => {
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual(fillPayload);
     expect(server.requests.at(0)?.params.arguments).toEqual({
-      template_id: "template-1",
+      template_id: "11111111-1111-4111-8111-111111111111",
       values: { intentional: "value" },
       allow_unused_values: true,
     });
@@ -1050,7 +1050,7 @@ describe("template fill strictness policies", () => {
         "template",
         "fill",
         "--template-id",
-        "template-1",
+        "11111111-1111-4111-8111-111111111111",
         "--input",
         '{"values":{"name":"ACME"}}',
         "--completion-mode",
@@ -1063,7 +1063,7 @@ describe("template fill strictness policies", () => {
 
     expect(result.exitCode).toBe(0);
     expect(server.requests.at(0)?.params.arguments).toEqual({
-      template_id: "template-1",
+      template_id: "11111111-1111-4111-8111-111111111111",
       values: { name: "ACME" },
       completion_mode: "allow_partial",
     });
@@ -1073,7 +1073,10 @@ describe("template fill strictness policies", () => {
 describe("template persistence discriminator split", () => {
   test("requires template consent as well as document-write consent", async () => {
     const server = startMockServer(() => ({
-      toolPayload: { entityId: "entity_1", versionNumber: 2 },
+      toolPayload: {
+        entityId: "33333333-3333-4333-8333-333333333333",
+        versionNumber: 2,
+      },
     }));
     const result = await runCli({
       args: [
@@ -1081,11 +1084,11 @@ describe("template persistence discriminator split", () => {
         "save-filled",
         "new-version",
         "--template-id",
-        "template_1",
+        "11111111-1111-4111-8111-111111111111",
         "--matter-id",
-        "workspace_1",
+        "22222222-2222-4222-8222-222222222222",
         "--entity-id",
-        "entity_1",
+        "33333333-3333-4333-8333-333333333333",
         "--idempotency-key",
         "retry_1",
         "--input",
@@ -1106,7 +1109,10 @@ describe("template persistence discriminator split", () => {
 
   test("new-version injects the destination and forwards values through --input", async () => {
     const server = startMockServer(() => ({
-      toolPayload: { entityId: "entity_1", versionNumber: 2 },
+      toolPayload: {
+        entityId: "33333333-3333-4333-8333-333333333333",
+        versionNumber: 2,
+      },
     }));
     const result = await runCli({
       args: [
@@ -1114,11 +1120,11 @@ describe("template persistence discriminator split", () => {
         "save-filled",
         "new-version",
         "--template-id",
-        "template_1",
+        "11111111-1111-4111-8111-111111111111",
         "--matter-id",
-        "workspace_1",
+        "22222222-2222-4222-8222-222222222222",
         "--entity-id",
-        "entity_1",
+        "33333333-3333-4333-8333-333333333333",
         "--idempotency-key",
         "retry_1",
         "--input",
@@ -1133,9 +1139,9 @@ describe("template persistence discriminator split", () => {
     expect(server.requests.at(0)?.params.name).toBe("save_filled_template");
     expect(server.requests.at(0)?.params.arguments).toEqual({
       action: "create_version",
-      template_id: "template_1",
-      matter_id: "workspace_1",
-      entity_id: "entity_1",
+      template_id: "11111111-1111-4111-8111-111111111111",
+      matter_id: "22222222-2222-4222-8222-222222222222",
+      entity_id: "33333333-3333-4333-8333-333333333333",
       idempotency_key: "retry_1",
       values: { "tenant.name": "ACME" },
     });

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -47,7 +47,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document/entity ID"
         },
         "cursor": {
@@ -80,7 +80,7 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to return a single matter's overview; omit to list matters"
         },
         "status": {
@@ -199,7 +199,7 @@
         },
         "source_id": {
           "type": "string",
-          "maxLength": 36,
+          "format": "uuid",
           "description": "Filter by source ID"
         },
         "date_from": {
@@ -267,7 +267,7 @@
       "properties": {
         "decision_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Case-law decision ID"
         },
         "cursor": {
@@ -298,7 +298,7 @@
       "properties": {
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID"
         }
       }
@@ -617,6 +617,7 @@
       "properties": {
         "template_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Template id to describe its fields in detail; omit to list templates"
         },
         "cursor": {
@@ -645,6 +646,7 @@
       "properties": {
         "template_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Template id, as returned by list_templates"
         },
         "values": {
@@ -732,18 +734,22 @@
         },
         "template_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Template id, as returned by list_templates"
         },
         "matter_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Matter receiving the filled DOCX."
         },
         "entity_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Existing document entity id; required only for create_version"
         },
         "parent_id": {
           "type": "string",
+          "format": "uuid",
           "description": "Folder entity id for a new document; valid only for create_document"
         },
         "name": {
@@ -791,7 +797,7 @@
       "properties": {
         "template_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Template to configure; omit when creating"
         },
         "name": {
@@ -1173,7 +1179,7 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list documents in."
         },
         "mode": {
@@ -1183,7 +1189,7 @@
         },
         "parent_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Folder entity ID whose direct children to list. Only valid in children mode; supplying it selects children mode when mode is omitted and is rejected together with mode 'flat'."
         },
         "limit": {
@@ -1224,12 +1230,12 @@
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Return this version's metadata and field values instead of the current version"
         },
         "compare_with_version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "With version_id, return a plain-text line diff of this version (base) against version_id (target)"
         },
         "include_versions": {
@@ -1263,12 +1269,12 @@
       "properties": {
         "entity_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Document entity ID to update; omit to create"
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to create the entity in; required when creating."
         },
         "name": {
@@ -1279,7 +1285,7 @@
         },
         "parent_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Folder entity ID: to place the new entity inside when creating, or to move the document into when updating"
         },
         "kind": {
@@ -1293,7 +1299,7 @@
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Version ID to annotate; required when setting label or description. Only valid when updating."
         },
         "label": {
@@ -1426,7 +1432,7 @@
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Delete only this version instead of the whole document"
         },
         "confirm": {
@@ -1457,7 +1463,7 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list properties for."
         },
         "limit": {
@@ -1498,7 +1504,7 @@
         },
         "property_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Property ID, as returned by list_properties"
         },
         "content": {
@@ -1640,7 +1646,7 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to update; omit to create a new matter"
         },
         "name": {
@@ -1651,7 +1657,7 @@
         },
         "client_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID to attach in the client role. Only valid when creating a matter."
         },
         "reference": {
@@ -1699,7 +1705,7 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to delete"
         },
         "confirm": {
@@ -1770,7 +1776,7 @@
       "properties": {
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID to update; omit to create"
         },
         "type": {
@@ -1853,7 +1859,7 @@
       "properties": {
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID to delete"
         },
         "confirm": {
@@ -1928,12 +1934,12 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list tasks in; required unless task_id is given."
         },
         "task_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Task entity ID to read in detail"
         },
         "date_from": {
@@ -1987,12 +1993,12 @@
       "properties": {
         "task_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Task entity ID to update; omit to create"
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to create the task in; required when creating."
         },
         "name": {
@@ -2069,12 +2075,12 @@
         },
         "link_entity_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Entity ID to link to the task (document, folder, or another task)"
         },
         "unlink_link_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Entity-link ID to remove"
         }
       }
@@ -2129,12 +2135,12 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID"
         },
         "contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Contact ID: with role to link the contact, or alone to unlink it from the matter"
         },
         "role": {
@@ -2154,7 +2160,7 @@
         },
         "matter_contact_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Existing matter-contact link ID to remove, from list_matters"
         }
       }
@@ -2181,17 +2187,17 @@
       "properties": {
         "clause_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Clause id to read in detail; omit to list"
         },
         "version_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "With clause_id, return this version's body instead of the current clause"
         },
         "category_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "List only clauses filed under this category (list mode)"
         },
         "query": {
@@ -2236,7 +2242,7 @@
       "properties": {
         "clause_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Clause id to update; omit to create"
         },
         "title": {
@@ -2318,7 +2324,7 @@
           "anyOf": [
             {
               "type": "string",
-              "minLength": 1
+              "format": "uuid"
             },
             {
               "type": "null"
@@ -2401,7 +2407,7 @@
       "properties": {
         "clause_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Clause id to delete"
         },
         "confirm": {
@@ -2433,7 +2439,7 @@
       "properties": {
         "playbook_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Playbook id to read in detail; omit to list playbooks"
         },
         "limit": {
@@ -2469,12 +2475,12 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to run the playbook over."
         },
         "playbook_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Playbook id to run"
         }
       }
@@ -2501,12 +2507,12 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list time entries in; required unless time_entry_id is given."
         },
         "time_entry_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Time entry ID to read in detail"
         },
         "entity_id": {
@@ -2569,12 +2575,12 @@
       "properties": {
         "time_entry_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Time entry ID to update; omit to create"
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to create the entry in; required when creating."
         },
         "entity_id": {
@@ -2678,7 +2684,7 @@
       "properties": {
         "time_entry_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Time entry ID to delete or write off"
         },
         "confirm": {
@@ -2708,7 +2714,7 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to resolve the rate in."
         },
         "user_id": {
@@ -2746,12 +2752,12 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID to list invoices in; required unless invoice_id is given."
         },
         "invoice_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Invoice ID to read in detail"
         },
         "limit": {
@@ -2898,7 +2904,7 @@
       "properties": {
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Only entries scoped to this matter."
         },
         "action": {
@@ -2995,7 +3001,7 @@
         },
         "matter_id": {
           "type": "string",
-          "minLength": 1,
+          "format": "uuid",
           "description": "Matter ID for add_member and remove_member."
         },
         "user_id": {

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -53,7 +53,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to return a single matter's overview; omit to list matters",
                 },
@@ -152,7 +152,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to update; omit to create a new matter",
                 },
@@ -164,7 +164,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 client_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Contact ID to attach in the client role. Only valid when creating a matter.",
                 },
@@ -227,7 +227,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID to delete",
                 },
                 confirm: {
@@ -306,12 +306,12 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID",
                 },
                 contact_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Contact ID: with role to link the contact, or alone to unlink it from the matter",
                 },
@@ -333,7 +333,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 matter_contact_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Existing matter-contact link ID to remove, from list_matters",
                 },
@@ -525,7 +525,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 source_id: {
                   type: "string",
-                  maxLength: 36,
+                  format: "uuid",
                   description: "Filter by source ID",
                 },
                 date_from: {
@@ -572,7 +572,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 decision_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Case-law decision ID",
                 },
                 cursor: {
@@ -682,7 +682,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID to list documents in.",
                 },
                 mode: {
@@ -693,7 +693,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 parent_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Folder entity ID whose direct children to list. Only valid in children mode; supplying it selects children mode when mode is omitted and is rejected together with mode 'flat'.",
                 },
@@ -782,13 +782,13 @@ export const generatedRouteMap: RouteNode = {
                 },
                 version_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Return this version's metadata and field values instead of the current version",
                 },
                 compare_with_version_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "With version_id, return a plain-text line diff of this version (base) against version_id (target)",
                 },
@@ -908,12 +908,12 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 entity_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Document entity ID to update; omit to create",
                 },
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to create the entity in; required when creating.",
                 },
@@ -926,7 +926,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 parent_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Folder entity ID: to place the new entity inside when creating, or to move the document into when updating",
                 },
@@ -943,7 +943,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 version_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Version ID to annotate; required when setting label or description. Only valid when updating.",
                 },
@@ -1022,7 +1022,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 version_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Delete only this version instead of the whole document",
                 },
@@ -1068,7 +1068,7 @@ export const generatedRouteMap: RouteNode = {
                   properties: {
                     matter_id: {
                       type: "string",
-                      minLength: 1,
+                      format: "uuid",
                       description: "Matter ID to list properties for.",
                     },
                     limit: {
@@ -1134,7 +1134,7 @@ export const generatedRouteMap: RouteNode = {
                     },
                     property_id: {
                       type: "string",
-                      minLength: 1,
+                      format: "uuid",
                       description:
                         "Property ID, as returned by list_properties",
                     },
@@ -1306,7 +1306,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 contact_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Contact ID",
                 },
               },
@@ -1453,7 +1453,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 contact_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Contact ID to update; omit to create",
                 },
                 type: {
@@ -1548,7 +1548,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 contact_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Contact ID to delete",
                 },
                 confirm: {
@@ -1983,7 +1983,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID for add_member and remove_member.",
                 },
                 user_id: {
@@ -2070,7 +2070,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID for add_member and remove_member.",
                 },
                 user_id: {
@@ -2180,7 +2180,7 @@ export const generatedRouteMap: RouteNode = {
                 },
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID for add_member and remove_member.",
                 },
                 user_id: {
@@ -2257,6 +2257,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 template_id: {
                   type: "string",
+                  format: "uuid",
                   description:
                     "Template id to describe its fields in detail; omit to list templates",
                 },
@@ -2317,6 +2318,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 template_id: {
                   type: "string",
+                  format: "uuid",
                   description: "Template id, as returned by list_templates",
                 },
                 values: {
@@ -2417,19 +2419,23 @@ export const generatedRouteMap: RouteNode = {
                     },
                     template_id: {
                       type: "string",
+                      format: "uuid",
                       description: "Template id, as returned by list_templates",
                     },
                     matter_id: {
                       type: "string",
+                      format: "uuid",
                       description: "Matter receiving the filled DOCX.",
                     },
                     entity_id: {
                       type: "string",
+                      format: "uuid",
                       description:
                         "Existing document entity id; required only for create_version",
                     },
                     parent_id: {
                       type: "string",
+                      format: "uuid",
                       description:
                         "Folder entity id for a new document; valid only for create_document",
                     },
@@ -2534,19 +2540,23 @@ export const generatedRouteMap: RouteNode = {
                     },
                     template_id: {
                       type: "string",
+                      format: "uuid",
                       description: "Template id, as returned by list_templates",
                     },
                     matter_id: {
                       type: "string",
+                      format: "uuid",
                       description: "Matter receiving the filled DOCX.",
                     },
                     entity_id: {
                       type: "string",
+                      format: "uuid",
                       description:
                         "Existing document entity id; required only for create_version",
                     },
                     parent_id: {
                       type: "string",
+                      format: "uuid",
                       description:
                         "Folder entity id for a new document; valid only for create_document",
                     },
@@ -2626,7 +2636,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 template_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Template to configure; omit when creating",
                 },
                 name: {
@@ -3062,13 +3072,13 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to list tasks in; required unless task_id is given.",
                 },
                 task_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Task entity ID to read in detail",
                 },
                 date_from: {
@@ -3255,12 +3265,12 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 task_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Task entity ID to update; omit to create",
                 },
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to create the task in; required when creating.",
                 },
@@ -3347,13 +3357,13 @@ export const generatedRouteMap: RouteNode = {
                 },
                 link_entity_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Entity ID to link to the task (document, folder, or another task)",
                 },
                 unlink_link_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Entity-link ID to remove",
                 },
               },
@@ -3472,18 +3482,18 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 clause_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Clause id to read in detail; omit to list",
                 },
                 version_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "With clause_id, return this version's body instead of the current clause",
                 },
                 category_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "List only clauses filed under this category (list mode)",
                 },
@@ -3595,7 +3605,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 clause_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Clause id to update; omit to create",
                 },
                 title: {
@@ -3690,7 +3700,7 @@ export const generatedRouteMap: RouteNode = {
                   anyOf: [
                     {
                       type: "string",
-                      minLength: 1,
+                      format: "uuid",
                     },
                     {
                       type: "null",
@@ -3788,7 +3798,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 clause_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Clause id to delete",
                 },
                 confirm: {
@@ -3836,7 +3846,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 playbook_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Playbook id to read in detail; omit to list playbooks",
                 },
@@ -3892,12 +3902,12 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID to run the playbook over.",
                 },
                 playbook_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Playbook id to run",
                 },
               },
@@ -3992,13 +4002,13 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to list time entries in; required unless time_entry_id is given.",
                 },
                 time_entry_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Time entry ID to read in detail",
                 },
                 entity_id: {
@@ -4171,12 +4181,12 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 time_entry_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Time entry ID to update; omit to create",
                 },
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to create the entry in; required when creating.",
                 },
@@ -4298,7 +4308,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 time_entry_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Time entry ID to delete or write off",
                 },
                 confirm: {
@@ -4360,7 +4370,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Matter ID to resolve the rate in.",
                 },
                 user_id: {
@@ -4422,13 +4432,13 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description:
                     "Matter ID to list invoices in; required unless invoice_id is given.",
                 },
                 invoice_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Invoice ID to read in detail",
                 },
                 limit: {
@@ -4774,7 +4784,7 @@ export const generatedRouteMap: RouteNode = {
               properties: {
                 matter_id: {
                   type: "string",
-                  minLength: 1,
+                  format: "uuid",
                   description: "Only entries scoped to this matter.",
                 },
                 action: {


### PR DESCRIPTION
## Proposed change

Most MCP tool inputs naming a persisted record were declared `v.pipe(v.string(), v.minLength(1))`, then branded with a `brandPersisted*Id` helper (which asserts the branded type without checking the shape) and matched against a `uuid` column. A malformed id therefore failed in Postgres as a `22P02` cast error and reached the caller as the generic `internal_error` envelope, naming no field, with a `DrizzleQueryError` captured as an exception.

`tool-utils.ts` already had `uuidInputSchema` for exactly this boundary, and its comment states the rule these schemas were missing:

> A UUID-shaped id input. Ids reach SQL as uuid columns, so a malformed one must fail here as a validation error naming the field rather than as a database cast failure reported as an internal error.

This converts every id input that reaches a uuid column: 47 parameters across `compat-tools`, `stella-tools`, `matter-tools`, `document-tools`, `template-tools`, `knowledge-tools`, `billing-tools` and `research-admin-tools`. Each was traced handler to query to Drizzle column type before conversion. Two hand-rolled `isUuid` guards (`search_case_law`'s `source_id`, `set_field_value`'s `property_id`) are removed as redundant, along with their now-unused imports.

### Ids that are not UUIDs

These keep their existing shape, each traced to a `text`/`varchar` column or to no column at all:

| Input | Why |
| --- | --- |
| `user_id`, `add_assignee_user_id`, `remove_assignee_user_id` | Auth-provider user ids are alphanumeric text; the columns holding them are `text`/`varchar` |
| `list_audit_log.resource_id` | One text column recording the id of any audited resource type, including the text user ids above |
| `save_time_entry.timezone_id` | An IANA time zone name (`Europe/Prague`) |
| `search_legislation.law_id`, `search_legislation.block_id` | External statute-corpus identifiers, fetched over HTTP and never stored; already shape-checked by their own regexes |
| `upload_document_version.file.file_id` | A host-assigned reference from the client's file payload, used only as a display-name fallback |

### Guard

`apps/api/src/mcp/uuid-id-inputs.test.ts` walks the advertised input schema of every registered tool (nested properties and union branches included) and fails on any property named `id` or ending in `_id` that carries no uuid check, unless it is listed in `NON_UUID_ID_INPUTS` with the reason it is not one. A second test fails any list entry that no longer names an advertised input, so an exception cannot outlive its reason, and a third asserts the walk finds ids at all so neither check can pass vacuously. For a `defineValibotMcpTool` tool the advertised schema is projected from the `v.strictObject` its handler parses, so the assertion binds the runtime validator rather than a mirror of it.

### Surface

The advertised schemas now carry `format: "uuid"` where they carried `minLength: 1`, which also tells a client the shape before it sends one. The three template tools whose JSON Schema is still hand-written alongside their validator carry the same marker through a new `uuidProp` helper, added beside `stringProp`; both sides moved together. The registry surface snapshot and the generated CLI registry snapshot and route map are regenerated to match, with a changeset for the `@stll/cli` surface.

The compat `fetch` tool's validation failure also carries a hint naming the next step, since a resource URI passed as `id` is a plausible client mistake: resource URIs are read with `resources/read`, not that tool.

Supersedes #3027, which fixes `fetch`'s `id` alone and defers the rest of the surface to a follow-up; this is that follow-up, and it includes #3027's change.

### Testing

- `fetch rejects a resource URI passed as an id` asserts the `validation_error` envelope, the `id` path, the hint, and that the scoped database handle is never reached.
- `bun --filter @stll/api test -- src/mcp` green (705 tests).
- Test fixtures across the MCP and CLI suites move from placeholder ids to UUIDs; no assertion was weakened or removed. `search_case_law`'s bespoke `Invalid parameter: source_id. Expected a UUID` message becomes the standard `Invalid UUID: Received "..."` with `path: "source_id"`, matching every other uuid input instead of keeping one special case.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface, this is tool input validation.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.
