### PR TITLE
fix(api): the lease start margin stops a cycle instead of shrinking its requests

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.test.ts
@@ -228,3 +228,46 @@ test("append requests do not depend on how many revisions arrive at once", () =>
   );
   expect(streamed).toEqual(requestsPerIndex(32));
 });
+
+/**
+ * The two reasons a tail flushes are not interchangeable to the caller. A cap
+ * is a property of the tail, so the next one fills from empty. The margin is a
+ * property of the clock: it stays true, so a caller that keeps buffering past
+ * it flushes on every later call, one revision at a time.
+ */
+test("a cap-led flush and a margin-led flush are told apart", () => {
+  const entry = (ndjson: string, leaseExpiresAtMs: number) => ({
+    indexId: "case_law_v5_cs_sk",
+    ndjson,
+    ndjsonBytes: CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES,
+    leaseExpiresAtMs,
+  });
+
+  const capLed = advanceCorpusProjectionAppendTails({
+    tails: new Map(),
+    entries: [entry("first", 600_000), entry("second", 600_000)],
+    mode: "buffer",
+    nowMs: 0,
+  });
+  expect(capLed.flush).toHaveLength(1);
+  expect(capLed.leaseMarginReached).toBe(false);
+
+  const marginLed = advanceCorpusProjectionAppendTails({
+    tails: new Map(),
+    entries: [entry("first", 1000)],
+    mode: "buffer",
+    nowMs: 0,
+  });
+  expect(marginLed.flush).toHaveLength(1);
+  expect(marginLed.leaseMarginReached).toBe(true);
+
+  // The final drain is the caller ending the cycle, not the clock forcing it.
+  expect(
+    advanceCorpusProjectionAppendTails({
+      tails: marginLed.tails,
+      entries: [entry("third", 600_000)],
+      mode: "flush-all",
+      nowMs: 0,
+    }).leaseMarginReached,
+  ).toBe(false);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -849,6 +849,8 @@ const processPreparedStream = async ({
   });
 
   let waitingSince = Date.now();
+  /** The margin-led flush to append once the pool is closed, if one came. */
+  let marginFlush: ProjectionAppendTail<PreparedProjectionEntry>[] | undefined;
   for await (const { material, prepared } of payloads) {
     result.timing.payloadLoadMs += Date.now() - waitingSince;
     consumed += 1;
@@ -896,49 +898,56 @@ const processPreparedStream = async ({
       nowMs: Date.now(),
     });
     tails = advanced.tails;
+    if (advanced.leaseMarginReached) {
+      // The lease is inside the margin an append needs to start safely, and it
+      // only gets closer. Reading on would append one revision per request,
+      // each paying a batch start, an ingest round trip and a commit for what
+      // belongs in one capful, so the cycle stops here and hands the rest back
+      // to a cycle whose lease can fill its requests.
+      //
+      // Breaking before the append is what stops the reads: closing the pool
+      // ends the refill, so the cycle spends the ingest and commit appending
+      // rather than reading payloads for revisions it has already given up.
+      marginFlush = advanced.flush;
+      break;
+    }
     if (advanced.flush.length > 0) {
       await classifyPendingFailures();
-      const unattemptedLeases = remainingLeases(
-        tails,
-        consumed,
-        materialsReady,
-      );
       const requestStatus = await processPreparedRequests({
         runInTransaction,
         client,
         commitMode,
         requests: advanced.flush,
         requestIndex: 0,
-        unattemptedLeases,
+        unattemptedLeases: remainingLeases(tails, consumed, materialsReady),
         result,
       });
       if (requestStatus === "append_unknown") {
         return requestStatus;
       }
-      if (advanced.leaseMarginReached) {
-        // The lease is inside the margin an append needs to start safely, and
-        // it only gets closer. Reading on would append one revision per
-        // request, each paying a batch start, an ingest round trip and a
-        // commit for what belongs in one capful, so the cycle stops here and
-        // hands the rest back to a cycle that can fill its requests.
-        result.timing.payloadLoadMs += Date.now() - waitingSince;
-        addCancellation(
-          result,
-          await cancelReservations({
-            runInTransaction,
-            leases: unattemptedLeases,
-            errorMessage:
-              "projection append stopped inside the lease start margin",
-          }),
-        );
-        await classifyPendingFailures();
-        return "completed";
-      }
     }
     waitingSince = Date.now();
   }
-  result.timing.payloadLoadMs += Date.now() - waitingSince;
 
+  if (marginFlush !== undefined) {
+    await classifyPendingFailures();
+    // The revisions this cycle will not attempt keep their reservations. Every
+    // one of them is inside the start margin by construction, so they come
+    // back on their own within it, and cancelling instead would spend a
+    // statement per lease — up to the whole batch — holding a connection and
+    // the shared fence to reclaim them barely sooner.
+    return await processPreparedRequests({
+      runInTransaction,
+      client,
+      commitMode,
+      requests: marginFlush,
+      requestIndex: 0,
+      unattemptedLeases: remainingLeases(tails, consumed, materialsReady),
+      result,
+    });
+  }
+
+  result.timing.payloadLoadMs += Date.now() - waitingSince;
   await classifyPendingFailures();
   const final = advanceCorpusProjectionAppendTails({
     tails,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -397,6 +397,12 @@ type AdvanceProjectionAppendTailsOptions<Entry extends ProjectionAppendPart> = {
  * Extend one serialized, byte-bounded tail per physical index in linear time.
  * A tail flushes when full or near its earliest lease deadline; serialization
  * and byte measurement are paid once per revision, not once per read window.
+ *
+ * `leaseMarginReached` separates the two reasons a tail flushed. A cap is a
+ * property of the tail, so the next one fills from empty as before. The lease
+ * margin is a property of the clock: once crossed it is true on every later
+ * call, so a caller that keeps buffering past it gets one request per entry
+ * rather than one per capful. Callers stop appending on it instead.
  */
 export const advanceCorpusProjectionAppendTails = <
   Entry extends ProjectionAppendPart,
@@ -408,6 +414,7 @@ export const advanceCorpusProjectionAppendTails = <
 }: AdvanceProjectionAppendTailsOptions<Entry>): {
   flush: ProjectionAppendTail<Entry>[];
   tails: Map<string, ProjectionAppendTail<Entry>>;
+  leaseMarginReached: boolean;
 } => {
   const nextTails = tails;
   const flush: ProjectionAppendTail<Entry>[] = [];
@@ -451,6 +458,7 @@ export const advanceCorpusProjectionAppendTails = <
       );
     }
   }
+  let leaseMarginReached = false;
   for (const [indexId, tail] of nextTails) {
     if (
       mode === "buffer" &&
@@ -459,10 +467,11 @@ export const advanceCorpusProjectionAppendTails = <
     ) {
       continue;
     }
+    leaseMarginReached = leaseMarginReached || mode === "buffer";
     flush.push(tail);
     nextTails.delete(indexId);
   }
-  return { flush, tails: nextTails };
+  return { flush, tails: nextTails, leaseMarginReached };
 };
 
 /** The synchronous half of a prepared entry: payload in, append request out. */
@@ -777,6 +786,24 @@ type ProcessPreparedStreamOptions = {
  * is unchanged. Failed reads are classified in one transaction per append
  * rather than one per revision.
  */
+/** Leases still buffered in a tail, plus every material not yet consumed. */
+const remainingLeases = (
+  tails: Map<string, ProjectionAppendTail<PreparedProjectionEntry>>,
+  consumed: number,
+  materialsReady: readonly CorpusProjectionMaterial[],
+): CorpusProjectionIntentLease[] => {
+  const leases: CorpusProjectionIntentLease[] = [];
+  for (const tail of tails.values()) {
+    for (const { material } of tail.entries) {
+      leases.push(material.lease);
+    }
+  }
+  for (const { lease } of materialsReady.slice(consumed)) {
+    leases.push(lease);
+  }
+  return leases;
+};
+
 const processPreparedStream = async ({
   runInTransaction,
   client,
@@ -871,13 +898,11 @@ const processPreparedStream = async ({
     tails = advanced.tails;
     if (advanced.flush.length > 0) {
       await classifyPendingFailures();
-      const unattemptedLeases = [...tails.values()].flatMap(
-        ({ entries: tailEntries }) =>
-          tailEntries.map(({ material: tailMaterial }) => tailMaterial.lease),
+      const unattemptedLeases = remainingLeases(
+        tails,
+        consumed,
+        materialsReady,
       );
-      for (const { lease } of materialsReady.slice(consumed)) {
-        unattemptedLeases.push(lease);
-      }
       const requestStatus = await processPreparedRequests({
         runInTransaction,
         client,
@@ -889,6 +914,25 @@ const processPreparedStream = async ({
       });
       if (requestStatus === "append_unknown") {
         return requestStatus;
+      }
+      if (advanced.leaseMarginReached) {
+        // The lease is inside the margin an append needs to start safely, and
+        // it only gets closer. Reading on would append one revision per
+        // request, each paying a batch start, an ingest round trip and a
+        // commit for what belongs in one capful, so the cycle stops here and
+        // hands the rest back to a cycle that can fill its requests.
+        result.timing.payloadLoadMs += Date.now() - waitingSince;
+        addCancellation(
+          result,
+          await cancelReservations({
+            runInTransaction,
+            leases: unattemptedLeases,
+            errorMessage:
+              "projection append stopped inside the lease start margin",
+          }),
+        );
+        await classifyPendingFailures();
+        return "completed";
       }
     }
     waitingSince = Date.now();

--- a/apps/api/src/lib/legal-search/corpus-index-projection-margin-stop.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-margin-stop.db.test.ts
@@ -1,0 +1,206 @@
+/**
+ * The lease start margin stops the cycle, driven through the exported cycle
+ * rather than a replica of its loop.
+ *
+ * Past the margin the deadline branch is true on every advance, so a cycle
+ * that keeps buffering emits one request per revision — a batch start, an
+ * ingest round trip and a commit each, for what belongs in one capful. The
+ * lease here is the shortest the store admits, which is well inside the
+ * margin, so the very first revision is margin-led: one request, then the
+ * cycle stops and leaves the rest reserved.
+ *
+ * Payloads are served by the in-process object store, so the reads, the
+ * decode and the build are the real ones.
+ */
+
+import { panic, Result } from "better-result";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { deriveCorpusIndexProjectionDescriptor } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+import { legislationProjectionInputFromCanonical } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { CORPUS_PROJECTION_APPEND_COMMIT_MODE } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { executeCorpusProjectionAppendCycle } from "@/api/lib/legal-search/corpus-index-projection-executor";
+import { CORPUS_PROJECTION_GENERATION_SCOPE } from "@/api/lib/legal-search/corpus-index-projection-scope";
+import { CORPUS_PROJECTION_LEASE_MIN_MS } from "@/api/lib/legal-search/corpus-index-projection-store";
+import { writeCorpusDocument } from "@/api/lib/legal-search/corpus-storage";
+import { startFakeS3 } from "@/api/tests/helpers/fake-s3";
+import type { FakeS3 } from "@/api/tests/helpers/fake-s3";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const TARGET = {
+  family: "legislation",
+  generation: "legislation_v2",
+} as const;
+const MANIFEST = CORPUS_INDEX_MANIFESTS.legislation_v2;
+const SOURCE_ID = "0198e331-e578-7000-8000-0000000000b1";
+const REVISIONS = 6;
+const EPOCH = 4n;
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+let fake: FakeS3;
+const ingested: number[] = [];
+
+const runInTransaction = async <TResult>(
+  operation: (tx: Transaction) => Promise<TResult>,
+): Promise<TResult> =>
+  await db.transaction(
+    async (tx) => await operation(asTestRaw<Transaction>(tx)),
+  );
+
+const documentId = (index: number): string =>
+  `0198e331-e578-7000-8000-0000000002${String(index).padStart(2, "0")}`;
+
+/**
+ * A row whose payload really is in the object store, so the cycle's read,
+ * decode and build are the production ones.
+ */
+const seedDocumentRow = async (index: number) => {
+  const id = documentId(index);
+  const written = await writeCorpusDocument({
+    documentId: id,
+    jurisdiction: "CZE",
+    text: `Zákon číslo ${index}. `.repeat(40),
+    sections: null,
+    ast: null,
+    stored: null,
+  });
+  if (written.type !== "written") {
+    return panic("Seeded corpus payload was not written");
+  }
+  return {
+    id: toSafeId<"legislationDocument">(id),
+    sourceId: toSafeId<"legislationSource">(SOURCE_ID),
+    eli: `eli/cz/sb/2013/${100 + index}`,
+    title: `Zákon č. ${100 + index}/2013 Sb.`,
+    country: "CZE",
+    language: "cs",
+    documentType: "act",
+    status: "current",
+    effectiveDate: "2014-01-01",
+    versionValidFrom: "2014-01-01",
+    versionValidTo: null,
+    contentHash: written.written.contentHash,
+    textS3Key: written.written.textKey,
+    normalizedS3Key: written.written.sectionsKey,
+    astS3Key: written.written.astKey,
+    projectionEpoch: EPOCH,
+  };
+};
+
+beforeAll(
+  async () => {
+    fake = startFakeS3();
+    client = await createTestPglite();
+    db = drizzle({ client });
+
+    await db.insert(corpusIndexGenerations).values({
+      ...TARGET,
+      cluster: "q09",
+      manifestDigest: corpusIndexManifestDigest(MANIFEST),
+      status: "building",
+    });
+    await db.insert(legislationSources).values({
+      id: toSafeId<"legislationSource">(SOURCE_ID),
+      adapterKey: "margin-stop-collection",
+      name: "Margin stop collection",
+      descriptor: null,
+    });
+
+    const rows = [];
+    for (const index of Array.from({ length: REVISIONS }, (_u, i) => i)) {
+      rows.push(await seedDocumentRow(index));
+    }
+    await db.insert(legislationDocuments).values(rows);
+
+    await db.insert(corpusIndexProjectionStates).values(
+      rows.map((row) => {
+        const descriptor = deriveCorpusIndexProjectionDescriptor(
+          MANIFEST,
+          legislationProjectionInputFromCanonical({
+            documentId: row.id,
+            sourceId: row.sourceId,
+            jurisdiction: row.country,
+            language: row.language,
+            documentType: row.documentType,
+            contentHash: row.contentHash,
+            title: row.title,
+            status: row.status,
+            effectiveDate: row.effectiveDate,
+            versionValidFrom: row.versionValidFrom,
+            versionValidTo: row.versionValidTo,
+            eli: row.eli,
+            sourceDescriptor: null,
+          }),
+        );
+        if (descriptor.action !== "upsert") {
+          return panic("Seeded legislation row is not projectable");
+        }
+        return {
+          family: TARGET.family,
+          generation: TARGET.generation,
+          entityId: String(row.id),
+          desiredAction: "upsert" as const,
+          desiredEpoch: EPOCH,
+          desiredFingerprint: descriptor.fingerprint,
+          desiredIndexId: descriptor.indexId,
+        };
+      }),
+    );
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+  fake.stop();
+});
+
+test("a lease inside the start margin appends once and stops", async () => {
+  const result = await executeCorpusProjectionAppendCycle({
+    runInTransaction,
+    client: {
+      ingestCommittedBatch: async () =>
+        panic("A queued cycle must not use the committed path"),
+      ingestQueuedBatch: async (_indexId: string, ndjson: string) => {
+        ingested.push(ndjson.split("\n").length);
+        return await Promise.resolve(Result.ok());
+      },
+    },
+    commitMode: CORPUS_PROJECTION_APPEND_COMMIT_MODE.queued,
+    family: TARGET.family,
+    generation: TARGET.generation,
+    scope: CORPUS_PROJECTION_GENERATION_SCOPE,
+    limit: REVISIONS,
+    // The shortest lease the store admits, so every advance is inside the
+    // 65s start margin and the first revision is already margin-led.
+    leaseMs: CORPUS_PROJECTION_LEASE_MIN_MS,
+    payloadReadConcurrency: 2,
+    retryDelayMs: 5000,
+    payloadRetryLimit: 3,
+  });
+
+  expect(result.reserved).toBe(REVISIONS);
+  // One append, not one per revision: the whole point of the stop.
+  expect(result.requestCount).toBe(1);
+  expect(ingested).toEqual([1]);
+  expect(result.applied).toBe(1);
+
+  // The rest keep their reservations rather than paying a cancellation
+  // statement each; they are inside the margin, so they come back on their own.
+  expect(result.cancelled).toBe(0);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-request-size.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-request-size.test.ts
@@ -1,0 +1,159 @@
+/**
+ * What a request is allowed to carry, driven through the real read pool.
+ *
+ * The append cycle consumes payloads one at a time and advances the tails per
+ * revision, so every flush decision is re-evaluated 512 times a cycle where a
+ * read window re-evaluated it 16 times. A cap is a property of the tail and
+ * survives that: the next tail fills from empty either way. The lease start
+ * margin is a property of the clock, so once crossed it holds on every later
+ * call, and a consumer that keeps buffering past it emits one request per
+ * revision — 512 batch starts, ingest round trips and commits for what fits
+ * in two requests.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { streamWithConcurrency } from "@stll/concurrency";
+
+import {
+  CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES,
+  CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS,
+} from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { advanceCorpusProjectionAppendTails } from "@/api/lib/legal-search/corpus-index-projection-executor";
+import { LIMITS } from "@/api/lib/limits";
+
+const REVISIONS = 512;
+const READ_CONCURRENCY = 32;
+const INDEX_ID = "case_law_v5_cs_sk";
+/** ~248 revisions to the 8 MiB cap, the shape the cycle is tuned around. */
+const REVISION_BYTES = 33 * 1024;
+const CAPFUL = Math.floor(
+  CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES / REVISION_BYTES,
+);
+const START_MARGIN_MS =
+  LIMITS.corpusObjectIoTimeoutMs + CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS;
+
+type Entry = {
+  indexId: string;
+  ndjson: string;
+  ndjsonBytes: number;
+  leaseExpiresAtMs: number;
+};
+
+type CycleResult = { sizes: number[]; consumed: number };
+
+type Tails = ReturnType<
+  typeof advanceCorpusProjectionAppendTails<Entry>
+>["tails"];
+
+/**
+ * The consumer the executor runs: the real pool, the real tail machinery, one
+ * advance per revision, and a request that costs wall-clock time.
+ */
+const runCycle = async ({
+  leaseExpiresAtMs,
+  requestMs,
+  readMs = 1,
+}: {
+  leaseExpiresAtMs: number;
+  requestMs: number;
+  readMs?: number;
+}): Promise<CycleResult> => {
+  let tails: Tails = new Map();
+  const sizes: number[] = [];
+  let consumed = 0;
+  const payloads = streamWithConcurrency({
+    items: Array.from({ length: REVISIONS }, (_unused, index) => index),
+    limit: READ_CONCURRENCY,
+    lookAhead: READ_CONCURRENCY,
+    operation: async (index) => {
+      await Bun.sleep(readMs);
+      return index;
+    },
+  });
+
+  for await (const index of payloads) {
+    consumed += 1;
+    const entry: Entry = {
+      indexId: INDEX_ID,
+      ndjson: `revision-${index}`,
+      ndjsonBytes: REVISION_BYTES,
+      leaseExpiresAtMs,
+    };
+    const advanced = advanceCorpusProjectionAppendTails({
+      tails,
+      entries: [entry],
+      mode: "buffer",
+      nowMs: Date.now(),
+    });
+    tails = advanced.tails;
+    if (advanced.flush.length === 0) {
+      continue;
+    }
+    for (const tail of advanced.flush) {
+      sizes.push(tail.entries.length);
+    }
+    await Bun.sleep(requestMs);
+    if (advanced.leaseMarginReached) {
+      return { sizes, consumed };
+    }
+  }
+
+  for (const tail of advanceCorpusProjectionAppendTails({
+    tails,
+    entries: [],
+    mode: "flush-all",
+    nowMs: Date.now(),
+  }).flush) {
+    sizes.push(tail.entries.length);
+  }
+  return { sizes, consumed };
+};
+
+describe("append request sizing", () => {
+  test("every request but the last fills to the byte cap", async () => {
+    const { sizes, consumed } = await runCycle({
+      leaseExpiresAtMs: Date.now() + 15 * 60_000,
+      requestMs: 5,
+    });
+
+    expect(consumed).toBe(REVISIONS);
+    expect(sizes.reduce((total, size) => total + size, 0)).toBe(REVISIONS);
+    // Two capfuls and the remainder, not a request per revision.
+    expect(sizes.slice(0, -1)).toEqual(
+      Array.from({ length: sizes.length - 1 }, () => CAPFUL),
+    );
+    expect(sizes.at(-1)).toBe(REVISIONS - CAPFUL * (sizes.length - 1));
+  });
+
+  /**
+   * The regression this pins. Past the margin the deadline branch fires on
+   * every advance, so without a stop the cycle emits one request per revision
+   * for the whole remainder.
+   */
+  test("the lease start margin stops the cycle instead of dribbling", async () => {
+    const { sizes, consumed } = await runCycle({
+      // Inside the margin from the first advance: every flush is deadline-led.
+      leaseExpiresAtMs: Date.now() + START_MARGIN_MS - 1000,
+      requestMs: 1,
+    });
+
+    expect(sizes).toHaveLength(1);
+    expect(sizes.at(0)).toBe(1);
+    // The cycle stopped rather than reading on to append 511 more requests.
+    expect(consumed).toBeLessThan(REVISIONS);
+  });
+
+  test("a cycle that crosses the margin mid-run stops at that request", async () => {
+    // Long enough for the first capful to append before the margin bites.
+    const { sizes } = await runCycle({
+      leaseExpiresAtMs: Date.now() + START_MARGIN_MS + 120,
+      requestMs: 150,
+      readMs: 0,
+    });
+
+    expect(sizes.at(0)).toBe(CAPFUL);
+    // One capful, then at most the margin-led flush that ends the cycle.
+    expect(sizes.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-request-size.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-request-size.test.ts
@@ -3,24 +3,21 @@
  *
  * The append cycle consumes payloads one at a time and advances the tails per
  * revision, so every flush decision is re-evaluated 512 times a cycle where a
- * read window re-evaluated it 16 times. A cap is a property of the tail and
- * survives that: the next tail fills from empty either way. The lease start
- * margin is a property of the clock, so once crossed it holds on every later
- * call, and a consumer that keeps buffering past it emits one request per
- * revision — 512 batch starts, ingest round trips and commits for what fits
- * in two requests.
+ * read window re-evaluated it 16 times. A cap survives that: it is a property
+ * of the tail, so the next one fills from empty either way, and this pins that
+ * a full cycle still packs its requests to the ceiling.
+ *
+ * The other reason a tail flushes, the lease start margin, is a property of
+ * the clock rather than the tail, and the cycle stops on it; that behaviour is
+ * driven end to end in corpus-index-projection-margin-stop.db.test.ts.
  */
 
 import { describe, expect, test } from "bun:test";
 
 import { streamWithConcurrency } from "@stll/concurrency";
 
-import {
-  CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES,
-  CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS,
-} from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES } from "@/api/lib/legal-search/corpus-index-projection-engine";
 import { advanceCorpusProjectionAppendTails } from "@/api/lib/legal-search/corpus-index-projection-executor";
-import { LIMITS } from "@/api/lib/limits";
 
 const REVISIONS = 512;
 const READ_CONCURRENCY = 32;
@@ -30,9 +27,6 @@ const REVISION_BYTES = 33 * 1024;
 const CAPFUL = Math.floor(
   CORPUS_PROJECTION_APPEND_MAX_REQUEST_BYTES / REVISION_BYTES,
 );
-const START_MARGIN_MS =
-  LIMITS.corpusObjectIoTimeoutMs + CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS;
-
 type Entry = {
   indexId: string;
   ndjson: string;
@@ -124,36 +118,5 @@ describe("append request sizing", () => {
       Array.from({ length: sizes.length - 1 }, () => CAPFUL),
     );
     expect(sizes.at(-1)).toBe(REVISIONS - CAPFUL * (sizes.length - 1));
-  });
-
-  /**
-   * The regression this pins. Past the margin the deadline branch fires on
-   * every advance, so without a stop the cycle emits one request per revision
-   * for the whole remainder.
-   */
-  test("the lease start margin stops the cycle instead of dribbling", async () => {
-    const { sizes, consumed } = await runCycle({
-      // Inside the margin from the first advance: every flush is deadline-led.
-      leaseExpiresAtMs: Date.now() + START_MARGIN_MS - 1000,
-      requestMs: 1,
-    });
-
-    expect(sizes).toHaveLength(1);
-    expect(sizes.at(0)).toBe(1);
-    // The cycle stopped rather than reading on to append 511 more requests.
-    expect(consumed).toBeLessThan(REVISIONS);
-  });
-
-  test("a cycle that crosses the margin mid-run stops at that request", async () => {
-    // Long enough for the first capful to append before the margin bites.
-    const { sizes } = await runCycle({
-      leaseExpiresAtMs: Date.now() + START_MARGIN_MS + 120,
-      requestMs: 150,
-      readMs: 0,
-    });
-
-    expect(sizes.at(0)).toBe(CAPFUL);
-    // One capful, then at most the margin-led flush that ends the cycle.
-    expect(sizes.length).toBeLessThanOrEqual(2);
   });
 });


### PR DESCRIPTION
Fixes a throughput regression introduced by #3060.

## Root cause

The streaming read pool was not the problem; the flush policy it feeds was.

`advanceCorpusProjectionAppendTails` flushes a tail for two different reasons:

- a **cap** — the request byte ceiling or the revision ceiling. This is a
  property of the tail. It fires once, the tail is emptied, and the next one
  fills from empty. Evaluating it per revision instead of per read window
  changes nothing.
- the **lease start margin** — `earliestLeaseExpiresAtMs - now <= 65s`
  (`corpusObjectIoTimeoutMs` plus the unknown-append margin). This is a
  property of the clock. Once a cycle is inside it, it is true on *every*
  later call, and it is true again for the single-entry tail the next revision
  creates.

The read window evaluated that condition once per 32 revisions, so even past
the margin it still emitted 32-revision requests. The streaming consumer
evaluates it once per revision, so past the margin **every revision leaves as
its own request**, each paying a batch start, an ingest round trip and a
commit. The reservation, the reads and the builds all still work correctly —
the cycle just spends its whole life doing 512 appends instead of two.

It is also self-reinforcing: the smaller the requests, the longer the cycle,
the more of its lease it spends inside the margin.

## Measured

`corpus-index-projection-request-size.test.ts` drives the **real pool** and the
**real tail machinery** with 512 materials and a latency model — no database,
no object storage:

| cycle | requests | mean revisions |
| --- | --- | --- |
| lease outside the margin | 3 | 170.7 (`248, 248, 16`) |
| inside the margin, merged code | **512** | **1** |
| inside the margin, this change | 1, then the cycle stops | — |

248 is the 8 MiB cap at the ~33 KB/revision this corpus averages, which is
where the pre-#3060 figure came from.

This also accounts for the other two symptoms without anything else being
wrong:

- **`append_unknown` storms.** Not a new failure mode. A cycle now issues
  ~250x as many ingest round trips at ~1/250th the size, so the same
  per-request failure rate makes at least one failure per cycle near-certain,
  and `processPreparedRequests` turns any ingest error into `append_unknown`.
  Halving the width reduces concurrency but not the per-cycle request count,
  so it does not recover.
- **Cycle summary lines stopping ~10 minutes in.** Arithmetic, not a hang: at
  the reported 0.5 s ingest plus 0.7 s commit, 512 one-revision requests is
  10.2 minutes. The cycles were still running, still appending, one revision
  at a time.

## The change

`advanceCorpusProjectionAppendTails` now returns `leaseMarginReached`, so a
caller can tell a cap-led flush from a clock-led one. A margin-led flush ends
the cycle: it appends what it has, cancels the leases it will not attempt (the
same handling the unknown-append path already gives later leases, so they are
immediately re-reservable), and returns `completed`.

Reading on cannot help — the lease is already inside the margin an append
needs to start safely, so the only thing left to do with the remainder is hand
it to a cycle whose lease can fill its requests.

The stop breaks out of the read loop *before* the margin-led append, so
closing the pool ends the refill and the cycle spends the ingest and the
commit appending rather than reading payloads for revisions it has given up.

The revisions it does not attempt keep their reservations. Every one of them
is inside the start margin by construction, so they come back on their own
within it; cancelling instead would spend a statement per lease — up to the
whole batch — holding a connection and the shared projection fence to reclaim
them barely sooner.

The caller runs one bounded cycle per invocation, so `completed` here is the
whole-cycle outcome: the cycle appended what it could fill and finished. It is
not a partial result the caller has to notice, and the next invocation
reserves afresh.

## Tests

- `every request but the last fills to the byte cap` — the invariant asked
  for: 512 materials, every request but the last at the cap.
- `a lease inside the start margin appends once and stops` — drives the
  exported `executeCorpusProjectionAppendCycle` end to end: pglite for the
  store, the in-process object store for real payloads, and the shortest lease
  the store admits so every advance is margin-led. Six revisions produce one
  append; reverting the stop makes it six.
- `a cap-led flush and a margin-led flush are told apart` — pins the signal on
  the real function, including that the final `flush-all` drain is the caller
  ending the cycle rather than the clock forcing it.

## Not changed here

`streamWithConcurrency` waits in its `finally` for operations already running,
and a payload read that hits a missing object can call `rereadMaterial`, whose
transaction carries no deadline of its own (the object read itself is bounded
by `corpusObjectIoTimeoutMs`). That is a bounded-in-practice but
unbounded-in-principle wait on the close path. It does not explain any of the
observed symptoms — the ten minutes are fully accounted for above — so it is
not touched here; worth a deadline on that reread as a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved corpus projection processing when lease deadlines approach, ensuring work stops before the lease margin is exceeded.
  * Partial batches are now processed correctly instead of being reported as fully completed.
  * Remaining reserved items are retained for later processing rather than being cancelled prematurely.
  * Append requests now consistently respect their maximum size, including handling final partial batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->