### PR TITLE
fix(api): keep the rows a quoted table puts in its header and footer

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
@@ -584,32 +584,45 @@ describe("parseEcjDecisionHtml", () => {
   });
 
   /**
-   * Rule 10 as an invariant rather than an example: a row shape the
+   * Rule 10 as an invariant rather than an example: a row the
    * marker/content rules do not match is still walked for its text.
    * The converter emits a numbered paragraph as a two-cell row, so the
    * shape rules read cell 1 as the marker and cell 2 as its content —
    * but a decision quoting a tariff or rate table carries a column per
-   * heading, description and rate, and a header row of `th`. Asserted
-   * across the row shapes rather than on one of them, because losing a
-   * cell is invisible downstream: the AST reads as complete.
+   * heading, description and rate, and a header row of `th`.
+   *
+   * Both dimensions the publisher varies are asserted together: how many
+   * cells a row holds, and which section it sits in. A row the source
+   * put in `<thead>` or `<tfoot>` never reaches the cell rules at all,
+   * so a check that fixes the section to `<tbody>` cannot see it go
+   * missing. Losing either way is invisible downstream — the AST reads
+   * as complete.
    */
-  test("keeps every cell of every row shape", () => {
-    const cellText = (row: number, cell: number) => `r${row}c${cell} content`;
+  test("keeps every cell of every row shape, in every row section", () => {
+    const sections = ["thead", "tbody", "tfoot"] as const;
+    const cellText = (section: string, row: number, cell: number) =>
+      `${section}-r${row}c${cell} content`;
     const shapes = [1, 2, 3, 4, 5];
-    const rows = shapes
-      .map((cellCount, row) => {
-        const tag = row % 2 === 0 ? "td" : "th";
-        const cells = Array.from(
-          { length: cellCount },
-          (_, cell) => `<${tag}><p>${cellText(row, cell)}</p></${tag}>`,
-        ).join("");
-        return `<tr>${cells}</tr>`;
+    const body = sections
+      .map((section) => {
+        const rows = shapes
+          .map((cellCount, row) => {
+            const tag = row % 2 === 0 ? "td" : "th";
+            const cells = Array.from(
+              { length: cellCount },
+              (_, cell) =>
+                `<${tag}><p>${cellText(section, row, cell)}</p></${tag}>`,
+            ).join("");
+            return `<tr>${cells}</tr>`;
+          })
+          .join("");
+        return `<${section}>${rows}</${section}>`;
       })
       .join("");
     const html = [
       "<html><body><div class='coj-normal' lang='en'>",
       "<p class='coj-sum-title-1'>JUDGMENT OF THE COURT</p>",
-      `<table><tbody>${rows}</tbody></table>`,
+      `<table>${body}</table>`,
       "</div></body></html>",
     ].join("");
 
@@ -624,10 +637,12 @@ describe("parseEcjDecisionHtml", () => {
       html,
     });
 
-    const missing = shapes.flatMap((cellCount, row) =>
-      Array.from({ length: cellCount }, (_, cell) =>
-        cellText(row, cell),
-      ).filter((text) => !fulltext.includes(text)),
+    const missing = sections.flatMap((section) =>
+      shapes.flatMap((cellCount, row) =>
+        Array.from({ length: cellCount }, (_, cell) =>
+          cellText(section, row, cell),
+        ).filter((text) => !fulltext.includes(text)),
+      ),
     );
     expect(missing).toEqual([]);
   });

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
@@ -933,10 +933,16 @@ const visitTable = (
   builder: BlockBuilder,
   $table: cheerio.Cheerio<AnyNode>,
 ): void => {
-  // `cheerio.load` runs a spec-compliant tree builder, so every row is
-  // reachable through an explicit `<tbody>` even when the source omits it.
+  // A spec-compliant tree builder gives every row an explicit section
+  // parent, but that parent is `<tbody>` only for rows the source left
+  // unsectioned: rows the source put in `<thead>` or `<tfoot>` stay
+  // there, as siblings of `<tbody>` rather than inside it. Reading
+  // `<tbody>` alone therefore drops a sectioned row whole — the column
+  // labels of a quoted tariff table, or the note under it — which is the
+  // one failure rule 10 does not allow, and which the cell selector
+  // below cannot catch because the row never reaches it.
   $table
-    .children("tbody")
+    .children("thead, tbody, tfoot")
     .children("tr")
     .each((_, tr) => {
       // `th` counts as a cell. A decision quoting a tariff or rate

--- a/apps/api/src/lib/legal-search/ingestion-constants.ts
+++ b/apps/api/src/lib/legal-search/ingestion-constants.ts
@@ -52,7 +52,7 @@ export const PARSER_VERSIONS = {
   [ADAPTER_KEYS.AT_UMSE]: 2,
   [ADAPTER_KEYS.AT_BKS]: 2,
   [ADAPTER_KEYS.AT_FINDOK]: 2,
-  [ADAPTER_KEYS.EU_ECJ]: 3,
+  [ADAPTER_KEYS.EU_ECJ]: 4,
 } as const satisfies Record<AdapterKey, number>;
 
 /**


### PR DESCRIPTION
## Proposed change

`visitTable` in `parsers/eu-ecj.ts` selected a table's rows with
`$table.children("tbody").children("tr")`.

A spec-compliant tree builder does give every row an explicit section parent, but
that parent is `<tbody>` only for rows the source left unsectioned. Rows the
source marks up as `<thead>` or `<tfoot>` stay in those sections, which are
siblings of `<tbody>`, not children of it. So any row the publisher placed in a
header or footer section was never selected, and was dropped whole before the
marker/content and cell rules could shape it: for a decision quoting a tariff or
rate table, that is the table's column labels and the note printed underneath.

This is the failure rule 10 of `handlers/case-law/CLAUDE.md` singles out. Shaping
a row wrong is recoverable and visible; dropping it is neither, because the AST
that comes out still reads as complete. The cell selector cannot catch it either,
since the row never reaches the cell rules at all.

The fix reads the rows of all three row sections. `<thead>`, `<tbody>` and
`<tfoot>` are the complete set of row-bearing sections in HTML, so naming them is
total rather than one more special case, and the rows keep source order. A
sectioned row then goes through the same marker/content shaping as any other:
first cell as the marker, second as its content, anything past the pair
contributing its own text.

The row-shape test previously varied the cell count and the `td`/`th` spelling
while holding the section fixed at `<tbody>`, which is precisely why this was
invisible to it. It now varies the section as well, so the assertion covers both
dimensions the publisher actually varies. Without the parser change the new case
loses all 30 header and footer cells and retention drops to 34.9%.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun --filter @stll/api typecheck`, `oxlint` on the changed files, and the case-law parser suites (179 tests) pass. The new test case fails on the parent commit and passes here.
- [ ] DARK MODE SUPPORT | Not applicable: backend parser change with no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.

## Note for review

Decisions already stored with their header and footer rows missing will not
change on their own: those rows need re-parsing from `sourceRaw`, which is a
separate operation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - EU Court of Justice case-law tables now retain rows located in table headers, bodies, and footers.
  - Text from all table cells is preserved during parsing, including column labels and notes.

- **Chores**
  - Updated the EU Court of Justice parser version so affected records can be reprocessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->