### PR TITLE
fix(legal-atlas-runner): the image accepts the build stamps its events report

### DIFF
--- a/apps/legal-atlas-runner/Dockerfile
+++ b/apps/legal-atlas-runner/Dockerfile
@@ -45,6 +45,16 @@ RUN out=$(DATABASE_URL=postgres://smoke:smoke@localhost:5432/smoke \
 
 FROM base AS runner
 ENV NODE_ENV=production
+# Stamp the running container with the release version so the runner tags its
+# PostHog events with build metadata, as the API and web images do. Without
+# these the resolver in apps/api/src/lib/version.ts has nothing to read and
+# every build reports the "dev" fallback.
+ARG STELLA_VERSION=dev
+ARG STELLA_COMMIT_SHA=dev
+ARG RAILWAY_GIT_COMMIT_SHA=dev
+ENV STELLA_VERSION=${STELLA_VERSION}
+ENV STELLA_COMMIT_SHA=${STELLA_COMMIT_SHA}
+ENV RAILWAY_GIT_COMMIT_SHA=${RAILWAY_GIT_COMMIT_SHA}
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js


### PR DESCRIPTION
## Proposed change

`apps/legal-atlas-runner` bundles the API's analytics client, so the events it
sends are tagged with `APP_VERSION` and `APP_COMMIT_SHA` from
`apps/api/src/lib/version.ts`. That resolver reads `STELLA_VERSION`,
`STELLA_COMMIT_SHA` and `RAILWAY_GIT_COMMIT_SHA` from the environment.

The runner image declares none of the three. `apps/api/Dockerfile` and
`apps/web/Dockerfile` both take them as build args and forward them to the
runtime environment; the runner stage has no such block. A `--build-arg` with no
matching `ARG` is discarded, so the runner image resolves the `"dev"` fallback
whatever the build supplies.

This declares the three args in the runner stage and forwards them, using the
same block the API image already carries. Scope is deliberately narrow:

- A build that passes no args still resolves to `"dev"`, so only a build
  supplying them changes.
- A value set on the container at runtime still takes precedence over the
  image `ENV`, so an already-stamped deployment is unaffected.

## Checklist

- [ ] **BUILD ASSURANCE** | Not verified locally (no Docker daemon available).
  The added block is byte-identical to the one `apps/api/Dockerfile` builds with
  today, and CI's `legal-atlas-image` job builds this Dockerfile.
- [x] **TESTING** | `bun test apps/api/src/lib/version.test.ts` passes (4/4). It
  covers the resolver's fallback semantics, including that an absent or `"dev"`
  stamp still resolves to `"dev"` — the no-change path for unstamped builds.
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: build configuration only.


---
_Generated by [Claude Code](https://claude.ai/code/session_012BCa5opdCuhEB7pWnDq9KJ)_