### PR TITLE
docs(api): template workflow reference resource for MCP agents

### DIFF
--- a/.changeset/template-workflow-reference.md
+++ b/.changeset/template-workflow-reference.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": minor
+---
+
+`stella reference show template-workflow` prints the end-to-end template procedure: author markers, create the template, read the discovered paths back, configure the fields, preview the fill, persist it into a matter, plus the completion gate and the marker rules that are easy to get wrong.

--- a/apps/api/src/mcp/README.md
+++ b/apps/api/src/mcp/README.md
@@ -27,9 +27,12 @@ The server exposes two MCP endpoints:
   gateway are not exposed.
 
 Both endpoints expose static MCP resources through `resources/list` and
-`resources/read`, including `stella://about` for canonical product identity and
-official URLs, and `stella://reference/template-markers` for the DOCX template
-marker grammar.
+`resources/read`: `stella://about` for canonical product identity and official
+URLs, `stella://reference/template-markers` for the DOCX template marker
+grammar, `stella://reference/template-fields` for the `save_template` field
+overlay, and `stella://reference/template-workflow` for the order those two are
+used in (author, create, read the discovered paths back, configure, preview,
+persist).
 
 OAuth protected-resource discovery is served from:
 

--- a/apps/api/src/mcp/instructions.test.ts
+++ b/apps/api/src/mcp/instructions.test.ts
@@ -7,6 +7,7 @@ import {
   MCP_INSTRUCTIONS_DEFAULT_MAX_CHARS,
   MCP_INSTRUCTIONS_DOCUMENTS_MAX_CHARS,
 } from "@/api/mcp/instructions";
+import { TEMPLATE_WORKFLOW_REFERENCE_URI } from "@/api/mcp/template-workflow-reference";
 
 // The server `instructions` ride on every initialize response, so they are a
 // per-session token cost. These budgets are hard ceilings: growth past them
@@ -46,6 +47,12 @@ describe("MCP server instructions", () => {
       expect(instructions).toContain("stella://about");
       expect(instructions).toContain("Never infer stella branding or URLs");
     }
+  });
+
+  test("the default surface points at the template workflow resource", () => {
+    // The resource is listed, but an agent that never calls resources/list
+    // starts at save_template and rediscovers the order by trial.
+    expect(MCP_INSTRUCTIONS.default).toContain(TEMPLATE_WORKFLOW_REFERENCE_URI);
   });
 
   test("the anonymized surface omits the write-only feedback tool", () => {

--- a/apps/api/src/mcp/instructions.ts
+++ b/apps/api/src/mcp/instructions.ts
@@ -35,7 +35,7 @@ Errors: a failed tool returns a single text content of \`{"error":{"code","messa
 
 Destructive tools (delete_*) refuse to run unless you pass \`confirm: true\`, and you must only set it after a human user has approved the irreversible action.
 
-Static reference documents are available via \`resources/list\` then \`resources/read\`.
+Static reference documents are available via \`resources/list\` then \`resources/read\`; driving templates end to end starts at stella://reference/template-workflow.
 
 Hit a bug or a gap? File it with the send_feedback tool.`;
 

--- a/apps/api/src/mcp/resources.test.ts
+++ b/apps/api/src/mcp/resources.test.ts
@@ -8,11 +8,17 @@ import { MCP_APP_RESOURCE_MIME_TYPE } from "@stll/api-contract";
 import { envBase } from "@/api/env-base";
 import { DOCUMENT_UPLOAD_APP_RESOURCE_URI } from "@/api/mcp/document-file-upload";
 import { listMcpResources, readMcpResource } from "@/api/mcp/resources";
+import { MCP_STATIC_TOOL_NAMES } from "@/api/mcp/static-tool-definitions";
 import { buildFieldReference } from "@/api/mcp/template-field-reference";
 import { buildMarkerReference } from "@/api/mcp/template-marker-reference";
+import {
+  buildWorkflowReference,
+  TEMPLATE_WORKFLOW_TOOL_NAMES,
+} from "@/api/mcp/template-workflow-reference";
 
 const MARKER_REFERENCE_URI = "stella://reference/template-markers";
 const FIELD_REFERENCE_URI = "stella://reference/template-fields";
+const WORKFLOW_REFERENCE_URI = "stella://reference/template-workflow";
 const PRODUCT_IDENTITY_URI = "stella://about";
 
 describe("MCP resources", () => {
@@ -27,6 +33,7 @@ describe("MCP resources", () => {
       expect(uris).toContain(PRODUCT_IDENTITY_URI);
       expect(uris).toContain(MARKER_REFERENCE_URI);
       expect(uris).toContain(FIELD_REFERENCE_URI);
+      expect(uris).toContain(WORKFLOW_REFERENCE_URI);
       // The reference documents are static, public, and tenant-independent, so
       // the set is identical across modes.
       expect(uris).toEqual(listMcpResources("default").map((r) => r.uri));
@@ -61,6 +68,70 @@ describe("MCP resources", () => {
     expect(content.text).toContain('`kind: "party"`');
     expect(content.text).toContain("dataBox");
     expect(content.text).toContain(MARKER_REFERENCE_URI);
+  });
+
+  test("reads the workflow reference describing the create-then-configure order", async () => {
+    const workflow = listMcpResources("default").find(
+      (resource) => resource.uri === WORKFLOW_REFERENCE_URI,
+    );
+    expect(workflow?.mimeType).toBe("text/markdown");
+
+    const result = await readMcpResource(WORKFLOW_REFERENCE_URI, "default");
+    const content = result.contents.at(0);
+    if (!content || !("text" in content)) {
+      throw new Error("Expected a text resource content entry");
+    }
+    expect(content.uri).toBe(WORKFLOW_REFERENCE_URI);
+    expect(content.text).toBe(buildWorkflowReference());
+    // The steps an agent cannot read off the tool list: create and configure
+    // are two calls, the discovered paths are read back in between, and the
+    // fill is previewed before anything is persisted.
+    expect(content.text).toContain("`docx_base64`");
+    expect(content.text).toContain("`arrays[]`");
+    expect(content.text).toContain("`output_mode`");
+    expect(content.text).toContain("`completion_mode`");
+    expect(content.text).toContain("`idempotency_key`");
+  });
+
+  // The workflow document names tools and resources by hand; these two checks
+  // are what stop it from outliving them. Tool names render from a list typed
+  // against the registry union, so a rename is already a compile error; the
+  // scan below catches the other direction, a name written into the prose that
+  // the registry never had.
+  test("every tool the workflow reference names is in the registry", () => {
+    const text = buildWorkflowReference();
+    const registryNames = new Set<string>(MCP_STATIC_TOOL_NAMES);
+    for (const name of TEMPLATE_WORKFLOW_TOOL_NAMES) {
+      expect(registryNames.has(name), `${name} is not a registry tool`).toBe(
+        true,
+      );
+      expect(text, `${name} is declared but never named`).toContain(name);
+    }
+
+    // Any snake_case token opening with a verb the registry uses for tool
+    // names reads as a tool name to an agent, so it must be one.
+    const toolVerbs = new Set(
+      MCP_STATIC_TOOL_NAMES.map((name) => name.split("_")[0]),
+    );
+    const mentioned = [...text.matchAll(/\b[a-z]+(?:_[a-z]+)+\b/gu)]
+      .map(([token]) => token)
+      .filter((token) => toolVerbs.has(token.split("_")[0] ?? ""));
+    expect(
+      [...new Set(mentioned)].filter((token) => !registryNames.has(token)),
+    ).toEqual([]);
+  });
+
+  test("every stella:// uri the workflow reference names is a listed resource", () => {
+    const listedUris = new Set(
+      listMcpResources("default").map((resource) => resource.uri),
+    );
+    const mentioned = [
+      ...buildWorkflowReference().matchAll(/stella:\/\/[\w/-]+/gu),
+    ].map(([uri]) => uri);
+    expect(mentioned.length).toBeGreaterThan(0);
+    expect(
+      [...new Set(mentioned)].filter((uri) => !listedUris.has(uri)),
+    ).toEqual([]);
   });
 
   test("exposes canonical lowercase branding and verified product links", async () => {

--- a/apps/api/src/mcp/resources.ts
+++ b/apps/api/src/mcp/resources.ts
@@ -18,6 +18,10 @@ import {
   buildMarkerReference,
   TEMPLATE_MARKER_REFERENCE_URI,
 } from "@/api/mcp/template-marker-reference";
+import {
+  buildWorkflowReference,
+  TEMPLATE_WORKFLOW_REFERENCE_URI,
+} from "@/api/mcp/template-workflow-reference";
 
 /**
  * MCP resources are static, no-argument documents (the textbook fit for a
@@ -98,6 +102,19 @@ const STATIC_RESOURCES: readonly StaticResource[] = [
     mimeType: "text/markdown",
     listed: true,
     read: buildFieldReference,
+  },
+  {
+    uri: TEMPLATE_WORKFLOW_REFERENCE_URI,
+    name: "template-workflow",
+    title: "Template workflow",
+    description:
+      "The order to drive stella's templates in: author markers, create the " +
+      "template, read the discovered paths back, configure fields, preview " +
+      "the fill, persist it into a matter. Read this before the first " +
+      "save_template call.",
+    mimeType: "text/markdown",
+    listed: true,
+    read: buildWorkflowReference,
   },
   {
     uri: DOCUMENT_UPLOAD_APP_RESOURCE_URI,

--- a/apps/api/src/mcp/template-docx-limits.ts
+++ b/apps/api/src/mcp/template-docx-limits.ts
@@ -1,0 +1,24 @@
+import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
+import { MCP_MAX_REQUEST_BODY_BYTES } from "@/api/mcp/constants";
+
+/**
+ * Ceilings on the two ways a DOCX reaches `save_template`. Owned here rather
+ * than in the tool module so the workflow reference renders the same numbers
+ * the schema enforces instead of restating them in prose.
+ */
+
+// A JSON-RPC request has a 512 KiB transport cap. Reserve half for the
+// envelope and the remaining tool arguments, then derive the base64 payload
+// ceiling from the part that can safely reach the validator.
+export const MAX_INLINE_DOCX_BASE64_LENGTH = Math.floor(
+  MCP_MAX_REQUEST_BODY_BYTES / 2,
+);
+
+export const MAX_INLINE_DOCX_BYTES = Math.floor(
+  (MAX_INLINE_DOCX_BASE64_LENGTH / 4) * 3,
+);
+
+/** Derived so the advertised ceiling cannot drift from the enforced one. */
+export const MAX_DOCX_MEGABYTES = Math.floor(
+  FILE_SIZE_LIMIT_BYTES.document / (1024 * 1024),
+);

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -83,6 +83,11 @@ import type { McpRequestContext } from "@/api/mcp/context";
 import { OPENAI_FILE_REFERENCE_SCHEMA } from "@/api/mcp/document-file-upload";
 import { hasEffectiveAuthority } from "@/api/mcp/effective-authority";
 import {
+  MAX_DOCX_MEGABYTES,
+  MAX_INLINE_DOCX_BASE64_LENGTH,
+  MAX_INLINE_DOCX_BYTES,
+} from "@/api/mcp/template-docx-limits";
+import {
   readTemplateFieldsInput,
   templateFieldInputSchema,
   toFieldMetaToolInput,
@@ -162,22 +167,6 @@ const TEMPLATE_FILL_COMPLETION_MODE_PROP = {
   ),
   default: DEFAULT_TEMPLATE_FILL_COMPLETION_MODE,
 } as const;
-
-// A JSON-RPC request has a 512 KiB transport cap. Reserve half for the
-// envelope and the remaining tool arguments, then derive the base64 payload
-// ceiling from the part that can safely reach this validator.
-const MAX_INLINE_DOCX_BASE64_LENGTH = Math.floor(
-  MCP_MAX_REQUEST_BODY_BYTES / 2,
-);
-
-const MAX_INLINE_DOCX_BYTES = Math.floor(
-  (MAX_INLINE_DOCX_BASE64_LENGTH / 4) * 3,
-);
-
-/** Derived so the advertised ceiling cannot drift from the enforced one. */
-const MAX_DOCX_MEGABYTES = Math.floor(
-  FILE_SIZE_LIMIT_BYTES.document / (1024 * 1024),
-);
 
 const saveTemplateArgsSchema = v.pipe(
   v.strictObject({

--- a/apps/api/src/mcp/template-workflow-reference.ts
+++ b/apps/api/src/mcp/template-workflow-reference.ts
@@ -1,0 +1,207 @@
+import type { McpToolName } from "@/api/lib/api-handlers";
+import { TEMPLATE_FIELD_REFERENCE_URI } from "@/api/mcp/template-field-reference";
+import { TEMPLATE_MARKER_REFERENCE_URI } from "@/api/mcp/template-marker-reference";
+
+/**
+ * End-to-end procedure for driving stella's template machinery from the MCP
+ * surface alone. The two grammar references say what a marker and a field
+ * configuration are; neither says which tool to call in which order, that
+ * create-then-configure is two steps, or that a fill can be previewed before
+ * anything is persisted. An agent that has only the tool list has to discover
+ * that order by trial, so it is written down here.
+ *
+ * Every tool this document names is typed as {@link McpToolName}, so a rename
+ * or removal in the registry is a compile error here rather than prose that
+ * quietly points at a tool that no longer exists.
+ */
+
+/**
+ * Canonical URI of the workflow resource. Owned here with the text it
+ * addresses, so the resource registry and the server instructions that point
+ * agents at it cannot drift apart.
+ */
+export const TEMPLATE_WORKFLOW_REFERENCE_URI =
+  "stella://reference/template-workflow";
+
+/**
+ * The tools the procedure below names. Typed against the registry union, and
+ * asserted present in the rendered text by `resources.test.ts`, so neither
+ * half can drift from the other.
+ */
+const TOOL = {
+  saveTemplate: "save_template",
+  listTemplates: "list_templates",
+  setPracticeJurisdictions: "set_practice_jurisdictions",
+  fillTemplate: "fill_template",
+  saveFilledTemplate: "save_filled_template",
+  sendFeedback: "send_feedback",
+} as const satisfies Record<string, McpToolName>;
+
+export const TEMPLATE_WORKFLOW_TOOL_NAMES = Object.values(TOOL);
+
+const {
+  fillTemplate: FILL_TEMPLATE,
+  listTemplates: LIST_TEMPLATES,
+  saveFilledTemplate: SAVE_FILLED_TEMPLATE,
+  saveTemplate: SAVE_TEMPLATE,
+  sendFeedback: SEND_FEEDBACK,
+  setPracticeJurisdictions: SET_PRACTICE_JURISDICTIONS,
+} = TOOL;
+
+type WorkflowStep = {
+  /** Short label shown as the step heading. */
+  title: string;
+  /** What to call, with the inputs and response fields that matter. */
+  detail: string;
+};
+
+const WORKFLOW_STEPS: readonly WorkflowStep[] = [
+  {
+    title: "Read the grammar",
+    detail:
+      `${TEMPLATE_MARKER_REFERENCE_URI} is the \`{{...}}\` marker grammar; ` +
+      `${TEMPLATE_FIELD_REFERENCE_URI} is the field configuration. Read both ` +
+      "before authoring or configuring anything.",
+  },
+  {
+    title: "Author markers in the ORIGINAL document",
+    detail:
+      "Add markers as literal text to the .docx the user gave you and send " +
+      "those bytes back verbatim. Never rebuild, re-render, or strip parts: " +
+      "macros, ActiveX, OLE objects, embedded fonts, and tracked changes all " +
+      "stay, and a .docm stays a .docm.",
+  },
+  {
+    title: "Create the template",
+    detail:
+      `${SAVE_TEMPLATE} with \`name\` and \`docx_base64\` (base64 of the raw ` +
+      "DOCX bytes, max ~10 MB decoded) and no `fields`. Returns " +
+      "`templateId`, `name`, `fieldCount`. Discovery decides which paths " +
+      "exist, so configure in a second call rather than guessing paths here.",
+  },
+  {
+    title: "Read the discovered paths back",
+    detail:
+      `${LIST_TEMPLATES} with \`template_id\`. Returns \`fields[]\` (\`path\`, ` +
+      "`label`, `inputType`, `required`, `hint`, `options`, `optionsFrom`, " +
+      "`formats`, `aiPrompt`, `aiAdapt`, `parts`, `format`, `dateFormat`), " +
+      "`arrays[]` (one entry per `{{#each}}` loop: its `path` plus the " +
+      "`itemFieldPaths` it repeats), `conditions[]` and `computed[]` " +
+      "(`name` + `expression`). Compare `fields[].path` against the markers " +
+      "you wrote: a path you expected and do not see was not discovered. Fix " +
+      "the document and create the template again before configuring — " +
+      "configuration cannot add a field the DOCX does not contain.",
+  },
+  {
+    title: "Configure the fields",
+    detail:
+      `${SAVE_TEMPLATE} with \`template_id\` and a \`fields\` overlay, and no ` +
+      "`docx_base64` and no `name`. Every entry's `path` must be one " +
+      `${LIST_TEMPLATES} reported; an undiscovered path is refused. The ` +
+      "overlay decides who fills each field (person, AI, registry lookup, " +
+      "matter or contact binding, formula) — see " +
+      `${TEMPLATE_FIELD_REFERENCE_URI}. The response echoes the full ` +
+      `configuration in the ${LIST_TEMPLATES} detail shape. A \`lookup\` ` +
+      "field resolves at fill time only for a registry the organization has " +
+      'enabled; a disabled one fails the fill with "The <registry> registry ' +
+      'is disabled for this organization." Registries are enabled by the ' +
+      `organization's practice jurisdictions (${SET_PRACTICE_JURISDICTIONS}) ` +
+      "or by an admin enabling that tool in stella's tool catalogue; the " +
+      "per-registry override is not settable over MCP.",
+  },
+  {
+    title: "Preview the fill",
+    detail:
+      `${FILL_TEMPLATE} with \`template_id\` and \`values\`, a path-to-value ` +
+      'map (`{"tenant.name":"ACME"}`). An `arrays[]` path takes an array of ' +
+      "objects, not flat dotted keys. Nothing is persisted. `output_mode` " +
+      "defaults to `text`: `paragraphs` (the rendered paragraphs and table " +
+      "cells), `charCount`, `truncated`, `completionStatus` (`complete` or " +
+      "`partial`), `templateName`, `fileName`, `unmatchedPlaceholders`, " +
+      '`unusedValues`, `structureErrors`. `output_mode: "docx"` returns the ' +
+      "same fill with `text` and the base64 archive in `docxBase64` instead; " +
+      "ask for it only when you keep the bytes. Unknown value keys fail " +
+      "unless `allow_unused_values` is true. Show the preview to the user " +
+      "before persisting.",
+  },
+  {
+    title: "Persist into a matter",
+    detail:
+      `${SAVE_FILLED_TEMPLATE} with \`action\` (\`create_document\`, ` +
+      "optionally under `parent_id`, or `create_version` with `entity_id`), " +
+      "`template_id`, `matter_id`, `values`, and an `idempotency_key` unique " +
+      "to this save — reuse it only to recover the same timed-out request. " +
+      "The fill happens server-side; no byte upload. Returns the entity and " +
+      "version identifiers plus `unmatchedPlaceholders` and `unusedValues`.",
+  },
+];
+
+const COMPLETION_GATE_NOTE =
+  `Completion gate: both ${FILL_TEMPLATE} and ${SAVE_FILLED_TEMPLATE} take ` +
+  "`completion_mode` (default `require_complete`) and run one gate. An " +
+  "unfilled placeholder is a `validation_error` naming every missing path, " +
+  "and the persisting tool refuses before anything is written. Set " +
+  "`allow_partial` only when a document with live `{{markers}}` is what the " +
+  "user asked for; otherwise collect the missing values and retry.";
+
+const AUTHORING_RULES = [
+  {
+    title: "One path per value, in every language",
+    detail:
+      "Mark every language or column occurrence of the same value with the " +
+      "SAME path. Identical paths collapse to one field and one question; " +
+      "language-specific variants create duplicate questions.",
+  },
+  {
+    title: "Item fields are prefixed by the loop path",
+    detail:
+      "Inside `{{#each X}}`, an item's field is `{{X.field}}`, not " +
+      "`{{field}}`. The loop path plus its `itemFieldPaths` is what " +
+      `${LIST_TEMPLATES} reports under \`arrays\`.`,
+  },
+  {
+    title: "Block markers own their paragraph",
+    detail:
+      "Each `{{#if}}` / `{{#each}}` opener and closer sits alone in its own " +
+      "paragraph, and a pair either shares a block-level parent or is " +
+      "confined to a single table row (which repeats the row). A pair that " +
+      "straddles a table boundary is ambiguous: it is refused as a structure " +
+      "error and its markers are neutralized instead of expanding.",
+  },
+] as const;
+
+const renderStep = ({ detail, title }: WorkflowStep, index: number): string =>
+  `${index + 1}. ${title}. ${detail}`;
+
+const renderRule = (rule: { title: string; detail: string }): string =>
+  `- ${rule.title}: ${rule.detail}`;
+
+/** Build the template-workflow reference text. */
+export const buildWorkflowReference = (): string => {
+  const stepLines = WORKFLOW_STEPS.map(renderStep).join("\n");
+  const ruleLines = AUTHORING_RULES.map(renderRule).join("\n");
+
+  return [
+    "stella template workflow (author, configure, fill, save)",
+    "",
+    "The order to call things in. A template is created from a DOCX first " +
+      "and configured second, because configuration can only name paths the " +
+      "DOCX already contains.",
+    "",
+    "Procedure:",
+    stepLines,
+    "",
+    COMPLETION_GATE_NOTE,
+    "",
+    "Rules that are easy to get wrong:",
+    ruleLines,
+    "",
+    "Errors: a failed tool returns one text content of " +
+      '`{"error":{"code","message","hint"}}` with isError set. A validation ' +
+      "failure adds `issues[]`, each with the offending input's dot-`path` " +
+      "(`values.tenant.name`, `fields.0.path`) and a `message`. Read `hint`: " +
+      "it states the next call.",
+    "",
+    `Something missing or wrong here? File it with ${SEND_FEEDBACK}.`,
+  ].join("\n");
+};

--- a/apps/api/src/mcp/template-workflow-reference.ts
+++ b/apps/api/src/mcp/template-workflow-reference.ts
@@ -1,4 +1,8 @@
 import type { McpToolName } from "@/api/lib/api-handlers";
+import {
+  MAX_DOCX_MEGABYTES,
+  MAX_INLINE_DOCX_BYTES,
+} from "@/api/mcp/template-docx-limits";
 import { TEMPLATE_FIELD_REFERENCE_URI } from "@/api/mcp/template-field-reference";
 import { TEMPLATE_MARKER_REFERENCE_URI } from "@/api/mcp/template-marker-reference";
 
@@ -35,6 +39,7 @@ const TOOL = {
   fillTemplate: "fill_template",
   saveFilledTemplate: "save_filled_template",
   sendFeedback: "send_feedback",
+  uploadDocumentVersion: "upload_document_version",
 } as const satisfies Record<string, McpToolName>;
 
 export const TEMPLATE_WORKFLOW_TOOL_NAMES = Object.values(TOOL);
@@ -46,6 +51,7 @@ const {
   saveTemplate: SAVE_TEMPLATE,
   sendFeedback: SEND_FEEDBACK,
   setPracticeJurisdictions: SET_PRACTICE_JURISDICTIONS,
+  uploadDocumentVersion: UPLOAD_DOCUMENT_VERSION,
 } = TOOL;
 
 type WorkflowStep = {
@@ -69,15 +75,24 @@ const WORKFLOW_STEPS: readonly WorkflowStep[] = [
       "Add markers as literal text to the .docx the user gave you and send " +
       "those bytes back verbatim. Never rebuild, re-render, or strip parts: " +
       "macros, ActiveX, OLE objects, embedded fonts, and tracked changes all " +
-      "stay, and a .docm stays a .docm.",
+      "survive the save. The stored template and every document filled from " +
+      "it are named and typed as .docx whatever the source file was called, " +
+      "so a macro-enabled package keeps its parts but not its .docm name.",
   },
   {
     title: "Create the template",
     detail:
-      `${SAVE_TEMPLATE} with \`name\` and \`docx_base64\` (base64 of the raw ` +
-      "DOCX bytes, max ~10 MB decoded) and no `fields`. Returns " +
-      "`templateId`, `name`, `fieldCount`. Discovery decides which paths " +
-      "exist, so configure in a second call rather than guessing paths here.",
+      `${SAVE_TEMPLATE} with \`name\`, the DOCX, and no \`fields\`. Two ways ` +
+      `to send it: \`file\`, a host file reference (the shape ` +
+      `${UPLOAD_DOCUMENT_VERSION} takes), up to ${MAX_DOCX_MEGABYTES} MB; or ` +
+      "`docx_base64`, base64 of the raw bytes, for a small document only " +
+      `(at most ${MAX_INLINE_DOCX_BYTES} bytes decoded), because the whole ` +
+      "call must fit one MCP request frame. Never strip parts out to fit " +
+      "that; use `file`. Returns `templateId`, `name`, `fieldCount` and " +
+      "`warnings[]` (`code`, `path`, `message`, `hint`): markers the save " +
+      "accepted that will not do what you meant. Fix them in the DOCX and " +
+      "create again before configuring. Discovery decides which paths exist, " +
+      "so configure in a second call rather than guessing paths here.",
   },
   {
     title: "Read the discovered paths back",
@@ -86,8 +101,9 @@ const WORKFLOW_STEPS: readonly WorkflowStep[] = [
       "`label`, `inputType`, `required`, `hint`, `options`, `optionsFrom`, " +
       "`formats`, `aiPrompt`, `aiAdapt`, `parts`, `format`, `dateFormat`), " +
       "`arrays[]` (one entry per `{{#each}}` loop: its `path` plus the " +
-      "`itemFieldPaths` it repeats), `conditions[]` and `computed[]` " +
-      "(`name` + `expression`). Compare `fields[].path` against the markers " +
+      "`itemFieldPaths` it repeats), `conditions[]`, `computed[]` " +
+      "(`name` + `expression`) and the same `warnings[]`. Compare " +
+      "`fields[].path` against the markers " +
       "you wrote: a path you expected and do not see was not discovered. Fix " +
       "the document and create the template again before configuring — " +
       "configuration cannot add a field the DOCX does not contain.",
@@ -101,7 +117,10 @@ const WORKFLOW_STEPS: readonly WorkflowStep[] = [
       "overlay decides who fills each field (person, AI, registry lookup, " +
       "matter or contact binding, formula) — see " +
       `${TEMPLATE_FIELD_REFERENCE_URI}. The response echoes the full ` +
-      `configuration in the ${LIST_TEMPLATES} detail shape. A \`lookup\` ` +
+      `configuration in the ${LIST_TEMPLATES} detail shape, \`warnings[]\` ` +
+      "included: the overlay recomputes them, so a condition that removes " +
+      "its own input or a lookup on a disabled registry shows up here. A " +
+      "`lookup` " +
       "field resolves at fill time only for a registry the organization has " +
       'enabled; a disabled one fails the fill with "The <registry> registry ' +
       'is disabled for this organization." Registries are enabled by the ' +
@@ -114,7 +133,10 @@ const WORKFLOW_STEPS: readonly WorkflowStep[] = [
     detail:
       `${FILL_TEMPLATE} with \`template_id\` and \`values\`, a path-to-value ` +
       'map (`{"tenant.name":"ACME"}`). An `arrays[]` path takes an array of ' +
-      "objects, not flat dotted keys. Nothing is persisted. `output_mode` " +
+      "objects, not flat dotted keys. No document is created, but the fill " +
+      "is recorded: a fill row and an EXECUTE audit event are written before " +
+      "the completion gate runs, so a preview that is then rejected as " +
+      "incomplete still appears in the audit log. `output_mode` " +
       "defaults to `text`: `paragraphs` (the rendered paragraphs and table " +
       "cells), `charCount`, `truncated`, `completionStatus` (`complete` or " +
       "`partial`), `templateName`, `fileName`, `unmatchedPlaceholders`, " +
@@ -138,11 +160,16 @@ const WORKFLOW_STEPS: readonly WorkflowStep[] = [
 
 const COMPLETION_GATE_NOTE =
   `Completion gate: both ${FILL_TEMPLATE} and ${SAVE_FILLED_TEMPLATE} take ` +
-  "`completion_mode` (default `require_complete`) and run one gate. An " +
-  "unfilled placeholder is a `validation_error` naming every missing path, " +
-  "and the persisting tool refuses before anything is written. Set " +
-  "`allow_partial` only when a document with live `{{markers}}` is what the " +
-  "user asked for; otherwise collect the missing values and retry.";
+  "`completion_mode` (default `require_complete`) and run one gate. Under " +
+  "the default, an unfilled placeholder or a failed AI draft is a " +
+  "`validation_error` naming every offending path, and the persisting tool " +
+  "refuses before anything is written. `allow_partial` lets the same fill " +
+  `through instead: ${FILL_TEMPLATE} reports \`completionStatus: "partial"\` ` +
+  `and ${SAVE_FILLED_TEMPLATE} writes the document with the shortfall in ` +
+  "`unmatchedPlaceholders` and `aiFieldErrors`. Set it only when a document " +
+  "with live `{{markers}}` is what the user asked for; otherwise collect the " +
+  "missing values and retry. A missing required value is refused in either " +
+  "mode, before the gate.";
 
 const AUTHORING_RULES = [
   {

--- a/packages/cli/src/generated/resource-tree.ts
+++ b/packages/cli/src/generated/resource-tree.ts
@@ -46,6 +46,15 @@ export const generatedResourceTree: ResourceNode = {
             uri: "stella://reference/template-fields",
           },
         },
+        "template-workflow": {
+          kind: "leaf",
+          spec: {
+            kind: "show",
+            commandPath: ["reference", "show", "template-workflow"],
+            name: "template-workflow",
+            uri: "stella://reference/template-workflow",
+          },
+        },
       },
     },
   },

--- a/packages/cli/src/generated/resources-snapshot.json
+++ b/packages/cli/src/generated/resources-snapshot.json
@@ -19,5 +19,12 @@
     "title": "Template field configuration",
     "description": "How save_template's fields overlay configures each template field: input types, validation, composite parts, registry lookups, contact and matter bindings, and who fills the field. Read this before passing fields.",
     "mimeType": "text/markdown"
+  },
+  {
+    "uri": "stella://reference/template-workflow",
+    "name": "template-workflow",
+    "title": "Template workflow",
+    "description": "The order to drive stella's templates in: author markers, create the template, read the discovered paths back, configure fields, preview the fill, persist it into a matter. Read this before the first save_template call.",
+    "mimeType": "text/markdown"
   }
 ]


### PR DESCRIPTION
The MCP surface documents the template marker grammar (`stella://reference/template-markers`) and the field configuration (`stella://reference/template-fields`), but not the order they are used in. An agent driving templates over MCP had to rediscover that a template is created from a DOCX first and configured second, that the discovered paths must be read back before configuring, that a fill can be previewed before anything is persisted, and how a disabled registry is enabled.

Adds a third listed resource, `stella://reference/template-workflow`, built in `template-workflow-reference.ts`:

- the numbered procedure with the exact tool names, inputs and response fields at each step (`save_template` create, `list_templates` detail, `save_template` configure, `fill_template` preview, `save_filled_template` persist);
- the shared completion gate (`completion_mode`, default `require_complete`) and `fill_template`'s `output_mode` (`text` by default, `docx` for the base64 archive);
- the error envelope (`{"error":{"code","message","hint"}}`, `issues[].path` on validation failures) and `send_feedback` for gaps;
- the three marker rules that get written wrong: one path for every language occurrence of a value, item fields inside `{{#each X}}` as `{{X.field}}`, and block markers alone on their paragraph or confined to one table row.

The default server instructions now name the resource, so an agent that never calls `resources/list` still finds it. The tool descriptions are unchanged: the `tools/list` payload has no room under the registry-quality ceiling.

Drift guards: tool names render from a list typed against the registry union, so a rename or removal is a compile error in the reference itself. `resources.test.ts` covers the other direction, that every tool name and `stella://` URI appearing in the rendered text exists in the registry and the resource list.

The CLI picks the resource up through codegen (`stella reference show template-workflow`).

Stacks on #3037 until that merges: the fill contract described here (`output_mode`, the shared `completion_mode`) is the one on that branch. The first commit here refreshes the registry-quality surface snapshot, which #3037 left carrying the pre-rename `output` property.
