### PR TITLE
docs: conventions-mcp skill for agent-facing tool contracts

### DIFF
--- a/.agents/skills/conventions-mcp/SKILL.md
+++ b/.agents/skills/conventions-mcp/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: conventions-mcp
+description: Apply when adding or changing an MCP tool, a capability the CLI generates, a tool input or output schema, a tool description, an error envelope, or an agent-facing reference resource. Enforces contracts that language models can actually drive, measured by evals rather than by schema soundness.
+---
+
+# Agent-Facing Contract Conventions
+
+An MCP tool or CLI capability is a user interface whose user is a language model.
+A schema can be type-sound, validated, and documented and still be undrivable:
+models copy examples, fill every property they see, retry with the same call,
+and cannot inspect bytes. Design for that behaviour and measure it.
+
+## Target Property
+
+A capable model, given only what `tools/list` and the reference resources expose,
+completes the workflow on the first or second attempt, and every rejection it
+receives names the next call to make. The authoring eval, not code review, decides
+whether a contract change helped.
+
+## Measure Before Believing
+
+1. **An eval is the acceptance test.** Every agent-facing workflow has an eval that
+   drives the real tools with the real schemas and scores each step separately
+   (authored, created, configured, filled, or the workflow's equivalents). Run it
+   before and after a contract change and put both tables in the PR. A change that
+   is "obviously better" without numbers is a hypothesis.
+2. **Keep the rejected call.** Record the raw input of every call the schema
+   rejected before the handler ran. A pass rate without the rejected payloads
+   cannot say whether the model or the contract failed.
+3. **Parse through the schema the handler uses.** The eval, the tests, and the
+   handler must validate the same object; a normalisation that lives only in one
+   handler's pre-step is invisible to the eval and drifts.
+
+## Shape Tools For How Models Behave
+
+4. **One tool, one intent.** Split create, configure, and update into separate
+   tools rather than one tool whose meaning depends on which optional arguments
+   are present. Cross-field "provide A or B, not both" checks are a sign the tool
+   has more than one job.
+5. **Few optionals, one discriminator.** Replace a set of mutually exclusive
+   optional keys with one discriminated union (`source: { type: "ai" | "lookup"
+   | ... }`). A model that fills every property cannot produce a contradictory
+   union member; it can produce six contradictory optionals.
+6. **Best effort over all-or-nothing for collections.** When a call carries a
+   list of entries, validate each entry independently, apply the valid ones, and
+   return the rest as per-entry `issues[]`. One bad property must not sink a call
+   that carried seven good entries.
+7. **Echo the next call.** Return, from the call that discovers state, the exact
+   payload the next call accepts (a `configure` skeleton, canonical path spelling,
+   allowed values). Copying beats inferring. Read-back must round-trip: the shape
+   a describe tool returns is the shape the configure tool accepts, byte for byte,
+   and a test pins that fixed point.
+8. **Idempotent and re-entrant.** Models retry with the same call and resend
+   everything they know. Accept the resend: upsert on a stable id, idempotency
+   keys that cover every argument, durable receipts replayed without re-executing.
+9. **Keep artefacts out of the model.** Bytes are the hardest step in any loop.
+   Prefer references (a host file reference, an id of something already stored)
+   over inline base64; when inline is the only path, bound it by the request
+   frame, derive the limit from the shared constant, and state it in the
+   description. Never let an error hint invite the model to shrink or rewrite a
+   document.
+
+## Every Error Is A Next Step
+
+10. **Structured envelope, closed codes.** Failures return `{ code, message, hint,
+    issues[] }` with codes from a closed set. `hint` names the corrective action,
+    the tool to call, and where to go (a deep link when the fix is in the UI).
+    "Disabled" without "enable it here" is a dead end.
+11. **Never leak the substrate.** A malformed id is a validation issue at the
+    boundary, never a database cast error reported as `internal_error`. Every id
+    input is declared with the shared id schema; a registry-wide test enforces it.
+12. **Warn about what the model probably meant.** Discovery and save return
+    `warnings[]` with closed codes for the known traps (unprefixed loop item,
+    unknown directive, split marker, and so on). A census test keeps the code
+    list and the reference in step.
+13. **Tolerate client encodings once, at the boundary.** Strict-schema clients send
+    `null` for unset optionals; treat null on a plain optional as absence on every
+    validation surface, through the tool factory, guarded by a registry-wide test.
+    Do not add per-tool tolerance code.
+
+## References Are Read Verbatim
+
+14. **Every sentence must be true of the code.** Reference resources and tool
+    descriptions are copied into model context as the complete contract. A
+    promised behaviour the code does not have (a preserved extension, a size limit
+    that is not the enforced one) is a bug, not a docs nit. Render numbers from the
+    constants; type tool names against the registry; keep drift tests.
+15. **One workflow resource per workflow.** Publish the ordered steps (create,
+    read back, configure, preview, persist) as a resource pointed to from the MCP
+    instructions, and keep the quiz or eval that checks a model understood it.
+16. **Decide grammar leniency by evidence.** When two independent models write the
+    same form the grammar rejects, that is a product signal: either accept the
+    form or make the reference unambiguous, then re-measure. Do not do both at
+    once.
+
+## Guards Make It Stick
+
+- Registry-wide tests over every tool definition: id schemas, null-optional
+  tolerance, description and reference drift, and a zero-diff capability export.
+- Total companion maps keyed by tool name (`as const satisfies Record<ToolName,
+  ...>`) for policy, consent, projection, and CLI disposition, so a new tool cannot
+  land without each decision.
+- Compile-time gates in the tool factory (a schema that is not wrapped, an id that
+  is not the shared schema) rather than review discipline.
+- The CLI is generated from the same catalog: a capability whose transport the
+  generator cannot invoke is not advertised anywhere, and generated artifacts are
+  regenerated in order (capability export, then CLI codegen) until the diff is
+  zero.
+
+## Existing References
+
+- Tool factory and boundary normalisation: `apps/api/src/mcp/valibot-tool-definition.ts`,
+  `apps/api/src/mcp/tool-utils.ts`
+- Registry-wide guards: `apps/api/src/mcp/uuid-id-inputs.test.ts`,
+  `apps/api/src/mcp/null-optional-inputs.test.ts`
+- Warnings census and references: `apps/api/src/lib/docx/template-warnings.ts`,
+  `apps/api/src/mcp/template-workflow-reference.ts`
+- Authoring eval: `apps/api/evals/template-authoring.ts`
+
+These are examples of the mechanisms, not proof that a new tool meets the bar:
+run the eval.

--- a/.agents/skills/conventions-mcp/SKILL.md
+++ b/.agents/skills/conventions-mcp/SKILL.md
@@ -24,9 +24,13 @@ whether a contract change helped.
    (authored, created, configured, filled, or the workflow's equivalents). Run it
    before and after a contract change and put both tables in the PR. A change that
    is "obviously better" without numbers is a hypothesis.
-2. **Keep the rejected call.** Record the raw input of every call the schema
-   rejected before the handler ran. A pass rate without the rejected payloads
-   cannot say whether the model or the contract failed.
+2. **Keep the rejected call, in the eval only.** The eval records the raw input
+   of every call the schema rejected before the handler ran; a pass rate without
+   the rejected payloads cannot say whether the model or the contract failed.
+   Eval fixtures are synthetic, so the trace may hold them whole. Production
+   telemetry for a rejected call records the tool name, the issue codes, and the
+   issue paths, never the payload: tool arguments carry matter content and
+   personal data.
 3. **Parse through the schema the handler uses.** The eval, the tests, and the
    handler must validate the same object; a normalisation that lives only in one
    handler's pre-step is invisible to the eval and drifts.

--- a/.ai/local-skills/conventions-mcp/SKILL.md
+++ b/.ai/local-skills/conventions-mcp/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: conventions-mcp
+description: Apply when adding or changing an MCP tool, a capability the CLI generates, a tool input or output schema, a tool description, an error envelope, or an agent-facing reference resource. Enforces contracts that language models can actually drive, measured by evals rather than by schema soundness.
+---
+
+# Agent-Facing Contract Conventions
+
+An MCP tool or CLI capability is a user interface whose user is a language model.
+A schema can be type-sound, validated, and documented and still be undrivable:
+models copy examples, fill every property they see, retry with the same call,
+and cannot inspect bytes. Design for that behaviour and measure it.
+
+## Target Property
+
+A capable model, given only what `tools/list` and the reference resources expose,
+completes the workflow on the first or second attempt, and every rejection it
+receives names the next call to make. The authoring eval, not code review, decides
+whether a contract change helped.
+
+## Measure Before Believing
+
+1. **An eval is the acceptance test.** Every agent-facing workflow has an eval that
+   drives the real tools with the real schemas and scores each step separately
+   (authored, created, configured, filled, or the workflow's equivalents). Run it
+   before and after a contract change and put both tables in the PR. A change that
+   is "obviously better" without numbers is a hypothesis.
+2. **Keep the rejected call.** Record the raw input of every call the schema
+   rejected before the handler ran. A pass rate without the rejected payloads
+   cannot say whether the model or the contract failed.
+3. **Parse through the schema the handler uses.** The eval, the tests, and the
+   handler must validate the same object; a normalisation that lives only in one
+   handler's pre-step is invisible to the eval and drifts.
+
+## Shape Tools For How Models Behave
+
+4. **One tool, one intent.** Split create, configure, and update into separate
+   tools rather than one tool whose meaning depends on which optional arguments
+   are present. Cross-field "provide A or B, not both" checks are a sign the tool
+   has more than one job.
+5. **Few optionals, one discriminator.** Replace a set of mutually exclusive
+   optional keys with one discriminated union (`source: { type: "ai" | "lookup"
+   | ... }`). A model that fills every property cannot produce a contradictory
+   union member; it can produce six contradictory optionals.
+6. **Best effort over all-or-nothing for collections.** When a call carries a
+   list of entries, validate each entry independently, apply the valid ones, and
+   return the rest as per-entry `issues[]`. One bad property must not sink a call
+   that carried seven good entries.
+7. **Echo the next call.** Return, from the call that discovers state, the exact
+   payload the next call accepts (a `configure` skeleton, canonical path spelling,
+   allowed values). Copying beats inferring. Read-back must round-trip: the shape
+   a describe tool returns is the shape the configure tool accepts, byte for byte,
+   and a test pins that fixed point.
+8. **Idempotent and re-entrant.** Models retry with the same call and resend
+   everything they know. Accept the resend: upsert on a stable id, idempotency
+   keys that cover every argument, durable receipts replayed without re-executing.
+9. **Keep artefacts out of the model.** Bytes are the hardest step in any loop.
+   Prefer references (a host file reference, an id of something already stored)
+   over inline base64; when inline is the only path, bound it by the request
+   frame, derive the limit from the shared constant, and state it in the
+   description. Never let an error hint invite the model to shrink or rewrite a
+   document.
+
+## Every Error Is A Next Step
+
+10. **Structured envelope, closed codes.** Failures return `{ code, message, hint,
+    issues[] }` with codes from a closed set. `hint` names the corrective action,
+    the tool to call, and where to go (a deep link when the fix is in the UI).
+    "Disabled" without "enable it here" is a dead end.
+11. **Never leak the substrate.** A malformed id is a validation issue at the
+    boundary, never a database cast error reported as `internal_error`. Every id
+    input is declared with the shared id schema; a registry-wide test enforces it.
+12. **Warn about what the model probably meant.** Discovery and save return
+    `warnings[]` with closed codes for the known traps (unprefixed loop item,
+    unknown directive, split marker, and so on). A census test keeps the code
+    list and the reference in step.
+13. **Tolerate client encodings once, at the boundary.** Strict-schema clients send
+    `null` for unset optionals; treat null on a plain optional as absence on every
+    validation surface, through the tool factory, guarded by a registry-wide test.
+    Do not add per-tool tolerance code.
+
+## References Are Read Verbatim
+
+14. **Every sentence must be true of the code.** Reference resources and tool
+    descriptions are copied into model context as the complete contract. A
+    promised behaviour the code does not have (a preserved extension, a size limit
+    that is not the enforced one) is a bug, not a docs nit. Render numbers from the
+    constants; type tool names against the registry; keep drift tests.
+15. **One workflow resource per workflow.** Publish the ordered steps (create,
+    read back, configure, preview, persist) as a resource pointed to from the MCP
+    instructions, and keep the quiz or eval that checks a model understood it.
+16. **Decide grammar leniency by evidence.** When two independent models write the
+    same form the grammar rejects, that is a product signal: either accept the
+    form or make the reference unambiguous, then re-measure. Do not do both at
+    once.
+
+## Guards Make It Stick
+
+- Registry-wide tests over every tool definition: id schemas, null-optional
+  tolerance, description and reference drift, and a zero-diff capability export.
+- Total companion maps keyed by tool name (`as const satisfies Record<ToolName,
+  ...>`) for policy, consent, projection, and CLI disposition, so a new tool cannot
+  land without each decision.
+- Compile-time gates in the tool factory (a schema that is not wrapped, an id that
+  is not the shared schema) rather than review discipline.
+- The CLI is generated from the same catalog: a capability whose transport the
+  generator cannot invoke is not advertised anywhere, and generated artifacts are
+  regenerated in order (capability export, then CLI codegen) until the diff is
+  zero.
+
+## Existing References
+
+- Tool factory and boundary normalisation: `apps/api/src/mcp/valibot-tool-definition.ts`,
+  `apps/api/src/mcp/tool-utils.ts`
+- Registry-wide guards: `apps/api/src/mcp/uuid-id-inputs.test.ts`,
+  `apps/api/src/mcp/null-optional-inputs.test.ts`
+- Warnings census and references: `apps/api/src/lib/docx/template-warnings.ts`,
+  `apps/api/src/mcp/template-workflow-reference.ts`
+- Authoring eval: `apps/api/evals/template-authoring.ts`
+
+These are examples of the mechanisms, not proof that a new tool meets the bar:
+run the eval.

--- a/.ai/local-skills/conventions-mcp/SKILL.md
+++ b/.ai/local-skills/conventions-mcp/SKILL.md
@@ -24,9 +24,13 @@ whether a contract change helped.
    (authored, created, configured, filled, or the workflow's equivalents). Run it
    before and after a contract change and put both tables in the PR. A change that
    is "obviously better" without numbers is a hypothesis.
-2. **Keep the rejected call.** Record the raw input of every call the schema
-   rejected before the handler ran. A pass rate without the rejected payloads
-   cannot say whether the model or the contract failed.
+2. **Keep the rejected call, in the eval only.** The eval records the raw input
+   of every call the schema rejected before the handler ran; a pass rate without
+   the rejected payloads cannot say whether the model or the contract failed.
+   Eval fixtures are synthetic, so the trace may hold them whole. Production
+   telemetry for a rejected call records the tool name, the issue codes, and the
+   issue paths, never the payload: tool arguments carry matter content and
+   personal data.
 3. **Parse through the schema the handler uses.** The eval, the tests, and the
    handler must validate the same object; a normalisation that lives only in one
    handler's pre-step is invisible to the eval and drifts.

--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -16,9 +16,11 @@ publishable code lives in `packages/`. Use Glob/Grep to explore.
 
 Before changing a convention-governed domain, read and apply the matching
 `.agents/skills/conventions-*/SKILL.md`. This includes AI, databases, i18n and
-user-facing strings, ingestion, performance guard failures and hot paths,
-architecture and scale, auth and data access, files and external APIs, tests,
-`apps/web` React effects, and user-facing UI. The skills own the detailed rules.
+user-facing strings, ingestion, MCP tools and CLI capabilities (agent-facing
+schemas, errors, and reference resources), performance guard failures and hot
+paths, architecture and scale, auth and data access, files and external APIs,
+tests, `apps/web` React effects, and user-facing UI. The skills own the detailed
+rules.
 
 ## Implementation Quality
 

--- a/.claude/skills/conventions-mcp/SKILL.md
+++ b/.claude/skills/conventions-mcp/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: conventions-mcp
+description: Apply when adding or changing an MCP tool, a capability the CLI generates, a tool input or output schema, a tool description, an error envelope, or an agent-facing reference resource. Enforces contracts that language models can actually drive, measured by evals rather than by schema soundness.
+---
+
+# Agent-Facing Contract Conventions
+
+An MCP tool or CLI capability is a user interface whose user is a language model.
+A schema can be type-sound, validated, and documented and still be undrivable:
+models copy examples, fill every property they see, retry with the same call,
+and cannot inspect bytes. Design for that behaviour and measure it.
+
+## Target Property
+
+A capable model, given only what `tools/list` and the reference resources expose,
+completes the workflow on the first or second attempt, and every rejection it
+receives names the next call to make. The authoring eval, not code review, decides
+whether a contract change helped.
+
+## Measure Before Believing
+
+1. **An eval is the acceptance test.** Every agent-facing workflow has an eval that
+   drives the real tools with the real schemas and scores each step separately
+   (authored, created, configured, filled, or the workflow's equivalents). Run it
+   before and after a contract change and put both tables in the PR. A change that
+   is "obviously better" without numbers is a hypothesis.
+2. **Keep the rejected call.** Record the raw input of every call the schema
+   rejected before the handler ran. A pass rate without the rejected payloads
+   cannot say whether the model or the contract failed.
+3. **Parse through the schema the handler uses.** The eval, the tests, and the
+   handler must validate the same object; a normalisation that lives only in one
+   handler's pre-step is invisible to the eval and drifts.
+
+## Shape Tools For How Models Behave
+
+4. **One tool, one intent.** Split create, configure, and update into separate
+   tools rather than one tool whose meaning depends on which optional arguments
+   are present. Cross-field "provide A or B, not both" checks are a sign the tool
+   has more than one job.
+5. **Few optionals, one discriminator.** Replace a set of mutually exclusive
+   optional keys with one discriminated union (`source: { type: "ai" | "lookup"
+   | ... }`). A model that fills every property cannot produce a contradictory
+   union member; it can produce six contradictory optionals.
+6. **Best effort over all-or-nothing for collections.** When a call carries a
+   list of entries, validate each entry independently, apply the valid ones, and
+   return the rest as per-entry `issues[]`. One bad property must not sink a call
+   that carried seven good entries.
+7. **Echo the next call.** Return, from the call that discovers state, the exact
+   payload the next call accepts (a `configure` skeleton, canonical path spelling,
+   allowed values). Copying beats inferring. Read-back must round-trip: the shape
+   a describe tool returns is the shape the configure tool accepts, byte for byte,
+   and a test pins that fixed point.
+8. **Idempotent and re-entrant.** Models retry with the same call and resend
+   everything they know. Accept the resend: upsert on a stable id, idempotency
+   keys that cover every argument, durable receipts replayed without re-executing.
+9. **Keep artefacts out of the model.** Bytes are the hardest step in any loop.
+   Prefer references (a host file reference, an id of something already stored)
+   over inline base64; when inline is the only path, bound it by the request
+   frame, derive the limit from the shared constant, and state it in the
+   description. Never let an error hint invite the model to shrink or rewrite a
+   document.
+
+## Every Error Is A Next Step
+
+10. **Structured envelope, closed codes.** Failures return `{ code, message, hint,
+    issues[] }` with codes from a closed set. `hint` names the corrective action,
+    the tool to call, and where to go (a deep link when the fix is in the UI).
+    "Disabled" without "enable it here" is a dead end.
+11. **Never leak the substrate.** A malformed id is a validation issue at the
+    boundary, never a database cast error reported as `internal_error`. Every id
+    input is declared with the shared id schema; a registry-wide test enforces it.
+12. **Warn about what the model probably meant.** Discovery and save return
+    `warnings[]` with closed codes for the known traps (unprefixed loop item,
+    unknown directive, split marker, and so on). A census test keeps the code
+    list and the reference in step.
+13. **Tolerate client encodings once, at the boundary.** Strict-schema clients send
+    `null` for unset optionals; treat null on a plain optional as absence on every
+    validation surface, through the tool factory, guarded by a registry-wide test.
+    Do not add per-tool tolerance code.
+
+## References Are Read Verbatim
+
+14. **Every sentence must be true of the code.** Reference resources and tool
+    descriptions are copied into model context as the complete contract. A
+    promised behaviour the code does not have (a preserved extension, a size limit
+    that is not the enforced one) is a bug, not a docs nit. Render numbers from the
+    constants; type tool names against the registry; keep drift tests.
+15. **One workflow resource per workflow.** Publish the ordered steps (create,
+    read back, configure, preview, persist) as a resource pointed to from the MCP
+    instructions, and keep the quiz or eval that checks a model understood it.
+16. **Decide grammar leniency by evidence.** When two independent models write the
+    same form the grammar rejects, that is a product signal: either accept the
+    form or make the reference unambiguous, then re-measure. Do not do both at
+    once.
+
+## Guards Make It Stick
+
+- Registry-wide tests over every tool definition: id schemas, null-optional
+  tolerance, description and reference drift, and a zero-diff capability export.
+- Total companion maps keyed by tool name (`as const satisfies Record<ToolName,
+  ...>`) for policy, consent, projection, and CLI disposition, so a new tool cannot
+  land without each decision.
+- Compile-time gates in the tool factory (a schema that is not wrapped, an id that
+  is not the shared schema) rather than review discipline.
+- The CLI is generated from the same catalog: a capability whose transport the
+  generator cannot invoke is not advertised anywhere, and generated artifacts are
+  regenerated in order (capability export, then CLI codegen) until the diff is
+  zero.
+
+## Existing References
+
+- Tool factory and boundary normalisation: `apps/api/src/mcp/valibot-tool-definition.ts`,
+  `apps/api/src/mcp/tool-utils.ts`
+- Registry-wide guards: `apps/api/src/mcp/uuid-id-inputs.test.ts`,
+  `apps/api/src/mcp/null-optional-inputs.test.ts`
+- Warnings census and references: `apps/api/src/lib/docx/template-warnings.ts`,
+  `apps/api/src/mcp/template-workflow-reference.ts`
+- Authoring eval: `apps/api/evals/template-authoring.ts`
+
+These are examples of the mechanisms, not proof that a new tool meets the bar:
+run the eval.

--- a/.claude/skills/conventions-mcp/SKILL.md
+++ b/.claude/skills/conventions-mcp/SKILL.md
@@ -24,9 +24,13 @@ whether a contract change helped.
    (authored, created, configured, filled, or the workflow's equivalents). Run it
    before and after a contract change and put both tables in the PR. A change that
    is "obviously better" without numbers is a hypothesis.
-2. **Keep the rejected call.** Record the raw input of every call the schema
-   rejected before the handler ran. A pass rate without the rejected payloads
-   cannot say whether the model or the contract failed.
+2. **Keep the rejected call, in the eval only.** The eval records the raw input
+   of every call the schema rejected before the handler ran; a pass rate without
+   the rejected payloads cannot say whether the model or the contract failed.
+   Eval fixtures are synthetic, so the trace may hold them whole. Production
+   telemetry for a rejected call records the tool name, the issue codes, and the
+   issue paths, never the payload: tool arguments carry matter content and
+   personal data.
 3. **Parse through the schema the handler uses.** The eval, the tests, and the
    handler must validate the same object; a normalisation that lives only in one
    handler's pre-step is invisible to the eval and drifts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,9 +246,11 @@ publishable code lives in `packages/`. Use Glob/Grep to explore.
 
 Before changing a convention-governed domain, read and apply the matching
 `.agents/skills/conventions-*/SKILL.md`. This includes AI, databases, i18n and
-user-facing strings, ingestion, performance guard failures and hot paths,
-architecture and scale, auth and data access, files and external APIs, tests,
-`apps/web` React effects, and user-facing UI. The skills own the detailed rules.
+user-facing strings, ingestion, MCP tools and CLI capabilities (agent-facing
+schemas, errors, and reference resources), performance guard failures and hot
+paths, architecture and scale, auth and data access, files and external APIs,
+tests, `apps/web` React effects, and user-facing UI. The skills own the detailed
+rules.
 
 ## Implementation Quality
 


### PR DESCRIPTION
Adds `conventions-mcp`, the convention skill for agent-facing contracts: MCP tools, CLI capabilities, their input and output schemas, error envelopes, and reference resources. Routes it from the Convention Routing section.

## Why

The template tooling work showed that a schema can be type-sound, validated, and documented and still be undrivable by a model: one tool with three jobs and thirty optional properties, all-or-nothing validation of a list, a path vocabulary the model had to infer, and bytes in the middle of every step. The eval, not review, exposed each of those.

## What the skill enforces

- An eval per agent-facing workflow, scored per step, run before and after a contract change, with rejected raw calls kept.
- One intent per tool; one discriminator instead of mutually exclusive optionals; best-effort application of collections with per-entry `issues[]`; echoing the next call's payload; idempotent resends; references over inline bytes.
- Every error is a next step: closed codes, hints that name the action and the place, no substrate leaks, `warnings[]` for known traps, null-as-absence at the boundary.
- Reference resources are read verbatim, so every sentence must be true of the code and rendered from the constants.
- Guards: registry-wide tests over all tool definitions, total companion maps keyed by tool name, compile-time gates in the tool factory, zero-diff generated artifacts.

Generated with `bun run sync-ai`; only the new skill and the routing sentence changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for designing and validating MCP tools and CLI capabilities, including input schemas, structured errors, idempotency and reference resources.
  - Expanded convention-routing guidance to cover agent-facing schemas, errors and supporting resources for MCP and CLI functionality.
  - Documented evaluation, boundary validation and registry safeguards for maintaining consistent tool and CLI contracts.
  - Added requirements for generated CLI artefacts and compile-time checks to support reliable capability definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->