### PR TITLE
fix(api): preserve partial template eval results

### DIFF
--- a/apps/api/evals/lib/template-authoring-score.test.ts
+++ b/apps/api/evals/lib/template-authoring-score.test.ts
@@ -235,10 +235,12 @@ describe("scoreAuthoringRun", () => {
   });
 
   test("a provider error outranks everything, and no call is its own outcome", () => {
-    expect(
-      scoreAuthoringRun({ turnError: "refused", attempt: savedAttempt() })
-        .outcome,
-    ).toBe("error");
+    const providerError = scoreAuthoringRun({
+      turnError: "provider refused the request",
+      attempt: savedAttempt(),
+    });
+    expect(providerError.outcome).toBe("error");
+    expect(providerError.note).toBe("provider refused the request");
     expect(scoreAuthoringRun({ turnError: null, attempt: null }).outcome).toBe(
       "no-call",
     );
@@ -260,6 +262,28 @@ describe("scoreAuthoringRun", () => {
     });
     expect(rejected.outcome).toBe("partial");
     expect(rejected.overlayIssues).toEqual(['No field "x"']);
+  });
+
+  test("an unsaved document earns partial credit for its authored markers", () => {
+    const score = scoreAuthoringRun({
+      turnError: null,
+      attempt: {
+        status: "unsaved",
+        paths: { missing: [], extra: [] },
+        traps: detectGrammarTraps({
+          blocks: [paragraph("Hello {{name}}")],
+          overlay: [],
+          booleanInputPaths: [],
+        }),
+        overlayIssues: [],
+        fidelity: [],
+      },
+    });
+
+    expect(score.outcome).toBe("partial");
+    expect(score.paths).toEqual({ missing: [], extra: [] });
+    expect(Object.values(score.traps).every((count) => count === 0)).toBe(true);
+    expect(score.note).toBe("authored DOCX was not saved");
   });
 });
 

--- a/apps/api/evals/lib/template-authoring-score.test.ts
+++ b/apps/api/evals/lib/template-authoring-score.test.ts
@@ -234,13 +234,32 @@ describe("scoreAuthoringRun", () => {
     ).toBe("partial");
   });
 
-  test("a provider error outranks everything, and no call is its own outcome", () => {
+  test("a provider error overrides the outcome without discarding saved diagnostics", () => {
     const providerError = scoreAuthoringRun({
       turnError: "provider refused the request",
-      attempt: savedAttempt(),
+      attempt: {
+        ...savedAttempt(),
+        paths: { missing: ["company"], extra: [] },
+        configDefects: ["company has no lookup"],
+      },
     });
     expect(providerError.outcome).toBe("error");
     expect(providerError.note).toBe("provider refused the request");
+    expect(providerError.paths.missing).toEqual(["company"]);
+    expect(providerError.configDefects).toEqual(["company has no lookup"]);
+  });
+
+  test("a provider error with no attempt has no diagnostics", () => {
+    const providerError = scoreAuthoringRun({
+      turnError: "provider refused the request",
+      attempt: null,
+    });
+    expect(providerError.outcome).toBe("error");
+    expect(providerError.note).toBe("provider refused the request");
+    expect(providerError.paths).toEqual({ missing: [], extra: [] });
+  });
+
+  test("no call without a provider error is its own outcome", () => {
     expect(scoreAuthoringRun({ turnError: null, attempt: null }).outcome).toBe(
       "no-call",
     );
@@ -284,6 +303,29 @@ describe("scoreAuthoringRun", () => {
     expect(score.paths).toEqual({ missing: [], extra: [] });
     expect(Object.values(score.traps).every((count) => count === 0)).toBe(true);
     expect(score.note).toBe("authored DOCX was not saved");
+  });
+
+  test("an unsaved document keeps its evidence when the turn errors", () => {
+    const score = scoreAuthoringRun({
+      turnError: "output token limit reached",
+      attempt: {
+        status: "unsaved",
+        paths: { missing: ["signing_date"], extra: [] },
+        traps: detectGrammarTraps({
+          blocks: [paragraph("{{#each attorneys}}"), paragraph("{{name}}")],
+          overlay: [],
+          booleanInputPaths: [],
+        }),
+        overlayIssues: [],
+        fidelity: ['dropped "POWER OF ATTORNEY"'],
+      },
+    });
+
+    expect(score.outcome).toBe("error");
+    expect(score.note).toBe("output token limit reached");
+    expect(score.paths.missing).toEqual(["signing_date"]);
+    expect(score.traps.unprefixed_item_path).toBe(1);
+    expect(score.fidelity).toEqual(['dropped "POWER OF ATTORNEY"']);
   });
 });
 

--- a/apps/api/evals/lib/template-authoring-score.ts
+++ b/apps/api/evals/lib/template-authoring-score.ts
@@ -406,18 +406,12 @@ const emptyScore = (): Omit<AuthoringRunScore, "outcome" | "note"> => ({
 });
 
 /**
- * Fold one run into an outcome plus its defect lists. A `pass` is a template
+ * Fold one attempt into an outcome plus its defect lists. A `pass` is a template
  * that discovered exactly the expected paths, tripped no grammar trap, passed
  * every production validation, configured every field the brief asked for,
  * and filled cleanly.
  */
-export const scoreAuthoringRun = ({
-  turnError,
-  attempt,
-}: ScoreAuthoringRunOptions): AuthoringRunScore => {
-  if (turnError !== null) {
-    return { ...emptyScore(), outcome: "error", note: turnError };
-  }
+const scoreAttempt = (attempt: SaveAttempt | null): AuthoringRunScore => {
   if (attempt === null) {
     return {
       ...emptyScore(),
@@ -472,6 +466,18 @@ export const scoreAuthoringRun = ({
     default:
       return assertNever(attempt);
   }
+};
+
+/** A turn error overrides completion, but never erases attempt evidence that
+ * was already produced before the provider or stream failed. */
+export const scoreAuthoringRun = ({
+  turnError,
+  attempt,
+}: ScoreAuthoringRunOptions): AuthoringRunScore => {
+  const score = scoreAttempt(attempt);
+  return turnError === null
+    ? score
+    : { ...score, outcome: "error", note: turnError };
 };
 
 // ── Syntax quiz ───────────────────────────────────────────

--- a/apps/api/evals/lib/template-authoring-score.ts
+++ b/apps/api/evals/lib/template-authoring-score.ts
@@ -352,6 +352,13 @@ export type SaveAttempt =
   | { status: "invalid-docx"; reason: string }
   | { status: "rejected"; overlayIssues: readonly string[] }
   | {
+      status: "unsaved";
+      paths: PathComparison;
+      traps: GrammarTrapCounts;
+      overlayIssues: readonly string[];
+      fidelity: readonly string[];
+    }
+  | {
       status: "saved";
       paths: PathComparison;
       traps: GrammarTrapCounts;
@@ -431,6 +438,16 @@ export const scoreAuthoringRun = ({
         outcome: "partial",
         overlayIssues: attempt.overlayIssues,
         note: "save_template rejected the call",
+      };
+    case "unsaved":
+      return {
+        ...emptyScore(),
+        outcome: "partial",
+        paths: attempt.paths,
+        traps: attempt.traps,
+        overlayIssues: attempt.overlayIssues,
+        fidelity: attempt.fidelity,
+        note: "authored DOCX was not saved",
       };
     case "saved": {
       const clean =

--- a/apps/api/evals/template-authoring.ts
+++ b/apps/api/evals/template-authoring.ts
@@ -37,7 +37,12 @@
  *   fidelity      source wording the template dropped instead of keeping
  *   round trip    leftover `{{`, blank repeated rows, a conditional row that
  *                 was not dropped, a date outside its requested locale
+ *   error         exact provider or stream error for the run
  *   tokens, ms
+ *
+ * A valid `write_docx` result still earns marker, grammar and fidelity credit
+ * when the turn ends before `save_template`; it remains a partial outcome
+ * because configuration and the fill round trip never completed.
  *
  * The `syntax-quiz` task has no DOCX: eight grammar questions answered as one
  * JSON object, scored exactly. Its wrong answers are reported in the
@@ -140,9 +145,9 @@ const DEFAULT_MODELS = [
 const DEFAULT_RUNS = 1;
 // Every run is a paid request; keep a typo from turning into a bill.
 const MAX_RUNS = 20;
-// A whole document plus its field overlay, with room for a reasoning model's
-// thinking tokens, which share this budget.
-const MAX_OUTPUT_TOKENS = 24_000;
+// A whole document plus its field overlay and the following save call, with
+// room for a reasoning model's thinking tokens, which share this budget.
+const MAX_OUTPUT_TOKENS = 48_000;
 const MAX_ITERATIONS = 10;
 const MODEL_REQUEST_TIMEOUT_MS = 240_000;
 
@@ -1177,9 +1182,11 @@ type ToolTrace = { name: string; input: unknown };
 const createAuthoringTools = ({
   trace,
   saveCalls,
+  writeCalls,
 }: {
   trace: ToolTrace[];
   saveCalls: SaveCall[];
+  writeCalls: AuthoredBlock[][];
 }): AnyServerTool[] => {
   const written = new Map<string, Buffer>();
 
@@ -1203,6 +1210,7 @@ const createAuthoringTools = ({
         ? { type: "paragraph", text: block.text }
         : { type: "table", rows: block.rows },
     );
+    writeCalls.push(authored);
     const buffer = await buildDocx(authored);
     written.set(ref, buffer);
     return { docx_ref: ref, bytes: buffer.byteLength };
@@ -1420,6 +1428,8 @@ type EvalRun = {
   taskId: string;
   repeat: number;
   score: AuthoringRunScore;
+  /** Exact provider or stream error for this run, retained in JSON output. */
+  error: string | null;
   calls: number;
   quiz: { correct: number; total: number } | null;
   latencyMs: number;
@@ -1480,6 +1490,35 @@ const buildAttempt = async ({
   };
 };
 
+const buildUnsavedAttempt = async ({
+  blocks,
+  task,
+  overlayIssues,
+}: {
+  blocks: readonly AuthoredBlock[];
+  task: EvalTask;
+  overlayIssues: readonly string[];
+}): Promise<SaveAttempt> => {
+  const discovered = await discoverTemplate(await buildDocx(blocks));
+  const paths = mergeManifestWithDiscovery(null, discovered).map(
+    (field) => field.path,
+  );
+  return {
+    status: "unsaved",
+    paths: comparePaths(task.expectedPaths, paths),
+    traps: detectGrammarTraps({
+      blocks,
+      overlay: [],
+      booleanInputPaths: task.booleanInputPaths,
+    }),
+    overlayIssues,
+    fidelity: checkSourceFidelity({
+      authored: authoredParagraphs(blocks),
+      preservedPhrases: task.preservedPhrases,
+    }),
+  };
+};
+
 const runAuthoringTask = async ({
   model,
   modelId,
@@ -1494,7 +1533,8 @@ const runAuthoringTask = async ({
   const organizationId = mintAuthProviderId<"organization">();
   const trace: ToolTrace[] = [];
   const saveCalls: SaveCall[] = [];
-  const tools = createAuthoringTools({ trace, saveCalls });
+  const writeCalls: AuthoredBlock[][] = [];
+  const tools = createAuthoringTools({ trace, saveCalls, writeCalls });
   const sourceDocx = await buildDocx(task.source);
   const prompt = [
     task.brief,
@@ -1522,20 +1562,28 @@ const runAuthoringTask = async ({
       last === undefined
         ? null
         : v.safeParse(SAVE_TEMPLATE_DEFINITION.inputSchemaSource, last.input);
-    const attempt: SaveAttempt | null =
+    const overlayIssues =
       parsed === null
-        ? null
-        : {
-            status: "rejected",
-            overlayIssues: parsed.success
-              ? ["save_template call never reached the handler"]
-              : validationIssues(parsed.issues),
-          };
+        ? []
+        : parsed.success
+          ? ["save_template call never reached the handler"]
+          : validationIssues(parsed.issues);
+    const authored = writeCalls.at(-1);
+    const attempt: SaveAttempt | null =
+      authored === undefined
+        ? parsed === null
+          ? null
+          : {
+              status: "rejected",
+              overlayIssues,
+            }
+        : await buildUnsavedAttempt({ blocks: authored, task, overlayIssues });
     return {
       modelId,
       taskId: task.id,
       repeat,
       score: scoreAuthoringRun({ turnError: turn.error, attempt }),
+      error: turn.error,
       calls: raw.length,
       quiz: null,
       latencyMs: turn.latencyMs,
@@ -1555,6 +1603,7 @@ const runAuthoringTask = async ({
     taskId: task.id,
     repeat,
     score: scoreAuthoringRun({ turnError: turn.error, attempt }),
+    error: turn.error,
     calls: saveCalls.length,
     quiz: null,
     latencyMs: turn.latencyMs,
@@ -1616,6 +1665,7 @@ const runSyntaxQuiz = async ({
     taskId: SYNTAX_QUIZ_TASK_ID,
     repeat,
     score,
+    error: turn.error,
     calls: answers.length,
     quiz: { correct: quiz.correct, total: quiz.total },
     latencyMs: turn.latencyMs,
@@ -1659,8 +1709,8 @@ const renderReport = (runs: readonly EvalRun[]): string => {
     const modelRuns = runs.filter((run) => run.modelId === modelId);
     lines.push(`\n### ${modelId}\n`);
     lines.push(
-      "| task | run | outcome | calls | missing | extra | traps | overlay | config | fidelity | round trip | tokens | ms |",
-      "| --- | ---: | --- | ---: | --- | --- | --- | --- | --- | --- | --- | ---: | ---: |",
+      "| task | run | outcome | error | calls | missing | extra | traps | overlay | config | fidelity | round trip | tokens | ms |",
+      "| --- | ---: | --- | --- | ---: | --- | --- | --- | --- | --- | --- | --- | ---: | ---: |",
     );
     for (const run of modelRuns) {
       const { score } = run;
@@ -1669,6 +1719,7 @@ const renderReport = (runs: readonly EvalRun[]): string => {
           `| ${run.taskId}`,
           String(run.repeat),
           score.outcome,
+          run.error === null ? "-" : cell([run.error]),
           String(run.calls),
           cell(score.paths.missing),
           cell(score.paths.extra),

--- a/apps/api/evals/template-authoring.ts
+++ b/apps/api/evals/template-authoring.ts
@@ -1178,7 +1178,7 @@ const WRITE_DOCX_DESCRIPTION =
   "it expands to the file's base64 bytes at the boundary.";
 
 type ToolTrace = { name: string; input: unknown };
-type WrittenDocx = { blocks: AuthoredBlock[]; buffer: Buffer };
+type WrittenDocx = { ref: string; blocks: AuthoredBlock[]; buffer: Buffer };
 
 const createAuthoringTools = ({
   trace,
@@ -1212,7 +1212,7 @@ const createAuthoringTools = ({
         : { type: "table", rows: block.rows },
     );
     const buffer = await buildDocx(authored);
-    writeCalls.push({ blocks: authored, buffer });
+    writeCalls.push({ ref, blocks: authored, buffer });
     written.set(ref, buffer);
     return { docx_ref: ref, bytes: buffer.byteLength };
   });
@@ -1514,7 +1514,12 @@ const buildUnsavedAttempt = async ({
       overlay: [],
       booleanInputPaths: task.booleanInputPaths,
     }),
-    overlayIssues,
+    overlayIssues: [
+      ...overlayIssues,
+      ...discovered.structureErrors.map(
+        (error) => `${error.directive}: ${error.message}`,
+      ),
+    ],
     fidelity: checkSourceFidelity({
       authored: authoredParagraphs(blocks),
       preservedPhrases: task.preservedPhrases,
@@ -1571,7 +1576,19 @@ const runAuthoringTask = async ({
         : parsed.success
           ? ["save_template call never reached the handler"]
           : validationIssues(parsed.issues);
-    const authored = writeCalls.at(-1);
+    // A rejected raw save can name an earlier write. Score that exact
+    // document; using the most recent write would attach its diagnostics to a
+    // different attempted save. With no save attempt, the last authored
+    // document remains the only available partial evidence.
+    const authored =
+      last === undefined
+        ? writeCalls.at(-1)
+        : parsed?.success
+          ? writeCalls.findLast(
+              (written) =>
+                written.ref === parsed.output.docx_base64.trim(),
+            )
+          : undefined;
     const attempt: SaveAttempt | null =
       authored === undefined
         ? parsed === null
@@ -1687,7 +1704,12 @@ const runSyntaxQuiz = async ({
 // ── Report ────────────────────────────────────────────────
 
 const cell = (values: readonly string[]): string =>
-  values.length === 0 ? "-" : values.join("; ").replaceAll("|", "\\|");
+  values.length === 0
+    ? "-"
+    : values
+        .join("; ")
+        .replaceAll(/\r\n|\r|\n/gu, "<br>")
+        .replaceAll("|", "\\|");
 
 const trapsCell = (traps: GrammarTrapCounts): string =>
   cell(

--- a/apps/api/evals/template-authoring.ts
+++ b/apps/api/evals/template-authoring.ts
@@ -1580,29 +1580,26 @@ const runAuthoringTask = async ({
     // document; using the most recent write would attach its diagnostics to a
     // different attempted save. With no save attempt, the last authored
     // document remains the only available partial evidence.
-    const authored =
-      last === undefined
-        ? writeCalls.at(-1)
-        : parsed?.success
-          ? writeCalls.findLast(
-              (written) =>
-                written.ref === parsed.output.docx_base64.trim(),
-            )
-          : undefined;
-    const attempt: SaveAttempt | null =
-      authored === undefined
-        ? parsed === null
-          ? null
-          : {
-              status: "rejected",
-              overlayIssues,
-            }
-        : await buildUnsavedAttempt({
-            blocks: authored.blocks,
-            buffer: authored.buffer,
-            task,
-            overlayIssues,
-          });
+    let authored: WrittenDocx | undefined;
+    if (last === undefined) {
+      authored = writeCalls.at(-1);
+    } else if (parsed?.success) {
+      authored = writeCalls.findLast(
+        (written) => written.ref === parsed.output.docx_base64.trim(),
+      );
+    }
+
+    let attempt: SaveAttempt | null;
+    if (authored === undefined) {
+      attempt = parsed === null ? null : { status: "rejected", overlayIssues };
+    } else {
+      attempt = await buildUnsavedAttempt({
+        blocks: authored.blocks,
+        buffer: authored.buffer,
+        task,
+        overlayIssues,
+      });
+    }
     return {
       modelId,
       taskId: task.id,

--- a/apps/api/evals/template-authoring.ts
+++ b/apps/api/evals/template-authoring.ts
@@ -1178,6 +1178,7 @@ const WRITE_DOCX_DESCRIPTION =
   "it expands to the file's base64 bytes at the boundary.";
 
 type ToolTrace = { name: string; input: unknown };
+type WrittenDocx = { blocks: AuthoredBlock[]; buffer: Buffer };
 
 const createAuthoringTools = ({
   trace,
@@ -1186,7 +1187,7 @@ const createAuthoringTools = ({
 }: {
   trace: ToolTrace[];
   saveCalls: SaveCall[];
-  writeCalls: AuthoredBlock[][];
+  writeCalls: WrittenDocx[];
 }): AnyServerTool[] => {
   const written = new Map<string, Buffer>();
 
@@ -1210,8 +1211,8 @@ const createAuthoringTools = ({
         ? { type: "paragraph", text: block.text }
         : { type: "table", rows: block.rows },
     );
-    writeCalls.push(authored);
     const buffer = await buildDocx(authored);
+    writeCalls.push({ blocks: authored, buffer });
     written.set(ref, buffer);
     return { docx_ref: ref, bytes: buffer.byteLength };
   });
@@ -1492,14 +1493,16 @@ const buildAttempt = async ({
 
 const buildUnsavedAttempt = async ({
   blocks,
+  buffer,
   task,
   overlayIssues,
 }: {
   blocks: readonly AuthoredBlock[];
+  buffer: Buffer;
   task: EvalTask;
   overlayIssues: readonly string[];
 }): Promise<SaveAttempt> => {
-  const discovered = await discoverTemplate(await buildDocx(blocks));
+  const discovered = await discoverTemplate(buffer);
   const paths = mergeManifestWithDiscovery(null, discovered).map(
     (field) => field.path,
   );
@@ -1533,7 +1536,7 @@ const runAuthoringTask = async ({
   const organizationId = mintAuthProviderId<"organization">();
   const trace: ToolTrace[] = [];
   const saveCalls: SaveCall[] = [];
-  const writeCalls: AuthoredBlock[][] = [];
+  const writeCalls: WrittenDocx[] = [];
   const tools = createAuthoringTools({ trace, saveCalls, writeCalls });
   const sourceDocx = await buildDocx(task.source);
   const prompt = [
@@ -1577,7 +1580,12 @@ const runAuthoringTask = async ({
               status: "rejected",
               overlayIssues,
             }
-        : await buildUnsavedAttempt({ blocks: authored, task, overlayIssues });
+        : await buildUnsavedAttempt({
+            blocks: authored.blocks,
+            buffer: authored.buffer,
+            task,
+            overlayIssues,
+          });
     return {
       modelId,
       taskId: task.id,

--- a/apps/api/evals/template-authoring.ts
+++ b/apps/api/evals/template-authoring.ts
@@ -1586,9 +1586,10 @@ const runAuthoringTask = async ({
     if (last === undefined) {
       authored = writeCalls.at(-1);
     } else if (parsed?.success) {
-      authored = writeCalls.findLast(
-        (written) => written.ref === parsed.output.docx_base64.trim(),
-      );
+      const ref = parsed.output.docx_base64;
+      if (ref !== undefined) {
+        authored = writeCalls.findLast((written) => written.ref === ref.trim());
+      }
     }
 
     let attempt: SaveAttempt | null;

--- a/apps/api/evals/template-authoring.ts
+++ b/apps/api/evals/template-authoring.ts
@@ -1570,12 +1570,14 @@ const runAuthoringTask = async ({
       last === undefined
         ? null
         : v.safeParse(SAVE_TEMPLATE_DEFINITION.inputSchemaSource, last.input);
-    const overlayIssues =
-      parsed === null
-        ? []
-        : parsed.success
-          ? ["save_template call never reached the handler"]
-          : validationIssues(parsed.issues);
+    let overlayIssues: string[];
+    if (parsed === null) {
+      overlayIssues = [];
+    } else if (parsed.success) {
+      overlayIssues = ["save_template call never reached the handler"];
+    } else {
+      overlayIssues = validationIssues(parsed.issues);
+    }
     // A rejected raw save can name an earlier write. Score that exact
     // document; using the most recent write would attach its diagnostics to a
     // different attempted save. With no save attempt, the last authored


### PR DESCRIPTION
Raises the template-authoring output budget so longer tool cycles can reach `save_template`.

When a turn ends after a valid `write_docx` call, the eval now reports marker, grammar, and source-fidelity results as an unsaved partial outcome. Per-run provider and stream errors are retained verbatim in JSON and shown in the Markdown report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unsaved authored documents are now assessed for partial credit instead of receiving no score.
  - Evaluation evidence is preserved when a provider or turn error occurs.
  - Provider errors now take precedence in the final outcome while retaining available diagnostics.
  - Runs without an attempted save are handled consistently.

- **Reporting**
  - Evaluation reports now include the exact provider or stream error.
  - Empty value lists and multiline report content are displayed more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->