### PR TITLE
fix(api): a cancelled append names the half of its start predicate that failed

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -13,7 +13,10 @@ import type {
   CorpusIndexDeleteSettlement,
   CorpusIndexError,
 } from "@/api/lib/legal-search/corpus-index-client";
-import type { CorpusIndexIntentStatus } from "@/api/lib/legal-search/corpus-index-projection-contract";
+import {
+  CORPUS_INDEX_APPEND_CANCEL_REASON,
+  type CorpusIndexIntentStatus,
+} from "@/api/lib/legal-search/corpus-index-projection-contract";
 import { lockRegisteredCorpusProjectionManifestForMutation } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import {
   CORPUS_PROJECTION_DELETE_MAX_REVISIONS,
@@ -829,7 +832,7 @@ export const recoverExpiredCorpusProjectionIntentsTx = async <
         leaseToken: null,
         leaseExpiresAt: null,
         cancelledAt: transitionAt,
-        lastError: "projection reservation lease expired before append",
+        lastError: CORPUS_INDEX_APPEND_CANCEL_REASON.leaseExpired,
         updatedAt: transitionAt,
       })
       .where(

--- a/apps/api/src/lib/legal-search/corpus-index-projection-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-contract.ts
@@ -41,6 +41,19 @@ export const CORPUS_INDEX_LAUNCH_BLOCKING_INTENT_STATUSES =
     (status) => CORPUS_INDEX_INTENT_LAUNCH_DISPOSITION[status] === "blocking",
   );
 
+/**
+ * Why a reserved revision was cancelled instead of starting its append. The
+ * start predicate rejects on the lease deadline or on the desired state, and
+ * the two mean opposite things: a run of expiries says a cycle is slower than
+ * the lease it takes, a run of desired-state cancellations says the entity
+ * changed underneath it. Recording one reason for both hides which happened,
+ * so the reason is chosen from the row rather than from the call site.
+ */
+export const CORPUS_INDEX_APPEND_CANCEL_REASON = {
+  leaseExpired: "projection reservation lease expired before append",
+  desiredStateChanged: "projection desired state changed before append",
+} as const;
+
 /** Phases that can create or expose one exact append revision. */
 export const CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES = [
   "reserved",

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -112,6 +112,42 @@ const setDatabaseClock = async (now: Date): Promise<void> => {
   );
 };
 
+/**
+ * A clock that moves between reads. Anything that reads it once per
+ * transaction sees `first`; a second read inside the same transaction sees
+ * `later`, which is how a statement that re-evaluates `clock_timestamp()`
+ * gives itself away.
+ */
+const setAdvancingDatabaseClock = async (
+  first: Date,
+  later: Date,
+): Promise<void> => {
+  await db.execute(
+    sql.raw(
+      `CREATE TABLE IF NOT EXISTS public.test_clock_reads (reads integer NOT NULL)`,
+    ),
+  );
+  await db.execute(sql.raw(`DELETE FROM public.test_clock_reads`));
+  await db.execute(sql.raw(`INSERT INTO public.test_clock_reads VALUES (0)`));
+  await db.execute(
+    sql.raw(`
+      CREATE OR REPLACE FUNCTION public.clock_timestamp()
+      RETURNS timestamptz
+      LANGUAGE plpgsql
+      VOLATILE
+      AS $$
+      DECLARE read_count integer;
+      BEGIN
+        UPDATE public.test_clock_reads SET reads = reads + 1 RETURNING reads INTO read_count;
+        RETURN CASE
+          WHEN read_count <= 1 THEN '${first.toISOString()}'::timestamptz
+          ELSE '${later.toISOString()}'::timestamptz
+        END;
+      END $$
+    `),
+  );
+};
+
 const withDatabaseClock = async <T>(
   operation: (tx: Transaction) => Promise<T>,
 ): Promise<T> =>
@@ -1376,6 +1412,53 @@ test("a single append start past the lease deadline records the expiry", async (
   ).toBe("stale_cancelled");
   expect(await readCancelReason()).toEqual([
     { lastError: CORPUS_INDEX_APPEND_CANCEL_REASON.leaseExpired },
+  ]);
+});
+
+test("a rejected append start reads one clock, so a later expiry cannot take the blame", async () => {
+  const lease = await reserveOneLease(new Date("2026-08-25T12:00:00.000Z"));
+  await db.transaction(async (tx) => {
+    await tx
+      .update(caseLawDecisions)
+      .set({ court: "Raced desired state court" })
+      .where(eq(caseLawDecisions.id, DECISION_ID));
+    return await advanceCorpusProjectionDesiredStateTx(
+      asTestRaw<Transaction>(tx),
+      { family: "case_law", entityId: DECISION_ID },
+    );
+  });
+  // The start attempt is rejected while the lease is still live; the lease
+  // then lapses before the cancellation runs. Reading the clock twice would
+  // report the expiry and lose the desired-state change that actually
+  // rejected it.
+  const rejectedAt = new Date("2026-08-25T12:00:10.000Z");
+  await setAdvancingDatabaseClock(
+    rejectedAt,
+    new Date("2026-08-25T12:02:00.000Z"),
+  );
+
+  expect(
+    await withDatabaseClock(
+      async (tx) =>
+        await startCorpusProjectionAppendTx(tx, {
+          intentId: lease.intentId,
+          leaseToken: lease.leaseToken,
+        }),
+    ),
+  ).toBe("stale_cancelled");
+  expect(
+    await db
+      .select({
+        lastError: corpusIndexProjectionIntents.lastError,
+        cancelledAt: corpusIndexProjectionIntents.cancelledAt,
+      })
+      .from(corpusIndexProjectionIntents)
+      .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID)),
+  ).toEqual([
+    {
+      lastError: CORPUS_INDEX_APPEND_CANCEL_REASON.desiredStateChanged,
+      cancelledAt: rejectedAt,
+    },
   ]);
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -34,6 +34,7 @@ import {
   reopenCorpusProjectionCleanupTx,
   settleCorpusProjectionCleanupTx,
 } from "@/api/lib/legal-search/corpus-index-projection-cleanup-store";
+import { CORPUS_INDEX_APPEND_CANCEL_REASON } from "@/api/lib/legal-search/corpus-index-projection-contract";
 import { advanceCorpusProjectionDesiredStateTx } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import {
   corpusIndexAppendPublishDelayMs,
@@ -1289,6 +1290,92 @@ test("one append request receives one post-lock database timestamp", async () =>
   ).toEqual([
     { appendStartedAt: requestStartedAt },
     { appendStartedAt: requestStartedAt },
+  ]);
+});
+
+const reserveOneLease = async (reservedAt: Date, leaseMs = 60_000) => {
+  const leases = await db.transaction(
+    async (tx) =>
+      await reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        limit: 1,
+        leaseMs,
+        testNow: reservedAt,
+        newIntentId: () => FIRST_INTENT_ID,
+        newLeaseToken: () => FIRST_LEASE_TOKEN,
+      }),
+  );
+  return leases.at(0) ?? panic("Expected one reserved projection lease");
+};
+
+const readCancelReason = async () =>
+  await db
+    .select({ lastError: corpusIndexProjectionIntents.lastError })
+    .from(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID));
+
+test("an append start past the lease deadline records the expiry, not drift", async () => {
+  const lease = await reserveOneLease(new Date("2026-08-25T12:00:00.000Z"));
+
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await startCorpusProjectionAppendBatchTx(asTestRaw<Transaction>(tx), {
+          leases: [lease],
+          testNow: new Date("2026-08-25T12:02:00.000Z"),
+        }),
+    ),
+  ).toEqual([{ intentId: lease.intentId, status: "stale_cancelled" }]);
+  // The desired state never moved, so naming it here would send the next
+  // diagnosis after epoch churn that did not happen.
+  expect(await readCancelReason()).toEqual([
+    { lastError: CORPUS_INDEX_APPEND_CANCEL_REASON.leaseExpired },
+  ]);
+});
+
+test("an append start under a moved desired state records the drift", async () => {
+  const lease = await reserveOneLease(new Date("2026-08-25T12:00:00.000Z"));
+  await db.transaction(async (tx) => {
+    await tx
+      .update(caseLawDecisions)
+      .set({ court: "Moved desired state court" })
+      .where(eq(caseLawDecisions.id, DECISION_ID));
+    return await advanceCorpusProjectionDesiredStateTx(
+      asTestRaw<Transaction>(tx),
+      { family: "case_law", entityId: DECISION_ID },
+    );
+  });
+
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await startCorpusProjectionAppendBatchTx(asTestRaw<Transaction>(tx), {
+          leases: [lease],
+          testNow: new Date("2026-08-25T12:00:10.000Z"),
+        }),
+    ),
+  ).toEqual([{ intentId: lease.intentId, status: "stale_cancelled" }]);
+  expect(await readCancelReason()).toEqual([
+    { lastError: CORPUS_INDEX_APPEND_CANCEL_REASON.desiredStateChanged },
+  ]);
+});
+
+test("a single append start past the lease deadline records the expiry", async () => {
+  const lease = await reserveOneLease(new Date("2026-08-25T12:00:00.000Z"));
+
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await startCorpusProjectionAppendTx(asTestRaw<Transaction>(tx), {
+          intentId: lease.intentId,
+          leaseToken: lease.leaseToken,
+          testNow: new Date("2026-08-25T12:02:00.000Z"),
+        }),
+    ),
+  ).toBe("stale_cancelled");
+  expect(await readCancelReason()).toEqual([
+    { lastError: CORPUS_INDEX_APPEND_CANCEL_REASON.leaseExpired },
   ]);
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -488,8 +488,12 @@ export const prepareCorpusProjectionReplacementsTx = async <
  * site, so the two causes cannot be filed under one message again.
  * PostgreSQL evaluates a SET expression against the pre-update row, so the
  * lease read here is still the one the start attempt tested.
+ *
+ * The parameter is a settled `Date`, never a SQL expression: the caller must
+ * have read one clock for the start attempt and this cancellation, or the two
+ * statements would compare the same lease against two different instants.
  */
-const appendCancelReason = (transitionAt: Date | SQL<Date>): SQL<string> =>
+const appendCancelReason = (transitionAt: Date): SQL<string> =>
   sql<string>`CASE
     WHEN ${corpusIndexProjectionIntents.leaseExpiresAt} IS NULL
       OR ${corpusIndexProjectionIntents.leaseExpiresAt} <= ${transitionAt}::timestamptz
@@ -558,7 +562,11 @@ export const startCorpusProjectionAppendTx = async (
   if (lockedIntents.length === 0) {
     return "lease_lost";
   }
-  const transitionAt = testNow ?? sql<Date>`clock_timestamp()`;
+  // One clock for the start attempt and the cancellation that reads why it
+  // failed. `clock_timestamp()` is volatile, so leaving it in the statements
+  // would let a lease that was live when the start was rejected read as
+  // expired a moment later and take the blame from the desired state.
+  const transitionAt = testNow ?? (await readPostgresClock(tx));
   const rows = await tx
     .update(corpusIndexProjectionIntents)
     .set({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -1,5 +1,15 @@
 import { panic } from "better-result";
-import { and, asc, eq, inArray, isNotNull, lte, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNotNull,
+  lte,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import {
@@ -9,7 +19,10 @@ import {
 } from "@/api/db/schema";
 import { createSafeId, type SafeId } from "@/api/lib/branded-types";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
-import type { CorpusIndexProjectionFailureKind } from "@/api/lib/legal-search/corpus-index-projection-contract";
+import {
+  CORPUS_INDEX_APPEND_CANCEL_REASON,
+  type CorpusIndexProjectionFailureKind,
+} from "@/api/lib/legal-search/corpus-index-projection-contract";
 import {
   lockActiveCorpusProjectionManifestForMutation,
   lockRegisteredCorpusProjectionManifestForMutation,
@@ -469,6 +482,21 @@ export const prepareCorpusProjectionReplacementsTx = async <
   return cleanups.filter(({ intentId }) => updatedIds.has(intentId));
 };
 
+/**
+ * Which half of the start predicate rejected this reserved revision. Both
+ * cancel paths read it off the row instead of naming a reason at the call
+ * site, so the two causes cannot be filed under one message again.
+ * PostgreSQL evaluates a SET expression against the pre-update row, so the
+ * lease read here is still the one the start attempt tested.
+ */
+const appendCancelReason = (transitionAt: Date | SQL<Date>): SQL<string> =>
+  sql<string>`CASE
+    WHEN ${corpusIndexProjectionIntents.leaseExpiresAt} IS NULL
+      OR ${corpusIndexProjectionIntents.leaseExpiresAt} <= ${transitionAt}::timestamptz
+    THEN ${CORPUS_INDEX_APPEND_CANCEL_REASON.leaseExpired}
+    ELSE ${CORPUS_INDEX_APPEND_CANCEL_REASON.desiredStateChanged}
+  END`;
+
 type StartCorpusProjectionAppendOptions = {
   intentId: ProjectionIntentId;
   leaseToken: string;
@@ -568,7 +596,7 @@ export const startCorpusProjectionAppendTx = async (
       leaseToken: null,
       leaseExpiresAt: null,
       cancelledAt: transitionAt,
-      lastError: "projection desired state changed before append",
+      lastError: appendCancelReason(transitionAt),
       updatedAt: transitionAt,
     })
     .where(
@@ -703,7 +731,7 @@ export const startCorpusProjectionAppendBatchTx = async (
       leaseToken: null,
       leaseExpiresAt: null,
       cancelledAt: transitionAt,
-      lastError: "projection desired state changed before append",
+      lastError: appendCancelReason(transitionAt),
       updatedAt: transitionAt,
     })
     .where(


### PR DESCRIPTION
## What

`startCorpusProjectionAppendTx` and `startCorpusProjectionAppendBatchTx` reject a reserved revision on two independent conditions:

```sql
lease_expires_at > <transition>          -- the lease is still ours
AND EXISTS (... desired_epoch / fingerprint / index_id match ...)
```

The cancel statement that runs afterwards matches on `status = 'reserved'` alone and wrote `"projection desired state changed before append"` for whichever condition failed. A revision whose lease simply ran out was recorded as desired-state drift.

The reason is now read off the row. PostgreSQL evaluates a `SET` expression against the pre-update row, so the lease tested in the `CASE` is the one the start attempt saw, and the same expression serves both cancel paths.

## Why it matters

The two causes call for opposite responses. A run of expiries says the cycle takes longer than the lease it holds — a duration or width problem. A run of desired-state cancellations says the entity changed underneath the reservation — churn upstream of the projection. `last_error` is the durable evidence for that question and is what generation status groups by, so one message for both conditions turns the counter into a false lead.

## Scope

The two cancel statements, plus the two messages moved into `corpus-index-projection-contract.ts` next to the other intent contracts. The expired-lease recovery in the cleanup store already wrote one of these strings by hand and now imports it, so the vocabulary has one owner and a third spelling cannot appear.

No transition, predicate, or return status changes: a cancelled revision still reports `stale_cancelled`.

Targeted `corpus-index-projection-store.db.test.ts` passes (24 tests), including three new cases: a batch start past the deadline records the expiry, a batch start under a moved desired state records the drift, and the single-revision start agrees with the batch. Typecheck, lint and the full suite are left to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of stale projection append operations when a reservation lease expires or the desired state changes.
  - Cancellation records now identify the specific reason for both individual and batch append operations.
  - Added clearer error details for expired reservations and changes to the desired projection state.

- **Tests**
  - Added coverage for lease-expiry and desired-state-change scenarios across single and batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->