### PR TITLE
fix(api): a failed document retry waits for its cooldown, not the backlog

### DIFF
--- a/apps/api/drizzle/20260907090000_sk_document_pending_retry_order/migration.sql
+++ b/apps/api/drizzle/20260907090000_sk_document_pending_retry_order/migration.sql
@@ -1,0 +1,57 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent build
+-- (which takes no lock those timeouts guard), then restore and reopen a
+-- transaction for Drizzle's migration row. Same shape as
+-- 20260906120000_corpus_projection_outstanding_intent_idx.
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+
+-- Drop by name first: a cancelled concurrent build leaves an INVALID index
+-- behind, and IF NOT EXISTS would then skip recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_document_pending_date_idx";
+--> statement-breakpoint
+-- The deferred-document queue's remaining tier, re-keyed without
+-- "document_fetch_attempts". Leading with the attempt count ordered every
+-- decision that had already failed once behind the entire untried backlog, so
+-- its retry waited for the backlog to drain rather than for its cooldown to
+-- pass. The tier now orders by decision date alone (remainingDocumentOrder),
+-- and the index has to match that order for the head of the queue to stay a
+-- bounded range scan instead of a sort over the backlog. Same predicate, so
+-- the index still covers exactly the pending set.
+--
+-- Built under a new name and the superseded one dropped after, rather than
+-- replaced in place: the queue reads this index every page, and a drop-then-
+-- build would leave it scanning the whole table for as long as the build runs.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_decisions_document_pending_date_idx"
+  ON "case_law_decisions" (
+    "source_id",
+    "decision_date" DESC NULLS LAST,
+    "id"
+  )
+  WHERE "fulltext" is null AND "document_url" is not null;
+--> statement-breakpoint
+-- stella-migration-safety: reviewed drop-object - drops the superseded
+-- index only, after its replacement above is built and valid. It carries no
+-- data and no constraint, and the only reader of it (the deferred-document
+-- queue) is served by the replacement, so a task running either revision of
+-- the code keeps an index for the same predicate. Rollback is the reverse
+-- build: the definition is in this file and in the migration that created it.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_document_pending_idx";
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260907090000_sk_document_pending_retry_order/migration.sql
+++ b/apps/api/drizzle/20260907090000_sk_document_pending_retry_order/migration.sql
@@ -28,9 +28,9 @@ DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_document_pending_date_idx"
 -- bounded range scan instead of a sort over the backlog. Same predicate, so
 -- the index still covers exactly the pending set.
 --
--- Built under a new name and the superseded one dropped after, rather than
--- replaced in place: the queue reads this index every page, and a drop-then-
--- build would leave it scanning the whole table for as long as the build runs.
+-- Built under a new name rather than replaced in place: the queue reads this
+-- index every page, and a drop-then-build would leave it scanning the whole
+-- table for as long as the build runs.
 -- squawk-ignore prefer-robust-stmts
 CREATE INDEX CONCURRENTLY "case_law_decisions_document_pending_date_idx"
   ON "case_law_decisions" (
@@ -40,14 +40,15 @@ CREATE INDEX CONCURRENTLY "case_law_decisions_document_pending_date_idx"
   )
   WHERE "fulltext" is null AND "document_url" is not null;
 --> statement-breakpoint
--- stella-migration-safety: reviewed drop-object - drops the superseded
--- index only, after its replacement above is built and valid. It carries no
--- data and no constraint, and the only reader of it (the deferred-document
--- queue) is served by the replacement, so a task running either revision of
--- the code keeps an index for the same predicate. Rollback is the reverse
--- build: the definition is in this file and in the migration that created it.
-DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_document_pending_idx";
---> statement-breakpoint
+-- The superseded "case_law_decisions_document_pending_idx" is deliberately
+-- left in place. A migration runs before the rolling deployment finishes, so
+-- tasks still on the previous revision keep ordering the tier by attempt
+-- count; dropping their index here would make each of their queue refills a
+-- sort over the whole backlog until the last one is replaced.
+--
+-- Removal condition: every runner is on the order this migration's index
+-- serves, i.e. the release carrying it is fully rolled out. A follow-up
+-- migration in a later release drops it.
 
 SET statement_timeout = '5s';
 --> statement-breakpoint

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -601,7 +601,11 @@ export const caseLawDecisions = p.pgTable(
     // Attempt count is deliberately not a key column: leading with it
     // ordered every retry behind the whole untried backlog, and keeping
     // it here would make the index unable to serve the order that fixed
-    // that.
+    // that. The attempt-led index it replaces
+    // (`case_law_decisions_document_pending_idx`) outlives this change on
+    // purpose, so tasks still on the previous revision keep an index for
+    // the order they issue; a follow-up migration drops it once the
+    // release carrying this one is fully rolled out.
     p
       .index("case_law_decisions_document_pending_date_idx")
       .on(t.sourceId, t.decisionDate.desc().nullsLast(), t.id)

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -595,18 +595,16 @@ export const caseLawDecisions = p.pgTable(
       .where(
         sql`${t.fulltext} is null and ${t.documentUrl} is not null and ${t.documentFetchRequestedAt} is not null`,
       ),
-    // Deferred-document queue, remaining tier: least-tried first, then
-    // newest decisions, per source. Matches the loader's ORDER BY so the
-    // head of the queue is a bounded index range scan rather than a sort
-    // over the backlog.
+    // Deferred-document queue, remaining tier: newest decisions first,
+    // per source. Matches the loader's ORDER BY so the head of the queue
+    // is a bounded index range scan rather than a sort over the backlog.
+    // Attempt count is deliberately not a key column: leading with it
+    // ordered every retry behind the whole untried backlog, and keeping
+    // it here would make the index unable to serve the order that fixed
+    // that.
     p
-      .index("case_law_decisions_document_pending_idx")
-      .on(
-        t.sourceId,
-        t.documentFetchAttempts,
-        t.decisionDate.desc().nullsLast(),
-        t.id,
-      )
+      .index("case_law_decisions_document_pending_date_idx")
+      .on(t.sourceId, t.decisionDate.desc().nullsLast(), t.id)
       .where(sql`${t.fulltext} is null and ${t.documentUrl} is not null`),
     // Same rule as on the citation side: null means "does not canonicalize",
     // and an empty string would make every such decision a candidate for

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -601,14 +601,29 @@ export const caseLawDecisions = p.pgTable(
     // Attempt count is deliberately not a key column: leading with it
     // ordered every retry behind the whole untried backlog, and keeping
     // it here would make the index unable to serve the order that fixed
-    // that. The attempt-led index it replaces
-    // (`case_law_decisions_document_pending_idx`) outlives this change on
-    // purpose, so tasks still on the previous revision keep an index for
-    // the order they issue; a follow-up migration drops it once the
-    // release carrying this one is fully rolled out.
+    // that.
     p
       .index("case_law_decisions_document_pending_date_idx")
       .on(t.sourceId, t.decisionDate.desc().nullsLast(), t.id)
+      .where(sql`${t.fulltext} is null and ${t.documentUrl} is not null`),
+    // The attempt-led index the one above replaces, kept for the length of
+    // one rollout. A migration lands before the deployment finishes, so
+    // tasks still on the previous revision go on ordering the tier by
+    // attempt count, and without this each of their queue refills would
+    // sort the whole backlog. Declared rather than merely left in the
+    // database so the schema states what the database holds.
+    //
+    // Removal condition: every runner on the date-led order, i.e. the
+    // release carrying it fully rolled out. Drop this declaration and the
+    // index together in a follow-up migration.
+    p
+      .index("case_law_decisions_document_pending_idx")
+      .on(
+        t.sourceId,
+        t.documentFetchAttempts,
+        t.decisionDate.desc().nullsLast(),
+        t.id,
+      )
       .where(sql`${t.fulltext} is null and ${t.documentUrl} is not null`),
     // Same rule as on the citation side: null means "does not canonicalize",
     // and an empty string would make every such decision a candidate for

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
@@ -564,19 +564,19 @@ if (!databaseUrl || !runPostgresTests) {
       expect(onlyThese(queue, [cooling, cooled])).toEqual([cooled]);
     });
 
-    test("decisions the source keeps refusing sink below untried ones", async () => {
-      // The livelock this prevents: a source answering 403 for the
-      // newest page would otherwise hand back the same rows every run,
-      // because they are the newest, and nothing behind them would ever
-      // be reached.
+    test("a refused decision comes back once its cooldown passes", async () => {
+      // What bounds a source answering 403 for the newest page is the
+      // cooldown, not the order: each refusal costs one attempt per
+      // cooldown. Ordering by attempts on top of that did not bound
+      // anything further, it only pushed the retry behind the backlog.
       const refusedIds = await Promise.all(
         [1, 2, 3].map(
           async (n) =>
             await insertDecision({
-              caseNumber: `livelock-refused-${n}-${suffix}`,
+              caseNumber: `retry-refused-${n}-${suffix}`,
               fulltext: null,
               documentUrl: `https://example.test/refused-${n}.pdf`,
-              // Newest decisions, so date order alone would put them first.
+              // Newest decisions, so date order puts them first.
               decisionDate: `2026-08-0${n}`,
               documentFetchAttempts: MAX_PRIORITY_FETCH_ATTEMPTS,
               documentFetchAttemptedAt: new Date(
@@ -586,7 +586,7 @@ if (!databaseUrl || !runPostgresTests) {
         ),
       );
       const untried = await insertDecision({
-        caseNumber: `livelock-untried-${suffix}`,
+        caseNumber: `retry-untried-${suffix}`,
         fulltext: null,
         documentUrl: "https://example.test/untried.pdf",
         decisionDate: "2026-01-01",
@@ -594,7 +594,12 @@ if (!databaseUrl || !runPostgresTests) {
 
       const queue = await loadPendingDocuments(scopedDb, QUEUE_READ_LIMIT);
 
-      expect(onlyThese(queue, [...refusedIds, untried]).at(0)).toBe(untried);
+      // Newest first, whatever each has already cost: the cooled
+      // refusals, then the older untried decision.
+      expect(onlyThese(queue, [...refusedIds, untried])).toEqual([
+        ...refusedIds.toReversed(),
+        untried,
+      ]);
     });
 
     test("requested decisions come first, then the newest of the rest", async () => {
@@ -664,7 +669,7 @@ if (!databaseUrl || !runPostgresTests) {
         scopedDb,
         sourceId,
         limit: QUEUE_READ_LIMIT,
-        after: { attempts: 0, decisionDate: "2026-04-02", id: first },
+        after: { decisionDate: "2026-04-02", id: first },
       });
 
       expect(onlyThese(page, [first, second])).toEqual([second]);

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.test.ts
@@ -90,9 +90,19 @@ describe("deferred document queue shape", () => {
     );
   });
 
-  test("the rest drain least-tried first, then newest, undated last", () => {
+  test("the rest drain newest first, undated last", () => {
     expect(compileOrder(remainingDocumentOrder)).toBe(
-      `"case_law_decisions"."document_fetch_attempts" asc, "case_law_decisions"."decision_date" desc nulls last, "case_law_decisions"."id" asc`,
+      `"case_law_decisions"."decision_date" desc nulls last, "case_law_decisions"."id" asc`,
+    );
+  });
+
+  test("the attempt count orders nothing in the remaining tier", () => {
+    // Leading with it partitions the tier: every decision that failed
+    // once sorts behind the whole untried backlog, so its retry waits
+    // for the backlog rather than for its cooldown. The cooldown in the
+    // predicate is what bounds a refused document, asserted above.
+    expect(compileOrder(remainingDocumentOrder)).not.toContain(
+      "document_fetch_attempts",
     );
   });
 });

--- a/apps/api/src/lib/legal-search/sk-document-backfill-retry-order.db.test.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill-retry-order.db.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The retry latency of the deferred document queue's remaining tier.
+ *
+ * A fetch that fails transiently leaves the decision pending and counts
+ * an attempt, and the cooldown in the tier's predicate is what decides
+ * when it may be tried again. Ordering the tier by attempt count first
+ * silently overrode that: every decision that had failed once sorted
+ * behind every decision still untried, so on a source whose backlog is
+ * untried decisions the retry waited for the backlog to drain rather
+ * than for the cooldown to pass.
+ *
+ * The fixture is that shape in miniature — one cooled failure among
+ * untried decisions, dated between them — and asserts the failure is
+ * served in its own date order rather than after every one of them.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { inArray } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
+import type { SafeId } from "@/api/lib/branded-types";
+import { loadRemainingDocuments } from "@/api/lib/legal-search/sk-document-backfill";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+const HOUR_MS = 60 * 60 * 1000;
+/** Comfortably past the tier's cooldown, whatever it is set to. */
+const COOLED_AT = new Date(Date.now() - 72 * HOUR_MS);
+
+type Seed = {
+  label: string;
+  decisionDate: string;
+  attempts: number;
+  attemptedAt: Date | null;
+};
+
+/**
+ * The cooled failure is dated between the untried decisions, so its
+ * place in the tier is decided by the order under test rather than by
+ * being the newest row in the fixture. `cooling` is the same failure
+ * inside its cooldown, which must not be offered at all.
+ */
+const SEEDS: readonly Seed[] = [
+  {
+    label: "cooling",
+    decisionDate: "2026-05-05",
+    attempts: 1,
+    attemptedAt: new Date(),
+  },
+  {
+    label: "untried-newest",
+    decisionDate: "2026-05-04",
+    attempts: 0,
+    attemptedAt: null,
+  },
+  {
+    label: "untried-newer",
+    decisionDate: "2026-05-03",
+    attempts: 0,
+    attemptedAt: null,
+  },
+  {
+    label: "cooled-failure",
+    decisionDate: "2026-05-02",
+    attempts: 1,
+    attemptedAt: COOLED_AT,
+  },
+  {
+    label: "untried-older",
+    decisionDate: "2026-05-01",
+    attempts: 0,
+    attemptedAt: null,
+  },
+  {
+    label: "untried-oldest",
+    decisionDate: "2026-04-30",
+    attempts: 0,
+    attemptedAt: null,
+  },
+];
+
+/** The tier's expected order, newest decision first. */
+const EXPECTED_LABELS = [
+  "untried-newest",
+  "untried-newer",
+  "cooled-failure",
+  "untried-older",
+  "untried-oldest",
+] as const;
+
+let testDb: TestDatabase;
+let scopedDb: ScopedDb;
+let sourceId: SafeId<"caseLawSource">;
+const created: SafeId<"caseLawDecision">[] = [];
+const seeded = new Map<string, SafeId<"caseLawDecision">>();
+const suffix = Bun.randomUUIDv7().slice(0, 8);
+
+const idFor = (label: string): SafeId<"caseLawDecision"> => {
+  const id = seeded.get(label);
+  if (id === undefined) {
+    throw new Error(`fixture did not seed ${label}`);
+  }
+  return id;
+};
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  scopedDb = asTestRaw<ScopedDb>(
+    async (callback: (tx: TestDatabase) => Promise<unknown>) =>
+      await callback(testDb),
+  );
+
+  const [source] = await testDb
+    .insert(caseLawSources)
+    .values({
+      adapterKey: ADAPTER_KEYS.SK_COURTS,
+      name: `SK retry order ${suffix}`,
+      enabled: false,
+    })
+    .returning({ id: caseLawSources.id });
+  if (!source) {
+    throw new Error("expected source row");
+  }
+  sourceId = source.id;
+
+  for (const seed of SEEDS) {
+    const [row] = await testDb
+      .insert(caseLawDecisions)
+      .values({
+        sourceId,
+        caseNumber: `retry-${suffix}-${seed.label}`,
+        court: "Okresný súd",
+        country: "SVK",
+        language: "sk",
+        fulltext: null,
+        documentUrl: `https://example.test/${seed.label}.pdf`,
+        decisionDate: seed.decisionDate,
+        documentFetchAttempts: seed.attempts,
+        documentFetchAttemptedAt: seed.attemptedAt,
+      })
+      .returning({ id: caseLawDecisions.id });
+    if (!row) {
+      throw new Error("expected decision row");
+    }
+    created.push(row.id);
+    seeded.set(seed.label, row.id);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  if (created.length > 0) {
+    await testDb
+      .delete(caseLawDecisions)
+      .where(inArray(caseLawDecisions.id, created));
+  }
+  await releaseTestDb();
+});
+
+const tier = async (): Promise<SafeId<"caseLawDecision">[]> => {
+  const rows = await loadRemainingDocuments({
+    scopedDb,
+    sourceId,
+    limit: SEEDS.length + 1,
+  });
+  return rows.map(({ id }) => id);
+};
+
+test("REGRESSION: a cooled failure is not queued behind the untried backlog", async () => {
+  const order = await tier();
+
+  // Its date, not its attempt count, decides where it sits: after the
+  // two newer untried decisions and before the two older ones. Under an
+  // attempt-led order it was last of the five.
+  expect(order).toEqual(EXPECTED_LABELS.map((label) => idFor(label)));
+});
+
+test("the fixture would starve the retry under an attempt-led order", async () => {
+  // Guards the assertion above against going vacuous: untried decisions
+  // an attempt-led order would place ahead of the retry have to exist on
+  // both sides of it, or the two orders agree and nothing is under test.
+  const order = await tier();
+  const retryIndex = order.indexOf(idFor("cooled-failure"));
+
+  expect(retryIndex).toBeGreaterThan(0);
+  expect(order.length - 1 - retryIndex).toBeGreaterThanOrEqual(2);
+});
+
+test("a failure still inside its cooldown stays out of the tier", async () => {
+  // The cooldown is what bounds a document the source keeps refusing;
+  // dropping the attempt count from the order must not loosen it.
+  const order = await tier();
+
+  expect(order).not.toContain(idFor("cooling"));
+});

--- a/apps/api/src/lib/legal-search/sk-document-backfill.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill.ts
@@ -310,15 +310,24 @@ export const requestedDocumentOrder = [
 ] as const;
 
 /**
- * Least-tried first, then newest decision. Attempts lead so a document
- * the source keeps refusing sinks below everything still untried rather
- * than holding the newest end of the range; within one attempt count the
- * newest decision is the one a reader is most likely to open next.
+ * Newest decision first, among the decisions that are ready to be tried.
+ *
+ * Readiness is the predicate's, not this order's: `outsideFetchCooldown`
+ * already admits only a decision never attempted or attempted longer ago
+ * than the cooldown, so every row this orders is one the queue may hand
+ * out now. That is what bounds a document the source keeps refusing —
+ * one attempt per cooldown, not one per pass.
+ *
+ * Attempt count deliberately does not lead. It reads as a tie-break but
+ * behaves as a partition: with a backlog of untried decisions, every row
+ * that failed once sorts behind all of them, so its retry waits for the
+ * backlog to drain rather than for its cooldown to pass. The cooldown is
+ * the retry delay; the order must not turn it into the backlog length.
+ *
  * NULLS LAST matches the index and puts undated decisions after every
  * dated one, rather than at the head of a DESC scan.
  */
 export const remainingDocumentOrder = [
-  asc(caseLawDecisions.documentFetchAttempts),
   sql`${caseLawDecisions.decisionDate} desc nulls last`,
   asc(caseLawDecisions.id),
 ] as const;
@@ -334,9 +343,8 @@ export const remainingDocumentOrder = [
  */
 export type RequestedDocumentCursor = SafeId<"caseLawDecision">;
 
-/** Keyset position in the remaining tier (attempts, decisionDate, id). */
+/** Keyset position in the remaining tier (decisionDate, id). */
 export type RemainingDocumentCursor = {
-  attempts: number;
   decisionDate: string | null;
   id: SafeId<"caseLawDecision">;
 };
@@ -412,12 +420,12 @@ export const loadRequestedDocuments = async ({
   });
 
 /**
- * Keyset boundary within one attempt count, for `decision_date DESC
- * NULLS LAST, id ASC`. A NULL date sorts after every date, so a cursor
- * on a dated row also has to admit the undated tail, and a cursor
- * already in that tail is ordered by id alone.
+ * Keyset boundary for `decision_date DESC NULLS LAST, id ASC`. A NULL
+ * date sorts after every date, so a cursor on a dated row also has to
+ * admit the undated tail, and a cursor already in that tail is ordered
+ * by id alone.
  */
-const remainingDateCursorPredicate = ({
+const remainingCursorPredicate = ({
   decisionDate,
   id,
 }: RemainingDocumentCursor) =>
@@ -431,20 +439,6 @@ const remainingDateCursorPredicate = ({
           gt(caseLawDecisions.id, id),
         ),
       );
-
-/**
- * Keyset boundary for `attempts ASC, decision_date DESC NULLS LAST, id
- * ASC`: everything in a later attempt count, plus what follows the
- * cursor inside its own.
- */
-const remainingCursorPredicate = (cursor: RemainingDocumentCursor) =>
-  or(
-    gt(caseLawDecisions.documentFetchAttempts, cursor.attempts),
-    and(
-      eq(caseLawDecisions.documentFetchAttempts, cursor.attempts),
-      remainingDateCursorPredicate(cursor),
-    ),
-  );
 
 /**
  * Remaining tier: newest decision first. A fresh decision is the one a


### PR DESCRIPTION
The deferred-document queue's remaining tier ordered by attempt count first:

```
attempts ASC, decision_date DESC NULLS LAST, id ASC
```

That reads as a tie-break but behaves as a partition. Every decision that had failed once sorted behind every decision still untried, so with a large untried backlog a transient failure did not come back after its cooldown; it came back after the backlog drained.

## Change

The tier now orders by decision date alone. Readiness is already the predicate's job: `outsideFetchCooldown` admits only a decision never attempted or attempted longer ago than the cooldown, so every row the order sees is one the queue may hand out now.

Dropping the attempt count does not unbound a document the source keeps refusing. The cooldown is what bounds it, at one attempt per cooldown rather than one per pass; leading with the attempt count added nothing to that and only moved the retry behind the backlog. The requested tier, and the attempt ceiling that moves a decision out of it into this one, are unchanged.

The remaining tier's keyset cursor loses its `attempts` component with the order it belonged to.

## Index

`case_law_decisions_document_pending_idx` was keyed to the old order, and the head of the queue is a bounded range scan only while the index matches the order it serves. The replacement, `case_law_decisions_document_pending_date_idx`, is keyed `(source_id, decision_date DESC NULLS LAST, id)` over the same partial predicate.

The migration builds the replacement `CONCURRENTLY` and leaves the superseded index in place. It does not drop it: a migration runs before the rolling deployment finishes, so tasks still on the previous revision keep ordering the tier by attempt count, and dropping the index they lead with would turn each of their queue refills into a sort over the whole backlog until the last one is replaced. Both orders therefore have an index for the whole rollout.

The migration names the removal condition — every runner on the new order, i.e. the release carrying this change fully rolled out — and a follow-up migration in a later release drops `case_law_decisions_document_pending_idx`.

## Tests

`sk-document-backfill-retry-order.db.test.ts` seeds one cooled failure dated between untried decisions and asserts it is served in its own date order rather than after all of them, that the fixture is one an attempt-led order would in fact starve (so the assertion cannot go vacuous), and that a failure still inside its cooldown stays out of the tier. Reverting the ordering change fails the first two.

The existing tier-shape and ordering tests are updated to the new rule.
