### PR TITLE
fix: correct clipboard backgrounds and close control placement

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -964,6 +964,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168dbdf4dced8f57fa4246ac9080598452b49d70bb2d0e46422142f113140dd8"
+dependencies = [
+ "num-traits",
+ "phf",
+ "serde",
+ "uncased",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3526,6 +3545,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+ "uncased",
 ]
 
 [[package]]
@@ -3535,6 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
+ "uncased",
 ]
 
 [[package]]
@@ -4630,6 +4651,7 @@ dependencies = [
  "chrono",
  "clipboard-rs",
  "clipboard-win",
+ "csscolorparser",
  "dirs 6.0.0",
  "futures-util",
  "hex",
@@ -5824,6 +5846,15 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -83,6 +83,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clipboard-rs = { version = "0.3.5", default-features = false, features = [
   "image",
 ] }
+csscolorparser = "=0.8.4"
 dirs = "6"
 futures-util = "0.3"
 hex = "0.4"

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -2589,8 +2589,8 @@ fn is_highlight_color(value: &str) -> bool {
     return true;
   }
   csscolorparser::parse(value).is_ok_and(|color| {
-    let [red, green, blue, alpha] = color.to_rgba8();
-    alpha > 0 && (red != green || green != blue)
+    let [red, green, blue, alpha] = color.clamp().to_array();
+    alpha > 0.0 && (red != green || green != blue)
   })
 }
 
@@ -4143,6 +4143,8 @@ mod tests {
       "rgb(255, 255, 0)",
       "rgb(100% 100% 0% / 50%)",
       "hsl(60 100% 50%)",
+      "rgba(255, 0, 0, 0.001)",
+      "rgb(10.1 10 10)",
     ] {
       let html = format!("<strong style='background: {color}'>text</strong>");
       let sanitized = sanitized_html(&html).unwrap();

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -2510,9 +2510,8 @@ fn sanitized_style(element: &str, style: &str) -> Option<String> {
       }
       // The theme token styles cards; the fallback keeps the highlight when
       // the HTML is pasted into another application.
-      "background" | "background-color" => {
-        is_plain_color(&value).then(|| format!("background: {HIGHLIGHT_BACKGROUND}"))
-      }
+      "background" | "background-color" => is_highlight_color(&value)
+        .then(|| format!("background: {HIGHLIGHT_BACKGROUND}")),
       _ => None,
     };
     if let Some(kept) = kept {
@@ -2583,36 +2582,16 @@ fn format_points(value: f32) -> String {
   text.trim_end_matches('0').trim_end_matches('.').to_string()
 }
 
-/// A colour literal a highlight can be mapped from: a name, `#hex` or an
-/// `rgb(...)` call. Anything else (`url(...)`, gradients, keywords) is not.
-fn is_plain_color(value: &str) -> bool {
-  if matches!(
-    value,
-    "" | "none"
-      | "transparent"
-      | "inherit"
-      | "initial"
-      | "unset"
-      | "white"
-      | "#fff"
-      | "#ffffff"
-  ) {
-    return false;
+/// Ignore neutral page backgrounds regardless of their CSS spelling. The exact
+/// generated token remains valid when stored HTML is sanitized again.
+fn is_highlight_color(value: &str) -> bool {
+  if value == HIGHLIGHT_BACKGROUND {
+    return true;
   }
-  if let Some(hex) = value.strip_prefix('#') {
-    return matches!(hex.len(), 3 | 4 | 6 | 8)
-      && hex.chars().all(|c| c.is_ascii_hexdigit());
-  }
-  if let Some(arguments) = value
-    .strip_prefix("rgb(")
-    .or_else(|| value.strip_prefix("rgba("))
-    .and_then(|rest| rest.strip_suffix(')'))
-  {
-    return arguments
-      .chars()
-      .all(|c| c.is_ascii_digit() || matches!(c, ',' | '.' | '%' | ' ' | '/'));
-  }
-  value.chars().all(|c| c.is_ascii_alphabetic())
+  csscolorparser::parse(value).is_ok_and(|color| {
+    let [red, green, blue, alpha] = color.to_rgba8();
+    alpha > 0 && (red != green || green != blue)
+  })
 }
 
 /// Word separates an auto-numbered list label from its paragraph with a span in
@@ -4086,6 +4065,119 @@ mod tests {
       "width=\"94\"",
     ] {
       assert!(!html.contains(dropped), "{dropped} survived: {html}");
+    }
+  }
+
+  #[test]
+  fn sanitizer_ignores_equivalent_white_backgrounds() {
+    for color in [
+      "white",
+      "#fff",
+      "#ffffff",
+      "#ffff",
+      "#ffffffff",
+      "rgb(255, 255, 255)",
+      "rgba(255, 255, 255, 1)",
+      "rgb(100% 100% 100%)",
+      "rgb(255 255 255 / 50%)",
+      "hsl(120 0% 100%)",
+    ] {
+      for property in ["background", "background-color"] {
+        let html = format!("<strong style='{property}: {color}'>text</strong>");
+        assert_eq!(
+          sanitized_html(&html).as_deref(),
+          Some("<strong>text</strong>"),
+          "{html}"
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn sanitizer_ignores_every_achromatic_rgb_background() {
+    for channel in 0..=255 {
+      for color in [
+        format!("rgb({channel}, {channel}, {channel})"),
+        format!("rgb({channel} {channel} {channel} / 50%)"),
+        format!("#{channel:02x}{channel:02x}{channel:02x}"),
+      ] {
+        let html = format!("<strong style='background: {color}'>text</strong>");
+        assert_eq!(
+          sanitized_html(&html).as_deref(),
+          Some("<strong>text</strong>"),
+          "{html}"
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn sanitizer_ignores_zero_alpha_independently_of_rgb_channels() {
+    for red in [0, 64, 128, 255] {
+      for green in [0, 64, 128, 255] {
+        for blue in [0, 64, 128, 255] {
+          for color in [
+            format!("rgba({red}, {green}, {blue}, 0)"),
+            format!("rgb({red} {green} {blue} / 0%)"),
+            format!("#{red:02x}{green:02x}{blue:02x}00"),
+          ] {
+            let html =
+              format!("<strong style='background-color: {color}'>text</strong>");
+            assert_eq!(
+              sanitized_html(&html).as_deref(),
+              Some("<strong>text</strong>"),
+              "{html}"
+            );
+          }
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn sanitizer_preserves_equivalent_highlights_on_repeated_import() {
+    for color in [
+      "yellow",
+      "#ff0",
+      "#ffff00",
+      "rgb(255, 255, 0)",
+      "rgb(100% 100% 0% / 50%)",
+      "hsl(60 100% 50%)",
+    ] {
+      let html = format!("<strong style='background: {color}'>text</strong>");
+      let sanitized = sanitized_html(&html).unwrap();
+      assert_eq!(
+        sanitized,
+        format!("<strong style=\"background: {HIGHLIGHT_BACKGROUND}\">text</strong>"),
+        "{html}"
+      );
+      assert_eq!(
+        sanitized_html(&sanitized).as_deref(),
+        Some(sanitized.as_str()),
+        "{html}"
+      );
+    }
+  }
+
+  #[test]
+  fn sanitizer_drops_invalid_and_context_dependent_backgrounds() {
+    for color in [
+      "currentcolor",
+      "inherit",
+      "notacolor",
+      "rgb()",
+      "rgb(1,2,3,4,5)",
+      "red trailing",
+      "var(--page-background)",
+      "url(javascript:alert(1))",
+      "linear-gradient(red, blue)",
+    ] {
+      let html = format!("<strong style='background: {color}'>text</strong>");
+      assert_eq!(
+        sanitized_html(&html).as_deref(),
+        Some("<strong>text</strong>"),
+        "{html}"
+      );
     }
   }
 

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -2031,17 +2031,7 @@ const ClipboardApp = () => {
           }
         />
       )}
-      <Button
-        aria-label={t("close")}
-        className="bg-background/80 absolute end-1 top-1 z-10 size-11 rounded-full backdrop-blur-sm"
-        onClick={requestHide}
-        size="icon"
-        title={t("close")}
-        variant="ghost"
-      >
-        <XIcon aria-hidden="true" className="size-4" />
-      </Button>
-      <main className="relative me-14 min-h-0 flex-1">
+      <main className="relative min-h-0 flex-1">
         {feedback}
 
         {filteredItems.length === 0 ? (
@@ -2141,7 +2131,7 @@ const ClipboardApp = () => {
         )}
       </main>
 
-      <footer className="clipboard-controls grid h-14 shrink-0 grid-cols-[auto_minmax(8rem,22rem)_auto_minmax(0,1fr)] items-center gap-2 px-3">
+      <footer className="clipboard-controls grid h-14 shrink-0 grid-cols-[auto_minmax(8rem,22rem)_auto_minmax(0,1fr)_auto] items-center gap-2 px-3">
         <div className="flex shrink-0 items-center gap-0.5">
           <a
             aria-label="Stella"
@@ -2406,6 +2396,16 @@ const ClipboardApp = () => {
             );
           })}
         </nav>
+        <Button
+          aria-label={t("close")}
+          className="size-11 shrink-0 rounded-full"
+          onClick={requestHide}
+          size="icon"
+          title={t("close")}
+          variant="ghost"
+        >
+          <XIcon aria-hidden="true" className="size-4" />
+        </Button>
       </footer>
     </div>
   );


### PR DESCRIPTION
Clipboard HTML import now parses CSS colours before deciding whether to preserve a highlight. Neutral and transparent backgrounds are removed consistently across colour spellings, while coloured highlights retain their precision and the generated highlight token survives repeated sanitization. Previously sanitized history retains its stored highlights.

Close now occupies the last column of the bottom toolbar, after the scrollable groups. The card rail uses the full viewport without a reserved side strip or an overlapping Close target.

Validated with 89 clipboard tests, Clippy, the dependency/license audit, and local preview interaction. The colour regressions were observed failing with the old predicate before the fix.
