### PR TITLE
fix(api): MCP tools treat null optional properties as omitted

### DIFF
--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -65,6 +65,7 @@ import {
   ISO_DATE_SCHEMA,
   MAX_LIST_LIMIT,
   notFoundResult,
+  nullAsAbsent,
   structuredErrorResult,
   toolDataResult,
   uuidInputSchema,
@@ -368,87 +369,89 @@ const loadUserNames = async ({
 
 // --- list_time_entries --------------------------------------------------
 
-const listTimeEntriesArgsSchema = v.pipe(
-  v.strictObject({
-    matter_id: v.optional(
-      uuidInputSchema(
-        "Matter ID to list time entries in; required unless " +
-          "time_entry_id is given.",
-      ),
-    ),
-    time_entry_id: v.optional(
-      uuidInputSchema("Time entry ID to read in detail"),
-    ),
-    entity_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.uuid(),
-        v.description(
-          "List only entries logged against this entity (document, folder, " +
-            "or task the time is billed to)",
+const listTimeEntriesArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      matter_id: v.optional(
+        uuidInputSchema(
+          "Matter ID to list time entries in; required unless " +
+            "time_entry_id is given.",
         ),
       ),
-    ),
-    user_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("List only entries recorded by this user"),
+      time_entry_id: v.optional(
+        uuidInputSchema("Time entry ID to read in detail"),
       ),
-    ),
-    date_from: v.optional(
-      v.pipe(
-        ISO_DATE_SCHEMA,
-        v.maxLength(10),
-        v.description(
-          "List only entries worked on or after this ISO date (YYYY-MM-DD)",
+      entity_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.uuid(),
+          v.description(
+            "List only entries logged against this entity (document, folder, " +
+              "or task the time is billed to)",
+          ),
         ),
       ),
-    ),
-    date_to: v.optional(
-      v.pipe(
-        ISO_DATE_SCHEMA,
-        v.maxLength(10),
-        v.description(
-          "List only entries worked on or before this ISO date (YYYY-MM-DD)",
+      user_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description("List only entries recorded by this user"),
         ),
       ),
-    ),
-    status: v.optional(
-      v.pipe(
-        v.picklist(TIME_ENTRY_STATUSES),
-        v.description("List only entries with this status"),
-      ),
-    ),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(MAX_LIST_LIMIT),
-        v.description("Max entries to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.maxLength(512),
-        v.description(
-          "Opaque cursor from a previous list_time_entries call to fetch the next page",
+      date_from: v.optional(
+        v.pipe(
+          ISO_DATE_SCHEMA,
+          v.maxLength(10),
+          v.description(
+            "List only entries worked on or after this ISO date (YYYY-MM-DD)",
+          ),
         ),
       ),
+      date_to: v.optional(
+        v.pipe(
+          ISO_DATE_SCHEMA,
+          v.maxLength(10),
+          v.description(
+            "List only entries worked on or before this ISO date (YYYY-MM-DD)",
+          ),
+        ),
+      ),
+      status: v.optional(
+        v.pipe(
+          v.picklist(TIME_ENTRY_STATUSES),
+          v.description("List only entries with this status"),
+        ),
+      ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(MAX_LIST_LIMIT),
+          v.description("Max entries to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(512),
+          v.description(
+            "Opaque cursor from a previous list_time_entries call to fetch the next page",
+          ),
+        ),
+      ),
+    }),
+    // List mode needs a workspace to scope to; detail mode uses time_entry_id
+    // alone.
+    v.forward(
+      v.partialCheck(
+        [["matter_id"], ["time_entry_id"]],
+        ({ matter_id, time_entry_id }) =>
+          time_entry_id !== undefined || matter_id !== undefined,
+        "Provide matter_id to list entries, or time_entry_id to read one entry",
+      ),
+      ["matter_id"],
     ),
-  }),
-  // List mode needs a workspace to scope to; detail mode uses time_entry_id
-  // alone.
-  v.forward(
-    v.partialCheck(
-      [["matter_id"], ["time_entry_id"]],
-      ({ matter_id, time_entry_id }) =>
-        time_entry_id !== undefined || matter_id !== undefined,
-      "Provide matter_id to list entries, or time_entry_id to read one entry",
-    ),
-    ["matter_id"],
   ),
 );
 
@@ -694,163 +697,167 @@ const handleListTimeEntriesTool: TypedMcpToolHandler<
 
 // --- save_time_entry ----------------------------------------------------
 
-const saveTimeEntryArgsSchema = v.pipe(
-  v.strictObject({
-    time_entry_id: v.optional(
-      uuidInputSchema("Time entry ID to update; omit to create"),
-    ),
-    matter_id: v.optional(
-      uuidInputSchema(
-        "Matter ID to create the entry in; required when creating.",
+const saveTimeEntryArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      time_entry_id: v.optional(
+        uuidInputSchema("Time entry ID to update; omit to create"),
       ),
-    ),
-    entity_id: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.uuid())),
-        v.description(
-          "Optional work item context (document, folder, or task). When " +
-            "updating, moves the entry to a different entity in the same " +
-            "matter; pass null to clear.",
+      matter_id: v.optional(
+        uuidInputSchema(
+          "Matter ID to create the entry in; required when creating.",
         ),
       ),
-    ),
-    date_worked: v.optional(
-      v.pipe(
-        ISO_DATE_SCHEMA,
-        v.maxLength(10),
-        v.description(
-          "Date the work was done (ISO YYYY-MM-DD); required when creating",
+      entity_id: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.uuid())),
+          v.description(
+            "Optional work item context (document, folder, or task). When " +
+              "updating, moves the entry to a different entity in the same " +
+              "matter; pass null to clear.",
+          ),
         ),
       ),
-    ),
-    timezone_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(64),
-        v.description(
-          "IANA time zone the date_worked is interpreted in (e.g. " +
-            "Europe/Prague); required when creating or changing date_worked",
+      date_worked: v.optional(
+        v.pipe(
+          ISO_DATE_SCHEMA,
+          v.maxLength(10),
+          v.description(
+            "Date the work was done (ISO YYYY-MM-DD); required when creating",
+          ),
         ),
       ),
-    ),
-    duration_minutes: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.description("Minutes worked (whole minutes); required when creating"),
-      ),
-    ),
-    narrative: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(10_000),
-        v.description("Description of the work; required when creating"),
-      ),
-    ),
-    invoice_narrative: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(10_000))),
-        v.description(
-          "Client-facing narrative shown on the invoice; pass null to clear. " +
-            "Only valid when updating.",
+      timezone_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(64),
+          v.description(
+            "IANA time zone the date_worked is interpreted in (e.g. " +
+              "Europe/Prague); required when creating or changing date_worked",
+          ),
         ),
       ),
-    ),
-    billable: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description("Whether the entry is billable to the client"),
-      ),
-    ),
-    no_charge: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description(
-          "Whether the entry is recorded but not charged. Only valid when updating.",
+      duration_minutes: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.description(
+            "Minutes worked (whole minutes); required when creating",
+          ),
         ),
       ),
-    ),
-    task_code: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(20))),
-        v.description("UTBMS/LEDES task code; pass null to clear"),
+      narrative: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(10_000),
+          v.description("Description of the work; required when creating"),
+        ),
       ),
-    ),
-    activity_code: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(20))),
-        v.description("UTBMS/LEDES activity code; pass null to clear"),
+      invoice_narrative: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(10_000))),
+          v.description(
+            "Client-facing narrative shown on the invoice; pass null to clear. " +
+              "Only valid when updating.",
+          ),
+        ),
       ),
-    ),
-  }),
-  // Creating (no time_entry_id) requires the full set the backing create schema
-  // demands; list them in one message so a partial create is rejected up front.
-  v.partialCheck(
-    [
-      ["time_entry_id"],
-      ["matter_id"],
-      ["date_worked"],
-      ["timezone_id"],
-      ["duration_minutes"],
-      ["narrative"],
-    ],
-    (i) =>
-      i.time_entry_id !== undefined ||
-      (i.matter_id !== undefined &&
-        i.date_worked !== undefined &&
-        i.timezone_id !== undefined &&
-        i.duration_minutes !== undefined &&
-        i.narrative !== undefined),
-    "Creating a time entry requires matter_id, date_worked, timezone_id, duration_minutes, and narrative",
-  ),
-  // matter_id names the workspace to create in; it cannot change on update.
-  v.forward(
+      billable: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description("Whether the entry is billable to the client"),
+        ),
+      ),
+      no_charge: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description(
+            "Whether the entry is recorded but not charged. Only valid when updating.",
+          ),
+        ),
+      ),
+      task_code: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(20))),
+          v.description("UTBMS/LEDES task code; pass null to clear"),
+        ),
+      ),
+      activity_code: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(20))),
+          v.description("UTBMS/LEDES activity code; pass null to clear"),
+        ),
+      ),
+    }),
+    // Creating (no time_entry_id) requires the full set the backing create schema
+    // demands; list them in one message so a partial create is rejected up front.
     v.partialCheck(
-      [["time_entry_id"], ["matter_id"]],
-      ({ time_entry_id, matter_id }) =>
-        time_entry_id === undefined || matter_id === undefined,
-      "matter_id applies only when creating; omit it when updating a time entry",
+      [
+        ["time_entry_id"],
+        ["matter_id"],
+        ["date_worked"],
+        ["timezone_id"],
+        ["duration_minutes"],
+        ["narrative"],
+      ],
+      (i) =>
+        i.time_entry_id !== undefined ||
+        (i.matter_id !== undefined &&
+          i.date_worked !== undefined &&
+          i.timezone_id !== undefined &&
+          i.duration_minutes !== undefined &&
+          i.narrative !== undefined),
+      "Creating a time entry requires matter_id, date_worked, timezone_id, duration_minutes, and narrative",
     ),
-    ["matter_id"],
-  ),
-  // invoice_narrative and no_charge are update-only in the backing
-  // handler, so reject them on a create.
-  v.partialCheck(
-    [["time_entry_id"], ["invoice_narrative"], ["no_charge"]],
-    ({ time_entry_id, invoice_narrative, no_charge }) =>
-      time_entry_id !== undefined ||
-      (invoice_narrative === undefined && no_charge === undefined),
-    "invoice_narrative and no_charge apply to an existing time entry; pass time_entry_id",
-  ),
-  // An update must request at least one change.
-  v.partialCheck(
-    [
-      ["time_entry_id"],
-      ["entity_id"],
-      ["date_worked"],
-      ["duration_minutes"],
-      ["narrative"],
-      ["invoice_narrative"],
-      ["billable"],
-      ["no_charge"],
-      ["task_code"],
-      ["activity_code"],
-    ],
-    (i) =>
-      i.time_entry_id === undefined ||
-      i.entity_id !== undefined ||
-      i.date_worked !== undefined ||
-      i.duration_minutes !== undefined ||
-      i.narrative !== undefined ||
-      i.invoice_narrative !== undefined ||
-      i.billable !== undefined ||
-      i.no_charge !== undefined ||
-      i.task_code !== undefined ||
-      i.activity_code !== undefined,
-    "Provide at least one change to the time entry",
+    // matter_id names the workspace to create in; it cannot change on update.
+    v.forward(
+      v.partialCheck(
+        [["time_entry_id"], ["matter_id"]],
+        ({ time_entry_id, matter_id }) =>
+          time_entry_id === undefined || matter_id === undefined,
+        "matter_id applies only when creating; omit it when updating a time entry",
+      ),
+      ["matter_id"],
+    ),
+    // invoice_narrative and no_charge are update-only in the backing
+    // handler, so reject them on a create.
+    v.partialCheck(
+      [["time_entry_id"], ["invoice_narrative"], ["no_charge"]],
+      ({ time_entry_id, invoice_narrative, no_charge }) =>
+        time_entry_id !== undefined ||
+        (invoice_narrative === undefined && no_charge === undefined),
+      "invoice_narrative and no_charge apply to an existing time entry; pass time_entry_id",
+    ),
+    // An update must request at least one change.
+    v.partialCheck(
+      [
+        ["time_entry_id"],
+        ["entity_id"],
+        ["date_worked"],
+        ["duration_minutes"],
+        ["narrative"],
+        ["invoice_narrative"],
+        ["billable"],
+        ["no_charge"],
+        ["task_code"],
+        ["activity_code"],
+      ],
+      (i) =>
+        i.time_entry_id === undefined ||
+        i.entity_id !== undefined ||
+        i.date_worked !== undefined ||
+        i.duration_minutes !== undefined ||
+        i.narrative !== undefined ||
+        i.invoice_narrative !== undefined ||
+        i.billable !== undefined ||
+        i.no_charge !== undefined ||
+        i.task_code !== undefined ||
+        i.activity_code !== undefined,
+      "Provide at least one change to the time entry",
+    ),
   ),
 );
 
@@ -992,18 +999,20 @@ const handleSaveTimeEntryTool: TypedMcpToolHandler<
 
 // --- delete_time_entry --------------------------------------------------
 
-const deleteTimeEntryArgsSchema = v.strictObject({
-  time_entry_id: uuidInputSchema("Time entry ID to delete or write off"),
-  confirm: v.optional(
-    v.pipe(
-      v.boolean(),
-      v.description(
-        "Must be true to run this irreversible operation. Set it only after " +
-          "a human user has explicitly approved the deletion.",
+const deleteTimeEntryArgsSchema = nullAsAbsent(
+  v.strictObject({
+    time_entry_id: uuidInputSchema("Time entry ID to delete or write off"),
+    confirm: v.optional(
+      v.pipe(
+        v.boolean(),
+        v.description(
+          "Must be true to run this irreversible operation. Set it only after " +
+            "a human user has explicitly approved the deletion.",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
 const handleDeleteTimeEntryTool: TypedMcpToolHandler<
   v.InferInput<typeof DELETE_TIME_ENTRY_PROJECTION>
@@ -1049,19 +1058,21 @@ const handleDeleteTimeEntryTool: TypedMcpToolHandler<
 
 // --- resolve_rate -------------------------------------------------------
 
-const resolveRateArgsSchema = v.strictObject({
-  matter_id: uuidInputSchema("Matter ID to resolve the rate in."),
-  user_id: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.description("User ID to resolve the rate for"),
-  ),
-  date: v.pipe(
-    ISO_DATE_SCHEMA,
-    v.maxLength(10),
-    v.description("Date to resolve the rate on (ISO YYYY-MM-DD)"),
-  ),
-});
+const resolveRateArgsSchema = nullAsAbsent(
+  v.strictObject({
+    matter_id: uuidInputSchema("Matter ID to resolve the rate in."),
+    user_id: v.pipe(
+      v.string(),
+      v.minLength(1),
+      v.description("User ID to resolve the rate for"),
+    ),
+    date: v.pipe(
+      ISO_DATE_SCHEMA,
+      v.maxLength(10),
+      v.description("Date to resolve the rate on (ISO YYYY-MM-DD)"),
+    ),
+  }),
+);
 
 const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
   if (!hasEffectiveAuthority(context, { rate: ["read"] })) {
@@ -1122,42 +1133,44 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
 
 // --- list_invoices ------------------------------------------------------
 
-const listInvoicesArgsSchema = v.pipe(
-  v.strictObject({
-    matter_id: v.optional(
-      uuidInputSchema(
-        "Matter ID to list invoices in; required unless invoice_id is " +
-          "given.",
-      ),
-    ),
-    invoice_id: v.optional(uuidInputSchema("Invoice ID to read in detail")),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(MAX_LIST_LIMIT),
-        v.description("Max invoices to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.maxLength(512),
-        v.description(
-          "Opaque cursor from a previous list_invoices call to fetch the next page",
+const listInvoicesArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      matter_id: v.optional(
+        uuidInputSchema(
+          "Matter ID to list invoices in; required unless invoice_id is " +
+            "given.",
         ),
       ),
+      invoice_id: v.optional(uuidInputSchema("Invoice ID to read in detail")),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(MAX_LIST_LIMIT),
+          v.description("Max invoices to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(512),
+          v.description(
+            "Opaque cursor from a previous list_invoices call to fetch the next page",
+          ),
+        ),
+      ),
+    }),
+    v.forward(
+      v.partialCheck(
+        [["matter_id"], ["invoice_id"]],
+        ({ matter_id, invoice_id }) =>
+          invoice_id !== undefined || matter_id !== undefined,
+        "Provide matter_id to list invoices, or invoice_id to read one invoice",
+      ),
+      ["matter_id"],
     ),
-  }),
-  v.forward(
-    v.partialCheck(
-      [["matter_id"], ["invoice_id"]],
-      ({ matter_id, invoice_id }) =>
-        invoice_id !== undefined || matter_id !== undefined,
-      "Provide matter_id to list invoices, or invoice_id to read one invoice",
-    ),
-    ["matter_id"],
   ),
 );
 
@@ -1388,7 +1401,7 @@ const handleListInvoicesTool: TypedMcpToolHandler<
 
 // --- get_usage ----------------------------------------------------------
 
-const getUsageArgsSchema = v.strictObject({});
+const getUsageArgsSchema = nullAsAbsent(v.strictObject({}));
 
 const handleGetUsageTool: TypedMcpToolHandler<
   v.InferInput<typeof GET_USAGE_PROJECTION>

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -528,7 +528,9 @@ type PartValidation =
 /**
  * Validate one input part (`body`/`params`/`query`) against the live handler
  * config's TypeBox schema, mirroring what the Elysia route boundary hands the
- * handler: Default -> Convert -> Clean -> Check. The Clean step matches
+ * handler: Default -> Convert -> Clean -> Check, over a value a strict
+ * tool-schema client's nulls have first been read out of (see
+ * {@link withNullOptionalsOmitted}). The Clean step matches
  * Elysia's default input normalization, verified empirically on this repo's
  * Elysia (1.4.29): unknown keys on a schema'd part are STRIPPED before
  * validation — for closed (`additionalProperties: false`) schemas too, which
@@ -566,6 +568,90 @@ const schemaWithoutField = (
   return { ...schema, properties };
 };
 
+/**
+ * Keywords that constrain what a schema accepts. A schema carrying none of
+ * them (`t.Any()`, `t.Unknown()`) accepts every value, null included.
+ */
+const CONSTRAINING_KEYWORDS = [
+  "type",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "enum",
+  "const",
+  "$ref",
+] as const;
+
+/** True when the schema accepts an explicit null: `t.Null()`, a union with a
+ * null branch, a `type` list including "null", or an unconstrained schema. */
+const admitsNull = (schema: unknown): boolean => {
+  if (!isRecord(schema)) {
+    return true;
+  }
+  const type = schema["type"];
+  if (type === "null" || (isUnknownArray(type) && type.includes("null"))) {
+    return true;
+  }
+  for (const keyword of ["anyOf", "oneOf"] as const) {
+    const branches = schema[keyword];
+    if (isUnknownArray(branches) && branches.some(admitsNull)) {
+      return true;
+    }
+  }
+  return CONSTRAINING_KEYWORDS.every((keyword) => !(keyword in schema));
+};
+
+/**
+ * Read one input part with `null` under a declared optional property meaning
+ * absence, the rule `nullAsAbsent` applies to native tool inputs. A strict
+ * tool-schema client must send every property a schema declares, so it sends
+ * null for the ones it is not setting, and null is not a value here.
+ *
+ * The rule comes off the schema, never a list: a property qualifies when the
+ * schema lets it be omitted (it is not in `required`) and does not itself admit
+ * null. A "pass null to clear" nullable therefore keeps its null, a required
+ * property set to null still fails Check, and a null under an undeclared key is
+ * left for Clean to strip exactly as before. Nested objects and arrays of
+ * objects are read the same way; a union branch is not, because which branch a
+ * value belongs to is not decided yet.
+ *
+ * Exported so the registry-wide guard can run it over the committed catalog,
+ * whose part schemas are the same `advertisedSchemas` projection this validates
+ * against. Reading JSON Schema keywords rather than TypeBox's `Kind` symbols is
+ * what lets one function serve both.
+ */
+export const withNullOptionalsOmitted = (
+  schema: unknown,
+  value: unknown,
+): unknown => {
+  if (!isRecord(schema)) {
+    return value;
+  }
+  const items = schema["items"];
+  if (items !== undefined && isUnknownArray(value)) {
+    return value.map((entry) => withNullOptionalsOmitted(items, entry));
+  }
+  const properties = schema["properties"];
+  if (!isRecord(properties) || !isRecord(value)) {
+    return value;
+  }
+  const required = schema["required"];
+  const requiredNames = new Set(isUnknownArray(required) ? required : []);
+  const present: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const property = properties[key];
+    if (property === undefined) {
+      present[key] = entry;
+      continue;
+    }
+    if (entry === null && !requiredNames.has(key) && !admitsNull(property)) {
+      continue;
+    }
+    present[key] = withNullOptionalsOmitted(property, entry);
+  }
+  return present;
+};
+
 const validatePart = (
   part: "body" | "params" | "query",
   schema: TSchema | undefined,
@@ -577,7 +663,13 @@ const validatePart = (
   // Object schemas are the norm; default an absent value to `{}` so required
   // fields surface as issues rather than a whole-object "expected object" error.
   const base = value === undefined ? {} : structuredClone(value);
-  const withDefaults = Value.Default(schema, base);
+  // Ahead of the chain, not just ahead of Check: a dropped null must take the
+  // property's declared default and must never reach Convert, so the part reads
+  // exactly as it would from a client that omitted the property.
+  const withDefaults = Value.Default(
+    schema,
+    withNullOptionalsOmitted(schema, base),
+  );
   const coerced = Value.Convert(schema, withDefaults);
   const cleaned = Value.Clean(schema, coerced);
   if (Value.Check(schema, cleaned)) {

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -24,6 +24,7 @@ import {
   errorResult,
   MAX_CURSOR_LENGTH,
   notFoundResult,
+  nullAsAbsent,
   structuredErrorResult,
   uuidInputSchema,
   validationErrorResult,
@@ -229,38 +230,42 @@ const getCompatFetchPayload = ({
   };
 };
 
-const compatSearchArgsSchema = v.strictObject({
-  query: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.maxLength(LIMITS.searchQueryMaxLength),
-    v.description("Search query"),
-  ),
-  cursor: v.optional(
-    v.pipe(
+const compatSearchArgsSchema = nullAsAbsent(
+  v.strictObject({
+    query: v.pipe(
       v.string(),
       v.minLength(1),
-      v.maxLength(MAX_CURSOR_LENGTH),
-      v.description(
-        "Opaque cursor from a previous search call to fetch the next page",
+      v.maxLength(LIMITS.searchQueryMaxLength),
+      v.description("Search query"),
+    ),
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(MAX_CURSOR_LENGTH),
+        v.description(
+          "Opaque cursor from a previous search call to fetch the next page",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
-const compatFetchArgsSchema = v.strictObject({
-  id: uuidInputSchema("Document/entity ID"),
-  cursor: v.optional(
-    v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.maxLength(MAX_CURSOR_LENGTH),
-      v.description(
-        "Opaque cursor from a previous fetch call to read the next window of text",
+const compatFetchArgsSchema = nullAsAbsent(
+  v.strictObject({
+    id: uuidInputSchema("Document/entity ID"),
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(MAX_CURSOR_LENGTH),
+        v.description(
+          "Opaque cursor from a previous fetch call to read the next window of text",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
 export const COMPAT_TOOL_DEFINITIONS = [
   defineValibotMcpTool({

--- a/apps/api/src/mcp/document-file-upload.ts
+++ b/apps/api/src/mcp/document-file-upload.ts
@@ -19,6 +19,7 @@ import { isMcpEgressPlan } from "@/api/mcp/tool-types";
 import type { McpToolResponse } from "@/api/mcp/tool-types";
 import {
   internalFailureResult,
+  nullAsAbsent,
   structuredErrorResult,
   uuidInputSchema,
 } from "@/api/mcp/tool-utils";
@@ -56,18 +57,22 @@ export const OPENAI_FILE_REFERENCE_SCHEMA = v.pipe(
   v.description("File reference supplied by a compatible MCP host"),
 );
 
-export const UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA = v.strictObject({
-  entity_id: uuidInputSchema(
-    "Existing document entity ID that will receive a new version",
-  ),
-  file: OPENAI_FILE_REFERENCE_SCHEMA,
-});
+export const UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA = nullAsAbsent(
+  v.strictObject({
+    entity_id: uuidInputSchema(
+      "Existing document entity ID that will receive a new version",
+    ),
+    file: OPENAI_FILE_REFERENCE_SCHEMA,
+  }),
+);
 
-export const OPEN_DOCUMENT_VERSION_UPLOAD_INPUT_SCHEMA = v.strictObject({
-  entity_id: uuidInputSchema(
-    "Existing document entity ID that will receive a new version",
-  ),
-});
+export const OPEN_DOCUMENT_VERSION_UPLOAD_INPUT_SCHEMA = nullAsAbsent(
+  v.strictObject({
+    entity_id: uuidInputSchema(
+      "Existing document entity ID that will receive a new version",
+    ),
+  }),
+);
 
 export type UploadDocumentVersionInput = v.InferOutput<
   typeof UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -100,10 +100,11 @@ import {
   isToolErrorResult,
   MAX_LIST_LIMIT,
   notFoundResult,
+  nullAsAbsent,
   structuredErrorResult,
   toolDataResult,
-  validationErrorResult,
   uuidInputSchema,
+  validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
@@ -608,57 +609,59 @@ const decodeEntityPageCursor = (
   return { createdAt, id: brandPersistedEntityId(id) };
 };
 
-const listDocumentsArgsSchema = v.pipe(
-  v.strictObject({
-    matter_id: uuidInputSchema("Matter ID to list documents in."),
-    mode: v.optional(
-      v.pipe(
-        v.picklist(["flat", "children"]),
-        v.description(
-          "'flat' lists every document and folder in the matter; 'children' " +
-            "lists only the direct children of parent_id (or the matter " +
-            "root when parent_id is omitted). Defaults to 'flat', or 'children' when " +
-            "parent_id is provided. Passing parent_id with mode 'flat' is " +
-            "rejected.",
+const listDocumentsArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      matter_id: uuidInputSchema("Matter ID to list documents in."),
+      mode: v.optional(
+        v.pipe(
+          v.picklist(["flat", "children"]),
+          v.description(
+            "'flat' lists every document and folder in the matter; 'children' " +
+              "lists only the direct children of parent_id (or the matter " +
+              "root when parent_id is omitted). Defaults to 'flat', or 'children' when " +
+              "parent_id is provided. Passing parent_id with mode 'flat' is " +
+              "rejected.",
+          ),
         ),
       ),
-    ),
-    parent_id: v.optional(
-      uuidInputSchema(
-        "Folder entity ID whose direct children to list. Only valid in " +
-          "children mode; supplying it selects children mode when mode is " +
-          "omitted and is rejected together with mode 'flat'.",
-      ),
-    ),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(MAX_LIST_LIMIT),
-        v.description("Max entities to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.maxLength(512),
-        v.description(
-          "Opaque cursor from a previous list_documents call to fetch the next page",
+      parent_id: v.optional(
+        uuidInputSchema(
+          "Folder entity ID whose direct children to list. Only valid in " +
+            "children mode; supplying it selects children mode when mode is " +
+            "omitted and is rejected together with mode 'flat'.",
         ),
       ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(MAX_LIST_LIMIT),
+          v.description("Max entities to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(512),
+          v.description(
+            "Opaque cursor from a previous list_documents call to fetch the next page",
+          ),
+        ),
+      ),
+    }),
+    // parent_id scopes to a folder's children, so it is meaningless in flat mode
+    // (which enumerates the whole matter). Reject the explicit contradiction; an
+    // omitted mode with parent_id resolves to children (see handler default).
+    v.forward(
+      v.partialCheck(
+        [["mode"], ["parent_id"]],
+        ({ mode, parent_id }) => mode !== "flat" || parent_id === undefined,
+        "parent_id requires mode 'children'",
+      ),
+      ["parent_id"],
     ),
-  }),
-  // parent_id scopes to a folder's children, so it is meaningless in flat mode
-  // (which enumerates the whole matter). Reject the explicit contradiction; an
-  // omitted mode with parent_id resolves to children (see handler default).
-  v.forward(
-    v.partialCheck(
-      [["mode"], ["parent_id"]],
-      ({ mode, parent_id }) => mode !== "flat" || parent_id === undefined,
-      "parent_id requires mode 'children'",
-    ),
-    ["parent_id"],
   ),
 );
 
@@ -792,45 +795,47 @@ const decodeVersionsPageCursor = (
   return { versionNumber, id: brandPersistedEntityVersionId(id) };
 };
 
-const readDocumentArgsSchema = v.pipe(
-  v.strictObject({
-    entity_id: uuidInputSchema("Document entity ID"),
-    version_id: v.optional(
-      uuidInputSchema(
-        "Return this version's metadata and field values instead of the current version",
-      ),
-    ),
-    compare_with_version_id: v.optional(
-      uuidInputSchema(
-        "With version_id, return a plain-text line diff of this version (base) against version_id (target)",
-      ),
-    ),
-    include_versions: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description("Also return the document's version history"),
-      ),
-    ),
-    versions_cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.maxLength(512),
-        v.description(
-          "Cursor from a previous call for the next page of version history",
+const readDocumentArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      entity_id: uuidInputSchema("Document entity ID"),
+      version_id: v.optional(
+        uuidInputSchema(
+          "Return this version's metadata and field values instead of the current version",
         ),
       ),
+      compare_with_version_id: v.optional(
+        uuidInputSchema(
+          "With version_id, return a plain-text line diff of this version (base) against version_id (target)",
+        ),
+      ),
+      include_versions: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description("Also return the document's version history"),
+        ),
+      ),
+      versions_cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(512),
+          v.description(
+            "Cursor from a previous call for the next page of version history",
+          ),
+        ),
+      ),
+    }),
+    // A diff needs both endpoints: compare_with_version_id (base) is only
+    // meaningful alongside version_id (target).
+    v.forward(
+      v.partialCheck(
+        [["version_id"], ["compare_with_version_id"]],
+        ({ version_id, compare_with_version_id }) =>
+          compare_with_version_id === undefined || version_id !== undefined,
+        "compare_with_version_id requires version_id (the target version)",
+      ),
+      ["compare_with_version_id"],
     ),
-  }),
-  // A diff needs both endpoints: compare_with_version_id (base) is only
-  // meaningful alongside version_id (target).
-  v.forward(
-    v.partialCheck(
-      [["version_id"], ["compare_with_version_id"]],
-      ({ version_id, compare_with_version_id }) =>
-        compare_with_version_id === undefined || version_id !== undefined,
-      "compare_with_version_id requires version_id (the target version)",
-    ),
-    ["compare_with_version_id"],
   ),
 );
 
@@ -1571,171 +1576,173 @@ const handleReadDocumentTool: TypedMcpToolHandler<
   return { egress: "structured", payload, textFields };
 };
 
-const saveDocumentArgsSchema = v.pipe(
-  v.strictObject({
-    entity_id: v.optional(
-      uuidInputSchema("Document entity ID to update; omit to create"),
-    ),
-    matter_id: v.optional(
-      uuidInputSchema(
-        "Matter ID to create the entity in; required when creating.",
+const saveDocumentArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      entity_id: v.optional(
+        uuidInputSchema("Document entity ID to update; omit to create"),
       ),
-    ),
-    name: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(LIMITS.entityNameMaxLength),
-        v.description(
-          "Display name: required when creating, or the new name when renaming",
+      matter_id: v.optional(
+        uuidInputSchema(
+          "Matter ID to create the entity in; required when creating.",
         ),
       ),
-    ),
-    parent_id: v.optional(
-      uuidInputSchema(
-        "Folder entity ID: to place the new entity inside when creating, or to " +
-          "move the document into when updating",
-      ),
-    ),
-    kind: v.optional(
-      v.pipe(
-        v.picklist(["document", "folder"]),
-        v.description(
-          "Entity kind to create; defaults to 'document'. Only valid when creating.",
+      name: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(LIMITS.entityNameMaxLength),
+          v.description(
+            "Display name: required when creating, or the new name when renaming",
+          ),
         ),
       ),
-    ),
-    move_to_root: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description(
-          "Move the document to the matter root (no parent folder). Only valid when updating.",
+      parent_id: v.optional(
+        uuidInputSchema(
+          "Folder entity ID: to place the new entity inside when creating, or to " +
+            "move the document into when updating",
         ),
       ),
-    ),
-    version_id: v.optional(
-      uuidInputSchema(
-        "Version ID to annotate; required when setting label or description. Only valid when updating.",
-      ),
-    ),
-    label: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.minLength(1), v.maxLength(128))),
-        v.description(
-          "New label for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged",
+      kind: v.optional(
+        v.pipe(
+          v.picklist(["document", "folder"]),
+          v.description(
+            "Entity kind to create; defaults to 'document'. Only valid when creating.",
+          ),
         ),
       ),
-    ),
-    description: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.minLength(1), v.maxLength(1024))),
-        v.description(
-          "New description for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged",
+      move_to_root: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description(
+            "Move the document to the matter root (no parent folder). Only valid when updating.",
+          ),
         ),
       ),
+      version_id: v.optional(
+        uuidInputSchema(
+          "Version ID to annotate; required when setting label or description. Only valid when updating.",
+        ),
+      ),
+      label: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.minLength(1), v.maxLength(128))),
+          v.description(
+            "New label for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged",
+          ),
+        ),
+      ),
+      description: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.minLength(1), v.maxLength(1024))),
+          v.description(
+            "New description for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged",
+          ),
+        ),
+      ),
+    }),
+    // Creating (no entity_id) requires matter_id and name.
+    v.forward(
+      v.partialCheck(
+        [["entity_id"], ["matter_id"]],
+        ({ entity_id, matter_id }) =>
+          entity_id !== undefined || matter_id !== undefined,
+        "matter_id is required to create a document",
+      ),
+      ["matter_id"],
     ),
-  }),
-  // Creating (no entity_id) requires matter_id and name.
-  v.forward(
-    v.partialCheck(
-      [["entity_id"], ["matter_id"]],
-      ({ entity_id, matter_id }) =>
-        entity_id !== undefined || matter_id !== undefined,
-      "matter_id is required to create a document",
-    ),
-    ["matter_id"],
-  ),
-  v.forward(
-    v.partialCheck(
-      [["entity_id"], ["name"]],
-      ({ entity_id, name }) => entity_id !== undefined || name !== undefined,
-      "name is required to create a document",
-    ),
-    ["name"],
-  ),
-  // matter_id and kind describe the entity to create; neither applies to an
-  // update.
-  v.forward(
-    v.partialCheck(
-      [["entity_id"], ["matter_id"]],
-      ({ entity_id, matter_id }) =>
-        entity_id === undefined || matter_id === undefined,
-      "matter_id applies only when creating; omit it when updating a document",
-    ),
-    ["matter_id"],
-  ),
-  v.forward(
-    v.partialCheck(
-      [["entity_id"], ["kind"]],
-      ({ entity_id, kind }) => entity_id === undefined || kind === undefined,
-      "kind applies only when creating a document",
-    ),
-    ["kind"],
-  ),
-  // move_to_root, version_id, label, and description are all update-only edits.
-  v.partialCheck(
-    [
-      ["entity_id"],
-      ["move_to_root"],
-      ["version_id"],
-      ["label"],
-      ["description"],
-    ],
-    ({ entity_id, move_to_root, version_id, label, description }) =>
-      entity_id !== undefined ||
-      (move_to_root === undefined &&
-        version_id === undefined &&
-        label === undefined &&
-        description === undefined),
-    "move_to_root, version_id, label, and description apply to an existing document; pass entity_id",
-  ),
-  // An update must request at least one mutation; an empty update is a no-op the
-  // caller almost certainly did not intend.
-  v.partialCheck(
-    [
-      ["entity_id"],
+    v.forward(
+      v.partialCheck(
+        [["entity_id"], ["name"]],
+        ({ entity_id, name }) => entity_id !== undefined || name !== undefined,
+        "name is required to create a document",
+      ),
       ["name"],
-      ["parent_id"],
+    ),
+    // matter_id and kind describe the entity to create; neither applies to an
+    // update.
+    v.forward(
+      v.partialCheck(
+        [["entity_id"], ["matter_id"]],
+        ({ entity_id, matter_id }) =>
+          entity_id === undefined || matter_id === undefined,
+        "matter_id applies only when creating; omit it when updating a document",
+      ),
+      ["matter_id"],
+    ),
+    v.forward(
+      v.partialCheck(
+        [["entity_id"], ["kind"]],
+        ({ entity_id, kind }) => entity_id === undefined || kind === undefined,
+        "kind applies only when creating a document",
+      ),
+      ["kind"],
+    ),
+    // move_to_root, version_id, label, and description are all update-only edits.
+    v.partialCheck(
+      [
+        ["entity_id"],
+        ["move_to_root"],
+        ["version_id"],
+        ["label"],
+        ["description"],
+      ],
+      ({ entity_id, move_to_root, version_id, label, description }) =>
+        entity_id !== undefined ||
+        (move_to_root === undefined &&
+          version_id === undefined &&
+          label === undefined &&
+          description === undefined),
+      "move_to_root, version_id, label, and description apply to an existing document; pass entity_id",
+    ),
+    // An update must request at least one mutation; an empty update is a no-op the
+    // caller almost certainly did not intend.
+    v.partialCheck(
+      [
+        ["entity_id"],
+        ["name"],
+        ["parent_id"],
+        ["move_to_root"],
+        ["version_id"],
+        ["label"],
+        ["description"],
+      ],
+      (input) => {
+        if (input.entity_id === undefined) {
+          return true;
+        }
+        const wantsRename = input.name !== undefined;
+        const wantsMove =
+          input.parent_id !== undefined || input.move_to_root === true;
+        const wantsVersionEdit =
+          input.version_id !== undefined &&
+          (input.label !== undefined || input.description !== undefined);
+        return wantsRename || wantsMove || wantsVersionEdit;
+      },
+      "Provide at least one change: name, parent_id/move_to_root, or version_id with label/description",
+    ),
+    // parent_id (move into folder) and move_to_root (move to matter root) are
+    // opposite moves; accepting both is ambiguous.
+    v.forward(
+      v.partialCheck(
+        [["parent_id"], ["move_to_root"]],
+        ({ parent_id, move_to_root }) =>
+          parent_id === undefined || move_to_root !== true,
+        "Provide either parent_id or move_to_root, not both",
+      ),
       ["move_to_root"],
+    ),
+    // label/description annotate a specific version, so they require version_id.
+    v.forward(
+      v.partialCheck(
+        [["version_id"], ["label"], ["description"]],
+        ({ version_id, label, description }) =>
+          (label === undefined && description === undefined) ||
+          version_id !== undefined,
+        "label and description require version_id",
+      ),
       ["version_id"],
-      ["label"],
-      ["description"],
-    ],
-    (input) => {
-      if (input.entity_id === undefined) {
-        return true;
-      }
-      const wantsRename = input.name !== undefined;
-      const wantsMove =
-        input.parent_id !== undefined || input.move_to_root === true;
-      const wantsVersionEdit =
-        input.version_id !== undefined &&
-        (input.label !== undefined || input.description !== undefined);
-      return wantsRename || wantsMove || wantsVersionEdit;
-    },
-    "Provide at least one change: name, parent_id/move_to_root, or version_id with label/description",
-  ),
-  // parent_id (move into folder) and move_to_root (move to matter root) are
-  // opposite moves; accepting both is ambiguous.
-  v.forward(
-    v.partialCheck(
-      [["parent_id"], ["move_to_root"]],
-      ({ parent_id, move_to_root }) =>
-        parent_id === undefined || move_to_root !== true,
-      "Provide either parent_id or move_to_root, not both",
     ),
-    ["move_to_root"],
-  ),
-  // label/description annotate a specific version, so they require version_id.
-  v.forward(
-    v.partialCheck(
-      [["version_id"], ["label"], ["description"]],
-      ({ version_id, label, description }) =>
-        (label === undefined && description === undefined) ||
-        version_id !== undefined,
-      "label and description require version_id",
-    ),
-    ["version_id"],
   ),
 );
 
@@ -2114,21 +2121,23 @@ const handleOpenDocumentVersionUploadTool: McpToolHandler = async ({
   });
 };
 
-const deleteDocumentArgsSchema = v.strictObject({
-  entity_id: uuidInputSchema("Document entity ID to delete"),
-  version_id: v.optional(
-    uuidInputSchema("Delete only this version instead of the whole document"),
-  ),
-  confirm: v.optional(
-    v.pipe(
-      v.boolean(),
-      v.description(
-        "Must be true to run this irreversible operation. Set it only after a " +
-          "human user has explicitly approved the deletion.",
+const deleteDocumentArgsSchema = nullAsAbsent(
+  v.strictObject({
+    entity_id: uuidInputSchema("Document entity ID to delete"),
+    version_id: v.optional(
+      uuidInputSchema("Delete only this version instead of the whole document"),
+    ),
+    confirm: v.optional(
+      v.pipe(
+        v.boolean(),
+        v.description(
+          "Must be true to run this irreversible operation. Set it only after a " +
+            "human user has explicitly approved the deletion.",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
 const handleDeleteDocumentTool: TypedMcpToolHandler<
   v.InferInput<typeof DELETED_TRUE_PROJECTION>
@@ -2197,27 +2206,29 @@ const handleDeleteDocumentTool: TypedMcpToolHandler<
   } satisfies v.InferInput<typeof DELETED_TRUE_PROJECTION>);
 };
 
-const listPropertiesArgsSchema = v.strictObject({
-  matter_id: uuidInputSchema("Matter ID to list properties for."),
-  limit: v.optional(
-    v.pipe(
-      v.number(),
-      v.integer(),
-      v.minValue(1),
-      v.maxValue(MAX_LIST_LIMIT),
-      v.description("Max properties to return"),
-    ),
-  ),
-  cursor: v.optional(
-    v.pipe(
-      v.string(),
-      v.maxLength(512),
-      v.description(
-        "Opaque cursor from a previous list_properties call to fetch the next page",
+const listPropertiesArgsSchema = nullAsAbsent(
+  v.strictObject({
+    matter_id: uuidInputSchema("Matter ID to list properties for."),
+    limit: v.optional(
+      v.pipe(
+        v.number(),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(MAX_LIST_LIMIT),
+        v.description("Max properties to return"),
       ),
     ),
-  ),
-});
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(512),
+        v.description(
+          "Opaque cursor from a previous list_properties call to fetch the next page",
+        ),
+      ),
+    ),
+  }),
+);
 
 const propertyPageCursorCodec = createTimestampIdCursorCodec({
   column: properties.createdAt,
@@ -2377,14 +2388,16 @@ const setFieldValueContentSchema = v.variant("type", [
   }),
 ]);
 
-const setFieldValueArgsSchema = v.strictObject({
-  entity_id: uuidInputSchema("Document entity ID whose cell to set"),
-  property_id: uuidInputSchema("Property ID, as returned by list_properties"),
-  content: v.pipe(
-    setFieldValueContentSchema,
-    v.description("The value to set; 'type' must match the property."),
-  ),
-});
+const setFieldValueArgsSchema = nullAsAbsent(
+  v.strictObject({
+    entity_id: uuidInputSchema("Document entity ID whose cell to set"),
+    property_id: uuidInputSchema("Property ID, as returned by list_properties"),
+    content: v.pipe(
+      setFieldValueContentSchema,
+      v.description("The value to set; 'type' must match the property."),
+    ),
+  }),
+);
 
 type SetFieldValueContent = v.InferOutput<typeof setFieldValueContentSchema>;
 

--- a/apps/api/src/mcp/feedback-tools.ts
+++ b/apps/api/src/mcp/feedback-tools.ts
@@ -7,7 +7,11 @@ import type {
   McpToolHandler,
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
-import { toolDataResult, validationErrorResult } from "@/api/mcp/tool-utils";
+import {
+  nullAsAbsent,
+  toolDataResult,
+  validationErrorResult,
+} from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 
 const FEEDBACK_KINDS = ["bug", "feature_request", "docs", "other"] as const;
@@ -30,41 +34,43 @@ const GITHUB_BODY_TRUNCATION_MARKER =
 const HIGH_SURROGATE_START = 55_296;
 const HIGH_SURROGATE_END = 56_319;
 
-const feedbackArgsSchema = v.strictObject({
-  kind: v.pipe(
-    v.picklist(FEEDBACK_KINDS),
-    v.description("Feedback category: bug, feature_request, docs, or other"),
-  ),
-  title: v.pipe(
-    v.string(),
-    v.trim(),
-    v.minLength(1),
-    v.maxLength(MAX_FEEDBACK_TITLE_CHARS),
-    v.description(
-      "Short one-line summary of the issue; no tenant data, ids, or secrets",
+const feedbackArgsSchema = nullAsAbsent(
+  v.strictObject({
+    kind: v.pipe(
+      v.picklist(FEEDBACK_KINDS),
+      v.description("Feedback category: bug, feature_request, docs, or other"),
     ),
-  ),
-  body: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.maxLength(MAX_FEEDBACK_BODY_CHARS),
-    v.description(
-      "Markdown details: reproduction steps, expected vs actual behavior, " +
-        "environment. Never include tenant data, client or matter names, " +
-        "ids, or secrets; they are redacted server-side.",
-    ),
-  ),
-  channel: v.optional(
-    v.pipe(
-      v.picklist(FEEDBACK_CHANNELS),
+    title: v.pipe(
+      v.string(),
+      v.trim(),
+      v.minLength(1),
+      v.maxLength(MAX_FEEDBACK_TITLE_CHARS),
       v.description(
-        "Delivery channel. github returns a prefilled issue URL the human " +
-          "submits under their own GitHub account.",
+        "Short one-line summary of the issue; no tenant data, ids, or secrets",
       ),
     ),
-    "github",
-  ),
-});
+    body: v.pipe(
+      v.string(),
+      v.minLength(1),
+      v.maxLength(MAX_FEEDBACK_BODY_CHARS),
+      v.description(
+        "Markdown details: reproduction steps, expected vs actual behavior, " +
+          "environment. Never include tenant data, client or matter names, " +
+          "ids, or secrets; they are redacted server-side.",
+      ),
+    ),
+    channel: v.optional(
+      v.pipe(
+        v.picklist(FEEDBACK_CHANNELS),
+        v.description(
+          "Delivery channel. github returns a prefilled issue URL the human " +
+            "submits under their own GitHub account.",
+        ),
+      ),
+      "github",
+    ),
+  }),
+);
 
 export const FEEDBACK_TOOL_DEFINITIONS = [
   defineValibotMcpTool({

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -77,6 +77,7 @@ import {
   errorResult,
   internalFailureResult,
   MCP_INTERNAL_ERROR_HINT,
+  nullAsAbsent,
   structuredErrorResult,
   toolDataResult,
   uuidInputSchema,
@@ -590,85 +591,87 @@ const playbookDetailTextFieldSpecs = (
 
 // --- list_clauses -------------------------------------------------------
 
-const listClausesArgsSchema = v.pipe(
-  v.strictObject({
-    clause_id: v.optional(
-      uuidInputSchema("Clause id to read in detail; omit to list"),
-    ),
-    version_id: v.optional(
-      uuidInputSchema(
-        "With clause_id, return this version's body instead of the current clause",
+const listClausesArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      clause_id: v.optional(
+        uuidInputSchema("Clause id to read in detail; omit to list"),
       ),
-    ),
-    category_id: v.optional(
-      uuidInputSchema(
-        "List only clauses filed under this category (list mode)",
-      ),
-    ),
-    query: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Filter clauses by a text query over title and body (list mode)",
+      version_id: v.optional(
+        uuidInputSchema(
+          "With clause_id, return this version's body instead of the current clause",
         ),
       ),
-    ),
-    include_categories: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description(
-          "Also return the organization's clause categories (list mode)",
+      category_id: v.optional(
+        uuidInputSchema(
+          "List only clauses filed under this category (list mode)",
         ),
       ),
-    ),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(LIMITS.clausesPageSizeMax),
-        v.description("Max clauses to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.maxLength(512),
-        v.description(
-          "Opaque cursor from a previous list_clauses call to fetch the next page",
+      query: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description(
+            "Filter clauses by a text query over title and body (list mode)",
+          ),
         ),
       ),
+      include_categories: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description(
+            "Also return the organization's clause categories (list mode)",
+          ),
+        ),
+      ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(LIMITS.clausesPageSizeMax),
+          v.description("Max clauses to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(512),
+          v.description(
+            "Opaque cursor from a previous list_clauses call to fetch the next page",
+          ),
+        ),
+      ),
+    }),
+    // version_id selects one version of a specific clause, so it needs clause_id.
+    v.forward(
+      v.partialCheck(
+        [["clause_id"], ["version_id"]],
+        ({ clause_id, version_id }) =>
+          version_id === undefined || clause_id !== undefined,
+        "version_id requires clause_id",
+      ),
+      ["version_id"],
     ),
-  }),
-  // version_id selects one version of a specific clause, so it needs clause_id.
-  v.forward(
+    // The list-only filters have no meaning in detail mode (a single clause_id).
     v.partialCheck(
-      [["clause_id"], ["version_id"]],
-      ({ clause_id, version_id }) =>
-        version_id === undefined || clause_id !== undefined,
-      "version_id requires clause_id",
+      [
+        ["clause_id"],
+        ["category_id"],
+        ["query"],
+        ["include_categories"],
+        ["limit"],
+        ["cursor"],
+      ],
+      (i) =>
+        i.clause_id === undefined ||
+        (i.category_id === undefined &&
+          i.query === undefined &&
+          i.include_categories === undefined &&
+          i.limit === undefined &&
+          i.cursor === undefined),
+      "category_id, query, include_categories, limit, and cursor apply to list mode; drop clause_id to list",
     ),
-    ["version_id"],
-  ),
-  // The list-only filters have no meaning in detail mode (a single clause_id).
-  v.partialCheck(
-    [
-      ["clause_id"],
-      ["category_id"],
-      ["query"],
-      ["include_categories"],
-      ["limit"],
-      ["cursor"],
-    ],
-    (i) =>
-      i.clause_id === undefined ||
-      (i.category_id === undefined &&
-        i.query === undefined &&
-        i.include_categories === undefined &&
-        i.limit === undefined &&
-        i.cursor === undefined),
-    "category_id, query, include_categories, limit, and cursor apply to list mode; drop clause_id to list",
   ),
 );
 
@@ -1009,113 +1012,120 @@ const clauseBodyArgSchema = v.pipe(
   ),
 );
 
-const saveClauseArgsSchema = v.pipe(
-  v.strictObject({
-    clause_id: v.optional(
-      uuidInputSchema("Clause id to update; omit to create"),
-    ),
-    title: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(256),
-        v.description("Clause title; required when creating"),
+const saveClauseArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      clause_id: v.optional(
+        uuidInputSchema("Clause id to update; omit to create"),
       ),
-    ),
-    body: v.optional(clauseBodyArgSchema),
-    category_id: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.uuid())),
-        v.description(
-          "Category id to file the clause under; pass null to clear",
+      title: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(256),
+          v.description("Clause title; required when creating"),
         ),
       ),
-    ),
-    language: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.minLength(1), v.maxLength(10))),
-        v.description("BCP-47 language tag for the clause; pass null to clear"),
-      ),
-    ),
-    description: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(2000))),
-        v.description("Short clause description; pass null to clear"),
-      ),
-    ),
-    usage_notes: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(2000))),
-        v.description("Guidance on when to use the clause; pass null to clear"),
-      ),
-    ),
-    metadata: v.optional(
-      v.pipe(
-        v.nullable(v.record(v.string(), v.unknown())),
-        v.description("Free-form metadata object; pass null to clear"),
-      ),
-    ),
-    snapshot_version: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description(
-          "When updating, also append a version snapshot of the body",
+      body: v.optional(clauseBodyArgSchema),
+      category_id: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.uuid())),
+          v.description(
+            "Category id to file the clause under; pass null to clear",
+          ),
         ),
       ),
-    ),
-  }),
-  // Creating (no clause_id) requires a title.
-  v.forward(
-    v.partialCheck(
-      [["clause_id"], ["title"]],
-      ({ clause_id, title }) => clause_id !== undefined || title !== undefined,
-      "title is required to create a clause",
-    ),
-    ["title"],
-  ),
-  // Creating (no clause_id) requires a body.
-  v.forward(
-    v.partialCheck(
-      [["clause_id"], ["body"]],
-      ({ clause_id, body }) => clause_id !== undefined || body !== undefined,
-      "body is required to create a clause",
-    ),
-    ["body"],
-  ),
-  // A version snapshot only makes sense for an existing clause.
-  v.forward(
-    v.partialCheck(
-      [["clause_id"], ["snapshot_version"]],
-      ({ clause_id, snapshot_version }) =>
-        clause_id !== undefined || snapshot_version === undefined,
-      "snapshot_version only applies when updating a clause",
-    ),
-    ["snapshot_version"],
-  ),
-  // An update must request at least one change.
-  v.partialCheck(
-    [
-      ["clause_id"],
+      language: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.minLength(1), v.maxLength(10))),
+          v.description(
+            "BCP-47 language tag for the clause; pass null to clear",
+          ),
+        ),
+      ),
+      description: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(2000))),
+          v.description("Short clause description; pass null to clear"),
+        ),
+      ),
+      usage_notes: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(2000))),
+          v.description(
+            "Guidance on when to use the clause; pass null to clear",
+          ),
+        ),
+      ),
+      metadata: v.optional(
+        v.pipe(
+          v.nullable(v.record(v.string(), v.unknown())),
+          v.description("Free-form metadata object; pass null to clear"),
+        ),
+      ),
+      snapshot_version: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description(
+            "When updating, also append a version snapshot of the body",
+          ),
+        ),
+      ),
+    }),
+    // Creating (no clause_id) requires a title.
+    v.forward(
+      v.partialCheck(
+        [["clause_id"], ["title"]],
+        ({ clause_id, title }) =>
+          clause_id !== undefined || title !== undefined,
+        "title is required to create a clause",
+      ),
       ["title"],
+    ),
+    // Creating (no clause_id) requires a body.
+    v.forward(
+      v.partialCheck(
+        [["clause_id"], ["body"]],
+        ({ clause_id, body }) => clause_id !== undefined || body !== undefined,
+        "body is required to create a clause",
+      ),
       ["body"],
-      ["category_id"],
-      ["language"],
-      ["description"],
-      ["usage_notes"],
-      ["metadata"],
+    ),
+    // A version snapshot only makes sense for an existing clause.
+    v.forward(
+      v.partialCheck(
+        [["clause_id"], ["snapshot_version"]],
+        ({ clause_id, snapshot_version }) =>
+          clause_id !== undefined || snapshot_version === undefined,
+        "snapshot_version only applies when updating a clause",
+      ),
       ["snapshot_version"],
-    ],
-    (i) =>
-      i.clause_id === undefined ||
-      i.title !== undefined ||
-      i.body !== undefined ||
-      i.category_id !== undefined ||
-      i.language !== undefined ||
-      i.description !== undefined ||
-      i.usage_notes !== undefined ||
-      i.metadata !== undefined ||
-      i.snapshot_version !== undefined,
-    "Provide at least one field to change",
+    ),
+    // An update must request at least one change.
+    v.partialCheck(
+      [
+        ["clause_id"],
+        ["title"],
+        ["body"],
+        ["category_id"],
+        ["language"],
+        ["description"],
+        ["usage_notes"],
+        ["metadata"],
+        ["snapshot_version"],
+      ],
+      (i) =>
+        i.clause_id === undefined ||
+        i.title !== undefined ||
+        i.body !== undefined ||
+        i.category_id !== undefined ||
+        i.language !== undefined ||
+        i.description !== undefined ||
+        i.usage_notes !== undefined ||
+        i.metadata !== undefined ||
+        i.snapshot_version !== undefined,
+      "Provide at least one field to change",
+    ),
   ),
 );
 
@@ -1239,18 +1249,20 @@ const handleSaveClauseTool: TypedMcpToolHandler<
 
 // --- delete_clause ------------------------------------------------------
 
-const deleteClauseArgsSchema = v.strictObject({
-  clause_id: uuidInputSchema("Clause id to delete"),
-  confirm: v.optional(
-    v.pipe(
-      v.boolean(),
-      v.description(
-        "Must be true to run this irreversible operation. Set it only after a " +
-          "human user has explicitly approved the deletion.",
+const deleteClauseArgsSchema = nullAsAbsent(
+  v.strictObject({
+    clause_id: uuidInputSchema("Clause id to delete"),
+    confirm: v.optional(
+      v.pipe(
+        v.boolean(),
+        v.description(
+          "Must be true to run this irreversible operation. Set it only after a " +
+            "human user has explicitly approved the deletion.",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
 const handleDeleteClauseTool: TypedMcpToolHandler<
   v.InferInput<typeof DELETED_TRUE_PROJECTION>
@@ -1282,37 +1294,41 @@ const handleDeleteClauseTool: TypedMcpToolHandler<
 
 // --- list_playbooks -----------------------------------------------------
 
-const listPlaybooksArgsSchema = v.pipe(
-  v.strictObject({
-    playbook_id: v.optional(
-      uuidInputSchema("Playbook id to read in detail; omit to list playbooks"),
-    ),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(LIMITS.playbookDefinitionsPageSizeMax),
-        v.description("Max playbooks to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.maxLength(512),
-        v.description(
-          "Opaque cursor from a previous list_playbooks call to fetch the next page",
+const listPlaybooksArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      playbook_id: v.optional(
+        uuidInputSchema(
+          "Playbook id to read in detail; omit to list playbooks",
         ),
       ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(LIMITS.playbookDefinitionsPageSizeMax),
+          v.description("Max playbooks to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(512),
+          v.description(
+            "Opaque cursor from a previous list_playbooks call to fetch the next page",
+          ),
+        ),
+      ),
+    }),
+    // limit/cursor page the list; they have no meaning for a single playbook_id.
+    v.partialCheck(
+      [["playbook_id"], ["limit"], ["cursor"]],
+      (i) =>
+        i.playbook_id === undefined ||
+        (i.limit === undefined && i.cursor === undefined),
+      "limit and cursor apply to list mode; drop playbook_id to list",
     ),
-  }),
-  // limit/cursor page the list; they have no meaning for a single playbook_id.
-  v.partialCheck(
-    [["playbook_id"], ["limit"], ["cursor"]],
-    (i) =>
-      i.playbook_id === undefined ||
-      (i.limit === undefined && i.cursor === undefined),
-    "limit and cursor apply to list mode; drop playbook_id to list",
   ),
 );
 
@@ -1400,10 +1416,12 @@ const handleListPlaybooksTool: TypedMcpToolHandler<
 
 // --- run_playbook -------------------------------------------------------
 
-const runPlaybookArgsSchema = v.strictObject({
-  matter_id: uuidInputSchema("Matter ID to run the playbook over."),
-  playbook_id: uuidInputSchema("Playbook id to run"),
-});
+const runPlaybookArgsSchema = nullAsAbsent(
+  v.strictObject({
+    matter_id: uuidInputSchema("Matter ID to run the playbook over."),
+    playbook_id: uuidInputSchema("Playbook id to run"),
+  }),
+);
 
 /**
  * A review whose workflow never started. Retryable by construction: the

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -91,15 +91,16 @@ import {
   ensureActiveWorkspace,
   ensureWorkspaceAccess,
   errorResult,
-  internalFailureResult,
   getWorkspaceStatus,
+  internalFailureResult,
   ISO_DATE_SCHEMA,
   MAX_LIST_LIMIT,
   notFoundResult,
+  nullAsAbsent,
   structuredErrorResult,
   toolDataResult,
-  validationErrorResult,
   uuidInputSchema,
+  validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 
@@ -218,90 +219,98 @@ const TASK_DETAIL_TEXT_FIELD_PATHS = deriveTextFieldPaths(
 
 // --- save_matter --------------------------------------------------------
 
-const saveMatterArgsSchema = v.pipe(
-  v.strictObject({
-    matter_id: v.optional(
-      uuidInputSchema("Matter ID to update; omit to create a new matter"),
-    ),
-    name: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(256),
-        v.description("Matter name; required when creating"),
+const saveMatterArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      matter_id: v.optional(
+        uuidInputSchema("Matter ID to update; omit to create a new matter"),
       ),
-    ),
-    client_id: v.optional(
-      uuidInputSchema(
-        "Contact ID to attach in the client role. Only valid when creating a matter.",
-      ),
-    ),
-    reference: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(64),
-        v.description(
-          "Matter reference (file number). Only valid when updating.",
+      name: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(256),
+          v.description("Matter name; required when creating"),
         ),
       ),
-    ),
-    billing_reference: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(128))),
-        v.description(
-          "Billing reference; pass null to clear. Only valid when updating.",
+      client_id: v.optional(
+        uuidInputSchema(
+          "Contact ID to attach in the client role. Only valid when creating a matter.",
         ),
       ),
-    ),
-    status: v.optional(
-      v.pipe(
-        v.picklist(MATTER_STATUSES),
-        v.description(
-          "Set 'archived' to archive the matter or 'active' to unarchive it. Only valid when updating.",
+      reference: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(64),
+          v.description(
+            "Matter reference (file number). Only valid when updating.",
+          ),
         ),
       ),
+      billing_reference: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(128))),
+          v.description(
+            "Billing reference; pass null to clear. Only valid when updating.",
+          ),
+        ),
+      ),
+      status: v.optional(
+        v.pipe(
+          v.picklist(MATTER_STATUSES),
+          v.description(
+            "Set 'archived' to archive the matter or 'active' to unarchive it. Only valid when updating.",
+          ),
+        ),
+      ),
+    }),
+    // Creating (no matter_id) requires a name.
+    v.forward(
+      v.partialCheck(
+        [["matter_id"], ["name"]],
+        ({ matter_id, name }) => matter_id !== undefined || name !== undefined,
+        "name is required to create a matter",
+      ),
+      ["name"],
     ),
-  }),
-  // Creating (no matter_id) requires a name.
-  v.forward(
+    // reference, billing_reference, status, and client_id apply to existing
+    // matters or to creation respectively; keep the two modes from mixing.
     v.partialCheck(
-      [["matter_id"], ["name"]],
-      ({ matter_id, name }) => matter_id !== undefined || name !== undefined,
-      "name is required to create a matter",
+      [["matter_id"], ["reference"], ["billing_reference"], ["status"]],
+      ({ matter_id, reference, billing_reference, status }) =>
+        matter_id !== undefined ||
+        (reference === undefined &&
+          billing_reference === undefined &&
+          status === undefined),
+      "reference, billing_reference, and status apply to an existing matter; pass matter_id",
     ),
-    ["name"],
-  ),
-  // reference, billing_reference, status, and client_id apply to existing
-  // matters or to creation respectively; keep the two modes from mixing.
-  v.partialCheck(
-    [["matter_id"], ["reference"], ["billing_reference"], ["status"]],
-    ({ matter_id, reference, billing_reference, status }) =>
-      matter_id !== undefined ||
-      (reference === undefined &&
-        billing_reference === undefined &&
-        status === undefined),
-    "reference, billing_reference, and status apply to an existing matter; pass matter_id",
-  ),
-  v.forward(
+    v.forward(
+      v.partialCheck(
+        [["matter_id"], ["client_id"]],
+        ({ matter_id, client_id }) =>
+          matter_id === undefined || client_id === undefined,
+        "client_id can only be set when creating a matter",
+      ),
+      ["client_id"],
+    ),
+    // An update must request at least one change.
     v.partialCheck(
-      [["matter_id"], ["client_id"]],
-      ({ matter_id, client_id }) =>
-        matter_id === undefined || client_id === undefined,
-      "client_id can only be set when creating a matter",
+      [
+        ["matter_id"],
+        ["name"],
+        ["reference"],
+        ["billing_reference"],
+        ["status"],
+      ],
+      ({ matter_id, name, reference, billing_reference, status }) =>
+        matter_id === undefined ||
+        name !== undefined ||
+        reference !== undefined ||
+        billing_reference !== undefined ||
+        status !== undefined,
+      "Provide at least one change: name, reference, billing_reference, or status",
     ),
-    ["client_id"],
-  ),
-  // An update must request at least one change.
-  v.partialCheck(
-    [["matter_id"], ["name"], ["reference"], ["billing_reference"], ["status"]],
-    ({ matter_id, name, reference, billing_reference, status }) =>
-      matter_id === undefined ||
-      name !== undefined ||
-      reference !== undefined ||
-      billing_reference !== undefined ||
-      status !== undefined,
-    "Provide at least one change: name, reference, billing_reference, or status",
   ),
 );
 
@@ -455,18 +464,20 @@ const handleSaveMatterTool: TypedMcpToolHandler<
 
 // --- delete_matter ------------------------------------------------------
 
-const deleteMatterArgsSchema = v.strictObject({
-  matter_id: uuidInputSchema("Matter ID to delete"),
-  confirm: v.optional(
-    v.pipe(
-      v.boolean(),
-      v.description(
-        "Must be true to run this irreversible operation. Set it only after a " +
-          "human user has explicitly approved the deletion.",
+const deleteMatterArgsSchema = nullAsAbsent(
+  v.strictObject({
+    matter_id: uuidInputSchema("Matter ID to delete"),
+    confirm: v.optional(
+      v.pipe(
+        v.boolean(),
+        v.description(
+          "Must be true to run this irreversible operation. Set it only after a " +
+            "human user has explicitly approved the deletion.",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
 const handleDeleteMatterTool: TypedMcpToolHandler<
   v.InferInput<typeof DELETED_TRUE_PROJECTION>
@@ -508,30 +519,32 @@ const handleDeleteMatterTool: TypedMcpToolHandler<
 
 // --- list_contacts ------------------------------------------------------
 
-const listContactsArgsSchema = v.strictObject({
-  q: v.optional(
-    v.pipe(
-      v.string(),
-      v.maxLength(512),
-      v.description("Search contact display names"),
+const listContactsArgsSchema = nullAsAbsent(
+  v.strictObject({
+    q: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(512),
+        v.description("Search contact display names"),
+      ),
     ),
-  ),
-  type: v.optional(
-    v.pipe(v.picklist(CONTACT_TYPES), v.description("Contact kind")),
-  ),
-  cursor: v.optional(
-    v.pipe(v.string(), v.description("Opaque cursor from the previous page")),
-  ),
-  limit: v.optional(
-    v.pipe(
-      v.number(),
-      v.integer(),
-      v.minValue(1),
-      v.maxValue(LIMITS.contactsPageSizeMax),
-      v.description("Maximum contacts to return"),
+    type: v.optional(
+      v.pipe(v.picklist(CONTACT_TYPES), v.description("Contact kind")),
     ),
-  ),
-});
+    cursor: v.optional(
+      v.pipe(v.string(), v.description("Opaque cursor from the previous page")),
+    ),
+    limit: v.optional(
+      v.pipe(
+        v.number(),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(LIMITS.contactsPageSizeMax),
+        v.description("Maximum contacts to return"),
+      ),
+    ),
+  }),
+);
 
 const handleListContactsTool: TypedMcpToolHandler<
   v.InferInput<typeof LIST_CONTACTS_PROJECTION>
@@ -613,64 +626,83 @@ export const deriveContactDisplayName = ({
     : personName || organizationName;
 };
 
-const saveContactArgsSchema = v.pipe(
-  v.strictObject({
-    contact_id: v.optional(
-      uuidInputSchema("Contact ID to update; omit to create"),
-    ),
-    type: v.optional(
-      v.pipe(
-        v.picklist(CONTACT_TYPES),
-        v.description("Contact kind; required when creating"),
+const saveContactArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      contact_id: v.optional(
+        uuidInputSchema("Contact ID to update; omit to create"),
       ),
-    ),
-    display_name: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(512),
-        v.description(
-          "Display name; when creating it defaults to first + last name " +
-            "(person) or organization name (organization); non-empty when " +
-            "updating",
+      type: v.optional(
+        v.pipe(
+          v.picklist(CONTACT_TYPES),
+          v.description("Contact kind; required when creating"),
         ),
       ),
-    ),
-    first_name: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(256))),
-        v.description("First name; pass null to clear"),
+      display_name: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(512),
+          v.description(
+            "Display name; when creating it defaults to first + last name " +
+              "(person) or organization name (organization); non-empty when " +
+              "updating",
+          ),
+        ),
       ),
-    ),
-    last_name: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(256))),
-        v.description("Last name; pass null to clear"),
+      first_name: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(256))),
+          v.description("First name; pass null to clear"),
+        ),
       ),
-    ),
-    organization_name: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(512))),
-        v.description("Organization name; pass null to clear"),
+      last_name: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(256))),
+          v.description("Last name; pass null to clear"),
+        ),
       ),
-    ),
-    notes: v.optional(
-      v.pipe(
-        v.nullable(v.string()),
-        v.description("Free-text notes; pass null to clear"),
+      organization_name: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(512))),
+          v.description("Organization name; pass null to clear"),
+        ),
       ),
+      notes: v.optional(
+        v.pipe(
+          v.nullable(v.string()),
+          v.description("Free-text notes; pass null to clear"),
+        ),
+      ),
+    }),
+    // Creating (no contact_id) requires type and a name to display.
+    v.forward(
+      v.partialCheck(
+        [["contact_id"], ["type"]],
+        ({ contact_id, type }) =>
+          contact_id !== undefined || type !== undefined,
+        "type is required to create a contact",
+      ),
+      ["type"],
     ),
-  }),
-  // Creating (no contact_id) requires type and a name to display.
-  v.forward(
-    v.partialCheck(
-      [["contact_id"], ["type"]],
-      ({ contact_id, type }) => contact_id !== undefined || type !== undefined,
-      "type is required to create a contact",
+    v.forward(
+      v.partialCheck(
+        [
+          ["contact_id"],
+          ["type"],
+          ["display_name"],
+          ["first_name"],
+          ["last_name"],
+          ["organization_name"],
+        ],
+        (input) =>
+          input.contact_id !== undefined ||
+          deriveContactDisplayName(input).length > 0,
+        "display_name is required to create a contact, or first_name/last_name (person) or organization_name (organization) to derive it from",
+      ),
+      ["display_name"],
     ),
-    ["type"],
-  ),
-  v.forward(
+    // An update must request at least one change.
     v.partialCheck(
       [
         ["contact_id"],
@@ -679,34 +711,18 @@ const saveContactArgsSchema = v.pipe(
         ["first_name"],
         ["last_name"],
         ["organization_name"],
+        ["notes"],
       ],
-      (input) =>
-        input.contact_id !== undefined ||
-        deriveContactDisplayName(input).length > 0,
-      "display_name is required to create a contact, or first_name/last_name (person) or organization_name (organization) to derive it from",
+      (i) =>
+        i.contact_id === undefined ||
+        i.type !== undefined ||
+        i.display_name !== undefined ||
+        i.first_name !== undefined ||
+        i.last_name !== undefined ||
+        i.organization_name !== undefined ||
+        i.notes !== undefined,
+      "Provide at least one field to change",
     ),
-    ["display_name"],
-  ),
-  // An update must request at least one change.
-  v.partialCheck(
-    [
-      ["contact_id"],
-      ["type"],
-      ["display_name"],
-      ["first_name"],
-      ["last_name"],
-      ["organization_name"],
-      ["notes"],
-    ],
-    (i) =>
-      i.contact_id === undefined ||
-      i.type !== undefined ||
-      i.display_name !== undefined ||
-      i.first_name !== undefined ||
-      i.last_name !== undefined ||
-      i.organization_name !== undefined ||
-      i.notes !== undefined,
-    "Provide at least one field to change",
   ),
 );
 
@@ -800,18 +816,20 @@ const handleSaveContactTool: TypedMcpToolHandler<
 
 // --- delete_contact -----------------------------------------------------
 
-const deleteContactArgsSchema = v.strictObject({
-  contact_id: uuidInputSchema("Contact ID to delete"),
-  confirm: v.optional(
-    v.pipe(
-      v.boolean(),
-      v.description(
-        "Must be true to run this irreversible operation. Set it only after a " +
-          "human user has explicitly approved the deletion.",
+const deleteContactArgsSchema = nullAsAbsent(
+  v.strictObject({
+    contact_id: uuidInputSchema("Contact ID to delete"),
+    confirm: v.optional(
+      v.pipe(
+        v.boolean(),
+        v.description(
+          "Must be true to run this irreversible operation. Set it only after a " +
+            "human user has explicitly approved the deletion.",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
 const handleDeleteContactTool: TypedMcpToolHandler<
   v.InferInput<typeof DELETED_TRUE_PROJECTION>
@@ -843,20 +861,22 @@ const handleDeleteContactTool: TypedMcpToolHandler<
 
 // --- lookup_business_registry -------------------------------------------
 
-const lookupBusinessRegistryArgsSchema = v.strictObject({
-  registry: v.pipe(
-    v.picklist(BUSINESS_REGISTRY_SLUGS),
-    v.description("Business register to query"),
-  ),
-  query: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.maxLength(256),
-    v.description(
-      "Canonical identifier (e.g. company number, VAT number) or company name",
+const lookupBusinessRegistryArgsSchema = nullAsAbsent(
+  v.strictObject({
+    registry: v.pipe(
+      v.picklist(BUSINESS_REGISTRY_SLUGS),
+      v.description("Business register to query"),
     ),
-  ),
-});
+    query: v.pipe(
+      v.string(),
+      v.minLength(1),
+      v.maxLength(256),
+      v.description(
+        "Canonical identifier (e.g. company number, VAT number) or company name",
+      ),
+    ),
+  }),
+);
 
 const handleLookupBusinessRegistryTool: TypedMcpToolHandler<
   v.InferInput<typeof LOOKUP_BUSINESS_REGISTRY_PROJECTION>
@@ -937,68 +957,70 @@ const resolveTaskWorkspace = async ({
   return { status: "ok", workspaceId: entity.workspaceId };
 };
 
-const listTasksArgsSchema = v.pipe(
-  v.strictObject({
-    matter_id: v.optional(
-      uuidInputSchema(
-        "Matter ID to list tasks in; required unless task_id is given.",
-      ),
-    ),
-    task_id: v.optional(uuidInputSchema("Task entity ID to read in detail")),
-    date_from: v.optional(
-      v.pipe(
-        ISO_DATE_SCHEMA,
-        v.maxLength(10),
-        v.description(
-          "List only tasks due on or after this ISO date (YYYY-MM-DD)",
+const listTasksArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      matter_id: v.optional(
+        uuidInputSchema(
+          "Matter ID to list tasks in; required unless task_id is given.",
         ),
       ),
-    ),
-    date_to: v.optional(
-      v.pipe(
-        ISO_DATE_SCHEMA,
-        v.maxLength(10),
-        v.description(
-          "List only tasks due on or before this ISO date (YYYY-MM-DD)",
+      task_id: v.optional(uuidInputSchema("Task entity ID to read in detail")),
+      date_from: v.optional(
+        v.pipe(
+          ISO_DATE_SCHEMA,
+          v.maxLength(10),
+          v.description(
+            "List only tasks due on or after this ISO date (YYYY-MM-DD)",
+          ),
         ),
       ),
-    ),
-    status: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(32),
-        v.description("List only tasks with this status"),
-      ),
-    ),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(MAX_LIST_LIMIT),
-        v.description("Max tasks to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.maxLength(512),
-        v.description(
-          "Opaque cursor from a previous list_tasks call to fetch the next page",
+      date_to: v.optional(
+        v.pipe(
+          ISO_DATE_SCHEMA,
+          v.maxLength(10),
+          v.description(
+            "List only tasks due on or before this ISO date (YYYY-MM-DD)",
+          ),
         ),
       ),
+      status: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(32),
+          v.description("List only tasks with this status"),
+        ),
+      ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(MAX_LIST_LIMIT),
+          v.description("Max tasks to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(512),
+          v.description(
+            "Opaque cursor from a previous list_tasks call to fetch the next page",
+          ),
+        ),
+      ),
+    }),
+    // List mode needs a workspace to scope to; detail mode uses task_id alone.
+    v.forward(
+      v.partialCheck(
+        [["matter_id"], ["task_id"]],
+        ({ matter_id, task_id }) =>
+          task_id !== undefined || matter_id !== undefined,
+        "Provide matter_id to list tasks, or task_id to read one task",
+      ),
+      ["matter_id"],
     ),
-  }),
-  // List mode needs a workspace to scope to; detail mode uses task_id alone.
-  v.forward(
-    v.partialCheck(
-      [["matter_id"], ["task_id"]],
-      ({ matter_id, task_id }) =>
-        task_id !== undefined || matter_id !== undefined,
-      "Provide matter_id to list tasks, or task_id to read one task",
-    ),
-    ["matter_id"],
   ),
 );
 
@@ -1275,159 +1297,161 @@ const handleListTasksTool: TypedMcpToolHandler<
 
 // --- save_task ----------------------------------------------------------
 
-const saveTaskArgsSchema = v.pipe(
-  v.strictObject({
-    task_id: v.optional(
-      uuidInputSchema("Task entity ID to update; omit to create"),
-    ),
-    matter_id: v.optional(
-      uuidInputSchema(
-        "Matter ID to create the task in; required when creating.",
+const saveTaskArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      task_id: v.optional(
+        uuidInputSchema("Task entity ID to update; omit to create"),
       ),
-    ),
-    name: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(255),
-        v.description("Task name; required when creating"),
-      ),
-    ),
-    status: v.optional(
-      v.pipe(v.picklist(TASK_STATUSES), v.description("Task status")),
-    ),
-    priority: v.optional(
-      v.pipe(v.picklist(ENTITY_PRIORITIES), v.description("Task priority")),
-    ),
-    item_type: v.optional(
-      v.pipe(
-        v.picklist(LIST_ITEM_TYPES),
-        v.description("What the List item represents"),
-      ),
-    ),
-    list_id: v.optional(
-      uuidInputSchema("List ID to create the item in (creating only)"),
-    ),
-    list_section_id: v.optional(
-      uuidInputSchema(
-        "Section of list_id to create the item under (creating only)",
-      ),
-    ),
-    list_description: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(v.string(), v.maxLength(10_000))),
-        v.description("List item description; pass null to clear"),
-      ),
-    ),
-    due_date: v.optional(
-      v.pipe(
-        v.nullable(v.pipe(ISO_DATE_SCHEMA, v.maxLength(10))),
-        v.description("Due date (ISO YYYY-MM-DD); pass null to clear"),
-      ),
-    ),
-    workflow_reason: v.optional(
-      v.pipe(
-        v.string(),
-        v.trim(),
-        v.minLength(1),
-        v.maxLength(1000),
-        v.description("Reason for a governed status or deadline change"),
-      ),
-    ),
-    add_assignee_user_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "User ID to assign to the task (must be a matter member)",
+      matter_id: v.optional(
+        uuidInputSchema(
+          "Matter ID to create the task in; required when creating.",
         ),
       ),
-    ),
-    remove_assignee_user_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("User ID to unassign from the task"),
+      name: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(255),
+          v.description("Task name; required when creating"),
+        ),
       ),
-    ),
-    link_entity_id: v.optional(
-      uuidInputSchema(
-        "Entity ID to link to the task (document, folder, or another task)",
+      status: v.optional(
+        v.pipe(v.picklist(TASK_STATUSES), v.description("Task status")),
       ),
-    ),
-    unlink_link_id: v.optional(uuidInputSchema("Entity-link ID to remove")),
-  }),
-  // Creating (no task_id) requires matter_id and name.
-  v.forward(
-    v.partialCheck(
-      [["task_id"], ["matter_id"]],
-      ({ task_id, matter_id }) =>
-        task_id !== undefined || matter_id !== undefined,
-      "matter_id is required to create a task",
-    ),
-    ["matter_id"],
-  ),
-  v.forward(
-    v.partialCheck(
-      [["task_id"], ["name"]],
-      ({ task_id, name }) => task_id !== undefined || name !== undefined,
-      "name is required to create a task",
-    ),
-    ["name"],
-  ),
-  // Assignee/link operations and matter_id only apply to an existing task.
-  v.partialCheck(
-    [
-      ["task_id"],
-      ["add_assignee_user_id"],
-      ["remove_assignee_user_id"],
-      ["link_entity_id"],
-      ["unlink_link_id"],
+      priority: v.optional(
+        v.pipe(v.picklist(ENTITY_PRIORITIES), v.description("Task priority")),
+      ),
+      item_type: v.optional(
+        v.pipe(
+          v.picklist(LIST_ITEM_TYPES),
+          v.description("What the List item represents"),
+        ),
+      ),
+      list_id: v.optional(
+        uuidInputSchema("List ID to create the item in (creating only)"),
+      ),
+      list_section_id: v.optional(
+        uuidInputSchema(
+          "Section of list_id to create the item under (creating only)",
+        ),
+      ),
+      list_description: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(v.string(), v.maxLength(10_000))),
+          v.description("List item description; pass null to clear"),
+        ),
+      ),
+      due_date: v.optional(
+        v.pipe(
+          v.nullable(v.pipe(ISO_DATE_SCHEMA, v.maxLength(10))),
+          v.description("Due date (ISO YYYY-MM-DD); pass null to clear"),
+        ),
+      ),
+      workflow_reason: v.optional(
+        v.pipe(
+          v.string(),
+          v.trim(),
+          v.minLength(1),
+          v.maxLength(1000),
+          v.description("Reason for a governed status or deadline change"),
+        ),
+      ),
+      add_assignee_user_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description(
+            "User ID to assign to the task (must be a matter member)",
+          ),
+        ),
+      ),
+      remove_assignee_user_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description("User ID to unassign from the task"),
+        ),
+      ),
+      link_entity_id: v.optional(
+        uuidInputSchema(
+          "Entity ID to link to the task (document, folder, or another task)",
+        ),
+      ),
+      unlink_link_id: v.optional(uuidInputSchema("Entity-link ID to remove")),
+    }),
+    // Creating (no task_id) requires matter_id and name.
+    v.forward(
+      v.partialCheck(
+        [["task_id"], ["matter_id"]],
+        ({ task_id, matter_id }) =>
+          task_id !== undefined || matter_id !== undefined,
+        "matter_id is required to create a task",
+      ),
       ["matter_id"],
-    ],
-    (i) =>
-      i.task_id !== undefined ||
-      (i.add_assignee_user_id === undefined &&
-        i.remove_assignee_user_id === undefined &&
-        i.link_entity_id === undefined &&
-        i.unlink_link_id === undefined),
-    "assignee and link changes require task_id (they apply to an existing task)",
-  ),
-  v.partialCheck(
-    [["task_id"], ["status"], ["due_date"], ["workflow_reason"]],
-    (i) =>
-      i.workflow_reason === undefined ||
-      (i.task_id !== undefined &&
-        (i.status !== undefined || i.due_date !== undefined)),
-    "workflow_reason only applies to status or due_date updates",
-  ),
-  // An update must request at least one action.
-  v.partialCheck(
-    [
-      ["task_id"],
+    ),
+    v.forward(
+      v.partialCheck(
+        [["task_id"], ["name"]],
+        ({ task_id, name }) => task_id !== undefined || name !== undefined,
+        "name is required to create a task",
+      ),
       ["name"],
-      ["status"],
-      ["priority"],
-      ["item_type"],
-      ["due_date"],
-      ["workflow_reason"],
-      ["add_assignee_user_id"],
-      ["remove_assignee_user_id"],
-      ["link_entity_id"],
-      ["unlink_link_id"],
-    ],
-    (i) =>
-      i.task_id === undefined ||
-      i.name !== undefined ||
-      i.status !== undefined ||
-      i.priority !== undefined ||
-      i.item_type !== undefined ||
-      i.due_date !== undefined ||
-      i.add_assignee_user_id !== undefined ||
-      i.remove_assignee_user_id !== undefined ||
-      i.link_entity_id !== undefined ||
-      i.unlink_link_id !== undefined,
-    "Provide at least one change to the task",
+    ),
+    // Assignee/link operations and matter_id only apply to an existing task.
+    v.partialCheck(
+      [
+        ["task_id"],
+        ["add_assignee_user_id"],
+        ["remove_assignee_user_id"],
+        ["link_entity_id"],
+        ["unlink_link_id"],
+        ["matter_id"],
+      ],
+      (i) =>
+        i.task_id !== undefined ||
+        (i.add_assignee_user_id === undefined &&
+          i.remove_assignee_user_id === undefined &&
+          i.link_entity_id === undefined &&
+          i.unlink_link_id === undefined),
+      "assignee and link changes require task_id (they apply to an existing task)",
+    ),
+    v.partialCheck(
+      [["task_id"], ["status"], ["due_date"], ["workflow_reason"]],
+      (i) =>
+        i.workflow_reason === undefined ||
+        (i.task_id !== undefined &&
+          (i.status !== undefined || i.due_date !== undefined)),
+      "workflow_reason only applies to status or due_date updates",
+    ),
+    // An update must request at least one action.
+    v.partialCheck(
+      [
+        ["task_id"],
+        ["name"],
+        ["status"],
+        ["priority"],
+        ["item_type"],
+        ["due_date"],
+        ["workflow_reason"],
+        ["add_assignee_user_id"],
+        ["remove_assignee_user_id"],
+        ["link_entity_id"],
+        ["unlink_link_id"],
+      ],
+      (i) =>
+        i.task_id === undefined ||
+        i.name !== undefined ||
+        i.status !== undefined ||
+        i.priority !== undefined ||
+        i.item_type !== undefined ||
+        i.due_date !== undefined ||
+        i.add_assignee_user_id !== undefined ||
+        i.remove_assignee_user_id !== undefined ||
+        i.link_entity_id !== undefined ||
+        i.unlink_link_id !== undefined,
+      "Provide at least one change to the task",
+    ),
   ),
 );
 
@@ -1826,18 +1850,20 @@ const handleSaveTaskTool: TypedMcpToolHandler<
 
 // --- delete_task --------------------------------------------------------
 
-const deleteTaskArgsSchema = v.strictObject({
-  task_id: uuidInputSchema("Task entity ID to delete"),
-  confirm: v.optional(
-    v.pipe(
-      v.boolean(),
-      v.description(
-        "Must be true to run this irreversible operation. Set it only after a " +
-          "human user has explicitly approved the deletion.",
+const deleteTaskArgsSchema = nullAsAbsent(
+  v.strictObject({
+    task_id: uuidInputSchema("Task entity ID to delete"),
+    confirm: v.optional(
+      v.pipe(
+        v.boolean(),
+        v.description(
+          "Must be true to run this irreversible operation. Set it only after a " +
+            "human user has explicitly approved the deletion.",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
 const handleDeleteTaskTool: TypedMcpToolHandler<
   v.InferInput<typeof DELETED_TRUE_PROJECTION>
@@ -1882,45 +1908,48 @@ const handleDeleteTaskTool: TypedMcpToolHandler<
 
 // --- link_matter_contact ------------------------------------------------
 
-const linkMatterContactArgsSchema = v.pipe(
-  v.strictObject({
-    matter_id: uuidInputSchema("Matter ID"),
-    contact_id: v.optional(
-      uuidInputSchema(
-        "Contact ID: with role to link the contact, or alone to unlink it " +
-          "from the matter",
-      ),
-    ),
-    role: v.optional(
-      v.pipe(
-        v.picklist(WORKSPACE_CONTACT_ROLES),
-        v.description(
-          "Party role for the linked contact; provide it only when linking",
+const linkMatterContactArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      matter_id: uuidInputSchema("Matter ID"),
+      contact_id: v.optional(
+        uuidInputSchema(
+          "Contact ID: with role to link the contact, or alone to unlink it " +
+            "from the matter",
         ),
       ),
-    ),
-    matter_contact_id: v.optional(
-      uuidInputSchema(
-        "Existing matter-contact link ID to remove, from list_matters",
+      role: v.optional(
+        v.pipe(
+          v.picklist(WORKSPACE_CONTACT_ROLES),
+          v.description(
+            "Party role for the linked contact; provide it only when linking",
+          ),
+        ),
       ),
-    ),
-  }),
-  // Exactly one target selector: contact_id (link with role, or unlink the
-  // contact) or matter_contact_id (unlink one specific link).
-  v.partialCheck(
-    [["contact_id"], ["matter_contact_id"]],
-    ({ contact_id, matter_contact_id }) =>
-      (contact_id === undefined) !== (matter_contact_id === undefined),
-    "Provide exactly one of contact_id or matter_contact_id",
-  ),
-  // role selects the link operation, so it only pairs with contact_id.
-  v.forward(
+      matter_contact_id: v.optional(
+        uuidInputSchema(
+          "Existing matter-contact link ID to remove, from list_matters",
+        ),
+      ),
+    }),
+    // Exactly one target selector: contact_id (link with role, or unlink the
+    // contact) or matter_contact_id (unlink one specific link).
     v.partialCheck(
-      [["contact_id"], ["role"]],
-      ({ contact_id, role }) => role === undefined || contact_id !== undefined,
-      "role only applies when linking a contact by contact_id",
+      [["contact_id"], ["matter_contact_id"]],
+      ({ contact_id, matter_contact_id }) =>
+        (contact_id === undefined) !== (matter_contact_id === undefined),
+      "Provide exactly one of contact_id or matter_contact_id",
     ),
-    ["role"],
+    // role selects the link operation, so it only pairs with contact_id.
+    v.forward(
+      v.partialCheck(
+        [["contact_id"], ["role"]],
+        ({ contact_id, role }) =>
+          role === undefined || contact_id !== undefined,
+        "role only applies when linking a contact by contact_id",
+      ),
+      ["role"],
+    ),
   ),
 );
 

--- a/apps/api/src/mcp/null-optional-inputs.test.ts
+++ b/apps/api/src/mcp/null-optional-inputs.test.ts
@@ -3,6 +3,9 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as v from "valibot";
 
+import capabilityCatalog from "@stll/cli/capability-catalog.json";
+
+import { withNullOptionalsOmitted } from "@/api/mcp/capability-tools";
 import { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions";
 
 /**
@@ -43,20 +46,25 @@ const advertisesNull = (schema: unknown): boolean => {
 
 /** Advertised properties a client may omit and that carry no meaning for
  * null: exactly the ones a strict client will send as null. */
-const optionalProperties = (definition: {
-  inputSchema: { properties?: Record<string, unknown>; required?: unknown };
-}): string[] => {
-  const { properties, required } = definition.inputSchema;
+const optionalProperties = (schema: unknown): string[] => {
+  if (!isRecord(schema)) {
+    return [];
+  }
+  const properties = schema["properties"];
+  const required = schema["required"];
   const requiredNames = new Set(
     Array.isArray(required)
       ? required.filter((name) => typeof name === "string")
       : [],
   );
-  return Object.entries(properties ?? {})
-    .filter(
-      ([name, schema]) => !requiredNames.has(name) && !advertisesNull(schema),
-    )
-    .map(([name]) => name);
+  return isRecord(properties)
+    ? Object.entries(properties)
+        .filter(
+          ([name, property]) =>
+            !requiredNames.has(name) && !advertisesNull(property),
+        )
+        .map(([name]) => name)
+    : [];
 };
 
 describe("MCP tool inputs read null as an omitted optional property", () => {
@@ -96,7 +104,7 @@ describe("MCP tool inputs read null as an omitted optional property", () => {
     const divergent: string[] = [];
     for (const definition of definitionsWithRuntimeSchema) {
       const omitted = parseOutcome(definition.inputSchemaSource, {});
-      for (const property of optionalProperties(definition)) {
+      for (const property of optionalProperties(definition.inputSchema)) {
         const withNull = parseOutcome(definition.inputSchemaSource, {
           [property]: null,
         });
@@ -109,6 +117,66 @@ describe("MCP tool inputs read null as an omitted optional property", () => {
     expect(
       divergent,
       `Setting these optional properties to null does not read as omitting them, so a strict tool-schema client that must send every property cannot call the tool: ${divergent.join(", ")}.`,
+    ).toEqual([]);
+  });
+
+  /**
+   * A property a client can read as accepting anything: it advertises no type
+   * and no branches, so `t.Any()` / `t.Unknown()` land here and their null is a
+   * value the handler asked for, not an unset property.
+   */
+  const acceptsAnything = (schema: unknown): boolean =>
+    isRecord(schema) &&
+    !("type" in schema) &&
+    !("anyOf" in schema) &&
+    !("oneOf" in schema);
+
+  /**
+   * Unlike the native tools, the capability path runs one chain for every
+   * capability, so there is no per-capability opt-in to forget. What this buys
+   * is coverage: `withNullOptionalsOmitted` is run over every part schema the
+   * committed catalog carries (the same `advertisedSchemas` projection
+   * `invoke_capability` validates against), so a schema shape it mishandles
+   * shows up as a property it rewrote or one whose null it carried through.
+   */
+  test("every optional capability property reads null as omission", () => {
+    const rewritten: string[] = [];
+    const carriedThrough: string[] = [];
+    for (const entry of capabilityCatalog) {
+      const schema: unknown = entry.inputSchema;
+      if (!isRecord(schema)) {
+        continue;
+      }
+      for (const part of ["body", "params", "query"] as const) {
+        const partSchema = schema[part];
+        if (!isRecord(partSchema) || !isRecord(partSchema["properties"])) {
+          continue;
+        }
+        const properties = partSchema["properties"];
+        for (const property of optionalProperties(partSchema)) {
+          const label = `${entry.id}.${part}.${property}`;
+          const read = JSON.stringify(
+            withNullOptionalsOmitted(partSchema, { [property]: null }),
+          );
+          if (read === "{}") {
+            continue;
+          }
+          if (read !== JSON.stringify({ [property]: null })) {
+            rewritten.push(label);
+          } else if (!acceptsAnything(properties[property])) {
+            carriedThrough.push(label);
+          }
+        }
+      }
+    }
+
+    expect(
+      rewritten,
+      `Reading a null under these capability properties rewrote the input instead of dropping the property: ${rewritten.join(", ")}.`,
+    ).toEqual([]);
+    expect(
+      carriedThrough,
+      `These capability properties are optional and constrain their value without admitting null, yet their null reaches validation as a value: ${carriedThrough.join(", ")}.`,
     ).toEqual([]);
   });
 

--- a/apps/api/src/mcp/null-optional-inputs.test.ts
+++ b/apps/api/src/mcp/null-optional-inputs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import nodePath from "node:path";
 import * as v from "valibot";
 
 import capabilityCatalog from "@stll/cli/capability-catalog.json";
@@ -194,7 +194,7 @@ describe("MCP tool inputs read null as an omitted optional property", () => {
     );
     const offenders: string[] = [];
     for (const file of sources) {
-      const source = readFileSync(join(directory, file), "utf8");
+      const source = readFileSync(nodePath.join(directory, file), "utf-8");
       for (const match of source.matchAll(
         /v\.safeParse\(\s*([\w.]+)\s*,\s*args\s*,?\s*\)/gu,
       )) {

--- a/apps/api/src/mcp/null-optional-inputs.test.ts
+++ b/apps/api/src/mcp/null-optional-inputs.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as v from "valibot";
+
+import { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions";
+
+/**
+ * A strict tool-schema client must send every property a tool declares, so it
+ * sends `null` for the optional ones it is not setting. Null is not a value on
+ * this surface: it reads as a rename, as an AI-drafted field, as an empty
+ * lookup path. `nullAsAbsent` makes the schema itself drop those nulls, so
+ * every consumer of the schema gets it rather than one handler that remembers.
+ *
+ * This walks the registry and requires the property to hold, tool by tool,
+ * instead of trusting that each new tool opts in.
+ */
+const definitionsWithRuntimeSchema = DEFAULT_MCP_TOOL_DEFINITIONS.filter(
+  (definition) => "inputSchemaSource" in definition,
+);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * A property that advertises `null` as one of its own values, such as
+ * save_document's `label` ("pass null to clear"). Null carries meaning there,
+ * so it is not absence and must reach the handler intact.
+ */
+const advertisesNull = (schema: unknown): boolean => {
+  if (!isRecord(schema)) {
+    return false;
+  }
+  const type = schema["type"];
+  if (type === "null" || (Array.isArray(type) && type.includes("null"))) {
+    return true;
+  }
+  return ["anyOf", "oneOf", "allOf"].some((keyword) => {
+    const branches = schema[keyword];
+    return Array.isArray(branches) && branches.some(advertisesNull);
+  });
+};
+
+/** Advertised properties a client may omit and that carry no meaning for
+ * null: exactly the ones a strict client will send as null. */
+const optionalProperties = (definition: {
+  inputSchema: { properties?: Record<string, unknown>; required?: unknown };
+}): string[] => {
+  const { properties, required } = definition.inputSchema;
+  const requiredNames = new Set(
+    Array.isArray(required)
+      ? required.filter((name) => typeof name === "string")
+      : [],
+  );
+  return Object.entries(properties ?? {})
+    .filter(
+      ([name, schema]) => !requiredNames.has(name) && !advertisesNull(schema),
+    )
+    .map(([name]) => name);
+};
+
+describe("MCP tool inputs read null as an omitted optional property", () => {
+  test("every valibot-defined tool parses through the null-as-absent wrapper", () => {
+    const unwrapped = definitionsWithRuntimeSchema
+      .filter(
+        ({ inputSchemaSource }) => !("advertisedSchema" in inputSchemaSource),
+      )
+      .map(({ name }) => name);
+
+    expect(
+      unwrapped,
+      `These tools parse their declared object directly, so a strict client's null for an unset optional property reaches validation as a value: ${unwrapped.join(", ")}. Wrap the schema in nullAsAbsent(...) from tool-utils.`,
+    ).toEqual([]);
+  });
+
+  /**
+   * The outcome of a parse, reduced to what a caller sees. A conditionally
+   * required property still reports its own rule (`name is required to create
+   * a template`); the property under test is that setting it to null must
+   * reach that rule at exactly the same place as omitting it.
+   */
+  const parseOutcome = (schema: v.GenericSchema, input: unknown): string => {
+    const parsed = v.safeParse(schema, input);
+    return parsed.success
+      ? `ok:${JSON.stringify(parsed.output)}`
+      : parsed.issues
+          .map(
+            (issue) =>
+              `${(issue.path ?? []).map(({ key }) => String(key)).join(".")}: ${issue.message}`,
+          )
+          .sort()
+          .join(" | ");
+  };
+
+  test("every advertised optional property parses null exactly as omission", () => {
+    const divergent: string[] = [];
+    for (const definition of definitionsWithRuntimeSchema) {
+      const omitted = parseOutcome(definition.inputSchemaSource, {});
+      for (const property of optionalProperties(definition)) {
+        const withNull = parseOutcome(definition.inputSchemaSource, {
+          [property]: null,
+        });
+        if (withNull !== omitted) {
+          divergent.push(`${definition.name}.${property}`);
+        }
+      }
+    }
+
+    expect(
+      divergent,
+      `Setting these optional properties to null does not read as omitting them, so a strict tool-schema client that must send every property cannot call the tool: ${divergent.join(", ")}.`,
+    ).toEqual([]);
+  });
+
+  /**
+   * The wrapper only helps the handlers that parse it. A handler parsing the
+   * declared object directly would keep the old behaviour with nothing to show
+   * for it in the registry, so bind the two here: every tool-argument parse in
+   * this directory reads either a definition's `inputSchemaSource` or a local
+   * schema declared through `nullAsAbsent`.
+   */
+  test("every handler parses its arguments through a null-as-absent schema", () => {
+    const directory = import.meta.dir;
+    const sources = readdirSync(directory).filter(
+      (file) => file.endsWith(".ts") && !file.endsWith(".test.ts"),
+    );
+    const offenders: string[] = [];
+    for (const file of sources) {
+      const source = readFileSync(join(directory, file), "utf8");
+      for (const match of source.matchAll(
+        /v\.safeParse\(\s*([\w.]+)\s*,\s*args\s*,?\s*\)/gu,
+      )) {
+        const [, schema] = match;
+        if (schema === undefined || schema.endsWith(".inputSchemaSource")) {
+          continue;
+        }
+        if (
+          new RegExp(
+            `(?:^|\\n)(?:export )?const ${schema} = nullAsAbsent\\(`,
+            "u",
+          ).test(source)
+        ) {
+          continue;
+        }
+        offenders.push(`${file}: ${schema}`);
+      }
+    }
+
+    expect(
+      offenders,
+      `These handlers parse tool arguments through a schema that does not drop a strict client's nulls: ${offenders.join(", ")}. Parse the definition's inputSchemaSource, or declare the schema as nullAsAbsent(...).`,
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/mcp/null-tolerance.test.ts
+++ b/apps/api/src/mcp/null-tolerance.test.ts
@@ -19,16 +19,21 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
  *    Elysia-parity TypeBox chain Default -> Convert -> Clean -> Check over the
  *    live handler config schemas.
  *
- * Observed, pinned behavior (identical intent on both paths):
- *  - null on a PLAIN optional field (no null in its type) is REJECTED with a
- *    clean `validation_error` envelope carrying `issues:[{path,message}]` an
- *    agent can self-correct from. null is never silently coerced to "absent",
- *    and never leaks past validation into a handler.
- *  - null on a NULLABLE field (declared `type: ["string","null"]` /
- *    `v.optional(v.nullable(...))` / a TypeBox null-union, the "pass null to
+ * Pinned behavior, which differs between the two paths:
+ *  - Static curated tools read null on a PLAIN optional field as the omission
+ *    a strict tool-schema client means by it: the property is dropped before
+ *    validation, so the call behaves exactly as if it had been left out. A
+ *    strict client must send every declared property, so rejecting the null
+ *    would make those tools uncallable.
+ *  - The capability invoke path still REJECTS null on a plain optional field
+ *    with a `validation_error` envelope carrying `issues:[{path,message}]`.
+ *    Its input is a nested `input` object the model composes deliberately,
+ *    not the tool's own declared property set.
+ *  - On BOTH paths, null on a NULLABLE field (declared `type: ["string","null"]`
+ *    / `v.optional(v.nullable(...))` / a TypeBox null-union, the "pass null to
  *    clear" convention) is ACCEPTED and passes through as a real null.
  *
- * No path was found where null leaks past validation into a handler.
+ * On neither path does an unexpected null leak past validation into a handler.
  */
 
 const emptyScopedDb = asTestRaw<McpRequestContext["scopedDb"]>(
@@ -40,6 +45,11 @@ const emptyScopedDb = asTestRaw<McpRequestContext["scopedDb"]>(
       for: async () => [],
       orderBy: () => builder,
       limit: async () => [],
+      // list_matters reads the org's practice jurisdictions once it gets past
+      // argument validation, which a null that reads as absence now does.
+      query: {
+        organizationSettings: { findFirst: async () => undefined },
+      },
     };
     return await run(builder);
   },
@@ -202,62 +212,38 @@ describe("null-tolerance premise", () => {
 
 // --- Path 1: static curated tools -------------------------------------------
 
-describe("static tools reject explicit null on plain optional fields", () => {
-  // Hand-rolled optional parsers key absence off `value === undefined`, so an
-  // explicit null falls through to the type check and is rejected. list_matters
-  // routes status/limit/cursor through parseOptionalEnum/Limit/Cursor.
-  const handRolledCases: { field: string; value: null }[] = [
-    { field: "status", value: null },
-    { field: "limit", value: null },
-    { field: "cursor", value: null },
-  ];
+describe("static tools read explicit null on plain optional fields as omission", () => {
+  // The tool's whole result, so each case requires the null call and the
+  // omitted call to be indistinguishable rather than only that the null was
+  // not named in an issue. A conditionally required property still reports its
+  // own rule (`name is required to create a matter`) in both calls; what this
+  // pins is that the null reaches that rule at exactly the same place.
+  const outcome = async (tool: string, args: Record<string, unknown>) =>
+    JSON.stringify(await call(tool, args));
 
-  for (const { field, value } of handRolledCases) {
-    test(`list_matters ${field}: null -> validation_error naming ${field}`, async () => {
-      const error = errorEnvelope(
-        await call("list_matters", { [field]: value }),
-      );
-      expect(error?.code).toBe("validation_error");
-      expect(error?.issues.some((issue) => issue.path === field)).toBe(true);
-    });
-  }
-
-  // matter_id: null is NOT undefined, so list_matters enters its detail branch
-  // (`args["matter_id"] !== undefined`) and rejects the null as a missing
-  // required id rather than silently listing.
-  test("list_matters matter_id: null -> validation_error (routed to detail branch)", async () => {
-    const error = errorEnvelope(
-      await call("list_matters", { matter_id: null }),
-    );
-    expect(error?.code).toBe("validation_error");
-    expect(error?.issues.some((issue) => issue.path === "matter_id")).toBe(
-      true,
-    );
-  });
-
-  // Valibot v.strictObject with a plain optional field: null is not the field's
-  // type, so safeParse fails at the boundary (before any workspace/DB access)
-  // with a field-scoped issue.
-  const valibotCases: {
+  const cases: {
     tool: string;
+    property: string;
     args: Record<string, unknown>;
-    path: string;
   }[] = [
-    { tool: "save_matter", args: { name: null }, path: "name" },
-    {
-      tool: "list_documents",
-      args: { matter_id: "ws_1", mode: null },
-      path: "mode",
-    },
+    // Hand-rolled optional parsers (parseOptionalEnum/Limit/Cursor).
+    { tool: "list_matters", property: "status", args: {} },
+    { tool: "list_matters", property: "limit", args: {} },
+    { tool: "list_matters", property: "cursor", args: {} },
+    // The detail-branch discriminator: null must list rather than route to a
+    // one-matter lookup with no id.
+    { tool: "list_matters", property: "matter_id", args: {} },
+    // Valibot strict objects with a plain optional property.
+    { tool: "save_matter", property: "name", args: {} },
+    { tool: "list_documents", property: "mode", args: { matter_id: "ws_1" } },
+    { tool: "list_templates", property: "template_id", args: {} },
   ];
 
-  for (const { tool, args, path } of valibotCases) {
-    test(`${tool} ${path}: null -> validation_error naming ${path}`, async () => {
-      const error = errorEnvelope(await call(tool, args));
-      expect(error?.code).toBe("validation_error");
-      expect(error?.issues.some((issue) => issue.path === path)).toBe(true);
-      // Rejected at the schema boundary: no handler ran.
-      expect(loadOrgSettingsMock).not.toHaveBeenCalled();
+  for (const { tool, property, args } of cases) {
+    test(`${tool} ${property}: null reads exactly as omitting it`, async () => {
+      expect(await outcome(tool, { ...args, [property]: null })).toBe(
+        await outcome(tool, args),
+      );
     });
   }
 });

--- a/apps/api/src/mcp/null-tolerance.test.ts
+++ b/apps/api/src/mcp/null-tolerance.test.ts
@@ -19,21 +19,20 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
  *    Elysia-parity TypeBox chain Default -> Convert -> Clean -> Check over the
  *    live handler config schemas.
  *
- * Pinned behavior, which differs between the two paths:
- *  - Static curated tools read null on a PLAIN optional field as the omission
- *    a strict tool-schema client means by it: the property is dropped before
- *    validation, so the call behaves exactly as if it had been left out. A
- *    strict client must send every declared property, so rejecting the null
- *    would make those tools uncallable.
- *  - The capability invoke path still REJECTS null on a plain optional field
- *    with a `validation_error` envelope carrying `issues:[{path,message}]`.
- *    Its input is a nested `input` object the model composes deliberately,
- *    not the tool's own declared property set.
- *  - On BOTH paths, null on a NULLABLE field (declared `type: ["string","null"]`
- *    / `v.optional(v.nullable(...))` / a TypeBox null-union, the "pass null to
+ * One rule, pinned identically on both:
+ *  - null on a PLAIN optional field (no null in its type) is ABSENCE. The
+ *    property is dropped before validation, so the call behaves exactly as if
+ *    it had been left out and takes the field's declared default. A strict
+ *    client must send every property a schema declares, so reading its null as
+ *    a value would make those surfaces uncallable.
+ *  - null on a NULLABLE field (declared `type: ["string","null"]` /
+ *    `v.optional(v.nullable(...))` / a TypeBox null-union, the "pass null to
  *    clear" convention) is ACCEPTED and passes through as a real null.
+ *  - null never reaches a handler as the value of a plain optional field.
  *
- * On neither path does an unexpected null leak past validation into a handler.
+ * Only DECLARED optional properties are read this way, so a required field set
+ * to null still fails, and a null under a key the schema does not declare is
+ * handled exactly as any other value under that key.
  */
 
 const emptyScopedDb = asTestRaw<McpRequestContext["scopedDb"]>(
@@ -271,53 +270,111 @@ describe("static tools accept explicit null on nullable ('pass null to clear') f
 
 // --- Path 2: capability invoke path (TypeBox Default->Convert->Clean->Check) --
 
-describe("invoke_capability rejects explicit null on plain optional fields", () => {
-  // Each case sets one plain (non-nullable) optional field to null; the TypeBox
-  // Check fails and the envelope carries a dot-path issue an agent can place.
+describe("invoke_capability reads explicit null on plain optional fields as omission", () => {
+  // A contact body with everything the schema requires, so each case below
+  // differs from its omitted twin in exactly the one null under test.
+  const contact = {
+    id: "0d0d3b3c-3a55-4f9d-9d3f-2c9b1c9a8f10",
+    type: "person",
+    displayName: "Ada Lovelace",
+  };
+
   const cases: {
     label: string;
     capability: string;
-    input: Record<string, unknown>;
-    pathPrefix: string;
+    withNull: Record<string, unknown>;
+    omitted: Record<string, unknown>;
   }[] = [
     {
       label: "time-entries.export-csv query.status",
       capability: "time-entries.export-csv",
-      input: { params: { matterId: "ws_1" }, query: { status: null } },
-      pathPrefix: "query.status",
+      withNull: { params: { matterId: "ws_1" }, query: { status: null } },
+      omitted: { params: { matterId: "ws_1" }, query: {} },
     },
     {
       label: "clauses.categories-create body.parentId",
       capability: "clauses.categories-create",
-      input: { body: { name: "X", parentId: null } },
-      pathPrefix: "body.parentId",
+      withNull: { body: { name: "X", parentId: null } },
+      omitted: { body: { name: "X" } },
     },
+    // One level down: a nested object property, read the same way as the part
+    // root so a strict client's nulls do not have to stop at the top level.
     {
-      label: "tasks.calendar body.datePropertyIds",
-      capability: "tasks.calendar",
-      input: {
+      label: "contacts.create body.billingAddress.city",
+      capability: "contacts.create",
+      withNull: {
+        body: {
+          ...contact,
+          billingAddress: { line1: "1 Main St", city: null },
+        },
+      },
+      omitted: {
+        body: { ...contact, billingAddress: { line1: "1 Main St" } },
+      },
+    },
+    // And inside an array of objects.
+    {
+      label: "contacts.create body.emails[].label",
+      capability: "contacts.create",
+      withNull: {
+        body: {
+          ...contact,
+          emails: [
+            {
+              type: "work",
+              address: "ada@example.com",
+              isPrimary: true,
+              label: null,
+            },
+          ],
+        },
+      },
+      omitted: {
+        body: {
+          ...contact,
+          emails: [
+            { type: "work", address: "ada@example.com", isPrimary: true },
+          ],
+        },
+      },
+    },
+  ];
+
+  for (const { label, capability, withNull, omitted } of cases) {
+    test(`${label}: null reads exactly as omitting it`, async () => {
+      const result = await invokeValidateOnly(capability, withNull);
+      // Asserting validity, not only equality, keeps the case from passing
+      // because both calls failed for some unrelated reason.
+      expect(parsePayload(result)).toEqual({ valid: true, capability });
+      expect(JSON.stringify(result)).toBe(
+        JSON.stringify(await invokeValidateOnly(capability, omitted)),
+      );
+    });
+  }
+
+  // A required property is not optional, so its null is still a value the
+  // schema rejects, with a dot-path issue an agent can place.
+  test("tasks.calendar body.datePropertyIds: null on a required field still fails", async () => {
+    const error = errorEnvelope(
+      await invokeValidateOnly("tasks.calendar", {
         params: { matterId: "ws_1" },
         body: {
           dateFrom: "2026-01-01T00:00:00.000Z",
           dateTo: "2026-01-31T00:00:00.000Z",
           datePropertyIds: null,
         },
-      },
-      pathPrefix: "body.datePropertyIds",
-    },
-  ];
+      }),
+    );
 
-  for (const { label, capability, input, pathPrefix } of cases) {
-    test(`${label}: null -> validation_error with a dot-path issue`, async () => {
-      const error = errorEnvelope(await invokeValidateOnly(capability, input));
-      expect(error?.code).toBe("validation_error");
-      expect(
-        error?.issues.some((issue) => issue.path.startsWith(pathPrefix)),
-      ).toBe(true);
-      // Refused at validation, before any execution/org-settings load.
-      expect(loadOrgSettingsMock).not.toHaveBeenCalled();
-    });
-  }
+    expect(error?.code).toBe("validation_error");
+    expect(
+      error?.issues.some((issue) =>
+        issue.path.startsWith("body.datePropertyIds"),
+      ),
+    ).toBe(true);
+    // Refused at validation, before any execution/org-settings load.
+    expect(loadOrgSettingsMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("invoke_capability accepts explicit null on nullable fields", () => {

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -49,6 +49,7 @@ import {
   ensureActiveWorkspace,
   errorResult,
   internalFailureResult,
+  nullAsAbsent,
   structuredErrorResult,
   toolDataResult,
   uuidInputSchema,
@@ -123,85 +124,87 @@ const widenDateOnlyBound = (bound: string, edge: "start" | "end"): string =>
     ? `${bound}T${edge === "start" ? "00:00:00.000" : "23:59:59.999"}Z`
     : bound;
 
-const listAuditLogArgsSchema = v.pipe(
-  v.strictObject({
-    matter_id: v.optional(
-      uuidInputSchema("Only entries scoped to this matter."),
-    ),
-    action: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Only entries with this audit action"),
+const listAuditLogArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      matter_id: v.optional(
+        uuidInputSchema("Only entries scoped to this matter."),
       ),
-    ),
-    resource_type: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Only entries about this resource type"),
-      ),
-    ),
-    resource_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description(
-          "Only entries about this resource id; requires resource_type",
+      action: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description("Only entries with this audit action"),
         ),
       ),
-    ),
-    user_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("Only entries whose actor is this user"),
-      ),
-    ),
-    from: v.optional(
-      v.pipe(
-        auditRangeBoundSchema,
-        v.description(
-          "Only entries created on or after this ISO date-time, or from the start of this YYYY-MM-DD date (UTC)",
+      resource_type: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description("Only entries about this resource type"),
         ),
       ),
-    ),
-    to: v.optional(
-      v.pipe(
-        auditRangeBoundSchema,
-        v.description(
-          "Only entries created on or before this ISO date-time, or up to the end of this YYYY-MM-DD date (UTC)",
+      resource_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description(
+            "Only entries about this resource id; requires resource_type",
+          ),
         ),
       ),
-    ),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(LIMITS.auditLogPageSizeMax),
-        v.description("Max entries to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(512),
-        v.description(
-          "Opaque cursor from a previous list_audit_log call to fetch the next page",
+      user_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description("Only entries whose actor is this user"),
         ),
       ),
+      from: v.optional(
+        v.pipe(
+          auditRangeBoundSchema,
+          v.description(
+            "Only entries created on or after this ISO date-time, or from the start of this YYYY-MM-DD date (UTC)",
+          ),
+        ),
+      ),
+      to: v.optional(
+        v.pipe(
+          auditRangeBoundSchema,
+          v.description(
+            "Only entries created on or before this ISO date-time, or up to the end of this YYYY-MM-DD date (UTC)",
+          ),
+        ),
+      ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(LIMITS.auditLogPageSizeMax),
+          v.description("Max entries to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(512),
+          v.description(
+            "Opaque cursor from a previous list_audit_log call to fetch the next page",
+          ),
+        ),
+      ),
+    }),
+    v.forward(
+      v.partialCheck(
+        [["resource_type"], ["resource_id"]],
+        ({ resource_id, resource_type }) =>
+          resource_id === undefined || resource_type !== undefined,
+        "resourceType is required when resourceId is provided",
+      ),
+      ["resource_id"],
     ),
-  }),
-  v.forward(
-    v.partialCheck(
-      [["resource_type"], ["resource_id"]],
-      ({ resource_id, resource_type }) =>
-        resource_id === undefined || resource_type !== undefined,
-      "resourceType is required when resourceId is provided",
-    ),
-    ["resource_id"],
   ),
 );
 
@@ -235,210 +238,215 @@ const LIST_AUDIT_LOG_TOOL_DEFINITION = defineValibotMcpTool({
 
 // --- search_legislation -------------------------------------------------
 
-const searchLegislationArgsSchema = v.pipe(
-  v.strictObject({
-    query: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(256),
-        v.description("Free-text search over consolidated legislation"),
-      ),
-    ),
-    title: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(256),
-        v.description("Filter search results by title text"),
-      ),
-    ),
-    department_code: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(32),
-        v.description("Filter search results by department code"),
-      ),
-    ),
-    legal_range_code: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(32),
-        v.description("Filter search results by legal-range code (law rank)"),
-      ),
-    ),
-    matter_code: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(32),
-        v.description("Filter search results by subject-matter code"),
-      ),
-    ),
-    date_from: v.optional(
-      v.pipe(
-        v.string(),
-        v.regex(BOE_DATE),
-        v.maxLength(8),
-        v.description("Only laws published on or after this date (YYYYMMDD)"),
-      ),
-    ),
-    date_to: v.optional(
-      v.pipe(
-        v.string(),
-        v.regex(BOE_DATE),
-        v.maxLength(8),
-        v.description("Only laws published on or before this date (YYYYMMDD)"),
-      ),
-    ),
-    limit: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(100),
-        v.description("Max search results to return"),
-      ),
-    ),
-    cursor: v.optional(
-      v.pipe(
-        v.string(),
-        v.regex(BOE_OFFSET_CURSOR),
-        v.maxLength(5),
-        v.description(
-          "Opaque cursor from a previous search_legislation call for the next page",
+const searchLegislationArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      query: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(256),
+          v.description("Free-text search over consolidated legislation"),
         ),
       ),
-    ),
-    law_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.regex(BOE_LAW_ID),
-        v.description(
-          "BOE consolidated-law id (e.g. BOE-A-1889-4763) to read; omit to search",
+      title: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(256),
+          v.description("Filter search results by title text"),
         ),
       ),
-    ),
-    block_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(128),
-        v.description(
-          "With law_id, return this text block's content instead of the whole law",
+      department_code: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(32),
+          v.description("Filter search results by department code"),
         ),
       ),
-    ),
-    relation_type: v.optional(
-      v.pipe(
-        v.picklist(RELATION_TYPE_VALUES),
-        v.description(
-          "With law_id, list related laws of this relation kind instead of the law body",
+      legal_range_code: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(32),
+          v.description("Filter search results by legal-range code (law rank)"),
         ),
       ),
-    ),
-    full_text: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description(
-          "With law_id (no block_id/relation_type), include the consolidated full text",
+      matter_code: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(32),
+          v.description("Filter search results by subject-matter code"),
         ),
       ),
+      date_from: v.optional(
+        v.pipe(
+          v.string(),
+          v.regex(BOE_DATE),
+          v.maxLength(8),
+          v.description("Only laws published on or after this date (YYYYMMDD)"),
+        ),
+      ),
+      date_to: v.optional(
+        v.pipe(
+          v.string(),
+          v.regex(BOE_DATE),
+          v.maxLength(8),
+          v.description(
+            "Only laws published on or before this date (YYYYMMDD)",
+          ),
+        ),
+      ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(100),
+          v.description("Max search results to return"),
+        ),
+      ),
+      cursor: v.optional(
+        v.pipe(
+          v.string(),
+          v.regex(BOE_OFFSET_CURSOR),
+          v.maxLength(5),
+          v.description(
+            "Opaque cursor from a previous search_legislation call for the next page",
+          ),
+        ),
+      ),
+      law_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.regex(BOE_LAW_ID),
+          v.description(
+            "BOE consolidated-law id (e.g. BOE-A-1889-4763) to read; omit to search",
+          ),
+        ),
+      ),
+      block_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(128),
+          v.description(
+            "With law_id, return this text block's content instead of the whole law",
+          ),
+        ),
+      ),
+      relation_type: v.optional(
+        v.pipe(
+          v.picklist(RELATION_TYPE_VALUES),
+          v.description(
+            "With law_id, list related laws of this relation kind instead of the law body",
+          ),
+        ),
+      ),
+      full_text: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description(
+            "With law_id (no block_id/relation_type), include the consolidated full text",
+          ),
+        ),
+      ),
+    }),
+    // block_id, relation_type, and full_text all read a specific law.
+    v.forward(
+      v.partialCheck(
+        [["law_id"], ["block_id"]],
+        ({ law_id, block_id }) =>
+          block_id === undefined || law_id !== undefined,
+        "block_id requires law_id",
+      ),
+      ["block_id"],
     ),
-  }),
-  // block_id, relation_type, and full_text all read a specific law.
-  v.forward(
+    v.forward(
+      v.partialCheck(
+        [["law_id"], ["relation_type"]],
+        ({ law_id, relation_type }) =>
+          relation_type === undefined || law_id !== undefined,
+        "relation_type requires law_id",
+      ),
+      ["relation_type"],
+    ),
+    v.forward(
+      v.partialCheck(
+        [["law_id"], ["full_text"]],
+        ({ law_id, full_text }) =>
+          full_text === undefined || law_id !== undefined,
+        "full_text requires law_id",
+      ),
+      ["full_text"],
+    ),
+    // block_id and relation_type each replace the law body; they cannot combine.
     v.partialCheck(
-      [["law_id"], ["block_id"]],
-      ({ law_id, block_id }) => block_id === undefined || law_id !== undefined,
-      "block_id requires law_id",
+      [["block_id"], ["relation_type"]],
+      ({ block_id, relation_type }) =>
+        block_id === undefined || relation_type === undefined,
+      "Provide at most one of block_id or relation_type",
     ),
-    ["block_id"],
-  ),
-  v.forward(
+    // full_text applies to the law body, not to a single block or the relations.
     v.partialCheck(
-      [["law_id"], ["relation_type"]],
-      ({ law_id, relation_type }) =>
-        relation_type === undefined || law_id !== undefined,
-      "relation_type requires law_id",
+      [["full_text"], ["block_id"], ["relation_type"]],
+      ({ full_text, block_id, relation_type }) =>
+        full_text === undefined ||
+        (block_id === undefined && relation_type === undefined),
+      "full_text does not apply with block_id or relation_type",
     ),
-    ["relation_type"],
-  ),
-  v.forward(
+    // Search filters belong to search mode; a law_id selects read mode.
     v.partialCheck(
-      [["law_id"], ["full_text"]],
-      ({ law_id, full_text }) =>
-        full_text === undefined || law_id !== undefined,
-      "full_text requires law_id",
+      [
+        ["law_id"],
+        ["query"],
+        ["title"],
+        ["department_code"],
+        ["legal_range_code"],
+        ["matter_code"],
+        ["date_from"],
+        ["date_to"],
+        ["limit"],
+        ["cursor"],
+      ],
+      (i) =>
+        i.law_id === undefined ||
+        (i.query === undefined &&
+          i.title === undefined &&
+          i.department_code === undefined &&
+          i.legal_range_code === undefined &&
+          i.matter_code === undefined &&
+          i.date_from === undefined &&
+          i.date_to === undefined &&
+          i.limit === undefined &&
+          i.cursor === undefined),
+      "Search filters apply to search mode; drop law_id to search",
     ),
-    ["full_text"],
-  ),
-  // block_id and relation_type each replace the law body; they cannot combine.
-  v.partialCheck(
-    [["block_id"], ["relation_type"]],
-    ({ block_id, relation_type }) =>
-      block_id === undefined || relation_type === undefined,
-    "Provide at most one of block_id or relation_type",
-  ),
-  // full_text applies to the law body, not to a single block or the relations.
-  v.partialCheck(
-    [["full_text"], ["block_id"], ["relation_type"]],
-    ({ full_text, block_id, relation_type }) =>
-      full_text === undefined ||
-      (block_id === undefined && relation_type === undefined),
-    "full_text does not apply with block_id or relation_type",
-  ),
-  // Search filters belong to search mode; a law_id selects read mode.
-  v.partialCheck(
-    [
-      ["law_id"],
-      ["query"],
-      ["title"],
-      ["department_code"],
-      ["legal_range_code"],
-      ["matter_code"],
-      ["date_from"],
-      ["date_to"],
-      ["limit"],
-      ["cursor"],
-    ],
-    (i) =>
-      i.law_id === undefined ||
-      (i.query === undefined &&
-        i.title === undefined &&
-        i.department_code === undefined &&
-        i.legal_range_code === undefined &&
-        i.matter_code === undefined &&
-        i.date_from === undefined &&
-        i.date_to === undefined &&
-        i.limit === undefined &&
-        i.cursor === undefined),
-    "Search filters apply to search mode; drop law_id to search",
-  ),
-  // Search mode needs at least one substantive filter (mirrors boe-search).
-  v.partialCheck(
-    [
-      ["law_id"],
-      ["query"],
-      ["title"],
-      ["department_code"],
-      ["legal_range_code"],
-      ["matter_code"],
-      ["date_from"],
-      ["date_to"],
-    ],
-    (i) =>
-      i.law_id !== undefined ||
-      i.query !== undefined ||
-      i.title !== undefined ||
-      i.department_code !== undefined ||
-      i.legal_range_code !== undefined ||
-      i.matter_code !== undefined ||
-      i.date_from !== undefined ||
-      i.date_to !== undefined,
-    "Provide law_id to read a law, or at least one search filter",
+    // Search mode needs at least one substantive filter (mirrors boe-search).
+    v.partialCheck(
+      [
+        ["law_id"],
+        ["query"],
+        ["title"],
+        ["department_code"],
+        ["legal_range_code"],
+        ["matter_code"],
+        ["date_from"],
+        ["date_to"],
+      ],
+      (i) =>
+        i.law_id !== undefined ||
+        i.query !== undefined ||
+        i.title !== undefined ||
+        i.department_code !== undefined ||
+        i.legal_range_code !== undefined ||
+        i.matter_code !== undefined ||
+        i.date_from !== undefined ||
+        i.date_to !== undefined,
+      "Provide law_id to read a law, or at least one search filter",
+    ),
   ),
 );
 
@@ -643,141 +651,143 @@ const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
 
 // --- manage_organization ------------------------------------------------
 
-const manageOrganizationArgsSchema = v.pipe(
-  v.strictObject({
-    action: v.pipe(
-      v.picklist(MANAGE_ORG_ACTIONS),
-      v.description("Administrative action to perform"),
-    ),
-    matter_id: v.optional(
-      uuidInputSchema("Matter ID for add_member and remove_member."),
-    ),
-    user_id: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.description("User id to add or remove for the member actions"),
+const manageOrganizationArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      action: v.pipe(
+        v.picklist(MANAGE_ORG_ACTIONS),
+        v.description("Administrative action to perform"),
       ),
-    ),
-    matter_number_pattern: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(128),
-        v.description(
-          "Matter-number pattern (update_org_settings); send with matter_number_padding",
+      matter_id: v.optional(
+        uuidInputSchema("Matter ID for add_member and remove_member."),
+      ),
+      user_id: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.description("User id to add or remove for the member actions"),
         ),
       ),
-    ),
-    matter_number_padding: v.optional(
-      v.pipe(
-        v.number(),
-        v.integer(),
-        v.minValue(1),
-        v.maxValue(6),
-        v.description(
-          "Matter-number zero-padding width (update_org_settings); send with matter_number_pattern",
+      matter_number_pattern: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(128),
+          v.description(
+            "Matter-number pattern (update_org_settings); send with matter_number_padding",
+          ),
         ),
       ),
-    ),
-    prompt_caching_enabled: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description(
-          "Toggle AI prompt caching for the organization (update_org_settings)",
+      matter_number_padding: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(6),
+          v.description(
+            "Matter-number zero-padding width (update_org_settings); send with matter_number_pattern",
+          ),
         ),
       ),
-    ),
-    document_processing_mode: v.optional(
-      v.pipe(
-        v.picklist(DOCUMENT_PROCESSING_MODES),
-        v.description(
-          "Set automatic PDF searchable-text extraction for the organization (update_org_settings)",
+      prompt_caching_enabled: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description(
+            "Toggle AI prompt caching for the organization (update_org_settings)",
+          ),
         ),
       ),
-    ),
-    // The CLI's --yes flow injects `confirm: true` for the destructive
-    // remove_member subcommand; the strictObject would otherwise reject it.
-    // Other actions accept but ignore it.
-    confirm: v.optional(
-      v.pipe(
-        v.boolean(),
-        v.description(
-          "Required for the remove_member action: must be true to remove a " +
-            "member (an irreversible action). Set it only after a human user " +
-            "has approved the removal; ignored by the other actions.",
+      document_processing_mode: v.optional(
+        v.pipe(
+          v.picklist(DOCUMENT_PROCESSING_MODES),
+          v.description(
+            "Set automatic PDF searchable-text extraction for the organization (update_org_settings)",
+          ),
         ),
       ),
+      // The CLI's --yes flow injects `confirm: true` for the destructive
+      // remove_member subcommand; the strictObject would otherwise reject it.
+      // Other actions accept but ignore it.
+      confirm: v.optional(
+        v.pipe(
+          v.boolean(),
+          v.description(
+            "Required for the remove_member action: must be true to remove a " +
+              "member (an irreversible action). Set it only after a human user " +
+              "has approved the removal; ignored by the other actions.",
+          ),
+        ),
+      ),
+    }),
+    // Member actions need a matter and a user.
+    v.forward(
+      v.partialCheck(
+        [["action"], ["matter_id"]],
+        ({ action, matter_id }) =>
+          action === "update_org_settings" || matter_id !== undefined,
+        "matter_id is required for add_member and remove_member",
+      ),
+      ["matter_id"],
     ),
-  }),
-  // Member actions need a matter and a user.
-  v.forward(
+    v.forward(
+      v.partialCheck(
+        [["action"], ["user_id"]],
+        ({ action, user_id }) =>
+          action === "update_org_settings" || user_id !== undefined,
+        "user_id is required for add_member and remove_member",
+      ),
+      ["user_id"],
+    ),
+    // Org-settings fields belong only to update_org_settings.
     v.partialCheck(
-      [["action"], ["matter_id"]],
-      ({ action, matter_id }) =>
-        action === "update_org_settings" || matter_id !== undefined,
-      "matter_id is required for add_member and remove_member",
+      [
+        ["action"],
+        ["matter_number_pattern"],
+        ["matter_number_padding"],
+        ["prompt_caching_enabled"],
+        ["document_processing_mode"],
+      ],
+      (i) =>
+        i.action === "update_org_settings" ||
+        (i.matter_number_pattern === undefined &&
+          i.matter_number_padding === undefined &&
+          i.prompt_caching_enabled === undefined &&
+          i.document_processing_mode === undefined),
+      "matter_number_pattern, matter_number_padding, prompt_caching_enabled, and document_processing_mode apply only to update_org_settings",
     ),
-    ["matter_id"],
-  ),
-  v.forward(
+    // matter_id/user_id are meaningless for an org-settings update.
     v.partialCheck(
-      [["action"], ["user_id"]],
-      ({ action, user_id }) =>
-        action === "update_org_settings" || user_id !== undefined,
-      "user_id is required for add_member and remove_member",
+      [["action"], ["matter_id"], ["user_id"]],
+      (i) =>
+        i.action !== "update_org_settings" ||
+        (i.matter_id === undefined && i.user_id === undefined),
+      "matter_id and user_id do not apply to update_org_settings",
     ),
-    ["user_id"],
-  ),
-  // Org-settings fields belong only to update_org_settings.
-  v.partialCheck(
-    [
-      ["action"],
-      ["matter_number_pattern"],
-      ["matter_number_padding"],
-      ["prompt_caching_enabled"],
-      ["document_processing_mode"],
-    ],
-    (i) =>
-      i.action === "update_org_settings" ||
-      (i.matter_number_pattern === undefined &&
-        i.matter_number_padding === undefined &&
-        i.prompt_caching_enabled === undefined &&
-        i.document_processing_mode === undefined),
-    "matter_number_pattern, matter_number_padding, prompt_caching_enabled, and document_processing_mode apply only to update_org_settings",
-  ),
-  // matter_id/user_id are meaningless for an org-settings update.
-  v.partialCheck(
-    [["action"], ["matter_id"], ["user_id"]],
-    (i) =>
-      i.action !== "update_org_settings" ||
-      (i.matter_id === undefined && i.user_id === undefined),
-    "matter_id and user_id do not apply to update_org_settings",
-  ),
-  // An org-settings update must change at least one field.
-  v.partialCheck(
-    [
-      ["action"],
-      ["matter_number_pattern"],
-      ["matter_number_padding"],
-      ["prompt_caching_enabled"],
-      ["document_processing_mode"],
-    ],
-    (i) =>
-      i.action !== "update_org_settings" ||
-      i.matter_number_pattern !== undefined ||
-      i.matter_number_padding !== undefined ||
-      i.prompt_caching_enabled !== undefined ||
-      i.document_processing_mode !== undefined,
-    "Provide at least one setting to change for update_org_settings",
-  ),
-  // The matter-number pattern and padding are a unit (mirrors the backing).
-  v.partialCheck(
-    [["matter_number_pattern"], ["matter_number_padding"]],
-    ({ matter_number_pattern, matter_number_padding }) =>
-      (matter_number_pattern === undefined) ===
-      (matter_number_padding === undefined),
-    "matter_number_pattern and matter_number_padding must be sent together",
+    // An org-settings update must change at least one field.
+    v.partialCheck(
+      [
+        ["action"],
+        ["matter_number_pattern"],
+        ["matter_number_padding"],
+        ["prompt_caching_enabled"],
+        ["document_processing_mode"],
+      ],
+      (i) =>
+        i.action !== "update_org_settings" ||
+        i.matter_number_pattern !== undefined ||
+        i.matter_number_padding !== undefined ||
+        i.prompt_caching_enabled !== undefined ||
+        i.document_processing_mode !== undefined,
+      "Provide at least one setting to change for update_org_settings",
+    ),
+    // The matter-number pattern and padding are a unit (mirrors the backing).
+    v.partialCheck(
+      [["matter_number_pattern"], ["matter_number_padding"]],
+      ({ matter_number_pattern, matter_number_padding }) =>
+        (matter_number_pattern === undefined) ===
+        (matter_number_padding === undefined),
+      "matter_number_pattern and matter_number_padding must be sent together",
+    ),
   ),
 );
 

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -93,12 +93,13 @@ import {
   MAX_LIST_LIMIT,
   MAX_SEARCH_LIMIT,
   notFoundResult,
+  nullAsAbsent,
   resolveWindowBounds,
   structuredErrorResult,
   toolDataResult,
   toPlainTextSnippet,
-  validationErrorResult,
   uuidInputSchema,
+  validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
@@ -496,158 +497,178 @@ const buildContactTextFieldSpecs = (
 // One Valibot schema per tool: the handler parses it and the advertised JSON
 // Schema is projected from it, so an unknown key is rejected on both.
 
-const listMattersArgsSchema = v.strictObject({
-  matter_id: v.optional(
-    uuidInputSchema(
-      "Matter ID to return a single matter's overview; omit to list matters",
-    ),
-  ),
-  status: v.optional(
-    v.pipe(
-      v.picklist(["active", "all"]),
-      v.description("Filter by matter status (list mode)"),
-    ),
-  ),
-  limit: v.optional(
-    v.pipe(
-      v.number(),
-      v.integer(),
-      v.minValue(1),
-      v.maxValue(MAX_LIST_LIMIT),
-      v.description("Max matters to return (list mode)"),
-    ),
-  ),
-  cursor: v.optional(
-    v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.maxLength(MAX_CURSOR_LENGTH),
-      v.description(
-        "Opaque cursor from a previous list_matters call to fetch the next page",
+const listMattersArgsSchema = nullAsAbsent(
+  v.strictObject({
+    matter_id: v.optional(
+      uuidInputSchema(
+        "Matter ID to return a single matter's overview; omit to list matters",
       ),
     ),
-  ),
-});
-
-const searchAcrossMattersArgsSchema = v.strictObject({
-  query: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.maxLength(LIMITS.searchQueryMaxLength),
-    v.description("Search query"),
-  ),
-  limit: v.optional(
-    v.pipe(
-      v.number(),
-      v.integer(),
-      v.minValue(1),
-      v.maxValue(MAX_SEARCH_LIMIT),
-      v.description("Max results to return"),
-    ),
-  ),
-  cursor: v.optional(
-    v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.maxLength(MAX_CURSOR_LENGTH),
-      v.description(
-        "Opaque cursor from a previous search_across_matters call to fetch the next page",
+    status: v.optional(
+      v.pipe(
+        v.picklist(["active", "all"]),
+        v.description("Filter by matter status (list mode)"),
       ),
     ),
-  ),
-});
-
-const searchCaseLawArgsSchema = v.strictObject({
-  query: v.pipe(
-    v.string(),
-    v.minLength(1),
-    v.maxLength(LIMITS.searchQueryMaxLength),
-    v.description("Search query"),
-  ),
-  limit: v.optional(
-    v.pipe(
-      v.number(),
-      v.integer(),
-      v.minValue(1),
-      v.maxValue(MAX_SEARCH_LIMIT),
-      v.description("Max results to return"),
-    ),
-  ),
-  cursor: v.optional(
-    v.pipe(
-      v.string(),
-      v.maxLength(128),
-      v.description("Opaque cursor from a previous search_case_law call"),
-    ),
-  ),
-  court: v.optional(
-    v.pipe(v.string(), v.maxLength(512), v.description("Filter by court name")),
-  ),
-  country: v.optional(
-    v.pipe(v.string(), v.maxLength(3), v.description("Filter by country code")),
-  ),
-  language: v.optional(
-    v.pipe(
-      v.string(),
-      v.maxLength(8),
-      v.description("Filter by language code"),
-    ),
-  ),
-  decision_type: v.optional(
-    v.pipe(
-      v.string(),
-      v.maxLength(128),
-      v.description("Filter by decision type"),
-    ),
-  ),
-  source_id: v.optional(uuidInputSchema("Filter by source ID")),
-  date_from: v.optional(
-    v.pipe(
-      v.string(),
-      v.maxLength(10),
-      v.description("Filter decisions from this ISO date (YYYY-MM-DD)"),
-    ),
-  ),
-  date_to: v.optional(
-    v.pipe(
-      v.string(),
-      v.maxLength(10),
-      v.description("Filter decisions up to this ISO date (YYYY-MM-DD)"),
-    ),
-  ),
-});
-
-const readContentAcrossMattersArgsSchema = v.strictObject({
-  entity_id: uuidInputSchema("Entity ID"),
-  cursor: v.optional(
-    v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.maxLength(MAX_CURSOR_LENGTH),
-      v.description(
-        "Opaque cursor from a previous call to read the next window of text",
+    limit: v.optional(
+      v.pipe(
+        v.number(),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(MAX_LIST_LIMIT),
+        v.description("Max matters to return (list mode)"),
       ),
     ),
-  ),
-});
-
-const readCaseLawDecisionArgsSchema = v.strictObject({
-  decision_id: uuidInputSchema("Case-law decision ID"),
-  cursor: v.optional(
-    v.pipe(
-      v.string(),
-      v.minLength(1),
-      v.maxLength(MAX_CURSOR_LENGTH),
-      v.description(
-        "Opaque cursor from a previous call to read the next window of decision text and citations",
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(MAX_CURSOR_LENGTH),
+        v.description(
+          "Opaque cursor from a previous list_matters call to fetch the next page",
+        ),
       ),
     ),
-  ),
-});
+  }),
+);
 
-const readContactArgsSchema = v.strictObject({
-  contact_id: uuidInputSchema("Contact ID"),
-});
+const searchAcrossMattersArgsSchema = nullAsAbsent(
+  v.strictObject({
+    query: v.pipe(
+      v.string(),
+      v.minLength(1),
+      v.maxLength(LIMITS.searchQueryMaxLength),
+      v.description("Search query"),
+    ),
+    limit: v.optional(
+      v.pipe(
+        v.number(),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(MAX_SEARCH_LIMIT),
+        v.description("Max results to return"),
+      ),
+    ),
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(MAX_CURSOR_LENGTH),
+        v.description(
+          "Opaque cursor from a previous search_across_matters call to fetch the next page",
+        ),
+      ),
+    ),
+  }),
+);
+
+const searchCaseLawArgsSchema = nullAsAbsent(
+  v.strictObject({
+    query: v.pipe(
+      v.string(),
+      v.minLength(1),
+      v.maxLength(LIMITS.searchQueryMaxLength),
+      v.description("Search query"),
+    ),
+    limit: v.optional(
+      v.pipe(
+        v.number(),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(MAX_SEARCH_LIMIT),
+        v.description("Max results to return"),
+      ),
+    ),
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(128),
+        v.description("Opaque cursor from a previous search_case_law call"),
+      ),
+    ),
+    court: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(512),
+        v.description("Filter by court name"),
+      ),
+    ),
+    country: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(3),
+        v.description("Filter by country code"),
+      ),
+    ),
+    language: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(8),
+        v.description("Filter by language code"),
+      ),
+    ),
+    decision_type: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(128),
+        v.description("Filter by decision type"),
+      ),
+    ),
+    source_id: v.optional(uuidInputSchema("Filter by source ID")),
+    date_from: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(10),
+        v.description("Filter decisions from this ISO date (YYYY-MM-DD)"),
+      ),
+    ),
+    date_to: v.optional(
+      v.pipe(
+        v.string(),
+        v.maxLength(10),
+        v.description("Filter decisions up to this ISO date (YYYY-MM-DD)"),
+      ),
+    ),
+  }),
+);
+
+const readContentAcrossMattersArgsSchema = nullAsAbsent(
+  v.strictObject({
+    entity_id: uuidInputSchema("Entity ID"),
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(MAX_CURSOR_LENGTH),
+        v.description(
+          "Opaque cursor from a previous call to read the next window of text",
+        ),
+      ),
+    ),
+  }),
+);
+
+const readCaseLawDecisionArgsSchema = nullAsAbsent(
+  v.strictObject({
+    decision_id: uuidInputSchema("Case-law decision ID"),
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(MAX_CURSOR_LENGTH),
+        v.description(
+          "Opaque cursor from a previous call to read the next window of decision text and citations",
+        ),
+      ),
+    ),
+  }),
+);
+
+const readContactArgsSchema = nullAsAbsent(
+  v.strictObject({
+    contact_id: uuidInputSchema("Contact ID"),
+  }),
+);
 
 const practiceJurisdictionInputSchema = v.strictObject({
   country_code: v.pipe(
@@ -660,18 +681,20 @@ const practiceJurisdictionInputSchema = v.strictObject({
   ),
 });
 
-const setPracticeJurisdictionsArgsSchema = v.strictObject({
-  jurisdictions: v.pipe(
-    v.array(practiceJurisdictionInputSchema),
-    v.minLength(1),
-    v.maxLength(LIMITS.practiceJurisdictionsPerOrganization),
-    v.description(
-      "Practice jurisdictions for this organization. country_code is an " +
-        "ISO 3166-1 alpha-2 code; exactly one entry should set is_primary " +
-        "to true.",
+const setPracticeJurisdictionsArgsSchema = nullAsAbsent(
+  v.strictObject({
+    jurisdictions: v.pipe(
+      v.array(practiceJurisdictionInputSchema),
+      v.minLength(1),
+      v.maxLength(LIMITS.practiceJurisdictionsPerOrganization),
+      v.description(
+        "Practice jurisdictions for this organization. country_code is an " +
+          "ISO 3166-1 alpha-2 code; exactly one entry should set is_primary " +
+          "to true.",
+      ),
     ),
-  ),
-});
+  }),
+);
 
 // MCP tool inputs are snake_case; the persisted jurisdiction shape is
 // camelCase.

--- a/apps/api/src/mcp/template-field-input.test.ts
+++ b/apps/api/src/mcp/template-field-input.test.ts
@@ -233,19 +233,22 @@ describe("template field input schema", () => {
     const parsed = parseFieldsOverlay([wireField]);
 
     expect(parsed.success).toBe(true);
-    expect(parsed.output?.fields).toEqual([
-      {
-        path: "company",
-        input_type: "text",
-        required: false,
-        lookup: {
-          registry: "krs",
-          formats: [{ key: "default", template: "[name]" }],
+    expect(parsed.output).toEqual({
+      template_id: TEMPLATE_ID,
+      fields: [
+        {
+          path: "company",
+          input_type: "text",
+          required: false,
+          lookup: {
+            registry: "krs",
+            formats: [{ key: "default", template: "[name]" }],
+          },
+          ai_sees_document: false,
+          ai_adapt: false,
         },
-        ai_sees_document: false,
-        ai_adapt: false,
-      },
-    ]);
+      ],
+    });
   });
 
   test("rejects the persisted camelCase spellings", () => {
@@ -286,7 +289,7 @@ describe("template field input schema", () => {
         const withNull = parseFieldsOverlay([{ path: "company", [key]: null }]);
         const omitted = parseFieldsOverlay([{ path: "company" }]);
         expect(withNull.success).toBe(omitted.success);
-        expect(withNull.output?.fields).toEqual(omitted.output?.fields);
+        expect(withNull.output).toEqual(omitted.output);
       });
     }
 
@@ -298,9 +301,10 @@ describe("template field input schema", () => {
           { path: "company", validation: { [key]: null } },
         ]);
         expect(withNull.success).toBe(true);
-        expect(withNull.output?.fields).toEqual([
-          { path: "company", validation: {} },
-        ]);
+        expect(withNull.output).toEqual({
+          template_id: TEMPLATE_ID,
+          fields: [{ path: "company", validation: {} }],
+        });
       });
     }
 

--- a/apps/api/src/mcp/template-field-input.test.ts
+++ b/apps/api/src/mcp/template-field-input.test.ts
@@ -8,11 +8,18 @@ import type {
   fieldSourceToolInputSchema,
 } from "@/api/lib/template-binding/binding-sources";
 import {
-  readTemplateFieldsInput,
   templateFieldInputSchema,
   toFieldMetaToolInput,
   toTemplateFieldWireInput,
 } from "@/api/mcp/template-field-input";
+import { saveTemplateArgsSchema } from "@/api/mcp/template-tools";
+
+const TEMPLATE_ID = "6f1f4d1e-59b0-4b4f-9a35-4b0ba0f7a1c9";
+
+/** The `fields` overlay read the way save_template reads it: through the tool
+ * input schema, which is where null-as-absence lives. */
+const parseFieldsOverlay = (fields: unknown) =>
+  v.safeParse(saveTemplateArgsSchema, { template_id: TEMPLATE_ID, fields });
 
 const sortedKeys = (entries: object): string[] => Object.keys(entries).sort();
 
@@ -223,12 +230,10 @@ describe("template field input schema", () => {
       format: null,
     });
 
-    const parsed = v.parse(
-      v.array(templateFieldInputSchema),
-      readTemplateFieldsInput([wireField]),
-    );
+    const parsed = parseFieldsOverlay([wireField]);
 
-    expect(parsed).toEqual([
+    expect(parsed.success).toBe(true);
+    expect(parsed.output?.fields).toEqual([
       {
         path: "company",
         input_type: "text",
@@ -256,16 +261,77 @@ describe("template field input schema", () => {
   });
 
   test("does not erase null typos borrowed from a different schema level", () => {
-    const parsed = v.safeParse(
-      v.array(templateFieldInputSchema),
-      readTemplateFieldsInput([
-        { path: "company", validation: { ai_prompt: null } },
-      ]),
-    );
+    const parsed = parseFieldsOverlay([
+      { path: "company", validation: { ai_prompt: null } },
+    ]);
 
     expect(parsed.success).toBe(false);
     expect(
       parsed.issues?.some((issue) => issue.path?.at(-1)?.key === "ai_prompt"),
     ).toBe(true);
+  });
+
+  /**
+   * The overlay is the level a strict tool-schema client fills in most, so
+   * every optional property it declares, at every nesting level, must read a
+   * `null` as the omission it means. Driving the table off the schemas
+   * themselves keeps it total as properties are added.
+   */
+  describe("reads null as absence for every declared optional property", () => {
+    for (const key of Object.keys(advertised)) {
+      if (key === "path") {
+        continue;
+      }
+      test(`fields[].${key}`, () => {
+        const withNull = parseFieldsOverlay([{ path: "company", [key]: null }]);
+        const omitted = parseFieldsOverlay([{ path: "company" }]);
+        expect(withNull.success).toBe(omitted.success);
+        expect(withNull.output?.fields).toEqual(omitted.output?.fields);
+      });
+    }
+
+    for (const key of Object.keys(
+      advertised.validation.wrapped.pipe[0].entries,
+    )) {
+      test(`fields[].validation.${key}`, () => {
+        const withNull = parseFieldsOverlay([
+          { path: "company", validation: { [key]: null } },
+        ]);
+        expect(withNull.success).toBe(true);
+        expect(withNull.output?.fields).toEqual([
+          { path: "company", validation: {} },
+        ]);
+      });
+    }
+
+    for (const key of Object.keys(
+      advertised.parts.wrapped.pipe[0].item.entries,
+    )) {
+      test(`fields[].parts[].${key}`, () => {
+        const parsed = parseFieldsOverlay([
+          {
+            path: "company",
+            format: "{{title}}",
+            parts: [{ key: "title", input_type: "text", [key]: null }],
+          },
+        ]);
+        // A part's `key` and `input_type` are required, so null stays an error
+        // there rather than silently becoming an omitted property.
+        expect(parsed.success).toBe(key !== "key" && key !== "input_type");
+      });
+    }
+
+    test("rejects a null under a key the overlay does not declare", () => {
+      const parsed = parseFieldsOverlay([
+        { path: "company", optionsFrom: null },
+      ]);
+
+      expect(parsed.success).toBe(false);
+      expect(
+        parsed.issues?.some(
+          (issue) => issue.path?.at(-1)?.key === "optionsFrom",
+        ),
+      ).toBe(true);
+    });
   });
 });

--- a/apps/api/src/mcp/template-field-input.ts
+++ b/apps/api/src/mcp/template-field-input.ts
@@ -23,7 +23,6 @@ import {
   hasCompatibleDerivedSources,
   hasCompleteCompositeField,
 } from "@/api/lib/docx/types";
-import { isRecord, isUnknownArray } from "@/api/lib/type-guards";
 
 const { entries: fieldEntries } = fieldMetaToolInputObjectSchema;
 const { entries: partEntries } = fieldPartSchema;
@@ -77,69 +76,6 @@ const templateFieldInputObjectSchema = v.strictObject({
   condition: fieldEntries.condition,
   date_format: fieldEntries.dateFormat,
 });
-
-/**
- * Declared property names per level of a `fields` entry, read off the schemas
- * themselves so {@link readTemplateFieldsInput} cannot drift from what the
- * surface accepts.
- */
-const FIELD_PROPERTIES = new Set(
-  Object.keys(templateFieldInputObjectSchema.entries),
-);
-const VALIDATION_PROPERTIES = new Set(
-  Object.keys(templateFieldValidationInputSchema.entries),
-);
-const PART_PROPERTIES = new Set(
-  Object.keys(templateFieldPartInputSchema.entries),
-);
-
-const withoutDeclaredNullProperties = (
-  entry: Record<string, unknown>,
-  declaredProperties: ReadonlySet<string>,
-): Record<string, unknown> =>
-  Object.fromEntries(
-    Object.entries(entry).filter(
-      ([key, value]) => value !== null || !declaredProperties.has(key),
-    ),
-  );
-
-/** Drop null only at the three schema levels where it means an omitted
- * optional field. Nested lookup/source/date-format objects keep their values,
- * so strict validation still reports a misplaced key even when it is null. */
-const withoutNullProperties = (entry: Record<string, unknown>): unknown => {
-  const field = withoutDeclaredNullProperties(entry, FIELD_PROPERTIES);
-  if (isRecord(field["validation"])) {
-    field["validation"] = withoutDeclaredNullProperties(
-      field["validation"],
-      VALIDATION_PROPERTIES,
-    );
-  }
-  if (isUnknownArray(field["parts"])) {
-    field["parts"] = field["parts"].map((part) =>
-      isRecord(part)
-        ? withoutDeclaredNullProperties(part, PART_PROPERTIES)
-        : part,
-    );
-  }
-  return field;
-};
-
-/**
- * Normalise a raw `fields` argument before validation: GPT-family clients send
- * `null` for an optional property they are not setting, and null is absence on
- * this surface. Without this, `ai_prompt: null` reads as an AI-drafted field
- * and collides with every other derived source, and `options_from: null` fails
- * the field-path check — a request that set none of them.
- *
- * Only DECLARED properties are dropped, so `strictObject` still rejects a
- * misspelled key whatever value it carries.
- */
-export const readTemplateFieldsInput = (value: unknown): unknown =>
-  isUnknownArray(value)
-    ? value.map((entry) =>
-        isRecord(entry) ? withoutNullProperties(entry) : entry,
-      )
-    : value;
 
 export const templateFieldInputSchema = v.pipe(
   templateFieldInputObjectSchema,

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -2786,6 +2786,100 @@ describe("MCP template tools", () => {
     );
   });
 
+  /**
+   * A strict tool-schema client must send every declared property, so it sends
+   * `null` for the ones it is not setting. Both branches of save_template have
+   * to read those nulls as omissions, or a configure call collides with the
+   * create rules and every derived-source property collides with the others.
+   */
+  test("save_template (configure) accepts a strict client's nulls for the properties it does not set", async () => {
+    configureTemplateFieldsMock.mockImplementation(async function* () {
+      yield* [];
+      return Result.ok({ manifest: { version: 1, fields: [] } });
+    });
+    describeStoredTemplateMock.mockResolvedValue({
+      name: "Company POA",
+      fields: [],
+      conditions: [],
+      computed: [],
+    });
+
+    const result = await handleMcpToolCall({
+      args: {
+        template_id: TEMPLATE_ID,
+        name: null,
+        docx_base64: null,
+        file: null,
+        fields: [
+          {
+            path: "company",
+            label: "Company",
+            hint: null,
+            input_type: "text",
+            options: null,
+            validation: null,
+            required: true,
+            ai_prompt: null,
+            ai_adapt: null,
+            ai_sees_document: null,
+            parts: null,
+            format: null,
+            options_from: null,
+            lookup: null,
+            source: null,
+            formula: null,
+            condition: null,
+            date_format: null,
+          },
+        ],
+      },
+      context: createContext(),
+      toolName: "save_template",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(configureTemplateFieldsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateId: TEMPLATE_ID,
+        fields: [
+          {
+            path: "company",
+            label: "Company",
+            inputType: "text",
+            required: true,
+          },
+        ],
+      }),
+    );
+  });
+
+  test("save_template (create) accepts a strict client's nulls for template_id and the unused file property", async () => {
+    createStoredTemplateMock.mockImplementation(async function* () {
+      yield* [];
+      return Result.ok({ id: "tmpl_new", name: "NDA", fieldCount: 3 });
+    });
+
+    const result = await handleMcpToolCall({
+      args: {
+        template_id: null,
+        name: "NDA",
+        docx_base64: await makeValidDocxBase64(),
+        file: null,
+        fields: null,
+      },
+      context: createContext(),
+      toolName: "save_template",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(parseToolPayload(result)).toEqual({
+      templateId: "tmpl_new",
+      name: "NDA",
+      fieldCount: 3,
+      warnings: [],
+    });
+  });
+
   test("save_template (configure) rejects a config whose path is unknown", async () => {
     configureTemplateFieldsMock.mockImplementation(async function* () {
       yield* [];

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -88,7 +88,6 @@ import {
   MAX_INLINE_DOCX_BYTES,
 } from "@/api/mcp/template-docx-limits";
 import {
-  readTemplateFieldsInput,
   templateFieldInputSchema,
   toFieldMetaToolInput,
   toTemplateFieldWireInput,
@@ -126,6 +125,7 @@ import {
   internalFailureResult,
   isToolErrorResult,
   notFoundResult,
+  nullAsAbsent,
   parseOptionalCursor,
   stringProp,
   structuredErrorResult,
@@ -170,83 +170,91 @@ const TEMPLATE_FILL_COMPLETION_MODE_PROP = {
   default: DEFAULT_TEMPLATE_FILL_COMPLETION_MODE,
 } as const;
 
-const saveTemplateArgsSchema = v.pipe(
-  v.strictObject({
-    template_id: v.optional(
-      uuidInputSchema("Template to configure; omit when creating"),
-    ),
-    name: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(256),
-        v.description("Display name; required when creating"),
+/**
+ * Exported so `template-field-input.test.ts` can exercise the `fields` overlay
+ * through the schema save_template actually parses, rather than through a
+ * second assembly of the same array that could drift from it.
+ */
+export const saveTemplateArgsSchema = nullAsAbsent(
+  v.pipe(
+    v.strictObject({
+      template_id: v.optional(
+        uuidInputSchema("Template to configure; omit when creating"),
       ),
-    ),
-    docx_base64: v.optional(
-      v.pipe(
-        v.string(),
-        v.minLength(1),
-        v.maxLength(MAX_INLINE_DOCX_BASE64_LENGTH),
-        v.description(
-          "Original .docx bytes, base64-encoded verbatim; the fallback for " +
-            "creating when the host cannot supply 'file'. Never strip parts " +
-            "out of the file to shrink it.",
+      name: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(256),
+          v.description("Display name; required when creating"),
         ),
       ),
-    ),
-    file: v.optional(OPENAI_FILE_REFERENCE_SCHEMA),
-    fields: v.optional(
-      v.pipe(
-        v.array(templateFieldInputSchema),
-        v.description(
-          `Field configuration overlay; see ${TEMPLATE_FIELD_REFERENCE_URI}`,
+      docx_base64: v.optional(
+        v.pipe(
+          v.string(),
+          v.minLength(1),
+          v.maxLength(MAX_INLINE_DOCX_BASE64_LENGTH),
+          v.description(
+            "Original .docx bytes, base64-encoded verbatim; the fallback for " +
+              "creating when the host cannot supply 'file'. Never strip parts " +
+              "out of the file to shrink it.",
+          ),
         ),
       ),
-    ),
-  }),
-  v.partialCheck(
-    [["template_id"], ["docx_base64"], ["file"]],
-    ({ template_id, docx_base64, file }) =>
-      (template_id === undefined) !==
-      (docx_base64 === undefined && file === undefined),
-    "Provide file or docx_base64 to create a template, or template_id to configure an existing template's fields",
-  ),
-  v.forward(
+      file: v.optional(OPENAI_FILE_REFERENCE_SCHEMA),
+      fields: v.optional(
+        v.pipe(
+          v.array(templateFieldInputSchema),
+          v.description(
+            `Field configuration overlay; see ${TEMPLATE_FIELD_REFERENCE_URI}`,
+          ),
+        ),
+      ),
+    }),
     v.partialCheck(
-      [["docx_base64"], ["file"]],
-      ({ docx_base64, file }) =>
-        docx_base64 === undefined || file === undefined,
-      "Provide either file or docx_base64, not both",
+      [["template_id"], ["docx_base64"], ["file"]],
+      ({ template_id, docx_base64, file }) =>
+        (template_id === undefined) !==
+        (docx_base64 === undefined && file === undefined),
+      "Provide file or docx_base64 to create a template, or template_id to configure an existing template's fields",
     ),
-    ["file"],
-  ),
-  v.forward(
-    v.partialCheck(
-      [["docx_base64"], ["file"], ["name"]],
-      ({ docx_base64, file, name }) =>
-        (docx_base64 === undefined && file === undefined) || name !== undefined,
-      "name is required to create a template",
+    v.forward(
+      v.partialCheck(
+        [["docx_base64"], ["file"]],
+        ({ docx_base64, file }) =>
+          docx_base64 === undefined || file === undefined,
+        "Provide either file or docx_base64, not both",
+      ),
+      ["file"],
     ),
-    ["name"],
-  ),
-  v.forward(
-    v.partialCheck(
-      [["template_id"], ["name"]],
-      ({ template_id, name }) =>
-        template_id === undefined || name === undefined,
-      "name applies only when creating a template; omit it when configuring",
+    v.forward(
+      v.partialCheck(
+        [["docx_base64"], ["file"], ["name"]],
+        ({ docx_base64, file, name }) =>
+          (docx_base64 === undefined && file === undefined) ||
+          name !== undefined,
+        "name is required to create a template",
+      ),
+      ["name"],
     ),
-    ["name"],
-  ),
-  v.forward(
-    v.partialCheck(
-      [["template_id"], ["fields"]],
-      ({ template_id, fields }) =>
-        template_id === undefined || fields !== undefined,
-      "fields is required to configure a template",
+    v.forward(
+      v.partialCheck(
+        [["template_id"], ["name"]],
+        ({ template_id, name }) =>
+          template_id === undefined || name === undefined,
+        "name applies only when creating a template; omit it when configuring",
+      ),
+      ["name"],
     ),
-    ["fields"],
+    v.forward(
+      v.partialCheck(
+        [["template_id"], ["fields"]],
+        ({ template_id, fields }) =>
+          template_id === undefined || fields !== undefined,
+        "fields is required to configure a template",
+      ),
+      ["fields"],
+    ),
   ),
 );
 
@@ -685,9 +693,19 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
   SAVE_TEMPLATE_TOOL_DEFINITION,
 ] as const satisfies readonly McpToolDefinition[];
 
-const listTemplatesArgsSchema = v.strictObject({
-  cursor: v.optional(v.pipe(v.string(), v.maxLength(512))),
-});
+/** The whole advertised list_templates surface, so the branch dispatch below
+ * reads arguments a strict client's nulls have already been dropped from
+ * rather than the raw ones. */
+const listTemplatesArgsSchema = nullAsAbsent(
+  v.strictObject({
+    template_id: v.optional(
+      uuidInputSchema(
+        "Template id to describe its fields in detail; omit to list templates",
+      ),
+    ),
+    cursor: v.optional(v.pipe(v.string(), v.maxLength(512))),
+  }),
+);
 
 // The list_templates cursor is the boundary template id alone; the query
 // resolves its (createdAt, id) in-DB.
@@ -710,10 +728,16 @@ const handleListTemplatesTool: TypedMcpToolHandler<
     return errorResult("Forbidden");
   }
 
+  const routed = v.safeParse(listTemplatesArgsSchema, args);
+  if (!routed.success) {
+    return validationErrorResult(routed.issues);
+  }
+  const { cursor: requestedCursor, template_id: templateId } = routed.output;
+
   // Detail mode: template_id returns one template's field configuration. The
   // list-only cursor does not apply, so reject the mixed request up front.
-  if (args["template_id"] !== undefined) {
-    if (args["cursor"] !== undefined) {
+  if (templateId !== undefined) {
+    if (requestedCursor !== undefined) {
       return structuredErrorResult({
         code: "validation_error",
         message:
@@ -728,12 +752,10 @@ const handleListTemplatesTool: TypedMcpToolHandler<
         hint: "Omit 'template_id' to list templates with 'cursor', or omit 'cursor' when requesting a single template_id.",
       });
     }
-    return await describeTemplateDetail({ args, context });
-  }
-
-  const parsed = v.safeParse(listTemplatesArgsSchema, args);
-  if (!parsed.success) {
-    return validationErrorResult(parsed.issues);
+    return await describeTemplateDetail({
+      args: { template_id: templateId },
+      context,
+    });
   }
 
   const cursor = parseOptionalCursor({ args, key: "cursor" });
@@ -812,9 +834,11 @@ const handleListTemplatesTool: TypedMcpToolHandler<
  * the schema, once the tool moves to `defineValibotMcpTool` and its advertised
  * schema is projected from this one.
  */
-export const describeTemplateArgsSchema = v.strictObject({
-  template_id: v.pipe(v.string(), v.uuid()),
-});
+export const describeTemplateArgsSchema = nullAsAbsent(
+  v.strictObject({
+    template_id: v.pipe(v.string(), v.uuid()),
+  }),
+);
 
 // Detail branch of list_templates: one template's field configuration. Reused
 // verbatim from the former describe_template tool, which list_templates
@@ -1026,16 +1050,18 @@ const assertTemplateFillUsage = async ({
   });
 };
 
-export const fillTemplateArgsSchema = v.strictObject({
-  template_id: v.pipe(v.string(), v.uuid()),
-  values: v.record(v.string(), v.unknown()),
-  allow_unused_values: v.optional(v.boolean()),
-  completion_mode: templateFillCompletionModeSchema,
-  output_mode: v.optional(
-    v.picklist(TEMPLATE_FILL_OUTPUT_MODES),
-    DEFAULT_TEMPLATE_FILL_OUTPUT_MODE,
-  ),
-});
+export const fillTemplateArgsSchema = nullAsAbsent(
+  v.strictObject({
+    template_id: v.pipe(v.string(), v.uuid()),
+    values: v.record(v.string(), v.unknown()),
+    allow_unused_values: v.optional(v.boolean()),
+    completion_mode: templateFillCompletionModeSchema,
+    output_mode: v.optional(
+      v.picklist(TEMPLATE_FILL_OUTPUT_MODES),
+      DEFAULT_TEMPLATE_FILL_OUTPUT_MODE,
+    ),
+  }),
+);
 
 const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
   const hasPermission = hasEffectiveAuthority(context, {
@@ -1230,17 +1256,19 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
   });
 };
 
-export const saveFilledTemplateArgsSchema = v.strictObject({
-  action: v.picklist(["create_document", "create_version"]),
-  template_id: v.pipe(v.string(), v.uuid()),
-  matter_id: v.pipe(v.string(), v.uuid()),
-  entity_id: v.optional(v.pipe(v.string(), v.uuid())),
-  parent_id: v.optional(v.pipe(v.string(), v.uuid())),
-  name: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(255))),
-  idempotency_key: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
-  values: v.record(v.string(), v.unknown()),
-  completion_mode: templateFillCompletionModeSchema,
-});
+export const saveFilledTemplateArgsSchema = nullAsAbsent(
+  v.strictObject({
+    action: v.picklist(["create_document", "create_version"]),
+    template_id: v.pipe(v.string(), v.uuid()),
+    matter_id: v.pipe(v.string(), v.uuid()),
+    entity_id: v.optional(v.pipe(v.string(), v.uuid())),
+    parent_id: v.optional(v.pipe(v.string(), v.uuid())),
+    name: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(255))),
+    idempotency_key: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+    values: v.record(v.string(), v.unknown()),
+    completion_mode: templateFillCompletionModeSchema,
+  }),
+);
 
 const resolveFilledDocxName = ({
   requested,
@@ -2110,10 +2138,10 @@ const configureExistingTemplate = async ({
 const handleSaveTemplateTool: TypedMcpToolHandler<
   v.InferInput<typeof SAVE_TEMPLATE_PROJECTION>
 > = async ({ args, context }) => {
-  const parsed = v.safeParse(SAVE_TEMPLATE_TOOL_DEFINITION.inputSchemaSource, {
-    ...args,
-    fields: readTemplateFieldsInput(args["fields"]),
-  });
+  const parsed = v.safeParse(
+    SAVE_TEMPLATE_TOOL_DEFINITION.inputSchemaSource,
+    args,
+  );
   if (!parsed.success) {
     return validationErrorResult(parsed.issues);
   }

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -16,6 +16,7 @@ import {
   decodePaginationCursor,
   encodePaginationCursor,
 } from "@/api/lib/pagination";
+import { isRecord, isUnknownArray } from "@/api/lib/type-guards";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { getAccessibleWorkspaceId } from "@/api/mcp/context";
 import type { McpErrorCode, McpValidationIssue } from "@/api/mcp/error-codes";
@@ -77,6 +78,144 @@ export const featureDisabledHint = (feature: string | undefined): string =>
  */
 export const uuidInputSchema = (description: string) =>
   v.pipe(v.string(), v.uuid(), v.description(description));
+
+/**
+ * An MCP tool's declared input: `v.strictObject(...)`, or a pipe over one.
+ * `entries` names every property the surface declares.
+ */
+type ToolObjectInputSchema = v.GenericSchema & {
+  readonly entries: v.ObjectEntries;
+};
+
+/**
+ * What a handler parses: the declared object with a strict client's nulls
+ * already dropped. The declared object stays reachable as `advertisedSchema`
+ * because JSON Schema projection reads a pipe's first schema, which here is
+ * the `unknown` root the transform needs.
+ */
+export type NullAsAbsentInputSchema = v.GenericSchema & {
+  readonly advertisedSchema: ToolObjectInputSchema;
+};
+
+/** One object or array level of a declared input, as far as null-dropping
+ * cares: which properties carry null as absence, and where to recurse. */
+type NullAsAbsentPlan =
+  | {
+      readonly kind: "object";
+      readonly absentWhenNull: ReadonlySet<string>;
+      readonly properties: ReadonlyMap<string, NullAsAbsentPlan>;
+    }
+  | { readonly kind: "array"; readonly item: NullAsAbsentPlan };
+
+const isObjectSchema = (
+  schema: unknown,
+): schema is { entries: Record<string, v.GenericSchema> } =>
+  isRecord(schema) && isRecord(schema["entries"]);
+
+const isArraySchema = (schema: unknown): schema is { item: v.GenericSchema } =>
+  isRecord(schema) && isRecord(schema["item"]);
+
+/** Strip `optional`/`nullable`/... wrappers and pipes down to the schema that
+ * declares the shape. */
+const declaredShapeOf = (schema: unknown): unknown => {
+  if (!isRecord(schema)) {
+    return schema;
+  }
+  const pipe = schema["pipe"];
+  if (isUnknownArray(pipe) && pipe.length > 0) {
+    return declaredShapeOf(pipe[0]);
+  }
+  const wrapped = schema["wrapped"];
+  return wrapped === undefined ? schema : declaredShapeOf(wrapped);
+};
+
+/**
+ * A property that accepts an omitted value but rejects an explicit null:
+ * exactly the properties where a client's null can only mean absence. A
+ * required property still fails on null, and one that accepts null keeps it.
+ */
+const isAbsentWhenNull = (schema: v.GenericSchema): boolean =>
+  v.safeParse(schema, undefined).success && !v.safeParse(schema, null).success;
+
+const nullAsAbsentPlan = (schema: unknown): NullAsAbsentPlan | undefined => {
+  const declared = declaredShapeOf(schema);
+  if (isObjectSchema(declared)) {
+    const absentWhenNull = new Set<string>();
+    const properties = new Map<string, NullAsAbsentPlan>();
+    for (const [key, property] of Object.entries(declared.entries)) {
+      if (isAbsentWhenNull(property)) {
+        absentWhenNull.add(key);
+      }
+      const nested = nullAsAbsentPlan(property);
+      if (nested !== undefined) {
+        properties.set(key, nested);
+      }
+    }
+    return { kind: "object", absentWhenNull, properties };
+  }
+  if (!isArraySchema(declared)) {
+    return undefined;
+  }
+  const item = nullAsAbsentPlan(declared.item);
+  return item === undefined ? undefined : { kind: "array", item };
+};
+
+const applyNullAsAbsent = (value: unknown, plan: NullAsAbsentPlan): unknown => {
+  switch (plan.kind) {
+    case "array":
+      return isUnknownArray(value)
+        ? value.map((entry) => applyNullAsAbsent(entry, plan.item))
+        : value;
+    case "object": {
+      if (!isRecord(value)) {
+        return value;
+      }
+      const normalized: Record<string, unknown> = {};
+      for (const [key, entry] of Object.entries(value)) {
+        if (entry === null && plan.absentWhenNull.has(key)) {
+          continue;
+        }
+        const nested = plan.properties.get(key);
+        normalized[key] =
+          nested === undefined ? entry : applyNullAsAbsent(entry, nested);
+      }
+      return normalized;
+    }
+    default:
+      return panic(`Unhandled null-as-absent plan: ${JSON.stringify(plan)}`);
+  }
+};
+
+/**
+ * Read a tool's input with `null` meaning absence, at every object level the
+ * schema declares.
+ *
+ * A strict tool-schema client must send every declared property, so it sends
+ * `null` for the ones it is not setting. Null is not a value on this surface:
+ * `ai_prompt: null` reads as an AI-drafted field and collides with every other
+ * derived source, `name: null` as a rename. Normalizing inside one handler
+ * leaves every other consumer of the schema (evals, tests, the capability
+ * catalog) with the raw contract, so the schema owns it instead.
+ *
+ * Only properties the schema itself declares as optional-and-null-rejecting
+ * are dropped, so a required property set to null and a null under a
+ * misspelled key both still fail strict validation.
+ */
+export const nullAsAbsent = <TSchema extends ToolObjectInputSchema>(
+  advertisedSchema: TSchema,
+) => {
+  const plan =
+    nullAsAbsentPlan(advertisedSchema) ??
+    panic("A tool input schema must declare object properties");
+  return Object.assign(
+    v.pipe(
+      v.unknown(),
+      v.transform((value: unknown) => applyNullAsAbsent(value, plan)),
+      advertisedSchema,
+    ),
+    { advertisedSchema },
+  );
+};
 
 type LocalToolExecutionOptions = {
   messages: [];
@@ -567,6 +706,15 @@ export const parseRequiredString = (
   return value;
 };
 
+/**
+ * Absence as a tool argument: omitted, or the `null` a strict tool-schema
+ * client sends for a declared property it is not setting. The schemas express
+ * the same rule through {@link nullAsAbsent}; these readers predate it and
+ * still parse raw arguments.
+ */
+const isAbsentArgument = (value: unknown): boolean =>
+  value === undefined || value === null;
+
 export const parseOptionalEnum = <TValues extends readonly string[]>({
   args,
   defaultValue,
@@ -579,7 +727,7 @@ export const parseOptionalEnum = <TValues extends readonly string[]>({
   values: TValues;
 }): TValues[number] | InternalToolErrorResult => {
   const value = args[key];
-  if (value === undefined) {
+  if (isAbsentArgument(value)) {
     return defaultValue;
   }
   if (typeof value !== "string" || !values.includes(value)) {
@@ -604,7 +752,7 @@ export const parseOptionalLimit = ({
   max: number;
 }): number | InternalToolErrorResult => {
   const value = args[key];
-  if (value === undefined) {
+  if (isAbsentArgument(value)) {
     return defaultValue;
   }
   if (
@@ -641,7 +789,7 @@ export const parseOptionalCursor = ({
   key: string;
 }): string | undefined | InternalToolErrorResult => {
   const value = args[key];
-  if (value === undefined) {
+  if (isAbsentArgument(value)) {
     return undefined;
   }
   if (typeof value !== "string" || value.length === 0) {

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -97,6 +97,18 @@ export type NullAsAbsentInputSchema = v.GenericSchema & {
   readonly advertisedSchema: ToolObjectInputSchema;
 };
 
+/**
+ * The wrapper's type for one declared object. Written out rather than inferred
+ * from the `v.pipe(...)` expression: every tool input schema in this directory
+ * goes through {@link nullAsAbsent}, so an inferred `SchemaWithPipe` over a
+ * three-item tuple would be instantiated at each of them and carried into every
+ * handler that reads `parsed.output`. This says the same thing in two nodes.
+ */
+type NullAsAbsentSchema<TSchema extends ToolObjectInputSchema> =
+  v.GenericSchema<unknown, v.InferOutput<TSchema>> & {
+    readonly advertisedSchema: TSchema;
+  };
+
 /** One object or array level of a declared input, as far as null-dropping
  * cares: which properties carry null as absence, and where to recurse. */
 type NullAsAbsentPlan =
@@ -203,7 +215,7 @@ const applyNullAsAbsent = (value: unknown, plan: NullAsAbsentPlan): unknown => {
  */
 export const nullAsAbsent = <TSchema extends ToolObjectInputSchema>(
   advertisedSchema: TSchema,
-) => {
+): NullAsAbsentSchema<TSchema> => {
   const plan =
     nullAsAbsentPlan(advertisedSchema) ??
     panic("A tool input schema must declare object properties");

--- a/apps/api/src/mcp/uuid-id-inputs.test.ts
+++ b/apps/api/src/mcp/uuid-id-inputs.test.ts
@@ -92,11 +92,14 @@ const declaresUuid = (schema: unknown): boolean => {
 /**
  * The validator each legacy tool's handler actually parses, keyed by tool name.
  * `list_templates` reaches its detail branch through `describeTemplateArgsSchema`.
+ * `advertisedSchema` is the declared object inside the null-as-absent wrapper
+ * the handler parses; the wrapper only drops nulls, so the declared object is
+ * what enforces the id formats.
  */
 const LEGACY_MANUAL_INPUT_VALIDATORS = {
-  list_templates: describeTemplateArgsSchema,
-  fill_template: fillTemplateArgsSchema,
-  save_filled_template: saveFilledTemplateArgsSchema,
+  list_templates: describeTemplateArgsSchema.advertisedSchema,
+  fill_template: fillTemplateArgsSchema.advertisedSchema,
+  save_filled_template: saveFilledTemplateArgsSchema.advertisedSchema,
 };
 
 /**

--- a/apps/api/src/mcp/valibot-tool-definition.test.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.test.ts
@@ -2,29 +2,36 @@ import { describe, expect, test } from "bun:test";
 import { expectTypeOf } from "expect-type";
 import * as v from "valibot";
 
+import { nullAsAbsent } from "@/api/mcp/tool-utils";
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 
 describe("Valibot-backed MCP tool definitions", () => {
   test("derives the wire schema from the handler's strict runtime schema", () => {
-    const inputSchema = v.strictObject({
-      from: v.pipe(
-        v.string(),
-        v.isoTimestamp(),
-        v.description("Inclusive ISO timestamp"),
-      ),
-      limit: v.optional(
-        v.pipe(
-          v.number(),
-          v.integer(),
-          v.minValue(1),
-          v.maxValue(100),
-          v.description("Maximum rows"),
+    const inputSchema = nullAsAbsent(
+      v.strictObject({
+        from: v.pipe(
+          v.string(),
+          v.isoTimestamp(),
+          v.description("Inclusive ISO timestamp"),
         ),
-      ),
-      score: v.optional(
-        v.pipe(v.number(), v.finite(), v.description("Finite relevance score")),
-      ),
-    });
+        limit: v.optional(
+          v.pipe(
+            v.number(),
+            v.integer(),
+            v.minValue(1),
+            v.maxValue(100),
+            v.description("Maximum rows"),
+          ),
+        ),
+        score: v.optional(
+          v.pipe(
+            v.number(),
+            v.finite(),
+            v.description("Finite relevance score"),
+          ),
+        ),
+      }),
+    );
     const definition = defineValibotMcpTool({
       access: "read",
       annotations: { title: "Read example", readOnlyHint: true },
@@ -94,12 +101,14 @@ describe("Valibot-backed MCP tool definitions", () => {
       annotations: { title: "Set example", readOnlyHint: false },
       anonymized: { exposure: "excluded", reason: "write" },
       description: "Set an example.",
-      inputSchema: v.strictObject({
-        content: v.variant("type", [
-          v.strictObject({ type: v.literal("text"), value: v.string() }),
-          v.strictObject({ type: v.literal("count"), value: v.number() }),
-        ]),
-      }),
+      inputSchema: nullAsAbsent(
+        v.strictObject({
+          content: v.variant("type", [
+            v.strictObject({ type: v.literal("text"), value: v.string() }),
+            v.strictObject({ type: v.literal("count"), value: v.number() }),
+          ]),
+        }),
+      ),
       name: "set_example",
       scope: "stella:documents_write",
     });
@@ -138,9 +147,11 @@ describe("Valibot-backed MCP tool definitions", () => {
         annotations: { title: "Read example", readOnlyHint: true },
         anonymized: { exposure: "passthrough" },
         description: "Read an example.",
-        inputSchema: v.strictObject({
-          score: v.pipe(v.number(), v.finite()),
-        }),
+        inputSchema: nullAsAbsent(
+          v.strictObject({
+            score: v.pipe(v.number(), v.finite()),
+          }),
+        ),
         name: "read_example",
         scope: "stella:read",
       }),
@@ -154,7 +165,7 @@ describe("Valibot-backed MCP tool definitions", () => {
         annotations: { title: "Read example", readOnlyHint: true },
         anonymized: { exposure: "passthrough" },
         description: "Read an example.",
-        inputSchema: v.looseObject({ query: v.string() }),
+        inputSchema: nullAsAbsent(v.looseObject({ query: v.string() })),
         name: "read_example",
         scope: "stella:read",
       }),

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -6,6 +6,7 @@ import type {
   McpToolDefinition,
   McpToolInputSchema,
 } from "@/api/mcp/tool-types";
+import type { NullAsAbsentInputSchema } from "@/api/mcp/tool-utils";
 
 const VALIBOT_MCP_JSON_SCHEMA_CONFIG = {
   errorMode: "throw",
@@ -21,7 +22,7 @@ type JsonSchemaProjectionWaiver = {
 };
 
 type ValibotMcpToolInput = Omit<McpToolDefinition, "inputSchema"> & {
-  inputSchema: v.GenericSchema;
+  inputSchema: NullAsAbsentInputSchema;
   jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
 };
 
@@ -170,6 +171,12 @@ const projectSchemaKeywordsIn = (value: unknown): unknown => {
  * handlers parse through the definition, while wire projection selects only
  * MCP protocol fields. The static compile-time ratchet also uses its presence
  * to distinguish derived schemas from legacy hand-maintained mirrors.
+ *
+ * `inputSchema` must be wrapped in `nullAsAbsent`, so that a strict
+ * tool-schema client's `null` for an unset optional property reads as
+ * absence for every consumer of the schema rather than in one handler. The
+ * wrapper is input-side only: projection reads the declared object it wraps,
+ * so the advertised schema is exactly what the object declares.
  */
 export const defineValibotMcpTool = <
   const TDefinition extends ValibotMcpToolInput,
@@ -180,7 +187,10 @@ export const defineValibotMcpTool = <
     definition;
   return {
     ...toolDefinition,
-    inputSchema: deriveMcpInputSchema(inputSchema, jsonSchemaProjectionWaiver),
+    inputSchema: deriveMcpInputSchema(
+      inputSchema.advertisedSchema,
+      jsonSchemaProjectionWaiver,
+    ),
     inputSchemaSource: inputSchema,
   };
 };


### PR DESCRIPTION
## Problem

A strict tool-schema client must send every property a tool declares, so it sends
`null` for the optional ones it is not setting. On the MCP surface null is not a
value: `save_template`'s `ai_prompt: null` reads as an AI-drafted field and
collides with every other derived source, `options_from: null` fails the
field-path check, and `name: null` reads as a rename that only the create branch
accepts. A configure call shaped `{ template_id, name: null, docx_base64: null,
file: null, fields: [...] }` was rejected outright.

The normalization for that existed, but only as a pre-step inside one handler:
`readTemplateFieldsInput` applied to `save_template`'s `fields` before
`v.safeParse`. Every other consumer of the same schema (anything parsing
`inputSchemaSource` directly, tests, the tool definitions the catalog exports)
got the raw contract, save_template's own top-level properties had no null
handling at all, no other MCP tool had any, and the capability invoke path
rejected such a null outright.

## The rule

One rule now holds on both MCP validation surfaces, the native tools and the
capability invoke path:

- `null` under a **declared optional property that does not itself admit null**
  is **absence**. The property is dropped before validation, so the call behaves
  exactly as if it had been left out and takes the property's declared default.
- `null` under a **declared-nullable** property (the "pass null to clear"
  convention) is a value and passes through untouched.
- A **required** property set to null is still an error, and a null under a key
  the schema does not declare is handled exactly as any other value under that
  key.
- Null never reaches a handler as the value of a plain optional property.

## Change

- `nullAsAbsent(objectSchema)` in `apps/api/src/mcp/tool-utils.ts` wraps a
  declared tool input and applies the rule recursively through nested object
  properties and arrays of objects. Both the declared key set and the
  optional-and-null-rejecting decision are read off the schema itself: a
  property qualifies only when it accepts an omitted value and rejects an
  explicit null.
- `defineValibotMcpTool` requires its `inputSchema` to be that wrapper and
  projects the advertised JSON Schema from the declared object it wraps. The wire
  contract is unchanged (re-running the capability catalog export produces no
  diff), and a new tool cannot ship without the behavior.
- Every MCP tool input schema in `apps/api/src/mcp/` is wrapped, including the
  four template tools whose advertised schema is still hand-written.
  `parseOptionalEnum` / `parseOptionalLimit` / `parseOptionalCursor` read null as
  absence for the handlers that still parse raw arguments, and `list_templates`
  routes its list and detail branches off the parsed arguments rather than the
  raw ones.
- `withNullOptionalsOmitted` in `apps/api/src/mcp/capability-tools.ts` applies
  the same rule to the capability invoke path, ahead of the Elysia-parity
  Default -> Convert -> Clean -> Check chain (ahead of the whole chain, not just
  Check, so a dropped null takes the property's declared default and never
  reaches Convert). It reads JSON Schema keywords (`properties`, `required`,
  `items`, `anyOf`/`oneOf` with a null branch) off the live TypeBox schemas, so
  the same function runs over the committed catalog in the guard test.
- `readTemplateFieldsInput` and the template-specific `withoutNullProperties` are
  deleted: the generic wrapper covers `fields[]`, `fields[].validation` and
  `fields[].parts[]` from the same schemas those sets were derived from.

`null-tolerance.test.ts` previously pinned the opposite rule ("null on a plain
optional field is rejected") on both paths. Its header and both halves now state
and assert the single rule above.

## Tests

- `null-optional-inputs.test.ts` (new, registry-wide): every advertised optional
  property of every registered tool must parse identically to omitting it; every
  valibot-defined tool must carry the wrapper; every `v.safeParse(schema, args)`
  in `apps/api/src/mcp/` must read a wrapped schema or a definition's
  `inputSchemaSource`, so a handler cannot quietly parse the declared object
  instead. For the capability path it runs `withNullOptionalsOmitted` over every
  part schema in the committed catalog and requires each optional constrained
  property's null to be dropped and nothing else about the input to change.
- `null-tolerance.test.ts`: the same parity assertion on both paths, including a
  nested object property and a property inside an array of objects on the
  capability path, plus a required property whose null still fails.
- `template-field-input.test.ts`: a table over the overlay's declared keys at all
  three levels, plus the existing check that a null under an undeclared key is
  still rejected.
- `template-tools.test.ts`: a strict-client-shaped configure call and create call.

Most of the diff is the formatter reindenting the wrapped schema literals; the
change reads more easily with whitespace hidden.
