### PR TITLE
perf(api): the projection intent probe reads outstanding revisions only

### DIFF
--- a/apps/api/drizzle/20260906120000_corpus_projection_outstanding_intent_idx/migration.sql
+++ b/apps/api/drizzle/20260906120000_corpus_projection_outstanding_intent_idx/migration.sql
@@ -1,0 +1,44 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent build
+-- (which takes no lock those timeouts guard), then restore and reopen a
+-- transaction for Drizzle's migration row. Same shape as
+-- 20260903120000_queue_reconciler_indexes.
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+
+-- Drop by name first: a cancelled concurrent build leaves an INVALID index
+-- behind, and IF NOT EXISTS would then skip recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "corpus_index_projection_intents_outstanding_idx";
+--> statement-breakpoint
+-- The append and erasure queues ask, per candidate entity, whether any of its
+-- revisions is still short of a terminal status. Only
+-- corpus_index_projection_intents_entity_idx could answer that, and its key
+-- carries no status, so the probe read every revision the entity ever had and
+-- checked each status in the heap. Settled revisions are never deleted, so
+-- that cost grows with how often the generation has been re-projected rather
+-- than with the work outstanding. Keyed on the identity the probe supplies and
+-- partial on the answer, the scan sees the outstanding revisions alone. The
+-- predicate is generated from the expression the queries use
+-- (corpusIndexProjectionIntentIsOutstanding), which is what lets PostgreSQL
+-- prove the implication and drop the status recheck.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "corpus_index_projection_intents_outstanding_idx"
+  ON "corpus_index_projection_intents" ("family", "generation", "entity_id", "epoch")
+  WHERE "status" NOT IN ('settled', 'cancelled');
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -10,6 +10,7 @@ import {
   CORPUS_INDEX_PROJECTION_WORK_STATUSES,
 } from "@/api/lib/legal-search/corpus-index-projection-contract";
 import {
+  corpusIndexProjectionIntentIsOutstanding,
   corpusIndexProjectionIsBlocked,
   corpusIndexProjectionNeedsWork,
   corpusIndexProjectionProducesAppend,
@@ -108,6 +109,14 @@ export const corpusIndexProjectionIntents = p.pgTable(
     p
       .index("corpus_index_projection_intents_entity_idx")
       .on(t.family, t.generation, t.entityId, t.createdAt),
+    // The append and erasure queues ask whether an entity still owes the index
+    // an exact action. Keyed on the identity they probe and partial on the
+    // answer, so the probe reads the outstanding revisions alone instead of
+    // walking a revision history that only ever grows.
+    p
+      .index("corpus_index_projection_intents_outstanding_idx")
+      .on(t.family, t.generation, t.entityId, t.epoch)
+      .where(corpusIndexProjectionIntentIsOutstanding(t.status)),
     p
       .index("corpus_index_projection_intents_expired_lease_idx")
       .on(t.family, t.generation, t.status, t.leaseExpiresAt)

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
@@ -17,6 +17,7 @@ import {
   entityIdsForCorpusProjectionWorkScope,
   type CorpusProjectionScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
+import { corpusIndexProjectionIntentIsOutstanding } from "@/api/lib/legal-search/corpus-index-projection-sql";
 import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 export const CORPUS_PROJECTION_ERASURE_MAX_BATCH_SIZE = 256;
@@ -286,7 +287,7 @@ export const advanceCorpusProjectionErasuresTx = async <
             AND outstanding.generation = ${corpusIndexProjectionStates.generation}
             AND outstanding.entity_id = ${corpusIndexProjectionStates.entityId}
             AND outstanding.epoch <= ${corpusIndexProjectionStates.desiredEpoch}
-            AND outstanding.status NOT IN ('settled', 'cancelled')
+            AND ${corpusIndexProjectionIntentIsOutstanding(sql`outstanding.status`)}
         )`,
       ),
     )

--- a/apps/api/src/lib/legal-search/corpus-index-projection-reservation-plan.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-reservation-plan.db.test.ts
@@ -1,0 +1,287 @@
+import { panic } from "better-result";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import { corpusIndexGenerations } from "@/api/db/schema";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { corpusProjectionReservationQueue } from "@/api/lib/legal-search/corpus-index-projection-store";
+import { isRecord } from "@/api/lib/type-guards";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const INDEX_ID = "case_law_v5_cs_sk";
+const GENERATION = "case_law_v5";
+/** Converged entities: in the table, out of the pending queue. */
+const CONVERGED = 2500;
+/** Pending entities an in-flight lease already owns, oldest in the queue. */
+const IN_FLIGHT = 100;
+/** Pending entities whose every earlier revision has settled. */
+const RESERVABLE = 400;
+const LIMIT = 64;
+const ELIGIBILITY_AT = new Date("2026-09-01T00:00:00.000Z");
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeEach(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+});
+
+afterEach(async () => {
+  await client.close();
+});
+
+const entity = (offset: string) =>
+  `('00000000-0000-4000-8000-' || lpad(to_hex(${offset}), 12, '0'))::uuid`;
+
+/** Deterministic id of the `depth`-th settled revision of entity `offset`. */
+const settledRevision = (offset: string, depth: string) =>
+  `('00000000-0000-4000-a00' || to_hex(${depth}) || '-' || lpad(to_hex(${offset}), 12, '0'))::uuid`;
+
+/**
+ * Append one settled revision per entity. Settled revisions are never deleted,
+ * so this history is the term that grows without bound as a generation is
+ * re-projected.
+ */
+const appendSettledHistory = async (depth: number): Promise<void> => {
+  await db.execute(
+    sql.raw(`
+      INSERT INTO corpus_index_projection_intents
+        (id, family, generation, entity_id, epoch, fingerprint, index_id, status,
+         expected_document_count, append_started_at, append_committed_at,
+         append_publish_barrier_at, cleanup_not_before, cleanup_started_at,
+         delete_opstamp, settled_at, created_at, updated_at)
+      SELECT
+        ${settledRevision("i", String(depth))},
+        'case_law', '${GENERATION}', ${entity("i")}, ${depth},
+        lpad(to_hex(i), 64, '0'), '${INDEX_ID}', 'settled', 3,
+        '2026-07-01'::timestamptz, '2026-07-01'::timestamptz,
+        '2026-07-01'::timestamptz, '2026-07-01'::timestamptz,
+        '2026-07-01'::timestamptz, 1, '2026-07-01'::timestamptz,
+        '2026-07-01'::timestamptz, '2026-07-01'::timestamptz
+      FROM generate_series(1, ${CONVERGED + IN_FLIGHT + RESERVABLE}) AS i
+    `),
+  );
+  await db.execute(sql.raw("VACUUM ANALYZE corpus_index_projection_intents"));
+};
+
+const seed = async (historyDepth: number): Promise<void> => {
+  await db.insert(corpusIndexGenerations).values({
+    family: "case_law",
+    generation: GENERATION,
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
+    status: "building",
+  });
+  for (let depth = 1; depth <= historyDepth; depth += 1) {
+    await appendSettledHistory(depth);
+  }
+  const liveEpoch = historyDepth + 1;
+
+  // Converged: the applied revision equals the desired one, so the pending
+  // queue never sees these rows.
+  await db.execute(
+    sql.raw(`
+      INSERT INTO corpus_index_projection_intents
+        (id, family, generation, entity_id, epoch, fingerprint, index_id, status,
+         expected_document_count, append_started_at, append_committed_at,
+         applied_at, created_at, updated_at)
+      SELECT
+        ('00000000-0000-4000-9000-' || lpad(to_hex(i), 12, '0'))::uuid,
+        'case_law', '${GENERATION}', ${entity("i")}, ${liveEpoch},
+        lpad(to_hex(i), 64, '0'), '${INDEX_ID}', 'applied', 3,
+        '2026-08-01'::timestamptz, '2026-08-01'::timestamptz,
+        '2026-08-01'::timestamptz, '2026-08-01'::timestamptz,
+        '2026-08-01'::timestamptz
+      FROM generate_series(1, ${CONVERGED}) AS i
+    `),
+  );
+  await db.execute(
+    sql.raw(`
+      INSERT INTO corpus_index_projection_states
+        (family, generation, entity_id, desired_action, desired_epoch,
+         desired_fingerprint, desired_index_id, work_status, applied_action,
+         applied_epoch, applied_revision, applied_fingerprint, applied_index_id,
+         applied_at, created_at, updated_at)
+      SELECT
+        'case_law', '${GENERATION}', ${entity("i")}, 'upsert', ${liveEpoch},
+        lpad(to_hex(i), 64, '0'), '${INDEX_ID}', 'eligible', 'upsert',
+        ${liveEpoch}, ('00000000-0000-4000-9000-' || lpad(to_hex(i), 12, '0'))::uuid,
+        lpad(to_hex(i), 64, '0'), '${INDEX_ID}',
+        '2026-08-01'::timestamptz, '2026-08-01'::timestamptz,
+        '2026-08-01'::timestamptz
+      FROM generate_series(1, ${CONVERGED}) AS i
+    `),
+  );
+
+  // In flight: pending, and an unexpired lease already owns the revision. The
+  // lease is not a row lock, so every reservation walks these again.
+  await db.execute(
+    sql.raw(`
+      INSERT INTO corpus_index_projection_intents
+        (id, family, generation, entity_id, epoch, fingerprint, index_id, status,
+         lease_token, lease_expires_at, created_at, updated_at)
+      SELECT
+        ('00000000-0000-4000-c000-' || lpad(to_hex(i), 12, '0'))::uuid,
+        'case_law', '${GENERATION}', ${entity(`i + ${CONVERGED}`)},
+        ${liveEpoch}, lpad(to_hex(i), 64, 'a'), '${INDEX_ID}', 'reserved',
+        gen_random_uuid(), '2026-09-02'::timestamptz,
+        '2026-08-30'::timestamptz, '2026-08-30'::timestamptz
+      FROM generate_series(1, ${IN_FLIGHT}) AS i
+    `),
+  );
+  await db.execute(
+    sql.raw(`
+      INSERT INTO corpus_index_projection_states
+        (family, generation, entity_id, desired_action, desired_epoch,
+         desired_fingerprint, desired_index_id, work_status, created_at, updated_at)
+      SELECT
+        'case_law', '${GENERATION}', ${entity(`i + ${CONVERGED}`)}, 'upsert',
+        ${liveEpoch}, lpad(to_hex(i), 64, 'a'), '${INDEX_ID}', 'eligible',
+        '2026-08-01'::timestamptz,
+        ('2026-08-10'::timestamptz + (i || ' seconds')::interval)
+      FROM generate_series(1, ${IN_FLIGHT}) AS i
+    `),
+  );
+
+  // Reservable: the desired epoch moved on and every earlier revision settled.
+  await db.execute(
+    sql.raw(`
+      INSERT INTO corpus_index_projection_states
+        (family, generation, entity_id, desired_action, desired_epoch,
+         desired_fingerprint, desired_index_id, work_status, applied_action,
+         applied_epoch, applied_revision, applied_fingerprint, applied_index_id,
+         applied_at, created_at, updated_at)
+      SELECT
+        'case_law', '${GENERATION}', ${entity(`i + ${CONVERGED + IN_FLIGHT}`)},
+        'upsert', ${liveEpoch}, lpad(to_hex(i), 64, 'b'), '${INDEX_ID}',
+        'eligible', 'upsert', ${historyDepth},
+        ${settledRevision(`i + ${CONVERGED + IN_FLIGHT}`, String(historyDepth))},
+        lpad(to_hex(i + ${CONVERGED + IN_FLIGHT}), 64, '0'), '${INDEX_ID}',
+        '2026-08-01'::timestamptz, '2026-08-01'::timestamptz,
+        ('2026-08-20'::timestamptz + (i || ' seconds')::interval)
+      FROM generate_series(1, ${RESERVABLE}) AS i
+    `),
+  );
+  await db.execute(sql.raw("VACUUM ANALYZE corpus_index_projection_states"));
+};
+
+type ReservationPlan = {
+  lines: string[];
+  reservedRows: number;
+  buffers: number;
+};
+
+const planText = ({ lines }: ReservationPlan): string => lines.join("\n");
+
+const indentOf = (line: string): number =>
+  line.length - line.trimStart().length;
+
+/** The intents scan node and the detail lines PostgreSQL nests under it. */
+const intentProbe = ({ lines }: ReservationPlan): string => {
+  const start = lines.findIndex((line) =>
+    line.includes("on corpus_index_projection_intents"),
+  );
+  if (start === -1) {
+    return panic(`No intents scan in plan:\n${lines.join("\n")}`);
+  }
+  const depth = indentOf(lines[start] ?? "");
+  const end = lines.findIndex(
+    (line, index) => index > start && indentOf(line) <= depth,
+  );
+  return lines.slice(start, end === -1 ? undefined : end).join("\n");
+};
+
+const explainRows = (explained: unknown): unknown[] => {
+  if (Array.isArray(explained)) {
+    return explained;
+  }
+  if (isRecord(explained) && Array.isArray(explained["rows"])) {
+    return explained["rows"];
+  }
+  return panic("EXPLAIN did not return plan rows");
+};
+
+const planLines = (explained: unknown): string[] =>
+  explainRows(explained).map((row) => {
+    const text = isRecord(row) ? row["QUERY PLAN"] : undefined;
+    return typeof text === "string"
+      ? text
+      : panic("EXPLAIN row has no plan text");
+  });
+
+const explainReservation = async (): Promise<ReservationPlan> =>
+  await db.transaction(async (transaction) => {
+    const tx = asTestRaw<Transaction>(transaction);
+    // A generation this small lets the planner hash the whole outstanding set
+    // instead of probing it. Production reserves against a set too large for
+    // that, so the guard pins the join to the shape that runs there and
+    // measures what one probe costs.
+    await tx.execute(sql`SET LOCAL enable_hashjoin = off`);
+    await tx.execute(sql`SET LOCAL enable_mergejoin = off`);
+    await tx.execute(sql`SET LOCAL enable_material = off`);
+    const queue = corpusProjectionReservationQueue(tx, {
+      family: "case_law",
+      generation: GENERATION,
+      limit: LIMIT,
+      eligibilityAt: ELIGIBILITY_AT,
+      scopedEntityIds: null,
+      scopedIndexId: null,
+    });
+    const lines = planLines(
+      await tx.execute(
+        sql`EXPLAIN (ANALYZE, BUFFERS, COSTS OFF) ${queue.getSQL()}`,
+      ),
+    );
+    const plan = lines.join("\n");
+    const reservedRows = Number(
+      /^Limit .*rows=(\d+)/mu.exec(plan)?.[1] ?? Number.NaN,
+    );
+    const topBuffers = /^\s*Buffers: shared hit=(\d+)(?: read=(\d+))?/mu.exec(
+      plan,
+    );
+    const buffers =
+      Number(topBuffers?.[1] ?? Number.NaN) + Number(topBuffers?.[2] ?? 0);
+    if (!Number.isFinite(reservedRows) || !Number.isFinite(buffers)) {
+      return panic(`EXPLAIN output is not measurable:\n${plan}`);
+    }
+    return { lines, reservedRows, buffers };
+  });
+
+test("the reservation queue reads outstanding revisions, not revision history", async () => {
+  await seed(2);
+  const shallow = await explainReservation();
+  expect(shallow.reservedRows).toBe(LIMIT);
+  expect(planText(shallow)).not.toContain("Seq Scan");
+  // The partial index answers the anti-join, so the probe never inspects,
+  // and never fetches the heap for, a quiescent revision.
+  expect(intentProbe(shallow)).toContain(
+    "corpus_index_projection_intents_outstanding_idx",
+  );
+  expect(intentProbe(shallow)).not.toContain("Rows Removed by Filter");
+
+  for (let depth = 3; depth <= 12; depth += 1) {
+    await appendSettledHistory(depth);
+  }
+  const deep = await explainReservation();
+  expect(deep.reservedRows).toBe(LIMIT);
+  expect(planText(deep)).not.toContain("Seq Scan");
+  expect(intentProbe(deep)).toContain(
+    "corpus_index_projection_intents_outstanding_idx",
+  );
+  expect(intentProbe(deep)).not.toContain("Rows Removed by Filter");
+
+  // Six times the settled history must not cost measurably more to skip.
+  expect(deep.buffers).toBeLessThanOrEqual(Math.round(shallow.buffers * 1.25));
+  // What remains is the in-flight prefix ahead of the reserved batch, not
+  // anything either table accumulates.
+  expect(deep.buffers / deep.reservedRows).toBeLessThanOrEqual(25);
+}, 600_000);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-sql.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-sql.ts
@@ -1,6 +1,9 @@
 import { sql, type SQLWrapper } from "drizzle-orm";
 
-import { CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES } from "@/api/lib/legal-search/corpus-index-projection-contract";
+import {
+  CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES,
+  CORPUS_INDEX_QUIESCENT_INTENT_STATUSES,
+} from "@/api/lib/legal-search/corpus-index-projection-contract";
 
 const sqlLiteralValues = (values: readonly string[]) =>
   sql.join(
@@ -51,3 +54,13 @@ export const corpusIndexProjectionIsBlocked = (workStatus: SQLWrapper) =>
 /** One source of truth for the partial append-epoch uniqueness boundary. */
 export const corpusIndexProjectionProducesAppend = (status: SQLWrapper) =>
   sql`${status} IN (${sqlLiteralValues(CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES)})`;
+
+/**
+ * One source of truth for "this entity still owes the index an exact action",
+ * shared by the append and erasure anti-joins and by the partial index that
+ * answers them. The index predicate and the query predicate are the same
+ * expression, so PostgreSQL can prove the implication and the probe never
+ * walks an entity's quiescent revision history, however long it grows.
+ */
+export const corpusIndexProjectionIntentIsOutstanding = (status: SQLWrapper) =>
+  sql`${status} NOT IN (${sqlLiteralValues(CORPUS_INDEX_QUIESCENT_INTENT_STATUSES)})`;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -30,6 +30,7 @@ import {
   type CorpusProjectionAppendScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
+  corpusIndexProjectionIntentIsOutstanding,
   corpusIndexProjectionNeedsWork,
   corpusIndexProjectionProducesAppend,
 } from "@/api/lib/legal-search/corpus-index-projection-sql";
@@ -121,45 +122,38 @@ const noOutstandingIntent = sql`NOT EXISTS (
       WHERE outstanding.family = ${corpusIndexProjectionStates.family}
         AND outstanding.generation = ${corpusIndexProjectionStates.generation}
         AND outstanding.entity_id = ${corpusIndexProjectionStates.entityId}
-        AND outstanding.status NOT IN ('settled', 'cancelled')
+        AND ${corpusIndexProjectionIntentIsOutstanding(sql`outstanding.status`)}
     )`;
 
+type CorpusProjectionReservationQueueOptions = {
+  family: CorpusFamily;
+  generation: string;
+  limit: number;
+  eligibilityAt: Date;
+  scopedEntityIds: readonly string[] | null;
+  scopedIndexId: string | null;
+};
+
 /**
- * Reserve exact append attempts only after every earlier revision for the
- * entity is terminal. This enforces delete-old, settle, then append-new; Plane
- * controls how often and how broadly this bounded primitive runs.
+ * The reservation queue read. Exported so the plan guard explains the exact
+ * statement the append cycle issues rather than a copy of it.
  */
-export const reserveCorpusProjectionIntentsTx = async <
-  Family extends CorpusFamily,
->(
+export const corpusProjectionReservationQueue = (
   tx: Transaction,
   {
     family,
     generation,
-    limit: requestedLimit,
-    leaseMs: requestedLeaseMs,
-    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
-    testNow,
-    newIntentId = () => createSafeId<"corpusIndexProjectionIntent">(),
-    newLeaseToken = () => Bun.randomUUIDv7(),
-  }: ReserveCorpusProjectionIntentsOptions<Family>,
-): Promise<CorpusProjectionIntentLease[]> => {
-  const limit = validateBatchSize(requestedLimit);
-  const leaseMs = validateLeaseMs(requestedLeaseMs);
-  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  const manifest = await lockActiveCorpusProjectionManifestForMutation(
-    tx,
-    family,
-    generation,
-  );
-  const scopedIndexId = indexIdForCorpusProjectionWorkScope(scope, manifest);
-  const eligibilityAt = testNow ?? (await readPostgresClock(tx));
+    limit,
+    eligibilityAt,
+    scopedEntityIds,
+    scopedIndexId,
+  }: CorpusProjectionReservationQueueOptions,
+) => {
   const runnableAt = sql<Date>`coalesce(
     ${corpusIndexProjectionStates.retryNotBefore},
     ${corpusIndexProjectionStates.updatedAt}
   )`;
-
-  const candidates = await tx
+  return tx
     .select({
       entityId: corpusIndexProjectionStates.entityId,
       epoch: corpusIndexProjectionStates.desiredEpoch,
@@ -205,6 +199,46 @@ export const reserveCorpusProjectionIntentsTx = async <
       of: corpusIndexProjectionStates,
       skipLocked: true,
     });
+};
+
+/**
+ * Reserve exact append attempts only after every earlier revision for the
+ * entity is terminal. This enforces delete-old, settle, then append-new; Plane
+ * controls how often and how broadly this bounded primitive runs.
+ */
+export const reserveCorpusProjectionIntentsTx = async <
+  Family extends CorpusFamily,
+>(
+  tx: Transaction,
+  {
+    family,
+    generation,
+    limit: requestedLimit,
+    leaseMs: requestedLeaseMs,
+    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
+    testNow,
+    newIntentId = () => createSafeId<"corpusIndexProjectionIntent">(),
+    newLeaseToken = () => Bun.randomUUIDv7(),
+  }: ReserveCorpusProjectionIntentsOptions<Family>,
+): Promise<CorpusProjectionIntentLease[]> => {
+  const limit = validateBatchSize(requestedLimit);
+  const leaseMs = validateLeaseMs(requestedLeaseMs);
+  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
+  const manifest = await lockActiveCorpusProjectionManifestForMutation(
+    tx,
+    family,
+    generation,
+  );
+  const scopedIndexId = indexIdForCorpusProjectionWorkScope(scope, manifest);
+  const eligibilityAt = testNow ?? (await readPostgresClock(tx));
+  const candidates = await corpusProjectionReservationQueue(tx, {
+    family,
+    generation,
+    limit,
+    eligibilityAt,
+    scopedEntityIds,
+    scopedIndexId,
+  });
 
   if (candidates.length === 0) {
     return [];

--- a/scripts/knip-exports-baseline.json
+++ b/scripts/knip-exports-baseline.json
@@ -1,6 +1,6 @@
 {
   "apps/api": {
-    "count": 779,
+    "count": 778,
     "files": {
       "apps/api/scripts/lib/capability-catalog.ts": 9,
       "apps/api/scripts/lib/enumerate-safe-handlers.ts": 7,
@@ -229,7 +229,7 @@
       "apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts": 1,
       "apps/api/src/lib/legal-search/corpus-index-projection-census.ts": 1,
       "apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts": 1,
-      "apps/api/src/lib/legal-search/corpus-index-projection-contract.ts": 5,
+      "apps/api/src/lib/legal-search/corpus-index-projection-contract.ts": 4,
       "apps/api/src/lib/legal-search/corpus-index-projection-convergence.ts": 1,
       "apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts": 2,
       "apps/api/src/lib/legal-search/corpus-index-projection-engine.ts": 3,


### PR DESCRIPTION
## What

The corpus projection append and erasure queues both ask, per candidate entity,
whether any revision of it is still short of a terminal status:

```sql
NOT EXISTS (
  SELECT 1 FROM corpus_index_projection_intents outstanding
  WHERE outstanding.family = ... AND outstanding.generation = ...
    AND outstanding.entity_id = ...
    AND outstanding.status NOT IN ('settled', 'cancelled')
)
```

The only index that could serve it was
`corpus_index_projection_intents_entity_idx` on
`(family, generation, entity_id, created_at)`. Its key carries no status, so the
probe returned every revision the entity ever had and checked each one's status
in the heap. Settled revisions are never deleted, so the cost of one probe grew
with how often the generation had been re-projected, not with the work
outstanding — and the reservation runs one probe per candidate it walks, not per
row it returns.

This adds `corpus_index_projection_intents_outstanding_idx`: keyed on the
identity the probe supplies, partial on the answer it wants.

## Plan, before and after

Measured on PGlite with a seeded generation of 3000 entities (2500 converged,
100 pending behind a live lease, 400 reservable), `LIMIT 64`, hash and merge
joins disabled so the plan keeps the nested-loop shape a large generation
produces. Buffers are `shared hit + read` for the whole statement.

Before, the probe walks the history and rejects it from the heap:

```
->  Index Scan using corpus_index_projection_intents_entity_idx on ... (loops=164)
      Index Cond: (family = ... AND generation = ... AND entity_id = ...)
      Filter: (status <> ALL ('{settled,cancelled}'::text[]))
      Rows Removed by Filter: 12
```

After, the index answers the predicate and the recheck is gone:

```
->  Index Scan using corpus_index_projection_intents_outstanding_idx on ... (loops=164)
      Index Cond: (family = ... AND generation = ... AND entity_id = ...)
```

| settled revisions per entity | before | after |
| --- | --- | --- |
| 2 | 1221 buffers (19.1 per reserved revision) | 893 (14.0) |
| 12 | 2661 buffers (41.6 per reserved revision) | 693 (10.8) |

Six times the history costs 2.2x as much to skip before the change and nothing
after it. What remains is the walk over pending rows an in-flight lease already
owns, which is bounded by concurrency rather than by anything either table
accumulates.

## The predicate has one definition

`corpusIndexProjectionIntentIsOutstanding` is generated from
`CORPUS_INDEX_QUIESCENT_INTENT_STATUSES` and is now the only place the status
set is written: the append anti-join, the erasure anti-join, and the index
predicate share it. That is also what makes the index usable — PostgreSQL drops
the status recheck only when it can prove the query predicate from the index
predicate, so a hand-copied literal list drifting by one status would silently
cost the scan its heap reads back. The two call sites previously carried the
list inline.

The index key ends in `epoch` so the erasure probe's `outstanding.epoch <=
desired_epoch` is an index condition too.

`corpus_index_projection_intents_append_epoch_uidx` carries the same key
columns and cannot be reused: it is partial on the append-producing statuses
alone, so it does not see a revision in cleanup, and widening it would drop the
uniqueness boundary it exists to enforce.

## Migration

`corpus_index_projection_intents` is in `HIGH_VOLUME_TABLES`, so the build is
`CREATE INDEX CONCURRENTLY`, which cannot run inside the migrator's
transaction. The migration follows `20260903120000_queue_reconciler_indexes`:
commit the migrator transaction, lift the timeouts for the concurrent build
(which takes no lock those timeouts guard), restore them and reopen a
transaction for Drizzle's migration row. The build is dropped by name first
because a cancelled concurrent build leaves an INVALID index that
`IF NOT EXISTS` would then skip. `check-migration-safety` and squawk pass.

## Reservation semantics are unchanged

Same predicate, same leases, same `FOR UPDATE ... SKIP LOCKED`, same retry
windows, same fencing, same ordering. The reservation query moves into
`corpusProjectionReservationQueue` unchanged so the new plan guard explains the
statement the append cycle issues rather than a copy of it.

## Tests

`corpus-index-projection-reservation-plan.db.test.ts` seeds the population
above, then deepens the settled history sixfold and re-explains. It asserts no
`Seq Scan`, that the outstanding index serves the probe, that the probe removes
no rows by filter (it never inspects a quiescent revision), and that buffers per
reserved revision neither grow with history nor exceed a fixed bound. Without
the index the guard fails on the first assertion.
