### PR TITLE
fix(desktop): clipboard over full-screen apps, link clips, image file copies

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -784,6 +784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,6 +1824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,12 +2395,25 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -88,9 +88,13 @@ dirs = "6"
 futures-util = "0.3"
 hex = "0.4"
 image = { version = "0.25", default-features = false, features = [
+  "bmp",
+  "gif",
   "ico",
+  "jpeg",
   "png",
   "tiff",
+  "webp",
 ] }
 keyring-core = "1"
 opener = "0.8"

--- a/apps/desktop/src-tauri/crates/macos-park/src/park.rs
+++ b/apps/desktop/src-tauri/crates/macos-park/src/park.rs
@@ -1,6 +1,8 @@
 use objc2::runtime::{AnyObject, NSObjectProtocol};
 use objc2::{ClassType, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
-use objc2_app_kit::{NSApplication, NSPanel, NSWindow, NSWindowStyleMask};
+use objc2_app_kit::{
+  NSApplication, NSPanel, NSWindow, NSWindowCollectionBehavior, NSWindowStyleMask,
+};
 use tauri::{Runtime, WebviewWindow};
 
 define_class!(
@@ -54,6 +56,16 @@ fn make_nonactivating_panel(ns_window: &NSWindow) {
   // this window.
   unsafe { AnyObject::set_class(ns_window, panel_class) };
   ns_window.setStyleMask(ns_window.styleMask() | NSWindowStyleMask::NonactivatingPanel);
+  // A full-screen app owns its own Space, and only a window marked
+  // FullScreenAuxiliary may be ordered onto it; the floating window level
+  // alone leaves the panel behind the full-screen app. CanJoinAllSpaces is
+  // what tao maps `visible_on_all_workspaces` to, and setting the behaviour
+  // replaces it wholesale, so keep it.
+  ns_window.setCollectionBehavior(
+    ns_window.collectionBehavior()
+      | NSWindowCollectionBehavior::FullScreenAuxiliary
+      | NSWindowCollectionBehavior::CanJoinAllSpaces,
+  );
   // The mask alone does not update the window server's prevents-activation
   // state on a window that already exists: keyboard use would stay
   // non-activating, but a click inside the panel would activate the app and

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -19,6 +19,7 @@ use std::{
   collections::{BTreeSet, HashMap, HashSet},
   io::{Cursor, Write},
   net::IpAddr,
+  path::Path,
   sync::{Arc, Mutex},
   time::{Duration as StdDuration, Instant},
 };
@@ -48,13 +49,11 @@ use icns::{IconFamily, PixelFormat};
 use image::{DynamicImage, ImageDecoder, codecs::bmp::BmpDecoder};
 #[cfg(target_os = "macos")]
 use objc2_app_kit::NSWorkspace;
-#[cfg(target_os = "windows")]
-use std::path::Path;
 #[cfg(target_os = "macos")]
 use std::{
   fs::File,
   io::BufReader,
-  path::{Component, Path, PathBuf},
+  path::{Component, PathBuf},
   sync::mpsc::sync_channel,
 };
 #[cfg(target_os = "windows")]
@@ -78,6 +77,13 @@ const MAX_ITEM_IMAGE_DIMENSION: u32 = 32_768;
 const MAX_ITEM_IMAGE_DECODE_BYTES: u64 = 192 * 1024 * 1024;
 const MAX_ITEM_IMAGE_PREVIEW_BYTES: usize = 512 * 1024;
 const MAX_ITEM_IMAGE_PREVIEW_EDGE: u32 = 512;
+/// Downscaling an oversized capture stops here: below this edge the clip has
+/// lost enough detail that keeping it would be worse than dropping it.
+const MIN_ITEM_IMAGE_STORED_EDGE: u32 = 512;
+/// Extensions a copied file must carry to be captured as an image; the
+/// decoder still decides whether the bytes are one.
+const CLIPBOARD_IMAGE_FILE_EXTENSIONS: [&str; 8] =
+  ["bmp", "gif", "jpeg", "jpg", "png", "tif", "tiff", "webp"];
 const MAX_HISTORY_IMAGE_BYTES: usize = 256 * 1024 * 1024;
 const MAX_ITEM_NAME_CHARACTERS: usize = 80;
 const MAX_HISTORY_BYTES: usize = 16 * 1024 * 1024;
@@ -1217,6 +1223,8 @@ struct ClipboardImageCapture {
   copied_at: DateTime<Utc>,
   height: u32,
   image: Vec<u8>,
+  /// Set when the copy names the image, as a copied file does.
+  name: Option<String>,
   preview: Vec<u8>,
   source_app: Option<ClipboardSourceApp>,
   source_app_visual: Option<ClipboardSourceAppVisual>,
@@ -1846,6 +1854,7 @@ impl ClipboardManager {
       copied_at,
       height,
       image,
+      name: captured_name,
       preview,
       source_app,
       source_app_visual,
@@ -1916,7 +1925,7 @@ impl ClipboardManager {
         height,
         id: id.clone(),
         image: Some(image.into()),
-        name,
+        name: name.or(captured_name),
         preview: Some(preview.into()),
         retention_class,
         source_app,
@@ -3272,7 +3281,7 @@ impl ClipboardHandler for HistoryClipboardHandler {
       }
       return;
     }
-    if should_ignore_formats(&formats) || self.clipboard.has(ContentFormat::Files) {
+    if should_ignore_formats(&formats) {
       return;
     }
     #[cfg(target_os = "windows")]
@@ -3289,6 +3298,10 @@ impl ClipboardHandler for HistoryClipboardHandler {
         (Some(app), source.visual)
       })
       .unwrap_or((None, None));
+    if self.clipboard.has(ContentFormat::Files) {
+      self.capture_copied_image_file(source_app, source_app_visual);
+      return;
+    }
     if self.clipboard.has(ContentFormat::Image) {
       match resolve_clipboard_image_capture(
         bounded_clipboard_image(&self.clipboard, &formats).and_then(|image| {
@@ -3301,12 +3314,12 @@ impl ClipboardHandler for HistoryClipboardHandler {
               return;
             }
             ClipboardCaptureOutcome::Rejected => {
-              tracing::debug!("clipboard image was not recorded; falling back to text");
+              tracing::warn!("clipboard image was not recorded; falling back to text");
             }
           }
         }
         ClipboardImageCaptureAttempt::ContinueWithText { error } => {
-          tracing::debug!(error = %error, "clipboard image could not be captured");
+          tracing::warn!(error = %error, "clipboard image could not be captured");
         }
       }
     }
@@ -3350,6 +3363,45 @@ impl ClipboardHandler for HistoryClipboardHandler {
 }
 
 impl HistoryClipboardHandler {
+  /// Captures a copied image file as an image clip. Every other file
+  /// selection is left alone: the history holds clips, not a file manager.
+  fn capture_copied_image_file(
+    &self,
+    source_app: Option<ClipboardSourceApp>,
+    source_app_visual: Option<ClipboardSourceAppVisual>,
+  ) {
+    let paths = match self.clipboard.get_files() {
+      Ok(paths) => paths,
+      Err(error) => {
+        tracing::debug!(error = %error, "clipboard file list could not be read");
+        return;
+      }
+    };
+    let Some(path) = single_clipboard_image_file(&paths) else {
+      tracing::debug!(
+        count = paths.len(),
+        "clipboard files are not a single image file"
+      );
+      return;
+    };
+    let capture = read_bounded_image_file(path)
+      .and_then(decode_bounded_clipboard_image)
+      .and_then(|image| normalized_image_capture(image, source_app, source_app_visual));
+    match capture {
+      Ok(capture) => {
+        self.capture(ClipboardCapture::Image(ClipboardImageCapture {
+          name: path
+            .file_stem()
+            .and_then(|stem| bounded_item_name(&stem.to_string_lossy())),
+          ..capture
+        }));
+      }
+      Err(error) => {
+        tracing::warn!(error = %error, "copied image file could not be captured");
+      }
+    }
+  }
+
   fn capture(&self, capture: ClipboardCapture) -> ClipboardCaptureOutcome {
     let source_page = capture.source_page().cloned();
     let outcome = match self.manager.lock() {
@@ -3557,6 +3609,47 @@ fn bounded_windows_clipboard_bytes(format: u32) -> Result<Vec<u8>, String> {
   Ok(encoded)
 }
 
+/// The one image file a copy selected, or None for anything else: a
+/// multi-file selection, or a path whose extension is not an image's.
+fn single_clipboard_image_file(paths: &[String]) -> Option<&Path> {
+  let [path] = paths else {
+    return None;
+  };
+  let path = Path::new(path);
+  let extension = path.extension()?.to_str()?;
+  CLIPBOARD_IMAGE_FILE_EXTENSIONS
+    .iter()
+    .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+    .then_some(path)
+}
+
+/// Reads a copied image file. The path comes from the user's own copy, but
+/// the watcher still only reads that one regular file, and only up to the
+/// source cap, so a directory or a huge file cannot pull the app under.
+fn read_bounded_image_file(path: &Path) -> Result<Vec<u8>, String> {
+  let metadata = std::fs::metadata(path)
+    .map_err(|error| format!("clipboard image file could not be read: {error}"))?;
+  if !metadata.is_file() {
+    return Err("clipboard image file is not a regular file".to_string());
+  }
+  let byte_size = usize::try_from(metadata.len())
+    .map_err(|_| "clipboard image source is too large".to_string())?;
+  validate_clipboard_image_source_size(byte_size)?;
+  let bytes = std::fs::read(path)
+    .map_err(|error| format!("clipboard image file could not be read: {error}"))?;
+  validate_clipboard_image_source_size(bytes.len())?;
+  Ok(bytes)
+}
+
+/// A name the capture itself supplies, held to the cap `set_item_name` keeps.
+fn bounded_item_name(value: &str) -> Option<String> {
+  let name = value.trim();
+  if name.is_empty() {
+    return None;
+  }
+  Some(name.chars().take(MAX_ITEM_NAME_CHARACTERS).collect())
+}
+
 fn validate_clipboard_image_source_size(byte_size: usize) -> Result<(), String> {
   if byte_size == 0 || byte_size > MAX_ITEM_IMAGE_SOURCE_BYTES {
     return Err("clipboard image source is too large".to_string());
@@ -3587,10 +3680,26 @@ fn normalized_image_capture(
   if width == 0 || height == 0 || pixels > MAX_ITEM_IMAGE_PIXELS {
     return Err("clipboard image dimensions are invalid".to_string());
   }
-  let image_bytes = encode_png_bounded(&image, MAX_ITEM_IMAGE_BYTES)?;
+  // A large screenshot re-encodes past the item cap as RGBA PNG. Halving the
+  // stored copy until it fits keeps the clip; the alternative is dropping it.
+  let mut stored = image;
+  let (image_bytes, width, height) = loop {
+    let (width, height) = stored.get_size();
+    match encode_png_bounded(&stored, MAX_ITEM_IMAGE_BYTES) {
+      Ok(encoded) => break (encoded, width, height),
+      Err(error) => {
+        if width.max(height) / 2 < MIN_ITEM_IMAGE_STORED_EDGE {
+          return Err(error);
+        }
+        stored = stored
+          .thumbnail(width / 2, height / 2)
+          .map_err(|error| format!("clipboard image downscale failed: {error}"))?;
+      }
+    }
+  };
   let mut preview_edge = MAX_ITEM_IMAGE_PREVIEW_EDGE;
   let preview = loop {
-    let thumbnail = image
+    let thumbnail = stored
       .thumbnail(preview_edge, preview_edge)
       .map_err(|error| format!("clipboard image preview failed: {error}"))?;
     match encode_png_bounded(&thumbnail, MAX_ITEM_IMAGE_PREVIEW_BYTES) {
@@ -3604,6 +3713,7 @@ fn normalized_image_capture(
     copied_at: Utc::now(),
     height,
     image: image_bytes,
+    name: None,
     preview,
     source_app,
     source_app_visual,
@@ -3825,6 +3935,12 @@ mod tests {
     let mut manager = ClipboardManager::new();
     manager.install(ClipboardLoad::MemoryOnly);
     manager
+  }
+
+  /// A path in the system temp directory no other test can collide with.
+  fn temp_test_path(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir()
+      .join(format!("stella-clipboard-{}-{name}", uuid::Uuid::new_v4()))
   }
 
   fn text_item(copied_at: DateTime<Utc>, text: &str) -> ClipboardItem {
@@ -4434,6 +4550,108 @@ mod tests {
 
     assert!(encode_png_bounded(&image, 8).is_err());
     assert!(encode_png_bounded(&image, MAX_ITEM_IMAGE_BYTES).is_ok());
+  }
+
+  #[test]
+  fn an_image_past_the_item_limit_is_stored_downscaled() {
+    let (width, height) = (3000_u32, 2500_u32);
+    // Noise so the encoding cannot compress under the cap.
+    let mut seed = 0x2545_f491_4f6c_dd1d_u64;
+    let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+    for _ in 0..width * height * 4 {
+      seed = seed
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+      pixels.push((seed >> 33) as u8);
+    }
+    let image = RustImageData::from_dynamic_image(image::DynamicImage::ImageRgba8(
+      image::RgbaImage::from_raw(width, height, pixels).unwrap(),
+    ));
+
+    let capture = normalized_image_capture(image, None, None).unwrap();
+
+    assert!(capture.image.len() <= MAX_ITEM_IMAGE_BYTES);
+    assert!(capture.width < width && capture.height < height);
+    assert!(capture.width.max(capture.height) >= MIN_ITEM_IMAGE_STORED_EDGE);
+    // The recorded size is the stored one, not the source's.
+    let stored = ImageReader::new(Cursor::new(capture.image.as_slice()))
+      .with_guessed_format()
+      .unwrap()
+      .into_dimensions()
+      .unwrap();
+    assert_eq!(stored, (capture.width, capture.height));
+  }
+
+  #[test]
+  fn only_a_single_image_file_selection_is_captured() {
+    let selected = ["/copies/Exhibit A.PNG".to_string()];
+    assert_eq!(
+      single_clipboard_image_file(&selected),
+      Some(Path::new("/copies/Exhibit A.PNG"))
+    );
+    assert!(single_clipboard_image_file(&[]).is_none());
+    assert!(
+      single_clipboard_image_file(&[
+        "/copies/one.png".to_string(),
+        "/copies/two.png".to_string(),
+      ])
+      .is_none()
+    );
+    assert!(single_clipboard_image_file(&["/copies/deed.pdf".to_string()]).is_none());
+    assert!(single_clipboard_image_file(&["/copies/README".to_string()]).is_none());
+  }
+
+  #[test]
+  fn a_copied_image_file_is_read_only_as_a_bounded_regular_file() {
+    let file = temp_test_path("copy.png");
+    std::fs::write(&file, b"exhibit bytes").unwrap();
+    assert_eq!(read_bounded_image_file(&file).unwrap(), b"exhibit bytes");
+    std::fs::remove_file(&file).unwrap();
+
+    let empty = temp_test_path("empty.png");
+    std::fs::write(&empty, b"").unwrap();
+    assert!(read_bounded_image_file(&empty).is_err());
+    std::fs::remove_file(&empty).unwrap();
+
+    let directory = temp_test_path("bundle.png");
+    std::fs::create_dir(&directory).unwrap();
+    assert!(read_bounded_image_file(&directory).is_err());
+    std::fs::remove_dir(&directory).unwrap();
+
+    assert!(read_bounded_image_file(&temp_test_path("missing.png")).is_err());
+  }
+
+  #[test]
+  fn a_capture_name_is_trimmed_bounded_and_kept_on_the_item() {
+    assert_eq!(
+      bounded_item_name("  Exhibit A  ").as_deref(),
+      Some("Exhibit A")
+    );
+    assert!(bounded_item_name("   ").is_none());
+    assert_eq!(
+      bounded_item_name(&"界".repeat(MAX_ITEM_NAME_CHARACTERS + 5))
+        .unwrap()
+        .chars()
+        .count(),
+      MAX_ITEM_NAME_CHARACTERS
+    );
+
+    let mut manager = ready_manager();
+    manager
+      .capture(ClipboardCapture::Image(ClipboardImageCapture {
+        checksum: "file-checksum".to_string(),
+        copied_at: Utc::now(),
+        height: 2,
+        image: vec![0x89, 0x50, 0x4e, 0x47],
+        name: bounded_item_name("Exhibit A"),
+        preview: vec![0x89, 0x50, 0x4e, 0x47],
+        source_app: None,
+        source_app_visual: None,
+        width: 3,
+      }))
+      .unwrap();
+
+    assert_eq!(manager.items[0].name(), Some("Exhibit A"));
   }
 
   #[test]
@@ -5780,6 +5998,7 @@ mod tests {
         copied_at: Utc::now(),
         height: 1,
         image: vec![1],
+        name: None,
         preview: vec![1],
         source_app: None,
         source_app_visual: None,
@@ -5802,6 +6021,7 @@ mod tests {
         copied_at,
         height: 2,
         image: vec![0x89, 0x50, 0x4e, 0x47],
+        name: None,
         preview: vec![0x89, 0x50, 0x4e, 0x47],
         source_app: None,
         source_app_visual: None,

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -3635,8 +3635,16 @@ fn read_bounded_image_file(path: &Path) -> Result<Vec<u8>, String> {
   let byte_size = usize::try_from(metadata.len())
     .map_err(|_| "clipboard image source is too large".to_string())?;
   validate_clipboard_image_source_size(byte_size)?;
-  let bytes = std::fs::read(path)
+  // The file can grow between the metadata check and the read, so the read
+  // itself stops one byte past the cap rather than trusting the length.
+  let file = std::fs::File::open(path)
     .map_err(|error| format!("clipboard image file could not be read: {error}"))?;
+  let mut bytes = Vec::with_capacity(byte_size);
+  std::io::Read::read_to_end(
+    &mut std::io::Read::take(file, MAX_ITEM_IMAGE_SOURCE_BYTES as u64 + 1),
+    &mut bytes,
+  )
+  .map_err(|error| format!("clipboard image file could not be read: {error}"))?;
   validate_clipboard_image_source_size(bytes.len())?;
   Ok(bytes)
 }

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -34,6 +34,7 @@ import {
   FolderPlusIcon,
   ImageIcon,
   KeyboardIcon,
+  LinkIcon,
   LockKeyholeIcon,
   PauseIcon,
   PencilIcon,
@@ -97,6 +98,7 @@ import {
   CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
+  clipboardItemLink,
   clipboardPointerMoved,
   clipboardRailScrollDelta,
   clipboardRailWindow,
@@ -334,7 +336,9 @@ const ClipboardCard = ({
     ? { "--clipboard-source-accent": accent }
     : undefined;
   const rendersHtml = item.type === "formattedText" && !query;
-  const fallbackName = item.type === "image" ? t("image") : t("unnamedClip");
+  const link = clipboardItemLink(item);
+  const fallbackName =
+    item.type === "image" ? t("image") : (link?.host ?? t("unnamedClip"));
   // An unnamed browser copy is named after the page it came from.
   const untitledName =
     item.sourceApp?.page && sourceLabel ? sourceLabel : fallbackName;
@@ -412,6 +416,11 @@ const ClipboardCard = ({
       <ImageIcon aria-hidden="true" className="text-muted-foreground size-6" />
     );
   }
+  if (link) {
+    metadataIcon = (
+      <LinkIcon aria-hidden="true" className="text-muted-foreground size-6" />
+    );
+  }
   if (groupName) {
     metadataIcon = (
       <TagsIcon aria-hidden="true" className="text-muted-foreground size-6" />
@@ -437,6 +446,9 @@ const ClipboardCard = ({
   }
   if (item.type === "image") {
     metadataTitle = t("image");
+  }
+  if (link) {
+    metadataTitle = t("link");
   }
 
   const beginNameEdit = () => {

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -1,3 +1,5 @@
+import { Result } from "better-result";
+
 import {
   findSearchMatchRanges,
   foldSearchMatchText,
@@ -53,10 +55,12 @@ export const clipboardItemLink = (
     .startsWith(CLIPBOARD_LINK_BARE_HOST_PREFIX)
     ? `https://${text}`
     : text;
-  if (!URL.canParse(candidate)) {
+  // `URL.canParse` is newer than the oldest supported system WebView.
+  const parsed = Result.try(() => new URL(candidate));
+  if (!Result.isOk(parsed)) {
     return null;
   }
-  const url = new URL(candidate);
+  const url = parsed.value;
   if (!CLIPBOARD_LINK_PROTOCOLS.has(url.protocol)) {
     return null;
   }

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -21,7 +21,7 @@ export const clipboardSourceLabel = (sourceApp: ClipboardSourceApp) =>
 export const clipboardSourceTitle = (sourceApp: ClipboardSourceApp) =>
   sourceApp.page?.url ?? sourceApp.name;
 
-export type ClipboardItemLink = { host: string; url: string };
+export type ClipboardItemLink = { host: string };
 
 /** Past this a clip is a document that happens to hold no spaces, not a link. */
 const CLIPBOARD_LINK_MAX_CHARACTERS = 2048;
@@ -61,15 +61,13 @@ export const clipboardItemLink = (
     return null;
   }
   if (url.protocol === "mailto:") {
-    return url.pathname.length === 0
-      ? null
-      : { host: url.pathname, url: url.href };
+    return url.pathname.length === 0 ? null : { host: url.pathname };
   }
   // `www.` on its own, and `www..com`, parse but leave an empty label.
   if (url.hostname.split(".").some((label) => label.length === 0)) {
     return null;
   }
-  return { host: url.hostname.replace(/^www\./u, ""), url: url.href };
+  return { host: url.hostname.replace(/^www\./u, "") };
 };
 
 export const CLIPBOARD_ITEM_DRAG_TYPE =

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -21,6 +21,57 @@ export const clipboardSourceLabel = (sourceApp: ClipboardSourceApp) =>
 export const clipboardSourceTitle = (sourceApp: ClipboardSourceApp) =>
   sourceApp.page?.url ?? sourceApp.name;
 
+export type ClipboardItemLink = { host: string; url: string };
+
+/** Past this a clip is a document that happens to hold no spaces, not a link. */
+const CLIPBOARD_LINK_MAX_CHARACTERS = 2048;
+
+const CLIPBOARD_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+const CLIPBOARD_LINK_BARE_HOST_PREFIX = "www.";
+
+/**
+ * The link a clip is, or null when it is text that merely contains one: the
+ * whole clip has to be the URL, so a paragraph quoting one stays text.
+ */
+export const clipboardItemLink = (
+  item: ClipboardItem,
+): ClipboardItemLink | null => {
+  if (item.type === "image") {
+    return null;
+  }
+  const text = item.plainText.trim();
+  if (
+    text.length === 0 ||
+    text.length > CLIPBOARD_LINK_MAX_CHARACTERS ||
+    /\s/u.test(text)
+  ) {
+    return null;
+  }
+  const candidate = text
+    .toLowerCase()
+    .startsWith(CLIPBOARD_LINK_BARE_HOST_PREFIX)
+    ? `https://${text}`
+    : text;
+  if (!URL.canParse(candidate)) {
+    return null;
+  }
+  const url = new URL(candidate);
+  if (!CLIPBOARD_LINK_PROTOCOLS.has(url.protocol)) {
+    return null;
+  }
+  if (url.protocol === "mailto:") {
+    return url.pathname.length === 0
+      ? null
+      : { host: url.pathname, url: url.href };
+  }
+  // `www.` on its own, and `www..com`, parse but leave an empty label.
+  if (url.hostname.split(".").some((label) => label.length === 0)) {
+    return null;
+  }
+  return { host: url.hostname.replace(/^www\./u, ""), url: url.href };
+};
+
 export const CLIPBOARD_ITEM_DRAG_TYPE =
   "application/x-stella-clipboard-item-id";
 

--- a/apps/desktop/src/i18n/langs/cs.json
+++ b/apps/desktop/src/i18n/langs/cs.json
@@ -142,6 +142,7 @@
     "groups": "Skupiny",
     "itemCount": "{count, plural, one {1 položka} few {{count} položky} other {{count} položek}}",
     "keyboardNavigate": "← → procházet",
+    "link": "Odkaz",
     "local": "Místní",
     "memoryOnly": "Šifrované úložiště není dostupné. Historie zůstane jen do ukončení stella desktop.",
     "moreOptions": "Další možnosti",

--- a/apps/desktop/src/i18n/langs/de.json
+++ b/apps/desktop/src/i18n/langs/de.json
@@ -142,6 +142,7 @@
     "groups": "Gruppen",
     "itemCount": "{count, plural, one {1 Eintrag} other {{count} Einträge}}",
     "keyboardNavigate": "← → navigieren",
+    "link": "Link",
     "local": "Lokal",
     "memoryOnly": "Der verschlüsselte Speicher ist nicht verfügbar. Der Verlauf bleibt nur bis zum Beenden von stella desktop erhalten.",
     "moreOptions": "Weitere Optionen",

--- a/apps/desktop/src/i18n/langs/en.json
+++ b/apps/desktop/src/i18n/langs/en.json
@@ -144,6 +144,7 @@
     "groups": "Groups",
     "itemCount": "{count, plural, one {1 item} other {{count} items}}",
     "keyboardNavigate": "← → navigate",
+    "link": "Link",
     "local": "Local",
     "memoryOnly": "Encrypted storage is unavailable. History will be kept only until stella desktop quits.",
     "moreOptions": "More options",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -142,6 +142,7 @@
     "groups": "Grupos",
     "itemCount": "{count, plural, one {1 elemento} other {{count} elementos}}",
     "keyboardNavigate": "← → navegar",
+    "link": "Enlace",
     "local": "Local",
     "memoryOnly": "El almacenamiento cifrado no está disponible. El historial se conservará solo hasta cerrar stella desktop.",
     "moreOptions": "Más opciones",

--- a/apps/desktop/src/i18n/langs/et.json
+++ b/apps/desktop/src/i18n/langs/et.json
@@ -142,6 +142,7 @@
     "groups": "Rühmad",
     "itemCount": "{count, plural, one {1 kirje} other {{count} kirjet}}",
     "keyboardNavigate": "← → liigu",
+    "link": "Link",
     "local": "Kohalik",
     "memoryOnly": "Krüpteeritud salvestusruum pole saadaval. Ajalugu säilib ainult stella desktop sulgemiseni.",
     "moreOptions": "Rohkem valikuid",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -142,6 +142,7 @@
     "groups": "Groupes",
     "itemCount": "{count, plural, one {1 élément} other {{count} éléments}}",
     "keyboardNavigate": "← → naviguer",
+    "link": "Lien",
     "local": "Local",
     "memoryOnly": "Le stockage chiffré est indisponible. L’historique sera conservé uniquement jusqu’à la fermeture de stella desktop.",
     "moreOptions": "Plus d’options",

--- a/apps/desktop/src/i18n/langs/hu.json
+++ b/apps/desktop/src/i18n/langs/hu.json
@@ -142,6 +142,7 @@
     "groups": "Csoportok",
     "itemCount": "{count, plural, one {1 elem} other {{count} elem}}",
     "keyboardNavigate": "← → navigálás",
+    "link": "Hivatkozás",
     "local": "Helyi",
     "memoryOnly": "A titkosított tárhely nem érhető el. Az előzmények csak a stella desktop bezárásáig maradnak meg.",
     "moreOptions": "További lehetőségek",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -142,6 +142,7 @@
     "groups": "Grupės",
     "itemCount": "{count, plural, one {1 elementas} few {{count} elementai} other {{count} elementų}}",
     "keyboardNavigate": "← → naršyti",
+    "link": "Nuoroda",
     "local": "Vietinė",
     "memoryOnly": "Šifruota saugykla nepasiekiama. Istorija bus laikoma tik iki stella desktop uždarymo.",
     "moreOptions": "Daugiau parinkčių",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -142,6 +142,7 @@
     "groups": "Grupas",
     "itemCount": "{count, plural, one {1 vienums} other {{count} vienumi}}",
     "keyboardNavigate": "← → pārvietoties",
+    "link": "Saite",
     "local": "Lokāli",
     "memoryOnly": "Šifrētā krātuve nav pieejama. Vēsture tiks saglabāta tikai līdz stella desktop aizvēršanai.",
     "moreOptions": "Vairāk iespēju",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -142,6 +142,7 @@
     "groups": "Grupy",
     "itemCount": "{count, plural, one {1 element} few {{count} elementy} other {{count} elementów}}",
     "keyboardNavigate": "← → nawigacja",
+    "link": "Link",
     "local": "Lokalnie",
     "memoryOnly": "Zaszyfrowana pamięć jest niedostępna. Historia zostanie zachowana tylko do zamknięcia stella desktop.",
     "moreOptions": "Więcej opcji",

--- a/apps/desktop/src/i18n/langs/sk.json
+++ b/apps/desktop/src/i18n/langs/sk.json
@@ -142,6 +142,7 @@
     "groups": "Skupiny",
     "itemCount": "{count, plural, one {1 položka} few {{count} položky} other {{count} položiek}}",
     "keyboardNavigate": "← → prechádzať",
+    "link": "Odkaz",
     "local": "Miestne",
     "memoryOnly": "Šifrované úložisko nie je dostupné. História zostane len do ukončenia stella desktop.",
     "moreOptions": "Ďalšie možnosti",

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -5,6 +5,7 @@ import {
   CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
+  clipboardItemLink,
   clipboardPointerMoved,
   clipboardTimelineKeyAction,
   clipboardRailScrollDelta,
@@ -658,5 +659,63 @@ test("formatClipboardAge uses stable low-noise buckets", () => {
     type: "elapsed",
     unit: "day",
     value: 3,
+  });
+});
+
+describe("clipboardItemLink", () => {
+  const linkOf = (plainText: string) =>
+    clipboardItemLink({ ...TEXT_ITEM, plainText });
+
+  test("reads https, http and www clips", () => {
+    expect(linkOf("https://example.com/deal")).toEqual({
+      host: "example.com",
+      url: "https://example.com/deal",
+    });
+    expect(linkOf("http://docs.example.co.uk/a?b=1")?.host).toBe(
+      "docs.example.co.uk",
+    );
+    expect(linkOf("www.example.com/deal")).toEqual({
+      host: "example.com",
+      url: "https://www.example.com/deal",
+    });
+  });
+
+  test("reads a mailto clip as its address", () => {
+    expect(linkOf("mailto:counsel@example.com")).toEqual({
+      host: "counsel@example.com",
+      url: "mailto:counsel@example.com",
+    });
+  });
+
+  test("ignores scheme case and surrounding whitespace", () => {
+    expect(linkOf("  HTTPS://Example.com  ")).toEqual({
+      host: "example.com",
+      url: "https://example.com/",
+    });
+  });
+
+  test("keeps text that merely contains a link as text", () => {
+    expect(linkOf("See https://example.com for the filing")).toBeNull();
+    expect(linkOf("https://example.com\nhttps://example.org")).toBeNull();
+  });
+
+  test("rejects a clip longer than the link cap", () => {
+    expect(linkOf(`https://example.com/${"a".repeat(2048)}`)).toBeNull();
+  });
+
+  test("rejects a clip that is not a link", () => {
+    expect(linkOf("Share purchase agreement")).toBeNull();
+    expect(linkOf("example.com")).toBeNull();
+    expect(linkOf("ftp://example.com/filing.zip")).toBeNull();
+    expect(clipboardItemLink(IMAGE_ITEM)).toBeNull();
+  });
+
+  test("reads a formatted clip whose plain text is a link", () => {
+    expect(
+      clipboardItemLink({
+        ...FORMATTED_ITEM,
+        plainText: "https://example.com/exhibit",
+      })?.host,
+    ).toBe("example.com");
   });
 });

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -667,31 +667,21 @@ describe("clipboardItemLink", () => {
     clipboardItemLink({ ...TEXT_ITEM, plainText });
 
   test("reads https, http and www clips", () => {
-    expect(linkOf("https://example.com/deal")).toEqual({
-      host: "example.com",
-      url: "https://example.com/deal",
-    });
+    expect(linkOf("https://example.com/deal")).toEqual({ host: "example.com" });
     expect(linkOf("http://docs.example.co.uk/a?b=1")?.host).toBe(
       "docs.example.co.uk",
     );
-    expect(linkOf("www.example.com/deal")).toEqual({
-      host: "example.com",
-      url: "https://www.example.com/deal",
-    });
+    expect(linkOf("www.example.com/deal")).toEqual({ host: "example.com" });
   });
 
   test("reads a mailto clip as its address", () => {
     expect(linkOf("mailto:counsel@example.com")).toEqual({
       host: "counsel@example.com",
-      url: "mailto:counsel@example.com",
     });
   });
 
   test("ignores scheme case and surrounding whitespace", () => {
-    expect(linkOf("  HTTPS://Example.com  ")).toEqual({
-      host: "example.com",
-      url: "https://example.com/",
-    });
+    expect(linkOf("  HTTPS://Example.com  ")).toEqual({ host: "example.com" });
   });
 
   test("keeps text that merely contains a link as text", () => {


### PR DESCRIPTION
Three fixes in the desktop clipboard manager.

## The clipboard window over a full-screen app (macOS)

The window is built with `visible_on_all_workspaces(true)`, which tao maps to
`NSWindowCollectionBehaviorCanJoinAllSpaces` only. A full-screen app runs in
its own Space and accepts only windows marked
`NSWindowCollectionBehaviorFullScreenAuxiliary`, so the panel stayed behind it
and the floating level did not help. `make_nonactivating_panel` now sets both
bits on the window's collection behaviour when it re-classes the window into
the non-activating panel.

## Link clips

`clipboardItemLink` in `clipboard-logic.ts` reads a clip as a link when its
whole trimmed text is a single token of at most 2048 characters that parses as
`http:`, `https:` or `mailto:`, or a bare `www.` host (parsed with `https://`
prefixed). Text that merely contains a URL stays text. The card then shows the
link icon, the `link` label, and the host as its fallback name; the persisted
and IPC shapes are unchanged, and the source-app and group precedence for the
metadata icon is untouched. `link` is added to all eleven language files.

## Image copies

- Copying a single image file (`png`, `jpg`, `jpeg`, `gif`, `tif`, `tiff`,
  `webp`, `bmp`) is captured as an image clip named after the file stem. The
  path comes from the user's copy but is treated as untrusted input: one
  regular file, read once, bounded by `MAX_ITEM_IMAGE_SOURCE_BYTES`, decoded
  through the existing `decode_bounded_clipboard_image` path. Every other file
  selection stays ignored, with a debug line naming why. `jpeg`, `gif`, `webp`
  and `bmp` are enabled on the `image` crate.
- An image whose RGBA PNG encoding exceeds `MAX_ITEM_IMAGE_BYTES` is halved and
  retried until it fits, stopping when the longer edge would fall below 512
  pixels. Previously such a clip was dropped. The capture records the stored
  dimensions, and the preview is derived from the stored copy.
- The two log lines that swallow an image capture failure are warnings now, so
  a dropped clip is visible at the desktop log's INFO level.

Tests: `single_clipboard_image_file`, `read_bounded_image_file`,
`bounded_item_name` plus the name reaching the item, and a large noisy image
being stored downscaled rather than rejected; seven cases for
`clipboardItemLink`.
