### PR TITLE
feat(api): block markers may prefix and suffix cell text in a table row

### DIFF
--- a/.changeset/row-form-block-markers.md
+++ b/.changeset/row-form-block-markers.md
@@ -1,0 +1,9 @@
+---
+"@stll/template-conditions": minor
+---
+
+`detectRowBlockPair` names the row block a table row declares when a `{{#each}}`
+/ `{{#if}}` opener prefixes one cell's text and its closer suffixes a later
+cell's text in the same row. Both the fill pipeline and the authoring scorer
+read the placement from this one function, so a row that repeats and a row the
+scorer accepts cannot disagree.

--- a/apps/api/evals/lib/template-authoring-score.test.ts
+++ b/apps/api/evals/lib/template-authoring-score.test.ts
@@ -118,6 +118,21 @@ describe("detectGrammarTraps", () => {
     ).toBe(1);
   });
 
+  test("a branch marker buried in a row's cell is still a trap", () => {
+    // Not a row block: only the opener and closer are ever hoisted, so this
+    // placement loses the branch.
+    expect(
+      traps([table(["{{#if paid}}Paid{{#else}}Unpaid", "Amount{{/if}}"])])
+        .block_marker_inline,
+    ).toBe(2);
+  });
+
+  test("a pair wrapping one cell's own paragraphs is still a trap", () => {
+    expect(
+      traps([table(["{{#each x}}Item\nFee{{/each}}"])]).block_marker_inline,
+    ).toBe(2);
+  });
+
   test("per-language paths for one value collapse to a language_variant_path", () => {
     const counts = traps([
       paragraph("Podpisano {{signing_date_pl}}"),

--- a/apps/api/evals/lib/template-authoring-score.test.ts
+++ b/apps/api/evals/lib/template-authoring-score.test.ts
@@ -15,6 +15,11 @@ const paragraph = (text: string): AuthoredBlock => ({
   text,
 });
 
+const table = (...rows: readonly string[][]): AuthoredBlock => ({
+  type: "table",
+  rows,
+});
+
 const traps = (
   blocks: readonly AuthoredBlock[],
   overlay = [],
@@ -82,6 +87,35 @@ describe("detectGrammarTraps", () => {
         paragraph("{{/if}}"),
       ]).block_marker_inline,
     ).toBe(0);
+  });
+
+  test("a row block opened and closed across one row's cells is a placement, not a trap", () => {
+    const counts = traps([
+      table(
+        ["Deliverable", "Fee"],
+        [
+          "{{#each deliverables}}{{deliverables.item}}",
+          "{{deliverables.fee}}{{/each}}",
+        ],
+      ),
+      table(["{{#if penalty}}Late fee", "{{penalty_amount}}{{/if}}"]),
+    ]);
+    expect(counts.block_marker_inline).toBe(0);
+    expect(counts.unprefixed_item_path).toBe(0);
+  });
+
+  test("an unclosed block marker in a plain paragraph is still a trap", () => {
+    expect(
+      traps([paragraph("{{#if penalty}}A penalty applies.")])
+        .block_marker_inline,
+    ).toBe(1);
+  });
+
+  test("a row whose opener has no closer is still a trap", () => {
+    expect(
+      traps([table(["{{#each deliverables}}{{deliverables.item}}", "Fee"])])
+        .block_marker_inline,
+    ).toBe(1);
   });
 
   test("per-language paths for one value collapse to a language_variant_path", () => {

--- a/apps/api/evals/lib/template-authoring-score.ts
+++ b/apps/api/evals/lib/template-authoring-score.ts
@@ -12,6 +12,7 @@
 
 import {
   assertNever,
+  detectRowBlockPair,
   isBlockDirectiveKind,
   scanInvalidMarkers,
   scanMarkers,
@@ -19,8 +20,9 @@ import {
 
 /**
  * One block of the document the model authored. A table cell holds a
- * paragraph, so `block_marker_inline` is decided per cell exactly as it is
- * per body paragraph.
+ * paragraph, so `block_marker_inline` is decided per cell exactly as it is per
+ * body paragraph — except for the row block a row's cells may declare between
+ * them, which is a supported placement (see {@link detectRowBlockPair}).
  */
 export type AuthoredBlock =
   | { type: "paragraph"; text: string }
@@ -75,14 +77,56 @@ const zeroTrapCounts = (): GrammarTrapCounts => ({
   condition_on_input: 0,
 });
 
+/**
+ * One paragraph as the trap detectors read it. `rowBlockStarts` holds the
+ * offsets of the block markers that open or close a ROW block — a pair that
+ * prefixes one cell of a table row and suffixes another — which is a supported
+ * placement, not a marker crowded into a paragraph.
+ */
+type ScannedParagraph = {
+  text: string;
+  rowBlockStarts: ReadonlySet<number>;
+};
+
+const NO_ROW_BLOCK: ReadonlySet<number> = new Set<number>();
+
+/**
+ * One table row's paragraphs, with the row block its cells declare (if any)
+ * marked. Cells are split on newlines because a newline inside a cell starts a
+ * new paragraph, exactly as it does in the body.
+ */
+const rowParagraphs = (row: readonly string[]): ScannedParagraph[] => {
+  const cells = row.map((cell) => cell.split("\n"));
+  const pair = detectRowBlockPair(cells);
+  const startsAt = (cellIndex: number, paragraphIndex: number): number[] =>
+    pair === null
+      ? []
+      : [pair.open, pair.close]
+          .filter(
+            (end) =>
+              end.cellIndex === cellIndex &&
+              end.paragraphIndex === paragraphIndex,
+          )
+          .map(({ marker }) => marker.start);
+
+  return cells.flatMap((paragraphs, cellIndex) =>
+    paragraphs.map((text, paragraphIndex) => {
+      const starts = startsAt(cellIndex, paragraphIndex);
+      return {
+        text,
+        rowBlockStarts: starts.length === 0 ? NO_ROW_BLOCK : new Set(starts),
+      };
+    }),
+  );
+};
+
 /** Every paragraph in document order, which the `{{#each}}` nesting walk
- *  depends on. A newline inside a table cell starts a new paragraph there, so
- *  `block_marker_inline` is judged per paragraph inside cells too. */
-const paragraphsOf = (blocks: readonly AuthoredBlock[]): string[] =>
+ *  depends on. */
+const paragraphsOf = (blocks: readonly AuthoredBlock[]): ScannedParagraph[] =>
   blocks.flatMap((block) =>
     block.type === "paragraph"
-      ? [block.text]
-      : block.rows.flatMap((row) => row.flatMap((cell) => cell.split("\n"))),
+      ? [{ text: block.text, rowBlockStarts: NO_ROW_BLOCK }]
+      : block.rows.flatMap(rowParagraphs),
   );
 
 const DIRECTIVE_SHAPED_RE = /^[#/@]/u;
@@ -188,7 +232,7 @@ export const detectGrammarTraps = ({
   const placeholderPaths: string[] = [];
   const arrayPaths = new Set<string>();
 
-  for (const text of paragraphsOf(blocks)) {
+  for (const { rowBlockStarts, text } of paragraphsOf(blocks)) {
     for (const invalid of scanInvalidMarkers(text)) {
       if (DIRECTIVE_SHAPED_RE.test(invalid.inner)) {
         counts.unknown_directive += 1;
@@ -199,8 +243,13 @@ export const detectGrammarTraps = ({
     }
 
     const markers = scanMarkers(text);
-    const blockMarkers = markers.filter((marker) =>
-      isBlockDirectiveKind(marker.meta.kind),
+    // A row block's two markers are placed as the grammar allows: the opener
+    // in front of one cell's text, the closer behind another's. Only markers
+    // that genuinely share a paragraph with other content are the trap.
+    const blockMarkers = markers.filter(
+      (marker) =>
+        isBlockDirectiveKind(marker.meta.kind) &&
+        !rowBlockStarts.has(marker.start),
     );
     if (blockMarkers.length > 0) {
       let remainder = text;

--- a/apps/api/evals/template-authoring.ts
+++ b/apps/api/evals/template-authoring.ts
@@ -1088,7 +1088,7 @@ const SYNTAX_QUIZ_QUESTIONS = {
   },
   block_marker_own_paragraph: {
     question:
-      "Must a block marker (`{{#each}}`, `{{#if}}`, `{{/each}}`, `{{/if}}`) occupy a paragraph of its own? true or false.",
+      "Outside a table row, must a block marker (`{{#each}}`, `{{#if}}`, `{{/each}}`, `{{/if}}`) occupy a paragraph of its own? true or false.",
     expected: true,
   },
   bilingual_same_path: {

--- a/apps/api/src/lib/docx/block-directives.ts
+++ b/apps/api/src/lib/docx/block-directives.ts
@@ -77,6 +77,7 @@ import type {
 } from "@stll/template-conditions";
 
 import { ancestorByLocalName, isElement, paragraphText, W_NS } from "./ooxml";
+import { normalizeRowBlockMarkers } from "./row-block-markers";
 import type {
   Block,
   BlockDirective,
@@ -750,6 +751,12 @@ export const processBlockDirectives = (
 ): ProcessResult => {
   const patchValues: Record<string, RichPatchValue> = {};
   const allErrors: TemplateStructureError[] = [];
+
+  // Row-form markers become own-paragraph markers before anything scans, so
+  // every rule below (row repeat, row condition, straddling errors) sees one
+  // placement. Discovery normalizes the same way, so the two agree on what a
+  // table row declares.
+  normalizeRowBlockMarkers(body);
 
   // Flatten top-level nested objects for value substitution.
   Object.assign(patchValues, flattenTemplateData(data));

--- a/apps/api/src/lib/docx/block-directives.ts
+++ b/apps/api/src/lib/docx/block-directives.ts
@@ -77,7 +77,10 @@ import type {
 } from "@stll/template-conditions";
 
 import { ancestorByLocalName, isElement, paragraphText, W_NS } from "./ooxml";
-import { normalizeRowBlockMarkers } from "./row-block-markers";
+import {
+  authoredParagraphIndices,
+  normalizeRowBlockMarkers,
+} from "./row-block-markers";
 import type {
   Block,
   BlockDirective,
@@ -798,7 +801,17 @@ export const processBlockDirectives = (
       }
 
       const { blocks, errors } = parseBlockTree(directives);
-      allErrors.push(...errors);
+      // `paragraphs` carries the marker paragraphs normalization hoisted out of
+      // a table row's cells; a reported position must name the paragraph the
+      // author wrote.
+      const authoredIndices = authoredParagraphIndices(paragraphs);
+      for (const error of errors) {
+        allErrors.push({
+          ...error,
+          paragraphIndex:
+            authoredIndices[error.paragraphIndex] ?? error.paragraphIndex,
+        });
+      }
 
       if (blocks.length === 0) {
         return;
@@ -826,9 +839,13 @@ export const processBlockDirectives = (
     if (remaining.length > 0) {
       const first = remaining[0];
       if (first) {
+        const authoredIndices = authoredParagraphIndices(
+          bodyParagraphs(bodyEl),
+        );
         allErrors.push({
           message: `Template nesting too deep: ${remaining.length} unresolved directive(s) after ${MAX_PASSES} passes`,
-          paragraphIndex: first.paragraphIndex,
+          paragraphIndex:
+            authoredIndices[first.paragraphIndex] ?? first.paragraphIndex,
           directive: "MAX_PASSES exceeded",
         });
       }
@@ -901,6 +918,7 @@ export const processBlockDirectives = (
           directive: `{{#if ${block.branches[0]?.condition ?? ""}}}`,
           markerParagraphs,
           markers: "{{#if}} and {{/if}}",
+          paragraphs,
           paragraphIndex: firstDirective,
         });
         return;
@@ -1128,6 +1146,8 @@ export const processBlockDirectives = (
     markerParagraphs: readonly slimdom.Element[];
     /** The marker pair named in the message, e.g. `{{#if}} and {{/if}}`. */
     markers: string;
+    /** The pass's paragraph snapshot `paragraphIndex` addresses. */
+    paragraphs: readonly slimdom.Element[];
     paragraphIndex: number;
   };
 
@@ -1137,14 +1157,16 @@ export const processBlockDirectives = (
     directive,
     markerParagraphs,
     markers,
+    paragraphs,
     paragraphIndex,
   }: ReportAmbiguousPlacementOptions): void => {
     for (const marker of markerParagraphs) {
       rewriteTextNodes(marker, () => "");
     }
+    const authoredIndices = authoredParagraphIndices(paragraphs);
     allErrors.push({
       message: `${markers} must sit in the same table row or share a block-level parent; a marker pair that straddles a table boundary is not supported`,
-      paragraphIndex,
+      paragraphIndex: authoredIndices[paragraphIndex] ?? paragraphIndex,
       directive,
     });
   };
@@ -1437,6 +1459,7 @@ export const processBlockDirectives = (
         directive: `{{#each ${block.arrayPath}}}`,
         markerParagraphs: [openerP, closerP],
         markers: "{{#each}} and {{/each}}",
+        paragraphs,
         paragraphIndex: openingIdx,
       });
       return;

--- a/apps/api/src/lib/docx/discover-template.test.ts
+++ b/apps/api/src/lib/docx/discover-template.test.ts
@@ -26,6 +26,9 @@ const WRAP = (body: string) =>
 <w:body>${body}</w:body></w:document>`;
 
 const P = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const TC = (...paragraphs: string[]) => `<w:tc>${paragraphs.join("")}</w:tc>`;
+const TR = (...cells: string[]) => `<w:tr>${cells.join("")}</w:tr>`;
+const TBL = (...rows: string[]) => `<w:tbl>${rows.join("")}</w:tbl>`;
 
 // ── Tests ────────────────────────────────────────────────
 
@@ -697,5 +700,67 @@ describe("template authoring warnings", () => {
     const result = await discoverTemplate(await makeDocx(xml));
 
     expect(result.conditionPaths).toEqual(["has_guarantor"]);
+  });
+});
+
+describe("row-form block markers", () => {
+  test("a loop opened and closed across one row's cells is discovered whole", async () => {
+    const rowForm = WRAP(
+      TBL(
+        TR(TC(P("Deliverable")), TC(P("Fee"))),
+        TR(
+          TC(P("{{#each deliverables}}{{deliverables.item}}")),
+          TC(P("{{deliverables.fee}}{{/each}}")),
+        ),
+      ),
+    );
+    const ownParagraphForm = WRAP(
+      TBL(
+        TR(TC(P("Deliverable")), TC(P("Fee"))),
+        TR(
+          TC(P("{{#each deliverables}}"), P("{{deliverables.item}}")),
+          TC(P("{{deliverables.fee}}"), P("{{/each}}")),
+        ),
+      ),
+    );
+    const result = await discoverTemplate(await makeDocx(rowForm));
+
+    expect(result.structureErrors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(
+      result.fields.find((field) => field.path === "deliverables"),
+    ).toEqual({
+      path: "deliverables",
+      kind: "array",
+      count: 2,
+      itemFields: [
+        { path: "fee", kind: "string", count: 1 },
+        { path: "item", kind: "string", count: 1 },
+      ],
+    });
+    // The two placements are the same template, so they discover the same schema.
+    expect(result).toEqual(
+      await discoverTemplate(await makeDocx(ownParagraphForm)),
+    );
+  });
+
+  test("a row condition across one row's cells discovers its driver", async () => {
+    const xml = WRAP(
+      TBL(
+        TR(
+          TC(P("{{#if penalty}}Late fee")),
+          TC(P("{{penalty_amount}}{{/if}}")),
+        ),
+      ),
+    );
+    const result = await discoverTemplate(await makeDocx(xml));
+
+    expect(result.structureErrors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.conditionPaths).toEqual(["penalty"]);
+    expect(
+      result.fields.find((field) => field.path === "penalty_amount")
+        ?.visibleWhen,
+    ).toBe("penalty");
   });
 });

--- a/apps/api/src/lib/docx/discover-template.ts
+++ b/apps/api/src/lib/docx/discover-template.ts
@@ -26,7 +26,10 @@ import {
   templateContentPartPaths,
   W_NS,
 } from "./ooxml";
-import { normalizeRowBlockMarkers } from "./row-block-markers";
+import {
+  authoredParagraphIndices,
+  normalizeRowBlockMarkers,
+} from "./row-block-markers";
 import {
   boundTemplateWarnings,
   collectParagraphWarnings,
@@ -433,9 +436,19 @@ const collectContainerStructure = ({
   warnings,
 }: ContainerStructureOptions) => {
   const paragraphs = body.getElementsByTagNameNS(W_NS, "p");
+  // Positions to report. Everything below indexes `paragraphs`, which carries
+  // the marker paragraphs normalization hoisted out of a table row's cells;
+  // a diagnostic has to name the paragraph the author can count to instead.
+  const authoredIndices = authoredParagraphIndices(paragraphs);
   const directives = scanBlockDirectives(body);
   const { blocks, errors: parseErrors } = parseBlockTree(directives);
-  errors.push(...parseErrors);
+  for (const error of parseErrors) {
+    errors.push({
+      ...error,
+      paragraphIndex:
+        authoredIndices[error.paragraphIndex] ?? error.paragraphIndex,
+    });
+  }
   const arrayScopes = new Map<number, readonly RowScope[]>();
   const activeArrays: RowScope[] = [];
   const directiveByParagraph = new Map(
@@ -472,7 +485,7 @@ const collectContainerStructure = ({
       warnings.push(
         ...collectParagraphWarnings({
           loops: activeArrays,
-          paragraphIndex: i,
+          paragraphIndex: authoredIndices[i] ?? i,
           text: paragraphText(paragraph),
         }),
       );
@@ -485,6 +498,7 @@ const collectContainerStructure = ({
 
   return {
     arrayScopes,
+    authoredIndices,
     blocks,
     conditionMap: buildConditionMapFromRanges(directives, paragraphs.length),
     directiveIndices,
@@ -538,6 +552,7 @@ const collectLoopItemFields = ({
 
 const collectParagraphPlaceholders = ({
   arrayScopes,
+  authoredIndices,
   conditionMap,
   conditionPaths,
   directiveIndices,
@@ -574,7 +589,7 @@ const collectParagraphPlaceholders = ({
     if (!inline.ok) {
       errors.push({
         message: inline.message,
-        paragraphIndex: i,
+        paragraphIndex: authoredIndices[i] ?? i,
         directive: inline.directive,
       });
     } else {

--- a/apps/api/src/lib/docx/discover-template.ts
+++ b/apps/api/src/lib/docx/discover-template.ts
@@ -26,6 +26,7 @@ import {
   templateContentPartPaths,
   W_NS,
 } from "./ooxml";
+import { normalizeRowBlockMarkers } from "./row-block-markers";
 import {
   boundTemplateWarnings,
   collectParagraphWarnings,
@@ -701,6 +702,10 @@ const collectParagraphPlaceholders = ({
  * extract field information from its paragraphs.
  */
 const analyzeContainer = (body: slimdom.Element): AnalysisResult => {
+  // Same rewrite the fill pipeline applies, so a row-form loop is discovered
+  // with its item paths and warns exactly as the own-paragraph form does.
+  normalizeRowBlockMarkers(body);
+
   const fields: FieldAccumulator = new Map();
   const placeholderCounts = new Map<string, number>();
   const errors: TemplateStructureError[] = [];
@@ -832,6 +837,9 @@ const analyzeHeadersAndFooters = async (
 
     const source = hdr ? "header" : "footer";
     const offset = source === "header" ? headerParaCount : footerParaCount;
+    // Count before analysis: normalizing a row-form marker adds a paragraph of
+    // its own, and the running offset must keep counting the authored file.
+    const paraCount = container.getElementsByTagNameNS(W_NS, "p").length;
     const analysis = analyzeContainer(container);
 
     // Tag errors with their source and offset indices to
@@ -841,7 +849,6 @@ const analyzeHeadersAndFooters = async (
       err.paragraphIndex += offset;
     }
 
-    const paraCount = container.getElementsByTagNameNS(W_NS, "p").length;
     if (source === "header") {
       headerParaCount += paraCount;
     } else {

--- a/apps/api/src/lib/docx/row-block-markers.test.ts
+++ b/apps/api/src/lib/docx/row-block-markers.test.ts
@@ -7,6 +7,7 @@ import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
 import { processBlockDirectives } from "./block-directives";
 import { processInlineConditions } from "./inline-conditions";
 import { paragraphText, W_NS } from "./ooxml";
+import type { TemplateData } from "./types";
 
 setDefaultTimeout(propertyTestTimeout(30_000));
 
@@ -32,16 +33,8 @@ const parseBody = (xml: string): slimdom.Element => {
   return body;
 };
 
-type Rendered = {
-  blockErrors: readonly { message: string; directive: string }[];
-  inlineErrors: readonly { message: string; directive: string }[];
-  patchValues: Record<string, unknown>;
-  rowCount: number;
-  texts: string[];
-};
-
 /** The full directive pipeline over one body, as patch-template runs it. */
-const render = (xml: string, data: Record<string, unknown>): Rendered => {
+const render = (xml: string, data: TemplateData) => {
   const body = parseBody(xml);
   const { errors, patchValues } = processBlockDirectives(body, data);
   const inlineErrors = processInlineConditions(body, data);
@@ -56,24 +49,22 @@ const render = (xml: string, data: Record<string, unknown>): Rendered => {
 
 const HEADER_ROW = TR(TC(P("Deliverable")), TC(P("Fee")));
 
-const eachRowForm = (rows: string) =>
-  WRAP(
-    TBL(
-      HEADER_ROW,
-      TR(
-        TC(P("{{#each deliverables}}{{deliverables.item}}")),
-        TC(P("{{deliverables.fee}}{{/each}}")),
-      ),
-      rows,
+const EACH_ROW_FORM = WRAP(
+  TBL(
+    HEADER_ROW,
+    TR(
+      TC(P("{{#each deliverables}}{{deliverables.item}}")),
+      TC(P("{{deliverables.fee}}{{/each}}")),
     ),
-  );
+  ),
+);
 
 // ── Row-form {{#each}} ───────────────────────────────────
 
 describe("row-form {{#each}} markers", () => {
   test("repeats the row per item and strips the markers", () => {
     const { blockErrors, inlineErrors, patchValues, rowCount, texts } = render(
-      eachRowForm(""),
+      EACH_ROW_FORM,
       {
         deliverables: [
           { item: "Report", fee: "100" },
@@ -101,7 +92,7 @@ describe("row-form {{#each}} markers", () => {
   });
 
   test("an empty list removes the template row and keeps the header", () => {
-    const { rowCount, texts } = render(eachRowForm(""), { deliverables: [] });
+    const { rowCount, texts } = render(EACH_ROW_FORM, { deliverables: [] });
 
     expect(rowCount).toBe(1);
     expect(texts).toEqual(["Deliverable", "Fee"]);

--- a/apps/api/src/lib/docx/row-block-markers.test.ts
+++ b/apps/api/src/lib/docx/row-block-markers.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import fc from "fast-check";
+import * as slimdom from "slimdom";
+
+import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
+
+import { processBlockDirectives } from "./block-directives";
+import { processInlineConditions } from "./inline-conditions";
+import { paragraphText, W_NS } from "./ooxml";
+
+setDefaultTimeout(propertyTestTimeout(30_000));
+
+// ── Fixture builders ─────────────────────────────────────
+
+const WRAP = (body: string) =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>${body}</w:body></w:document>`;
+
+const P = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const TC = (...paragraphs: string[]) => `<w:tc>${paragraphs.join("")}</w:tc>`;
+const TR = (...cells: string[]) => `<w:tr>${cells.join("")}</w:tr>`;
+const TBL = (...rows: string[]) => `<w:tbl>${rows.join("")}</w:tbl>`;
+
+const parseBody = (xml: string): slimdom.Element => {
+  const body = slimdom
+    .parseXmlDocument(xml)
+    .getElementsByTagNameNS(W_NS, "body")[0];
+  if (!body) {
+    throw new Error("No w:body element found");
+  }
+  return body;
+};
+
+type Rendered = {
+  blockErrors: readonly { message: string; directive: string }[];
+  inlineErrors: readonly { message: string; directive: string }[];
+  patchValues: Record<string, unknown>;
+  rowCount: number;
+  texts: string[];
+};
+
+/** The full directive pipeline over one body, as patch-template runs it. */
+const render = (xml: string, data: Record<string, unknown>): Rendered => {
+  const body = parseBody(xml);
+  const { errors, patchValues } = processBlockDirectives(body, data);
+  const inlineErrors = processInlineConditions(body, data);
+  return {
+    blockErrors: errors,
+    inlineErrors,
+    patchValues,
+    rowCount: body.getElementsByTagNameNS(W_NS, "tr").length,
+    texts: [...body.getElementsByTagNameNS(W_NS, "p")].map(paragraphText),
+  };
+};
+
+const HEADER_ROW = TR(TC(P("Deliverable")), TC(P("Fee")));
+
+const eachRowForm = (rows: string) =>
+  WRAP(
+    TBL(
+      HEADER_ROW,
+      TR(
+        TC(P("{{#each deliverables}}{{deliverables.item}}")),
+        TC(P("{{deliverables.fee}}{{/each}}")),
+      ),
+      rows,
+    ),
+  );
+
+// ── Row-form {{#each}} ───────────────────────────────────
+
+describe("row-form {{#each}} markers", () => {
+  test("repeats the row per item and strips the markers", () => {
+    const { blockErrors, inlineErrors, patchValues, rowCount, texts } = render(
+      eachRowForm(""),
+      {
+        deliverables: [
+          { item: "Report", fee: "100" },
+          { item: "Audit", fee: "200" },
+          { item: "Filing", fee: "300" },
+        ],
+      },
+    );
+
+    expect(blockErrors).toEqual([]);
+    expect(inlineErrors).toEqual([]);
+    // header row + one row per item
+    expect(rowCount).toBe(4);
+    expect(texts).toEqual([
+      "Deliverable",
+      "Fee",
+      "{{__each_deliverables_0_item}}",
+      "{{__each_deliverables_0_fee}}",
+      "{{__each_deliverables_1_item}}",
+      "{{__each_deliverables_1_fee}}",
+      "{{__each_deliverables_2_item}}",
+      "{{__each_deliverables_2_fee}}",
+    ]);
+    expect(patchValues["__each_deliverables_2_fee"]).toBe("300");
+  });
+
+  test("an empty list removes the template row and keeps the header", () => {
+    const { rowCount, texts } = render(eachRowForm(""), { deliverables: [] });
+
+    expect(rowCount).toBe(1);
+    expect(texts).toEqual(["Deliverable", "Fee"]);
+  });
+
+  test("keeps the run formatting of the text around the markers", () => {
+    const body = parseBody(
+      WRAP(
+        TBL(
+          TR(
+            TC(
+              `<w:p><w:r><w:t>{{#each deliverables}}</w:t></w:r><w:r><w:rPr><w:b/></w:rPr><w:t>{{deliverables.item}}</w:t></w:r></w:p>`,
+            ),
+            TC(P("{{deliverables.fee}}{{/each}}")),
+          ),
+        ),
+      ),
+    );
+    processBlockDirectives(body, { deliverables: [{ item: "a", fee: "1" }] });
+
+    const boldRuns = [...body.getElementsByTagNameNS(W_NS, "r")].filter(
+      (run) => run.getElementsByTagNameNS(W_NS, "b").length > 0,
+    );
+    expect(boldRuns.map(paragraphText)).toEqual([
+      "{{__each_deliverables_0_item}}",
+    ]);
+  });
+
+  test("an opener with no closer in the row keeps today's error", () => {
+    const { inlineErrors, rowCount } = render(
+      WRAP(
+        TBL(
+          TR(
+            TC(P("{{#each deliverables}}{{deliverables.item}}")),
+            TC(P("Fee")),
+          ),
+        ),
+      ),
+      { deliverables: [{ item: "a" }] },
+    );
+
+    expect(rowCount).toBe(1);
+    expect(inlineErrors).toEqual([
+      {
+        message:
+          'Unclosed inline {{#each}} — the {{/each}} must be in the same paragraph in paragraph "{{#each deliverables}}{{deliverables.item}}"',
+        paragraphIndex: 0,
+        directive: "{{#each deliverables}}",
+      },
+    ]);
+  });
+
+  test("a closer with no opener in the row keeps today's error", () => {
+    const { inlineErrors } = render(
+      WRAP(TBL(TR(TC(P("Item")), TC(P("{{deliverables.fee}}{{/each}}"))))),
+      { deliverables: [{ fee: "1" }] },
+    );
+
+    expect(inlineErrors).toEqual([
+      {
+        message:
+          'Orphaned inline {{/each}} without an open {{#each}} in paragraph "{{deliverables.fee}}{{/each}}"',
+        paragraphIndex: 1,
+        directive: "{{/each}}",
+      },
+    ]);
+  });
+
+  test("text before the opener stays inline mode and errors as today", () => {
+    const { inlineErrors, rowCount } = render(
+      WRAP(
+        TBL(
+          TR(
+            TC(P("Item: {{#each deliverables}}{{deliverables.item}}")),
+            TC(P("{{deliverables.fee}}{{/each}}")),
+          ),
+        ),
+      ),
+      { deliverables: [{ item: "a", fee: "1" }] },
+    );
+
+    expect(rowCount).toBe(1);
+    expect(inlineErrors.map(({ directive }) => directive)).toEqual([
+      "{{#each deliverables}}",
+      "{{/each}}",
+    ]);
+    expect(inlineErrors[0]?.message).toStartWith(
+      "Unclosed inline {{#each}} — the {{/each}} must be in the same paragraph",
+    );
+  });
+
+  test("two row blocks nested in one row report a structure error", () => {
+    const { inlineErrors, rowCount } = render(
+      WRAP(
+        TBL(
+          TR(
+            TC(P("{{#each deliverables}}{{deliverables.item}}")),
+            TC(P("{{#if paid}}paid")),
+            TC(P("yes{{/if}}")),
+            TC(P("{{deliverables.fee}}{{/each}}")),
+          ),
+        ),
+      ),
+      { deliverables: [{ item: "a", fee: "1" }], paid: true },
+    );
+
+    expect(rowCount).toBe(1);
+    expect(inlineErrors.map(({ directive }) => directive)).toEqual([
+      "{{#each deliverables}}",
+      "{{#if paid}}",
+      "{{/if}}",
+      "{{/each}}",
+    ]);
+  });
+
+  test("a pair straddling two rows is still refused", () => {
+    const { blockErrors, inlineErrors } = render(
+      WRAP(
+        TBL(
+          TR(TC(P("{{#each deliverables}}{{deliverables.item}}"))),
+          TR(TC(P("{{deliverables.fee}}{{/each}}"))),
+        ),
+      ),
+      { deliverables: [{ item: "a", fee: "1" }] },
+    );
+
+    expect(blockErrors).toEqual([]);
+    expect(inlineErrors.map(({ directive }) => directive)).toEqual([
+      "{{#each deliverables}}",
+      "{{/each}}",
+    ]);
+  });
+});
+
+// ── Row-form {{#if}} ─────────────────────────────────────
+
+describe("row-form {{#if}} markers", () => {
+  const ifRowForm = WRAP(
+    TBL(
+      TR(TC(P("Clause")), TC(P("Amount"))),
+      TR(TC(P("{{#if penalty}}Late fee")), TC(P("{{penalty_amount}}{{/if}}"))),
+    ),
+  );
+
+  test("keeps the row with the markers stripped when the condition holds", () => {
+    const { blockErrors, inlineErrors, rowCount, texts } = render(ifRowForm, {
+      penalty: true,
+      penalty_amount: "500",
+    });
+
+    expect(blockErrors).toEqual([]);
+    expect(inlineErrors).toEqual([]);
+    expect(rowCount).toBe(2);
+    expect(texts).toEqual([
+      "Clause",
+      "Amount",
+      "Late fee",
+      "{{penalty_amount}}",
+    ]);
+  });
+
+  test("removes the whole row when the condition fails", () => {
+    const { rowCount, texts } = render(ifRowForm, {
+      penalty: false,
+      penalty_amount: "500",
+    });
+
+    expect(rowCount).toBe(1);
+    expect(texts).toEqual(["Clause", "Amount"]);
+  });
+});
+
+// ── Equivalence with the own-paragraph form ──────────────
+
+describe("row form and own-paragraph form agree", () => {
+  const eachRowXml = WRAP(
+    TBL(
+      HEADER_ROW,
+      TR(
+        TC(P("{{#each deliverables}}{{deliverables.item}}")),
+        TC(P("{{deliverables.fee}}{{/each}}")),
+      ),
+    ),
+  );
+  const eachParagraphXml = WRAP(
+    TBL(
+      HEADER_ROW,
+      TR(
+        TC(P("{{#each deliverables}}"), P("{{deliverables.item}}")),
+        TC(P("{{deliverables.fee}}"), P("{{/each}}")),
+      ),
+    ),
+  );
+  const ifRowXml = WRAP(
+    TBL(
+      HEADER_ROW,
+      TR(TC(P("{{#if penalty}}Late fee")), TC(P("{{penalty_amount}}{{/if}}"))),
+    ),
+  );
+  const ifParagraphXml = WRAP(
+    TBL(
+      HEADER_ROW,
+      TR(
+        TC(P("{{#if penalty}}"), P("Late fee")),
+        TC(P("{{penalty_amount}}"), P("{{/if}}")),
+      ),
+    ),
+  );
+
+  const item = fc.record({
+    item: fc.string({ maxLength: 8 }).filter((s) => !s.includes("{")),
+    fee: fc.string({ maxLength: 8 }).filter((s) => !s.includes("{")),
+  });
+
+  test("the two placements render the same rows for the same values", () => {
+    fc.assert(
+      fc.property(
+        fc.array(item, { maxLength: 5 }),
+        fc.boolean(),
+        (deliverables, penalty) => {
+          const data = { deliverables, penalty, penalty_amount: "500" };
+          for (const [rowXml, paragraphXml] of [
+            [eachRowXml, eachParagraphXml],
+            [ifRowXml, ifParagraphXml],
+          ] as const) {
+            const rowForm = render(rowXml, data);
+            const paragraphForm = render(paragraphXml, data);
+            expect(rowForm.blockErrors).toEqual([]);
+            expect(rowForm.inlineErrors).toEqual([]);
+            expect(rowForm.texts).toEqual(paragraphForm.texts);
+            expect(rowForm.rowCount).toBe(paragraphForm.rowCount);
+            expect(rowForm.patchValues).toEqual(paragraphForm.patchValues);
+          }
+        },
+      ),
+      propertyConfig({ numRuns: 50 }),
+    );
+  });
+});

--- a/apps/api/src/lib/docx/row-block-markers.test.ts
+++ b/apps/api/src/lib/docx/row-block-markers.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import fc from "fast-check";
+import JSZip from "jszip";
 import * as slimdom from "slimdom";
 
 import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
 
 import { processBlockDirectives } from "./block-directives";
+import { discoverTemplate } from "./discover-template";
 import { processInlineConditions } from "./inline-conditions";
 import { paragraphText, W_NS } from "./ooxml";
 import type { TemplateData } from "./types";
@@ -22,6 +24,12 @@ const P = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 const TC = (...paragraphs: string[]) => `<w:tc>${paragraphs.join("")}</w:tc>`;
 const TR = (...cells: string[]) => `<w:tr>${cells.join("")}</w:tr>`;
 const TBL = (...rows: string[]) => `<w:tbl>${rows.join("")}</w:tbl>`;
+
+const makeDocx = async (documentXml: string): Promise<Buffer> => {
+  const zip = new JSZip();
+  zip.file("word/document.xml", documentXml);
+  return Buffer.from(await zip.generateAsync({ type: "nodebuffer" }));
+};
 
 const parseBody = (xml: string): slimdom.Element => {
   const body = slimdom
@@ -262,6 +270,106 @@ describe("row-form {{#if}} markers", () => {
 
     expect(rowCount).toBe(1);
     expect(texts).toEqual(["Clause", "Amount"]);
+  });
+
+  test("a branch marker buried in a cell refuses the row and keeps the branch", () => {
+    // Only the opener and closer are hoisted, so accepting this would drop
+    // "Unpaid" with the row whenever the condition is false.
+    for (const paid of [true, false]) {
+      const { inlineErrors, rowCount, texts } = render(
+        WRAP(
+          TBL(
+            TR(
+              TC(P("{{#if paid}}Paid{{#else}}Unpaid")),
+              TC(P("Amount{{/if}}")),
+            ),
+          ),
+        ),
+        { paid },
+      );
+
+      expect(rowCount).toBe(1);
+      expect(texts).toEqual([
+        "{{#if paid}}Paid{{#else}}Unpaid",
+        "Amount{{/if}}",
+      ]);
+      expect(inlineErrors.map(({ directive }) => directive)).toEqual([
+        "{{#if paid}}",
+        "{{/if}}",
+      ]);
+    }
+  });
+
+  test("a pair wrapping one cell's paragraphs is not a row block", () => {
+    const { inlineErrors, rowCount } = render(
+      WRAP(TBL(TR(TC(P("{{#if penalty}}Late fee"), P("500{{/if}}"))))),
+      { penalty: false },
+    );
+
+    expect(rowCount).toBe(1);
+    expect(inlineErrors.map(({ directive }) => directive)).toEqual([
+      "{{#if penalty}}",
+      "{{/if}}",
+    ]);
+  });
+});
+
+// ── Reported paragraph positions ─────────────────────────
+
+describe("diagnostics name the authored paragraph", () => {
+  /** A table row plus a later paragraph whose inline `{{#if}}` never closes.
+   *  The malformed paragraph is the third the author typed: two table cells,
+   *  then it. */
+  const withRow = (firstCell: string, secondCell: string) =>
+    WRAP(
+      TBL(TR(TC(P(firstCell)), TC(P(secondCell)))) +
+        P("Buyer {{#if has_spouse}} and spouse"),
+    );
+
+  const AUTHORED_INDEX = 2;
+
+  test("a row form before a malformed marker does not shift its index", async () => {
+    const rowForm = await discoverTemplate(
+      await makeDocx(
+        withRow(
+          "{{#each deliverables}}{{deliverables.item}}",
+          "{{deliverables.fee}}{{/each}}",
+        ),
+      ),
+    );
+    const noBlock = await discoverTemplate(
+      await makeDocx(withRow("Item", "Fee")),
+    );
+
+    // Normalization hoists two marker paragraphs into the row; neither may take
+    // a position of its own, because extractText and the preview still address
+    // the authored file.
+    expect(rowForm.structureErrors.map((e) => e.paragraphIndex)).toEqual([
+      AUTHORED_INDEX,
+    ]);
+    expect(noBlock.structureErrors.map((e) => e.paragraphIndex)).toEqual([
+      AUTHORED_INDEX,
+    ]);
+  });
+
+  test("a split-marker warning after a row form names the authored paragraph", async () => {
+    const result = await discoverTemplate(
+      await makeDocx(
+        WRAP(
+          TBL(
+            TR(
+              TC(P("{{#each deliverables}}{{deliverables.item}}")),
+              TC(P("{{deliverables.fee}}{{/each}}")),
+            ),
+          ) + P("Total {{amount"),
+        ),
+      ),
+    );
+
+    expect(result.warnings.map(({ code }) => code)).toEqual(["split_marker"]);
+    expect(result.warnings[0]?.message).toContain(
+      `paragraph ${AUTHORED_INDEX}`,
+    );
   });
 });
 

--- a/apps/api/src/lib/docx/row-block-markers.ts
+++ b/apps/api/src/lib/docx/row-block-markers.ts
@@ -48,6 +48,17 @@ const cellParagraphs = (cell: slimdom.Element): slimdom.Element[] =>
   );
 
 /**
+ * The authored paragraph each hoisted marker paragraph was cut out of.
+ *
+ * A hoisted paragraph exists only so the block engine sees the canonical
+ * placement; the author never typed it and cannot count to it in Word. Every
+ * diagnostic that names a paragraph position therefore resolves through
+ * {@link authoredParagraphIndex}, which gives a hoisted marker the index of the
+ * paragraph it came from and no index of its own.
+ */
+const hoistedFrom = new WeakMap<slimdom.Element, slimdom.Element>();
+
+/**
  * Cut one marker out of its paragraph's runs and re-emit it as its own
  * paragraph beside that one, so the block engine sees the canonical placement.
  */
@@ -73,6 +84,7 @@ const hoistMarker = (
   text.appendChild(doc.createTextNode(marker.raw));
   run.appendChild(text);
   markerParagraph.appendChild(run);
+  hoistedFrom.set(markerParagraph, paragraph);
   parent.insertBefore(
     markerParagraph,
     placement === "before" ? paragraph : paragraph.nextSibling,
@@ -99,4 +111,37 @@ export const normalizeRowBlockMarkers = (container: slimdom.Element): void => {
     hoistMarker(paragraphsByCell, pair.close, "after");
     hoistMarker(paragraphsByCell, pair.open, "before");
   }
+};
+
+/**
+ * For each position in `paragraphs`, the position that paragraph holds in the
+ * file the author wrote: hoisted marker paragraphs take no index of their own,
+ * and each reports the index of the paragraph it was cut from.
+ *
+ * Every diagnostic that names a paragraph resolves through this, so a template
+ * using the row form reports the same positions as the same template written
+ * the long way — the positions `extractText` and the preview address. Built
+ * once per paragraph snapshot; the index it translates must address that same
+ * snapshot.
+ *
+ * A paragraph that was never hoisted and is not in the snapshot keeps its own
+ * position: that is a paragraph the loop engine cloned, which has no authored
+ * position at all, so its position is the only honest answer.
+ */
+export const authoredParagraphIndices = (
+  paragraphs: readonly slimdom.Element[],
+): number[] => {
+  const authoredBySource = new Map<slimdom.Element, number>();
+  let authored = 0;
+  for (const paragraph of paragraphs) {
+    if (hoistedFrom.has(paragraph)) {
+      continue;
+    }
+    authoredBySource.set(paragraph, authored);
+    authored += 1;
+  }
+  return paragraphs.map((paragraph, index) => {
+    const source = hoistedFrom.get(paragraph) ?? paragraph;
+    return authoredBySource.get(source) ?? index;
+  });
 };

--- a/apps/api/src/lib/docx/row-block-markers.ts
+++ b/apps/api/src/lib/docx/row-block-markers.ts
@@ -1,0 +1,102 @@
+/**
+ * Rewrite a table row's lenient block markers into the canonical
+ * own-paragraph form, before discovery or the block engine looks at the row.
+ *
+ * A `{{#each}}` / `{{#if}}` opener that prefixes a cell's text, closed by a
+ * `{{/each}}` / `{{/if}}` that suffixes a later cell's text in the same
+ * `w:tr`, means what the own-paragraph placement means: the row is the unit.
+ * Authoring agents write it constantly for a "one row per item" table, so it
+ * is accepted rather than reported as an unclosed inline block.
+ *
+ *     | {{#each deliverables}}{{deliverables.item}} | {{deliverables.fee}}{{/each}} |
+ *
+ * Normalizing (rather than teaching the engine a second placement) is what
+ * keeps the two forms from drifting: the row-repeat, the row condition, the
+ * straddling-marker errors, the loop-item discovery, and the authoring
+ * warnings all keep running on exactly one shape. The marker text is cut from
+ * its run with the same run-splitting the inline engine uses, so the cell's
+ * remaining runs keep their formatting, and the cut marker is re-emitted as a
+ * paragraph of its own directly around the cell paragraph it came from — a
+ * paragraph the engine strips again while expanding or pruning the row.
+ *
+ * {@link detectRowBlockPair} owns the grammar side of the decision and is
+ * shared with the authoring eval, so both judge a row the same way.
+ */
+
+import type * as slimdom from "slimdom";
+
+import { detectRowBlockPair } from "@stll/template-conditions";
+import type { RowBlockMarker } from "@stll/template-conditions";
+
+import { ancestorByLocalName, W_NS } from "./ooxml";
+import { paragraphSpanText, replaceParagraphTextRanges } from "./rich-patch";
+
+/** The row's own cells; a nested table's cells belong to its own rows. */
+const rowCells = (row: slimdom.Element): slimdom.Element[] =>
+  [...row.getElementsByTagNameNS(W_NS, "tc")].filter(
+    (cell) =>
+      cell.parentNode !== null &&
+      ancestorByLocalName(cell.parentNode, "tr") === row,
+  );
+
+/** The cell's own paragraphs; a nested table's paragraphs belong to its cells. */
+const cellParagraphs = (cell: slimdom.Element): slimdom.Element[] =>
+  [...cell.getElementsByTagNameNS(W_NS, "p")].filter(
+    (paragraph) =>
+      paragraph.parentNode !== null &&
+      ancestorByLocalName(paragraph.parentNode, "tc") === cell,
+  );
+
+/**
+ * Cut one marker out of its paragraph's runs and re-emit it as its own
+ * paragraph beside that one, so the block engine sees the canonical placement.
+ */
+const hoistMarker = (
+  paragraphsByCell: readonly (readonly slimdom.Element[])[],
+  { cellIndex, marker, paragraphIndex }: RowBlockMarker,
+  placement: "after" | "before",
+): void => {
+  const paragraph = paragraphsByCell[cellIndex]?.[paragraphIndex];
+  const parent = paragraph?.parentNode;
+  const doc = paragraph?.ownerDocument;
+  if (!paragraph || !parent || !doc) {
+    return;
+  }
+
+  replaceParagraphTextRanges(paragraph, [
+    { start: marker.start, end: marker.end, value: "" },
+  ]);
+
+  const markerParagraph = doc.createElementNS(W_NS, "w:p");
+  const run = doc.createElementNS(W_NS, "w:r");
+  const text = doc.createElementNS(W_NS, "w:t");
+  text.appendChild(doc.createTextNode(marker.raw));
+  run.appendChild(text);
+  markerParagraph.appendChild(run);
+  parent.insertBefore(
+    markerParagraph,
+    placement === "before" ? paragraph : paragraph.nextSibling,
+  );
+};
+
+/**
+ * Rewrite every row-form block pair in `container` into the own-paragraph
+ * form. Idempotent in effect: a rewritten marker owns its paragraph, which the
+ * detector ignores.
+ */
+export const normalizeRowBlockMarkers = (container: slimdom.Element): void => {
+  for (const row of [...container.getElementsByTagNameNS(W_NS, "tr")]) {
+    const paragraphsByCell = rowCells(row).map(cellParagraphs);
+    const pair = detectRowBlockPair(
+      paragraphsByCell.map((paragraphs) => paragraphs.map(paragraphSpanText)),
+    );
+    if (!pair) {
+      continue;
+    }
+    // Closer first: hoisting it inserts a sibling paragraph, which leaves the
+    // opener's own runs and offsets untouched either way, and reading the row
+    // back-to-front matches every other marker rewrite in the pipeline.
+    hoistMarker(paragraphsByCell, pair.close, "after");
+    hoistMarker(paragraphsByCell, pair.open, "before");
+  }
+};

--- a/apps/api/src/mcp/template-marker-reference.ts
+++ b/apps/api/src/mcp/template-marker-reference.ts
@@ -132,8 +132,10 @@ const NON_DIRECTIVE_RULES = [
       "`{{#each deliverables}}{{deliverables.item}}`, last cell " +
       "`{{deliverables.fee}}{{/each}}`. A conditional row: first cell " +
       "`{{#if penalty}}Late fee`, last cell `{{penalty_amount}}{{/if}}`. " +
-      "Nothing may precede the opener or follow the closer in those cells, " +
-      "one pair per row only, and the pair must not straddle a row boundary.",
+      "The two halves must sit in DIFFERENT cells of the same row; nothing " +
+      "may precede the opener or follow the closer in those cells, a branch " +
+      "(`{{#elseif}}`, `{{#else}}`) must own its paragraph, one pair per row " +
+      "only, and the pair must not straddle a row boundary.",
   },
   {
     title: "Markers Word splits into runs",

--- a/apps/api/src/mcp/template-marker-reference.ts
+++ b/apps/api/src/mcp/template-marker-reference.ts
@@ -43,7 +43,8 @@ const DIRECTIVE_DESCRIPTIONS = {
     title: "Conditional block (open)",
     detail:
       "Include the enclosed paragraphs only when the condition holds. Block " +
-      "markers must each occupy their own paragraph.",
+      "markers each occupy their own paragraph, except in a table row (see " +
+      "the table rule below).",
     example: "{{#if is_company}} … {{/if}}",
   },
   elseif: {
@@ -124,8 +125,15 @@ const NON_DIRECTIVE_RULES = [
     detail:
       "A block marker pair (`#if` or `#each` family) confined to ONE table row " +
       "acts on the whole row: the row repeats per item, or is dropped when no " +
-      "branch wins. Opening and closing markers must not straddle a row " +
-      "boundary.",
+      "branch wins. Inside such a row the pair may either own its paragraphs " +
+      "or hug the row's text — the opener directly in FRONT of one cell's " +
+      "text and the closer directly BEHIND a later cell's text, which keeps " +
+      "the row readable as a table. A repeating row: first cell " +
+      "`{{#each deliverables}}{{deliverables.item}}`, last cell " +
+      "`{{deliverables.fee}}{{/each}}`. A conditional row: first cell " +
+      "`{{#if penalty}}Late fee`, last cell `{{penalty_amount}}{{/if}}`. " +
+      "Nothing may precede the opener or follow the closer in those cells, " +
+      "one pair per row only, and the pair must not straddle a row boundary.",
   },
   {
     title: "Markers Word splits into runs",
@@ -175,7 +183,8 @@ export const buildMarkerReference = (): string => {
     "Write a normal DOCX and embed these markers as literal text. Inline " +
       "markers (fillable values, clause slots, numbering) sit within a " +
       "paragraph; block markers (#if / #each families) each occupy their own " +
-      "paragraph.",
+      "paragraph, except in a table row, where a pair may wrap the row's own " +
+      "text (see the table rule).",
     "",
     "Marker kinds:",
     directiveLines,

--- a/apps/api/src/mcp/template-workflow-reference.ts
+++ b/apps/api/src/mcp/template-workflow-reference.ts
@@ -187,13 +187,16 @@ const AUTHORING_RULES = [
       `${LIST_TEMPLATES} reports under \`arrays\`.`,
   },
   {
-    title: "Block markers own their paragraph",
+    title: "Block markers own their paragraph, or wrap a table row",
     detail:
       "Each `{{#if}}` / `{{#each}}` opener and closer sits alone in its own " +
       "paragraph, and a pair either shares a block-level parent or is " +
-      "confined to a single table row (which repeats the row). A pair that " +
-      "straddles a table boundary is ambiguous: it is refused as a structure " +
-      "error and its markers are neutralized instead of expanding.",
+      "confined to a single table row (which repeats the row). Within one row " +
+      "the pair may instead prefix a cell's text and suffix a later cell's " +
+      "text — `{{#each deliverables}}{{deliverables.item}}` in one cell and " +
+      "`{{deliverables.fee}}{{/each}}` in another act on the whole row. A " +
+      "pair that straddles a table boundary is ambiguous: it is refused as a " +
+      "structure error and its markers are neutralized instead of expanding.",
   },
 ] as const;
 

--- a/apps/api/src/mcp/template-workflow-reference.ts
+++ b/apps/api/src/mcp/template-workflow-reference.ts
@@ -192,11 +192,16 @@ const AUTHORING_RULES = [
       "Each `{{#if}}` / `{{#each}}` opener and closer sits alone in its own " +
       "paragraph, and a pair either shares a block-level parent or is " +
       "confined to a single table row (which repeats the row). Within one row " +
-      "the pair may instead prefix a cell's text and suffix a later cell's " +
+      "the pair may instead prefix a cell's text and suffix a LATER cell's " +
       "text — `{{#each deliverables}}{{deliverables.item}}` in one cell and " +
-      "`{{deliverables.fee}}{{/each}}` in another act on the whole row. A " +
-      "pair that straddles a table boundary is ambiguous: it is refused as a " +
-      "structure error and its markers are neutralized instead of expanding.",
+      "`{{deliverables.fee}}{{/each}}` in another act on the whole row; both " +
+      "halves must be in the same row and in different cells. A pair that " +
+      "straddles a table boundary is refused either way, and how it is " +
+      "refused depends on how it was written: a pair whose markers each own " +
+      "their paragraph is reported as a structure error and its markers are " +
+      "emptied, so the fill continues without expanding them, while a pair " +
+      "sharing its paragraphs with text is reported as an unclosed and an " +
+      "orphaned inline marker and both stay in the document as literal text.",
   },
 ] as const;
 

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -237,3 +237,8 @@ export type {
   MarkerMeta,
   ScannedMarker,
 } from "./markers.js";
+
+// Row-form block placement — shared by the fill/discovery pipeline and the
+// authoring eval so both agree on what a table row declares.
+export { detectRowBlockPair } from "./row-blocks.js";
+export type { RowBlockMarker, RowBlockPair } from "./row-blocks.js";

--- a/packages/template-conditions/src/row-blocks.test.ts
+++ b/packages/template-conditions/src/row-blocks.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectRowBlockPair } from "./row-blocks.js";
+
+/** One cell holding a single paragraph, the shape a table row usually has. */
+const row = (...cells: string[]): string[][] => cells.map((cell) => [cell]);
+
+describe("detectRowBlockPair", () => {
+  test("an opener prefixing a cell and a closer suffixing a later cell pair up", () => {
+    const pair = detectRowBlockPair(
+      row(
+        "{{#each deliverables}}{{deliverables.item}}",
+        "{{deliverables.fee}}{{/each}}",
+      ),
+    );
+
+    expect(pair?.open).toMatchObject({ cellIndex: 0, paragraphIndex: 0 });
+    expect(pair?.open.marker.raw).toBe("{{#each deliverables}}");
+    expect(pair?.close).toMatchObject({ cellIndex: 1, paragraphIndex: 0 });
+    expect(pair?.close.marker.raw).toBe("{{/each}}");
+  });
+
+  test("the {{#if}} family pairs the same way", () => {
+    const pair = detectRowBlockPair(
+      row("{{#if penalty}}Late fee", "{{penalty_amount}}{{/if}}"),
+    );
+
+    expect(pair?.open.marker.meta.kind).toBe("if");
+    expect(pair?.close.marker.meta.kind).toBe("endif");
+  });
+
+  test("leading and trailing whitespace does not break the placement", () => {
+    expect(
+      detectRowBlockPair(row("  {{#each x}}{{x.a}}", "{{x.b}}{{/each}}  ")),
+    ).not.toBeNull();
+  });
+
+  test("the opener must stand in front of everything the cell says", () => {
+    expect(
+      detectRowBlockPair(row("Item: {{#each x}}{{x.a}}", "{{x.b}}{{/each}}")),
+    ).toBeNull();
+  });
+
+  test("the closer must stand behind everything the cell says", () => {
+    expect(
+      detectRowBlockPair(row("{{#each x}}{{x.a}}", "{{x.b}}{{/each}} net")),
+    ).toBeNull();
+  });
+
+  test("a half pair is left to the engine's structure errors", () => {
+    expect(detectRowBlockPair(row("{{#each x}}{{x.a}}", "Fee"))).toBeNull();
+    expect(detectRowBlockPair(row("Item", "{{x.b}}{{/each}}"))).toBeNull();
+  });
+
+  test("mismatched families do not pair", () => {
+    expect(
+      detectRowBlockPair(row("{{#each x}}{{x.a}}", "{{x.b}}{{/if}}")),
+    ).toBeNull();
+  });
+
+  test("two row blocks in one row are out of scope", () => {
+    expect(
+      detectRowBlockPair(
+        row(
+          "{{#each x}}{{x.a}}",
+          "{{#if paid}}paid",
+          "yes{{/if}}",
+          "{{x.b}}{{/each}}",
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  test("a pair that closes inside its own paragraph is inline, not a row block", () => {
+    expect(
+      detectRowBlockPair(row("{{#if paid}}paid{{/if}}", "Fee")),
+    ).toBeNull();
+  });
+
+  test("an inline pair beside a row block leaves the row block detectable", () => {
+    const pair = detectRowBlockPair(
+      row(
+        "{{#each x}}{{x.a}}",
+        "{{#if x.paid}}paid{{/if}}",
+        "{{x.b}}{{/each}}",
+      ),
+    );
+
+    expect(pair?.open.cellIndex).toBe(0);
+    expect(pair?.close.cellIndex).toBe(2);
+  });
+
+  test("markers that own their paragraph belong to the block engine", () => {
+    expect(
+      detectRowBlockPair([
+        ["{{#each x}}", "{{x.a}}"],
+        ["{{x.b}}", "{{/each}}"],
+      ]),
+    ).toBeNull();
+  });
+
+  test("a cell's first and last content paragraph carry the markers", () => {
+    expect(
+      detectRowBlockPair([
+        ["{{#each x}}{{x.a}}", "note"],
+        ["note", "{{x.b}}{{/each}}"],
+      ]),
+    ).not.toBeNull();
+    expect(
+      detectRowBlockPair([
+        ["note", "{{#each x}}{{x.a}}"],
+        ["{{x.b}}{{/each}}", "note"],
+      ]),
+    ).toBeNull();
+  });
+
+  test("a stray {{#else}} is not a row block", () => {
+    expect(
+      detectRowBlockPair(row("{{#if paid}}paid", "no{{#else}}", "yes{{/if}}")),
+    ).toBeNull();
+  });
+});

--- a/packages/template-conditions/src/row-blocks.test.ts
+++ b/packages/template-conditions/src/row-blocks.test.ts
@@ -119,4 +119,43 @@ describe("detectRowBlockPair", () => {
       detectRowBlockPair(row("{{#if paid}}paid", "no{{#else}}", "yes{{/if}}")),
     ).toBeNull();
   });
+
+  test("a branch marker stranded in the opener's cell refuses the pair", () => {
+    // Only the opener and the closer are ever hoisted, so a `{{#else}}` buried
+    // in a cell would be dropped with the row when the condition is false.
+    expect(
+      detectRowBlockPair(
+        row("{{#if paid}}Paid{{#else}}Unpaid", "Amount{{/if}}"),
+      ),
+    ).toBeNull();
+    expect(
+      detectRowBlockPair(
+        row("{{#if paid}}Paid", "Unpaid{{#elseif refunded}}", "Amount{{/if}}"),
+      ),
+    ).toBeNull();
+  });
+
+  test("a branch that closes inside its own paragraph leaves the row block", () => {
+    const pair = detectRowBlockPair(
+      row(
+        "{{#each x}}{{x.a}}",
+        "{{#if x.paid}}yes{{#else}}no{{/if}}",
+        "{{x.b}}{{/each}}",
+      ),
+    );
+
+    expect(pair?.open.marker.meta.kind).toBe("each");
+    expect(pair?.close.cellIndex).toBe(2);
+  });
+
+  test("both markers in one cell's paragraphs is not a row block", () => {
+    // Cell to cell only: this reads as a block scoped to the cell, and the row
+    // is the only unit the placement can act on.
+    expect(
+      detectRowBlockPair([["{{#each x}}Item", "Fee{{/each}}"]]),
+    ).toBeNull();
+    expect(
+      detectRowBlockPair([["{{#each x}}Item", "Fee{{/each}}"], ["Net"]]),
+    ).toBeNull();
+  });
 });

--- a/packages/template-conditions/src/row-blocks.ts
+++ b/packages/template-conditions/src/row-blocks.ts
@@ -51,6 +51,14 @@ const isOpenKind = (kind: string): kind is OpenKind =>
  * spouse{{/if}}`), which the inline engine already owns; only what is left
  * over can reach across cells.
  *
+ * A branch marker (`{{#elseif}}`, `{{#else}}`) counts as left over unless its
+ * `{{#if}}` also closes in this paragraph. Only the opener and the closer of a
+ * row block are hoisted, so a branch marker stranded between them would stay
+ * buried in the cell text: a false condition would drop the whole row and the
+ * branch that should have rendered with it, and a true one would leave the
+ * marker behind as an inline orphan. Counting it here refuses the placement
+ * instead.
+ *
  * A paragraph that is nothing but a directive is the canonical form and
  * belongs to the block engine, so it contributes nothing here.
  */
@@ -58,30 +66,45 @@ const danglingBlockMarkers = (text: string): ScannedMarker[] => {
   if (blockDirectiveLinePattern().test(text)) {
     return [];
   }
-  const open: { kind: OpenKind; marker: ScannedMarker }[] = [];
+  type OpenFrame = {
+    kind: OpenKind;
+    marker: ScannedMarker;
+    /** `{{#elseif}}` / `{{#else}}` markers belonging to this frame. */
+    branches: ScannedMarker[];
+  };
+  const open: OpenFrame[] = [];
   const dangling: ScannedMarker[] = [];
   for (const marker of scanMarkers(text)) {
     const { kind } = marker.meta;
     if (isOpenKind(kind)) {
-      open.push({ kind, marker });
+      open.push({ kind, marker, branches: [] });
       continue;
     }
     if (kind === "endeach" || kind === "endif") {
       const innermost = open.at(-1);
       if (innermost && CLOSER_OF[innermost.kind] === kind) {
+        // The frame closed here, so its branch markers closed with it.
         open.pop();
       } else {
         dangling.push(marker);
       }
       continue;
     }
-    if ((kind === "elseif" || kind === "else") && open.at(-1)?.kind !== "if") {
-      dangling.push(marker);
+    if (kind === "elseif" || kind === "else") {
+      const innermost = open.at(-1);
+      if (innermost?.kind === "if") {
+        innermost.branches.push(marker);
+      } else {
+        dangling.push(marker);
+      }
     }
   }
-  return [...dangling, ...open.map(({ marker }) => marker)].toSorted(
-    (a, b) => a.start - b.start,
-  );
+  // A frame still open at the end of the paragraph reaches outside it, and so
+  // does every branch marker that belonged to it.
+  for (const { branches, marker } of open) {
+    dangling.push(marker, ...branches);
+  }
+  return dangling.toSorted((a, b) => a.start - b.start);
 };
 
 const firstContentParagraph = (paragraphs: readonly string[]): number =>
@@ -113,10 +136,11 @@ const suffixesCell = (
  * document order.
  *
  * A row qualifies when exactly two block markers reach outside their own
- * paragraph, they are a matching opener/closer pair, the opener prefixes its
- * cell and the closer suffixes its cell. Everything else — one half of a pair,
- * two nested pairs, a stray `{{#else}}` — is left to the engine's existing
- * structure errors rather than guessed at.
+ * paragraph, they are a matching opener/closer pair, the closer sits in a LATER
+ * cell than the opener, the opener prefixes its cell and the closer suffixes
+ * its cell. Everything else — one half of a pair, two nested pairs, a stray
+ * `{{#else}}`, a pair wrapping the paragraphs of a single cell — is left to the
+ * engine's existing structure errors rather than guessed at.
  */
 export const detectRowBlockPair = (
   cells: readonly (readonly string[])[],
@@ -139,6 +163,12 @@ export const detectRowBlockPair = (
   }
   const openKind = open.marker.meta.kind;
   if (!isOpenKind(openKind) || close.marker.meta.kind !== CLOSER_OF[openKind]) {
+    return null;
+  }
+  // Cell to cell, never within one cell: a pair wrapping the paragraphs of a
+  // single cell reads as a block scoped to that cell, not to the row, and the
+  // row is the only unit this placement can act on.
+  if (open.cellIndex >= close.cellIndex) {
     return null;
   }
   if (

--- a/packages/template-conditions/src/row-blocks.ts
+++ b/packages/template-conditions/src/row-blocks.ts
@@ -1,0 +1,151 @@
+/**
+ * Row-form block markers: the lenient placement authoring agents actually
+ * write for a "one row per item" table.
+ *
+ * The canonical placement gives a block marker its own paragraph. In a table
+ * that costs an extra empty-looking paragraph in the first and last cell, so
+ * an author instead types the opener in front of the first cell's text and the
+ * closer behind the last cell's text:
+ *
+ *     | {{#each deliverables}}{{deliverables.item}} | {{deliverables.fee}}{{/each}} |
+ *
+ * Both placements mean the same thing — the `w:tr` is the unit — so this
+ * module recognizes the row form purely from text, and the consumer rewrites
+ * it into the canonical form before any engine runs.
+ *
+ * Text-only and structure-free on purpose: the fill/discovery pipeline feeds
+ * it OOXML run text, the authoring eval feeds it the cells a model produced,
+ * and neither can drift from the other's idea of what a row block is.
+ */
+
+import { blockDirectiveLinePattern, scanMarkers } from "./markers.js";
+import type { ScannedMarker } from "./markers.js";
+
+/** One end of a row block, addressed within the row that was scanned. */
+export type RowBlockMarker = {
+  /** Index into the row's cells. */
+  cellIndex: number;
+  /** Index into that cell's paragraphs. */
+  paragraphIndex: number;
+  marker: ScannedMarker;
+};
+
+export type RowBlockPair = {
+  open: RowBlockMarker;
+  close: RowBlockMarker;
+};
+
+const CLOSER_OF = {
+  each: "endeach",
+  if: "endif",
+} as const satisfies Record<"each" | "if", "endeach" | "endif">;
+
+type OpenKind = keyof typeof CLOSER_OF;
+
+const isOpenKind = (kind: string): kind is OpenKind =>
+  kind === "each" || kind === "if";
+
+/**
+ * Block markers in one paragraph that do not pair inside it. A pair that opens
+ * and closes within the paragraph is an inline span (`the Buyer{{#if x}} and
+ * spouse{{/if}}`), which the inline engine already owns; only what is left
+ * over can reach across cells.
+ *
+ * A paragraph that is nothing but a directive is the canonical form and
+ * belongs to the block engine, so it contributes nothing here.
+ */
+const danglingBlockMarkers = (text: string): ScannedMarker[] => {
+  if (blockDirectiveLinePattern().test(text)) {
+    return [];
+  }
+  const open: { kind: OpenKind; marker: ScannedMarker }[] = [];
+  const dangling: ScannedMarker[] = [];
+  for (const marker of scanMarkers(text)) {
+    const { kind } = marker.meta;
+    if (isOpenKind(kind)) {
+      open.push({ kind, marker });
+      continue;
+    }
+    if (kind === "endeach" || kind === "endif") {
+      const innermost = open.at(-1);
+      if (innermost && CLOSER_OF[innermost.kind] === kind) {
+        open.pop();
+      } else {
+        dangling.push(marker);
+      }
+      continue;
+    }
+    if ((kind === "elseif" || kind === "else") && open.at(-1)?.kind !== "if") {
+      dangling.push(marker);
+    }
+  }
+  return [...dangling, ...open.map(({ marker }) => marker)].toSorted(
+    (a, b) => a.start - b.start,
+  );
+};
+
+const firstContentParagraph = (paragraphs: readonly string[]): number =>
+  paragraphs.findIndex((text) => text.trim() !== "");
+
+const lastContentParagraph = (paragraphs: readonly string[]): number =>
+  paragraphs.findLastIndex((text) => text.trim() !== "");
+
+/** The marker stands in front of everything the cell says. */
+const prefixesCell = (
+  paragraphs: readonly string[],
+  { marker, paragraphIndex }: RowBlockMarker,
+): boolean =>
+  paragraphIndex === firstContentParagraph(paragraphs) &&
+  (paragraphs[paragraphIndex] ?? "").slice(0, marker.start).trim() === "";
+
+/** The marker stands behind everything the cell says. */
+const suffixesCell = (
+  paragraphs: readonly string[],
+  { marker, paragraphIndex }: RowBlockMarker,
+): boolean =>
+  paragraphIndex === lastContentParagraph(paragraphs) &&
+  (paragraphs[paragraphIndex] ?? "").slice(marker.end).trim() === "";
+
+/**
+ * The one row block a table row declares in the lenient form, or `null`.
+ *
+ * `cells` is the row's cells in document order, each as its paragraph texts in
+ * document order.
+ *
+ * A row qualifies when exactly two block markers reach outside their own
+ * paragraph, they are a matching opener/closer pair, the opener prefixes its
+ * cell and the closer suffixes its cell. Everything else — one half of a pair,
+ * two nested pairs, a stray `{{#else}}` — is left to the engine's existing
+ * structure errors rather than guessed at.
+ */
+export const detectRowBlockPair = (
+  cells: readonly (readonly string[])[],
+): RowBlockPair | null => {
+  const located: RowBlockMarker[] = [];
+  for (const [cellIndex, paragraphs] of cells.entries()) {
+    for (const [paragraphIndex, text] of paragraphs.entries()) {
+      for (const marker of danglingBlockMarkers(text)) {
+        located.push({ cellIndex, paragraphIndex, marker });
+      }
+    }
+  }
+
+  if (located.length !== 2) {
+    return null;
+  }
+  const [open, close] = located;
+  if (!open || !close) {
+    return null;
+  }
+  const openKind = open.marker.meta.kind;
+  if (!isOpenKind(openKind) || close.marker.meta.kind !== CLOSER_OF[openKind]) {
+    return null;
+  }
+  if (
+    !prefixesCell(cells[open.cellIndex] ?? [], open) ||
+    !suffixesCell(cells[close.cellIndex] ?? [], close)
+  ) {
+    return null;
+  }
+  return { open, close };
+};


### PR DESCRIPTION
## The rule

**Before.** Every `{{#if}}` / `{{#each}}` opener and closer had to occupy its
own paragraph. A pair confined to one `w:tr` already acted on the whole row,
but only in that placement. Writing the pair around a cell's text was refused:

```
Unclosed inline {{#each}} — the {{/each}} must be in the same paragraph
Orphaned inline {{/each}} without an open {{#each}}
```

**After.** Inside one table row the pair may also hug the row's own text: the
opener directly in front of one cell's text, the closer directly behind a later
cell's text. That is a ROW block, exactly as the own-paragraph placement is —
the row repeats per item, or is dropped when no branch wins, and the two
markers are cut from the cell text.

| Deliverable | Fee |
| --- | --- |
| `{{#each deliverables}}{{deliverables.item}}` | `{{deliverables.fee}}{{/each}}` |

A conditional row is the same shape: `{{#if penalty}}Late fee` in the first
cell, `{{penalty_amount}}{{/if}}` in the last. Authoring agents commonly write
this form for a one-row-per-item table, and it reads as a normal table in Word.

**Still an error, with today's messages.** An opener at the start of a cell with
no closer anywhere in the row; a closer at the end of a cell with no opener;
text before the opener or after the closer in those cells (that is inline mode);
two row blocks nested in one row; a pair that straddles a row boundary.

## What changed

**Detection** (`packages/template-conditions/src/row-blocks.ts`, new).
`detectRowBlockPair` takes a row as its cells, each as its paragraph texts, and
returns the one row block it declares. A marker pairing inside its own paragraph
is an inline span and is ignored; a paragraph that is nothing but a directive
belongs to the block engine and is ignored. A row qualifies only when exactly
two markers are left over, they are a matching opener/closer pair, the opener
prefixes its cell and the closer suffixes its cell. Pure and text-only, so the
fill pipeline and the authoring scorer cannot drift on what a row block is.

**Rendering** (`apps/api/src/lib/docx/row-block-markers.ts`, new). The row form
is rewritten into the own-paragraph form before anything scans: each marker is
cut from its runs with the same run-splitting the inline engine uses (the cell's
other runs keep their formatting) and re-emitted as a paragraph of its own
beside the one it came from. Everything downstream — the row repeat, the row
condition, `removeBlockUnit`, the straddling-marker errors, loop-item
discovery, the authoring warnings — then runs on a single shape, with no second
placement to keep in sync. `processBlockDirectives` and `analyzeContainer` both
call it, so fill and discovery agree.

**Discovery** needs no new code: the array root is discovered with its
`itemFieldPaths` and emits no warnings, because by the time discovery scans, the
markers stand alone. No new warning code was needed in `template-warnings.ts`.

**Reference.** `template-marker-reference.ts` states the row form with both
example rows and its limits (nothing before the opener or after the closer, one
pair per row, no straddling). `template-workflow-reference.ts` restated the
own-paragraph rule and now names the row form too.

**Eval scorer** (`evals/lib/template-authoring-score.ts`). The
`block_marker_inline` trap is judged per paragraph as before, but a row block's
two markers no longer count: they are a supported placement. A block marker
crowded into an ordinary paragraph, and a row whose opener has no closer, still
count one each. The scorer reads the placement from `detectRowBlockPair`, the
same function the pipeline uses.

## Tests

- `apps/api/src/lib/docx/row-block-markers.test.ts` (new): a header row plus one
  row-form template row renders N rows for N items with the right cell text and
  no leftover markers, the header untouched; an empty list removes the template
  row; run formatting around the markers survives; the `{{#if}}` row form keeps
  the row (markers stripped) when true and removes it when false; an opener with
  no closer, a closer with no opener, text before the opener, two nested row
  blocks, and a pair across two rows each keep today's error. Plus a property:
  for arbitrary item lists and either branch, the row form and the equivalent
  own-paragraph form produce the same paragraphs, the same row count and the
  same expanded values.
- `discover-template.test.ts`: the row form discovers `deliverables` with its
  item fields and no warnings, and its whole discovery result equals the
  own-paragraph form's; a row condition discovers its driver and `visibleWhen`.
- `packages/template-conditions/src/row-blocks.test.ts` (new): 13 cases pinning
  the detector's grammar decision.
- `evals/lib/template-authoring-score.test.ts`: the row form counts zero
  `block_marker_inline`; an unclosed block in a plain paragraph, and a row
  opener with no closer, still count one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Table rows can now use `{{`#each`}}` and `{{`#if`}}` markers spanning cells, enabling row repetition and conditional rendering.
  - Supported row markers are processed consistently with paragraph-based markers.
  - Documentation now describes valid row-spanning marker placement and boundary rules.

- **Bug Fixes**
  - Improved marker discovery, validation, warnings, and rendering for supported table-row layouts.
  - Invalid, incomplete, nested, or cross-row markers continue to be rejected clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->