### PR TITLE
fix(web): wait for hydration commit before locale restore

### DIFF
--- a/.changeset/honest-hydration-commit.md
+++ b/.changeset/honest-hydration-commit.md
@@ -1,5 +1,6 @@
 ---
-"@stll/ssr-kit": patch
+"@stll/ssr-kit": minor
 ---
 
-Wait for server-rendered hydration to commit before initializing browser state.
+Require hydration callbacks to resolve after their render commits, replacing the
+removed `scheduleAfterPaint` option.

--- a/.changeset/honest-hydration-commit.md
+++ b/.changeset/honest-hydration-commit.md
@@ -1,0 +1,5 @@
+---
+"@stll/ssr-kit": patch
+---
+
+Wait for server-rendered hydration to commit before initializing browser state.

--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, startTransition } from "react";
+import { StrictMode, startTransition, useLayoutEffect } from "react";
 import { hydrateRoot } from "react-dom/client";
 
 import { CancelledError } from "@tanstack/react-query";
@@ -12,11 +12,26 @@ import { detached } from "@/lib/detached";
 import { installPreloadErrorRecovery } from "@/lib/preload-error-recovery";
 import { isPublicSsrPath } from "@/lib/public-ssr-paths";
 
-const hydrate = () => {
+type HydrationCommitSignalProps = {
+  onCommit: () => void;
+};
+
+const HydrationCommitSignal = ({ onCommit }: HydrationCommitSignalProps) => {
+  useLayoutEffect(() => {
+    onCommit();
+  }, [onCommit]);
+  return null;
+};
+
+const hydrate = async () => {
+  const hydrationCommit = Promise.withResolvers<undefined>();
   startTransition(() => {
     hydrateRoot(
       document,
       <StrictMode>
+        <HydrationCommitSignal
+          onCommit={() => hydrationCommit.resolve(undefined)}
+        />
         <RenderStormCanary>
           <StartClient />
         </RenderStormCanary>
@@ -34,13 +49,15 @@ const hydrate = () => {
       },
     );
   });
+  await hydrationCommit.promise;
 };
 
 // Recover from failed route-chunk imports before they blank the screen.
 installPreloadErrorRecovery();
 
 // The server renders public paths with bundled English. They hydrate against
-// that same state before persisted browser state loads after first paint.
+// that same state before persisted browser state loads after the hydration
+// commit.
 // Client-only paths resolve browser state before their first render.
 detached(
   bootHydratedClient({

--- a/packages/ssr-kit/README.md
+++ b/packages/ssr-kit/README.md
@@ -14,16 +14,19 @@ const isServerRendered = createPathMatcher([
 ]);
 ```
 
-The hydration entry keeps ordering explicit. An SSR document hydrates first,
-then initializes browser-owned state after paint; a client-only document
-initializes that state before its first render.
+The hydration entry keeps ordering explicit. An SSR document reports when its
+hydration commit completes, then initializes browser-owned state; a client-only
+document initializes that state before its first render.
 
 ```ts
 import { bootHydratedClient } from "@stll/ssr-kit/hydration";
 
 await bootHydratedClient({
   type: "server-rendered",
-  hydrate,
+  hydrate: hydrateAndWaitForCommit,
   initializeClientState,
 });
 ```
+
+`hydrateAndWaitForCommit` must resolve from the hydration tree's layout effect,
+not when the framework's hydrate function returns.

--- a/packages/ssr-kit/src/hydration.test.ts
+++ b/packages/ssr-kit/src/hydration.test.ts
@@ -3,37 +3,32 @@ import { describe, expect, test } from "bun:test";
 import { bootHydratedClient } from "./hydration";
 
 describe("client hydration boot", () => {
-  test("hydrates server markup before deferred browser state", async () => {
+  test("waits for the server markup to commit before loading browser state", async () => {
     const events: string[] = [];
-    let continueAfterPaint: (() => void) | undefined;
-    const afterPaint = new Promise<void>((resolve) => {
-      continueAfterPaint = resolve;
-    });
+    const hydrationCommit = Promise.withResolvers<undefined>();
     const completion = bootHydratedClient({
       type: "server-rendered",
-      hydrate: () => {
+      hydrate: async () => {
         events.push("hydrate");
+        await hydrationCommit.promise;
+        events.push("commit");
       },
       initializeClientState: async () => {
         events.push("initialize");
       },
-      scheduleAfterPaint: async () => {
-        events.push("schedule");
-        await afterPaint;
-      },
     });
 
-    expect(events).toEqual(["hydrate", "schedule"]);
-    continueAfterPaint?.();
+    expect(events).toEqual(["hydrate"]);
+    hydrationCommit.resolve(undefined);
     await completion;
-    expect(events).toEqual(["hydrate", "schedule", "initialize"]);
+    expect(events).toEqual(["hydrate", "commit", "initialize"]);
   });
 
   test("initializes browser state before rendering a client-only document", async () => {
     const events: string[] = [];
     await bootHydratedClient({
       type: "client-rendered",
-      hydrate: () => {
+      hydrate: async () => {
         events.push("hydrate");
       },
       initializeClientState: async () => {
@@ -49,7 +44,7 @@ describe("client hydration boot", () => {
     const failure = new TypeError("state unavailable");
     const completion = bootHydratedClient({
       type: "client-rendered",
-      hydrate: () => {
+      hydrate: async () => {
         events.push("hydrate");
       },
       initializeClientState: async () => {

--- a/packages/ssr-kit/src/hydration.ts
+++ b/packages/ssr-kit/src/hydration.ts
@@ -1,9 +1,7 @@
 import { panic } from "better-result";
 
-type ScheduleAfterPaint = () => Promise<void>;
-
 type HydrationBootBase = {
-  hydrate: () => void;
+  hydrate: () => Promise<void>;
   initializeClientState: () => Promise<unknown>;
 };
 
@@ -13,28 +11,21 @@ export type HydrationBootOptions =
     })
   | (HydrationBootBase & {
       type: "server-rendered";
-      scheduleAfterPaint?: ScheduleAfterPaint | undefined;
     });
-
-const defaultScheduleAfterPaint: ScheduleAfterPaint = async () => {
-  await new Promise<void>((resolve) => {
-    globalThis.requestAnimationFrame(() => {
-      globalThis.setTimeout(() => {
-        resolve();
-      }, 0);
-    });
-  });
-};
 
 export const bootHydratedClient = async (
   options: HydrationBootOptions,
 ): Promise<unknown> => {
   switch (options.type) {
-    case "client-rendered":
-      return await options.initializeClientState().finally(options.hydrate);
+    case "client-rendered": {
+      try {
+        return await options.initializeClientState();
+      } finally {
+        await options.hydrate();
+      }
+    }
     case "server-rendered":
-      options.hydrate();
-      await (options.scheduleAfterPaint ?? defaultScheduleAfterPaint)();
+      await options.hydrate();
       return await options.initializeClientState();
     default: {
       options satisfies never;


### PR DESCRIPTION
A persisted browser locale could replace the server-rendered English state before concurrent hydration committed. React then discarded the server tree, and the staging smoke found the public law date picker unresponsive after the resulting hydration mismatch.

This change makes the hydration callback resolve only from a layout effect in the committed tree. Server-rendered routes now wait for that signal before restoring browser-owned state; client-rendered routes keep restoring state before their first render.

Validation:
- `bun run verify`
- `bun --filter @stll/web build`
- post-rebase `@stll/ssr-kit` tests, lint, and typecheck
- post-rebase `@stll/web` lint and typecheck
- public law sitemap and hydration contract tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered application startup by waiting for hydration to commit before restoring persisted browser state.
  * Ensured client-only rendering continues to initialise reliably, including when hydration encounters an error.

* **Documentation**
  * Updated hydration guidance and examples to reflect commit-based initialisation.
  * Clarified that custom hydration handlers must resolve after the hydration tree’s layout effect.

* **Breaking Changes**
  * Removed the post-paint scheduling option from hydration configuration.
  * Hydration handlers must now return a promise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->