### PR TITLE
fix(api): a source of only decorative markers is not content loss

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -437,6 +437,25 @@ describe("validateAst", () => {
       expect(result.ok).toBe(true);
     });
 
+    test("dropped numbers and short tokens still report loss", () => {
+      // Numbers and one- or two-letter tokens are content a decision can
+      // lose — an awarded amount, a date, a roman-numbered ruling item — but
+      // none of them is a missing-word candidate. So the no-content exemption
+      // must be keyed on decoration, not on that filter, or a source whose
+      // text is entirely numeric would have its loss silenced.
+      const html = `<html><body><p>I</p><p>42 43</p></body></html>`;
+      const blocks: Block[] = [makeHeading("I")];
+
+      const result = validateAst(html, blocks);
+
+      expect(result.stats.missingWords).toHaveLength(0);
+      expect(result.stats.retainedPct).toBeLessThan(90);
+      expect(
+        result.issues.find((i) => i.code === "CONTENT_LOSS")?.severity,
+      ).toBe("error");
+      expect(result.ok).toBe(false);
+    });
+
     test("one meaningful word among the markers still reports loss", () => {
       const html = MARKER_ONLY_SOURCE.replace(
         "</body>",

--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -56,6 +56,18 @@ const TEXTLESS_SOURCE =
   `<!DOCTYPE html><html lang="cs"><head><title>39 A 1/2026-35 - text` +
   `</title></head><body>N/A</body></html>`;
 
+/**
+ * A decision the court holds only as a scan, in the shape Aspose exports
+ * it: real paragraphs whose entire content is the figure placeholder,
+ * split across the spans a font change produces. Nothing here is text an
+ * AST could carry.
+ */
+const MARKER_ONLY_SOURCE =
+  `<html><body><div>` +
+  `<p><span>[OBR</span><span>Á</span><span>ZEK]</span></p>` +
+  `<p><span>[OBRÁZEK]</span></p>` +
+  `</div></body></html>`;
+
 // ── Content completeness ────────────────────────────────────
 
 describe("validateAst", () => {
@@ -405,6 +417,42 @@ describe("validateAst", () => {
 
       expect(result.issues.some((i) => i.code === "EMPTY_AST")).toBe(true);
       expect(result.ok).toBe(true);
+    });
+
+    test("empty AST over an all-marker source is not content loss", () => {
+      const result = validateAst(MARKER_ONLY_SOURCE, []);
+
+      // Unlike the text-less fixture above, this source does extract
+      // text — so it reaches the branch that measures retention, which is
+      // the whole point: every extracted word is a decorative marker the
+      // AST is right to drop.
+      expect(result.stats.originalLength).toBeGreaterThan(0);
+      expect(result.stats.retainedPct).toBe(100);
+      expect(result.stats.missingWords).toHaveLength(0);
+
+      expect(result.issues.some((i) => i.code === "CONTENT_LOSS")).toBe(false);
+      expect(result.issues.find((i) => i.code === "EMPTY_AST")?.severity).toBe(
+        "warning",
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("one meaningful word among the markers still reports loss", () => {
+      const html = MARKER_ONLY_SOURCE.replace(
+        "</body>",
+        "<p>Odůvodnění rozsudku</p></body>",
+      );
+
+      const result = validateAst(html, []);
+
+      expect(result.stats.retainedPct).toBe(0);
+      expect(
+        result.issues.find((i) => i.code === "CONTENT_LOSS")?.severity,
+      ).toBe("error");
+      expect(result.issues.find((i) => i.code === "EMPTY_AST")?.severity).toBe(
+        "error",
+      );
+      expect(result.ok).toBe(false);
     });
 
     test("warns when no headings present", () => {

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -281,13 +281,24 @@ export const validateAst = (
     blocks.flatMap((b) => (b.plainText ? [b.plainText] : [])).join(" "),
   );
 
-  const retainedPct =
-    originalText.length > 0
-      ? (astText.length / originalText.length) * 100
-      : 100;
-
   const originalWords = extractWords(originalText);
   const astWords = extractWords(astText);
+
+  // `extractWords` already drops decorative markers, skip words, bare
+  // numbers and tokens too short to count, so an empty set means the source
+  // carries nothing meaningful for an AST to lose. Measuring retention over
+  // its raw characters then reports total loss against a faithful parse: a
+  // scanned decision published as nothing but [OBRÁZEK] placeholders reads
+  // 0.0% retained with zero missing meaningful words, which is a
+  // contradiction on its face. Judging presence by the same rule the
+  // missing-word check uses can only ever clear such a phantom, because a
+  // source holding any meaningful word keeps the ratio.
+  const sourceHasMeaningfulText = originalWords.size > 0;
+
+  const retainedPct = sourceHasMeaningfulText
+    ? (astText.length / originalText.length) * 100
+    : 100;
+
   // A decorative marker fused to its neighbour must not read as missing
   // when the peeled remainder is accounted for. It is accounted for when
   // it is present in the AST, or when it is not a meaningful word in its
@@ -324,17 +335,17 @@ export const validateAst = (
   // ── 2. Structural checks ──────────────────────────────
 
   if (blocks.length === 0) {
-    // No blocks is loss only when there was something to lose. A source
-    // carrying no extractable text is represented faithfully by no
-    // blocks, and `retainedPct` already reads 100 for it; calling that an
-    // error reports content loss against a document whose emptiness the
-    // pipeline separately reports as `decision_empty`, sending whoever
-    // sweeps these logs after a parser bug that is not there. It stays an
-    // issue, so the parse still surfaces as structurally degraded.
+    // No blocks is loss only when there was something meaningful to lose. A
+    // source carrying no such text is represented faithfully by no blocks,
+    // and `retainedPct` reads 100 for it; calling that an error reports
+    // content loss against a document whose emptiness the pipeline
+    // separately reports as `decision_empty`, sending whoever sweeps these
+    // logs after a parser bug that is not there. It stays an issue, so the
+    // parse still surfaces as structurally degraded.
     issues.push({
       code: "EMPTY_AST",
       message: "AST has no blocks",
-      severity: originalText.length > 0 ? "error" : "warning",
+      severity: sourceHasMeaningfulText ? "error" : "warning",
     });
   }
 

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -161,6 +161,31 @@ const peelDecorativeMarkers = (word: string): string => {
   return peeled;
 };
 
+// Whether the source's extracted text is nothing but the publisher's own
+// decorative furniture — a scan published as [OBRÁZEK] placeholders, the NSS
+// emblem and its "ČESKÁ REPUBLIKA / JMÉNEM REPUBLIKY" header. Such a source
+// has nothing for an AST to lose, so a retention ratio over its characters
+// reports total loss against a faithful parse.
+//
+// Deliberately narrower than `isMeaningfulWord`, which also drops bare
+// numbers and one- or two-letter tokens: those are content a decision can
+// lose (awarded amounts, dates, a docket's parts, a roman-numbered ruling
+// item), so reusing the missing-word filter here would silence real loss on a
+// source whose text is entirely numeric. Only a token that peels away to
+// nothing, or to a skip word, counts as decoration.
+const CONTENT_CHAR = /[\p{L}\p{N}]/u;
+const holdsOnlyDecoration = (text: string): boolean =>
+  separateSkipMarkers(text)
+    .split(/\s+/u)
+    .every((word) => {
+      const bare = word.replace(/[[\]]/gu, "").toLowerCase();
+      if (!CONTENT_CHAR.test(bare) || SKIP_WORDS.has(bare)) {
+        return true;
+      }
+      const peeled = peelDecorativeMarkers(bare);
+      return peeled === "" || SKIP_WORDS.has(peeled);
+    });
+
 /** Flatten inline nodes to text (line-break → space). */
 const inlineText = (inlines: readonly Inline[]): string => {
   let text = "";
@@ -284,18 +309,9 @@ export const validateAst = (
   const originalWords = extractWords(originalText);
   const astWords = extractWords(astText);
 
-  // `extractWords` already drops decorative markers, skip words, bare
-  // numbers and tokens too short to count, so an empty set means the source
-  // carries nothing meaningful for an AST to lose. Measuring retention over
-  // its raw characters then reports total loss against a faithful parse: a
-  // scanned decision published as nothing but [OBRÁZEK] placeholders reads
-  // 0.0% retained with zero missing meaningful words, which is a
-  // contradiction on its face. Judging presence by the same rule the
-  // missing-word check uses can only ever clear such a phantom, because a
-  // source holding any meaningful word keeps the ratio.
-  const sourceHasMeaningfulText = originalWords.size > 0;
+  const sourceHasContent = !holdsOnlyDecoration(originalText);
 
-  const retainedPct = sourceHasMeaningfulText
+  const retainedPct = sourceHasContent
     ? (astText.length / originalText.length) * 100
     : 100;
 
@@ -335,8 +351,8 @@ export const validateAst = (
   // ── 2. Structural checks ──────────────────────────────
 
   if (blocks.length === 0) {
-    // No blocks is loss only when there was something meaningful to lose. A
-    // source carrying no such text is represented faithfully by no blocks,
+    // No blocks is loss only when there was something to lose. A source
+    // carrying nothing but decoration is represented faithfully by no blocks,
     // and `retainedPct` reads 100 for it; calling that an error reports
     // content loss against a document whose emptiness the pipeline
     // separately reports as `decision_empty`, sending whoever sweeps these
@@ -345,7 +361,7 @@ export const validateAst = (
     issues.push({
       code: "EMPTY_AST",
       message: "AST has no blocks",
-      severity: sourceHasMeaningfulText ? "error" : "warning",
+      severity: sourceHasContent ? "error" : "warning",
     });
   }
 


### PR DESCRIPTION
## Proposed change

`validateAst` measures completeness two ways that can contradict each other.
`retainedPct` divides AST characters by the source's raw extracted characters,
while `missingWords` first drops decorative markers, skip words, bare numbers
and tokens too short to count.

For a decision a court holds only as a scan, the whole extracted body is
`[OBRÁZEK]` figure placeholders. Nothing is reported missing, but `retainedPct`
reads 0.0% because the AST has no characters, so `CONTENT_LOSS` and `EMPTY_AST`
both fire at ERROR against a parse that dropped nothing. Rule 11's
`ast_content_lost` is the signal an operator is meant to act on, so a phantom
there costs attention that belongs to real loss.

The fix asks whether the source's extracted text is nothing but the publisher's
own decorative furniture, and skips the ratio only then:

```ts
const sourceHasContent = !holdsOnlyDecoration(originalText);
```

used at both sites. A token counts as decoration only when it peels away to
nothing or to a skip word.

The `EMPTY_AST` branch already documented this premise in its comment
(*"`retainedPct` already reads 100 for it"*). That held only for a source
extracting no characters at all; it now also holds for one extracting nothing
but decoration.

Same family as #2284 and #2406, which peeled decorative markers off individual
words. This is the whole-document case those could not reach.

### Why not reuse the missing-word filter

The first commit did exactly that (`originalWords.size > 0`), and it was wrong
in a way worth recording, because `extractWords` answers a different question.
It also drops bare numbers and one- or two-letter tokens, which are content a
decision can lose: an awarded amount, a date, a docket's parts, a
roman-numbered ruling item. A source of `I` and `42 43` whose AST keeps only
`I` therefore took the exemption and reported **no issue at all** — the numbers
were gone, they are not missing-word candidates, and forcing 100% retention
silenced the one check that would have caught it.

Second commit keys the exemption on decoration directly, so only genuine
furniture earns it. Found by Codex in review; the third test below is its
counterexample, and it fails on the first commit.

Deliberately out of scope: `retainedPct` stays character-based for partial
losses, so a document mixing markers with real text is judged exactly as it is
today. Making the ratio itself meaningful-word-based would move retention for
every document and shift some across the 90% threshold in both directions;
that is a separate call.

## Tests

Three added. The first two use the shape Aspose actually exports (placeholder
split across the spans a font change produces):

- `empty AST over an all-marker source is not content loss` — asserts the
  fixture reaches the retention branch (`originalLength > 0`, unlike the
  existing text-less sibling), then that retention reads 100, no
  `CONTENT_LOSS`, and `EMPTY_AST` at `warning`. **Fails on `main`.**
- `one meaningful word among the markers still reports loss` — the same source
  plus a single real phrase still reports `CONTENT_LOSS` and `EMPTY_AST` at
  `error`.
- `dropped numbers and short tokens still report loss` — Codex's
  counterexample: numbers and short tokens are not missing-word candidates, so
  only the ratio can catch their loss, and it must still run. **Fails on the
  first commit.**

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

Dark mode and screenshot are not applicable: this is a backend validator with
no rendered surface.

Verified locally on the rebased head: `validate-ast.test.ts` 40 pass, the whole
`ingestion/parsers` suite 182 pass, `oxlint-guardrails.test.ts` 25 pass,
`typecheck` clean, `oxlint` and the result-boundary config clean on both
changed files, `ratchet --check` OK at 69 metrics.
