### PR TITLE
feat(web): AVT domain model and shared primitives (1/5)

### DIFF
--- a/apps/web/src/routes/dev/-components/avt/avt-store.test.ts
+++ b/apps/web/src/routes/dev/-components/avt/avt-store.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
+
+import { useAvtStore } from "@/routes/dev/-components/avt/avt-store";
+
+afterEach(() => {
+  setSystemTime();
+  useAvtStore.setState({ reviews: {} });
+});
+
+describe("AVT review decision timestamps", () => {
+  test("records the time of direct status and override decisions", () => {
+    setSystemTime(new Date("2026-01-01T12:00:00Z"));
+    useAvtStore.getState().setReviewStatus("claim-1", "reviewed");
+    const statusStamp = useAvtStore.getState().reviews["claim-1"]?.decisionAt;
+
+    setSystemTime(new Date("2026-01-02T12:00:00Z"));
+    useAvtStore.getState().setOverride("claim-1", "supported");
+    const overrideStamp = useAvtStore.getState().reviews["claim-1"]?.decisionAt;
+
+    expect(statusStamp).not.toBeNull();
+    expect(overrideStamp).not.toBeNull();
+    expect(overrideStamp).not.toBe(statusStamp);
+  });
+
+  test("clears stale dispositions when a record conflict changes", () => {
+    useAvtStore.setState({
+      reviews: {
+        "claim-1": {
+          status: "reviewed",
+          override: "supported",
+          note: "Keep this note",
+          savedAt: "2026-01-01 12:00",
+          decisionAt: "2026-01-01T12:00:00.000Z",
+        },
+      },
+    });
+
+    useAvtStore
+      .getState()
+      .resolveRecordConflict("claim-1", { kind: "escalated" });
+
+    expect(useAvtStore.getState().reviews["claim-1"]).toMatchObject({
+      status: null,
+      override: null,
+      note: "Keep this note",
+      savedAt: "2026-01-01 12:00",
+      recordConflictResolution: { kind: "escalated" },
+    });
+  });
+});

--- a/apps/web/src/routes/dev/-components/avt/avt-store.ts
+++ b/apps/web/src/routes/dev/-components/avt/avt-store.ts
@@ -1,0 +1,203 @@
+/**
+ * AVT — client-side store for anchor-fact edits and per-claim review
+ * state. In-memory only (no persistence, no backend) for this pass —
+ * matches the "vibecode a rough version" scope. `facts` are seeded
+ * from the sample record so edits made in the anchor-facts panel are
+ * visible everywhere a fact is cited (detail cards, record-conflict
+ * resolution), rather than each screen holding its own copy.
+ */
+
+import { create } from "zustand";
+
+import { Temporal } from "@stll/time";
+
+import { ANCHOR_FACTS } from "@/routes/dev/-components/avt/sample-data";
+import type {
+  AnchorFact,
+  ClaimReview,
+  ConfidenceLevel,
+  RecordConflictResolution,
+  ReviewerOverrideState,
+  ReviewStatus,
+} from "@/routes/dev/-components/avt/types";
+import { EMPTY_REVIEW } from "@/routes/dev/-components/avt/types";
+
+/** Store an absolute instant; UI owners localize it for the viewer. */
+const nowInstant = (): string => Temporal.Now.instant().toString();
+
+const seedFacts = (): Record<string, AnchorFact> => {
+  const facts: Record<string, AnchorFact> = {};
+  for (const fact of ANCHOR_FACTS) {
+    facts[fact.id] = { ...fact };
+  }
+  return facts;
+};
+
+type AvtState = {
+  facts: Record<string, AnchorFact>;
+  reviews: Record<string, ClaimReview>;
+};
+
+type AvtActions = {
+  setFactConfidence: (factId: string, confidence: ConfidenceLevel) => void;
+  acceptFact: (factId: string) => void;
+  editFact: (factId: string, text: string) => void;
+
+  setReviewStatus: (claimId: string, status: ReviewStatus | null) => void;
+  setOverride: (
+    claimId: string,
+    override: ReviewerOverrideState | null,
+  ) => void;
+  setNote: (claimId: string, note: string) => void;
+  bulkSetReviewed: (claimIds: readonly string[]) => void;
+  reopenClaim: (claimId: string) => void;
+  resolveRecordConflict: (
+    claimId: string,
+    resolution: RecordConflictResolution | null,
+  ) => void;
+};
+
+const patchReview = (
+  state: AvtState,
+  claimId: string,
+  patch: Partial<ClaimReview>,
+): Pick<AvtState, "reviews"> => ({
+  reviews: {
+    ...state.reviews,
+    [claimId]: { ...(state.reviews[claimId] ?? EMPTY_REVIEW), ...patch },
+  },
+});
+
+export const useAvtStore = create<AvtState & AvtActions>()((set) => ({
+  facts: seedFacts(),
+  reviews: {},
+
+  setFactConfidence: (factId, confidence) => {
+    set((state) => {
+      const fact = state.facts[factId];
+      if (!fact) {
+        return state;
+      }
+      return { facts: { ...state.facts, [factId]: { ...fact, confidence } } };
+    });
+  },
+
+  acceptFact: (factId) => {
+    set((state) => {
+      const fact = state.facts[factId];
+      if (!fact) {
+        return state;
+      }
+      return {
+        facts: {
+          ...state.facts,
+          [factId]: { ...fact, flag: false, accepted: true },
+        },
+      };
+    });
+  },
+
+  editFact: (factId, text) => {
+    set((state) => {
+      const fact = state.facts[factId];
+      if (!fact) {
+        return state;
+      }
+      return {
+        facts: {
+          ...state.facts,
+          [factId]: { ...fact, fact: text, flag: false, accepted: true },
+        },
+      };
+    });
+  },
+
+  setReviewStatus: (claimId, status) => {
+    set((state) =>
+      patchReview(state, claimId, { status, decisionAt: nowInstant() }),
+    );
+  },
+
+  setOverride: (claimId, override) => {
+    set((state) =>
+      patchReview(state, claimId, { override, decisionAt: nowInstant() }),
+    );
+  },
+
+  setNote: (claimId, note) => {
+    set((state) =>
+      patchReview(state, claimId, {
+        note,
+        savedAt: note
+          ? nowInstant()
+          : (state.reviews[claimId]?.savedAt ?? null),
+      }),
+    );
+  },
+
+  /** One audit-trail action for the long tail of routine, not-yet-settled claims. */
+  bulkSetReviewed: (claimIds) => {
+    if (claimIds.length === 0) {
+      return;
+    }
+    const decisionAt = nowInstant();
+    set((state) => {
+      const reviews = { ...state.reviews };
+      for (const claimId of claimIds) {
+        const current = reviews[claimId] ?? EMPTY_REVIEW;
+        if (current.status === "reviewed" || current.status === "disputed") {
+          continue;
+        }
+        reviews[claimId] = {
+          ...current,
+          status: "reviewed",
+          decisionAt,
+          bulk: true,
+        };
+      }
+      return { reviews };
+    });
+  },
+
+  /**
+   * Re-open a set-aside claim: the reviewer has decided it IS a
+   * checkable fact. No live model is wired up in this build, so this
+   * always lands on the same deterministic fallback the prototype uses
+   * offline — "no coverage, pending check".
+   *
+   * `resolveClaimView` derives the resulting `nocover` state from
+   * `reopened` alone, so no `override` is written here: an override is a
+   * reviewer's annotation sitting alongside the tool's verdict, and
+   * recording one made a re-opened claim render an "Overridden to No
+   * coverage" badge nobody asked for, contradicting the panel's own
+   * "pending check" message.
+   *
+   * Any earlier `status` and `override` are cleared, because both
+   * described the claim as it was BEFORE the reclassification. Left in
+   * place, a claim previously marked reviewed stayed settled while
+   * pending a re-check, and a stale override still won in
+   * `effectiveState` — so the tiles and underlines went on showing the
+   * superseded verdict rather than the pending one.
+   */
+  reopenClaim: (claimId) => {
+    set((state) =>
+      patchReview(state, claimId, {
+        reopened: true,
+        status: null,
+        override: null,
+        decisionAt: nowInstant(),
+      }),
+    );
+  },
+
+  resolveRecordConflict: (claimId, resolution) => {
+    set((state) =>
+      patchReview(state, claimId, {
+        recordConflictResolution: resolution,
+        status: null,
+        override: null,
+        decisionAt: nowInstant(),
+      }),
+    );
+  },
+}));

--- a/apps/web/src/routes/dev/-components/avt/sample-data.ts
+++ b/apps/web/src/routes/dev/-components/avt/sample-data.ts
@@ -1,0 +1,504 @@
+/**
+ * AVT — sample case data (anonymised UK financial-inquiry scenario).
+ *
+ * Ported verbatim from the prototype's `app/data.js`. This is
+ * placeholder content for the client-side pass; swapping in a real
+ * Stella document later means writing an adapter from Stella's
+ * `fields`/`justifications` records into this same shape (see
+ * `types.ts`), not rebuilding the screens below.
+ */
+
+import type {
+  AnchorFact,
+  CaseDocument,
+  Claim,
+} from "@/routes/dev/-components/avt/types";
+
+export const ANCHOR_FACTS: readonly AnchorFact[] = [
+  {
+    id: "CAL-01",
+    fact: 'Calendar invitation "Intro — E.W. / J. Harrow" shown as accepted.',
+    source: "Outlook export",
+    page: "p.14",
+    date: "9 Mar 2021",
+    kind: "Calendar",
+    confidence: "High",
+    period: "9 Mar 2021",
+  },
+  {
+    id: "EM-04",
+    fact: 'Email from J. Harrow: "Good to have met you earlier today."',
+    source: "Email bundle",
+    page: "p.212",
+    date: "9 Mar 2021",
+    kind: "Email",
+    confidence: "High",
+    period: "9 Mar 2021",
+  },
+  {
+    id: "EM-07",
+    fact: "Email from E. Whitfield approving the Brightwater drawdown.",
+    source: "Email bundle",
+    page: "p.488",
+    date: "2 Jul 2021",
+    kind: "Email",
+    confidence: "High",
+    period: "2 Jul 2021",
+  },
+  {
+    id: "BANK-02",
+    fact: "Brightwater facility drawdown authorised under signatory E. Whitfield.",
+    source: "Barclays statement",
+    page: "p.7",
+    date: "5 Jul 2021",
+    kind: "Bank record",
+    confidence: "High",
+    period: "Jul 2021",
+  },
+  {
+    id: "AGR-01",
+    fact: "Agreed fact: E. Whitfield was an authorised signatory on the Brightwater mandate.",
+    source: "Agreed Facts",
+    page: "§4.2",
+    date: "—",
+    kind: "Agreed fact",
+    confidence: "High",
+    period: "1 Jan – 31 Dec 2021",
+  },
+  {
+    id: "EM-09",
+    fact: 'Email characterising the £40,000 as a "consultancy fee".',
+    source: "Email bundle",
+    page: "p.661",
+    date: "19 Aug 2021",
+    kind: "Email",
+    confidence: "Medium",
+    period: "19 Aug 2021",
+    interpNote:
+      '"Consultancy fee" is the writer\'s own label; the characterisation does not by itself settle the true nature of the payment, which is the point in dispute.',
+  },
+  {
+    id: "MSG-02",
+    fact: 'Message: "this just settles what I owe you from before."',
+    source: "WhatsApp export",
+    page: "p.33",
+    date: "18 Aug 2021",
+    kind: "Message",
+    confidence: "Low",
+    period: "18 Aug 2021",
+    interpNote:
+      '"...what I owe you from before" does not itself identify the debt being settled — it is consistent with the loan the witness describes, but does not on its own establish it.',
+  },
+  {
+    id: "BANK-03",
+    fact: "Transfer of £40,000 from the Meridian operating account to E. Whitfield.",
+    source: "Barclays statement",
+    page: "p.9",
+    date: "20 Aug 2021",
+    kind: "Bank record",
+    confidence: "High",
+    period: "20 Aug 2021",
+  },
+  {
+    id: "MSG-05",
+    fact: 'WhatsApp thread between E. Whitfield and C. Vance discussing "the Harrow situation".',
+    source: "WhatsApp export",
+    page: "p.51",
+    date: "12 Aug 2021",
+    kind: "Message",
+    confidence: "High",
+    period: "12 Aug 2021",
+  },
+  {
+    id: "CAL-08",
+    fact: 'Calendar "Annual leave" blocked across 2–20 August.',
+    source: "Outlook export",
+    page: "p.40",
+    date: "2–20 Aug 2021",
+    kind: "Calendar",
+    confidence: "High",
+    period: "2–20 Aug 2021",
+  },
+  {
+    id: "EM-12",
+    fact: "Email sent from E. Whitfield's account at 14:07.",
+    source: "Email bundle",
+    page: "p.703",
+    date: "25 Aug 2021",
+    kind: "Email",
+    confidence: "High",
+    period: "25 Aug 2021",
+  },
+  {
+    id: "DOC-01",
+    fact: "Engagement letter bearing E. Whitfield's signature, dated 14 June 2021.",
+    source: "Engagement letter",
+    page: "p.1",
+    date: "14 Jun 2021",
+    kind: "Document",
+    confidence: "High",
+    period: "14 Jun 2021",
+  },
+  {
+    id: "BANK-05",
+    fact: "Credit of £40,000 to E. Whitfield's personal account.",
+    source: "HSBC statement (personal)",
+    page: "p.3",
+    date: "23 Aug 2021",
+    kind: "Bank record",
+    confidence: "High",
+    period: "23 Aug 2021",
+  },
+  {
+    id: "CAL-06",
+    fact: 'Calendar "Brightwater review — Boardroom 2", 09:30.',
+    source: "Outlook export",
+    page: "p.31",
+    date: "3 May 2021",
+    kind: "Calendar",
+    confidence: "High",
+    period: "3 May 2021",
+  },
+  {
+    id: "HAND-01",
+    fact: 'Handwritten attendance sheet; "E.W." appears under the "dial-in" column.',
+    source: "Scanned attendance sheet",
+    page: "p.1",
+    date: "3 May 2021",
+    kind: "Document",
+    confidence: "Medium",
+    period: "3 May 2021",
+    medium: "Handwritten",
+    interpNote:
+      'The initials are legible — the doubt is not the handwriting. What is uncertain is the inference: a name in the "dial-in" column may indicate remote attendance, but these columns are not a reliable record of how each person attended.',
+  },
+  {
+    id: "HAND-02",
+    fact: 'Handwritten margin note: "approx £40k — confirm w/ E".',
+    source: "Scanned counsel notes",
+    page: "p.6",
+    date: "undated",
+    kind: "Document",
+    confidence: "Low",
+    period: "—",
+    medium: "Handwritten",
+    flag: true,
+    interpNote:
+      'Explicitly provisional — "approx" and "confirm w/ E" show the figure was unconfirmed when written. It records an intention to verify, not a verified amount.',
+  },
+  {
+    id: "LEDG-01",
+    fact: "Meridian internal remittance advice records the 23 Aug payment to E. Whitfield as £45,000.",
+    source: "Meridian ledger export",
+    page: "p.118",
+    date: "23 Aug 2021",
+    kind: "Ledger",
+    confidence: "High",
+    period: "23 Aug 2021",
+  },
+  {
+    id: "EM-15",
+    fact: "Email from E. Whitfield to Compliance disclosing the arrangement, header timestamp 10 Aug 2021.",
+    source: "Email bundle",
+    page: "p.640",
+    date: "10 Aug 2021",
+    kind: "Email",
+    confidence: "High",
+    period: "10 Aug 2021",
+  },
+  {
+    id: "LOG-01",
+    fact: "Compliance case-management log records the same disclosure as received on 17 Aug 2021.",
+    source: "Compliance system export",
+    page: "case 4471",
+    date: "17 Aug 2021",
+    kind: "System log",
+    confidence: "High",
+    period: "17 Aug 2021",
+  },
+];
+
+export const CLAIMS: readonly Claim[] = [
+  {
+    id: "c1",
+    type: "fact",
+    state: "supported",
+    score: 88,
+    refs: [
+      { factId: "CAL-01", rel: "supports" },
+      { factId: "EM-04", rel: "supports" },
+    ],
+  },
+  {
+    id: "c2",
+    type: "fact",
+    state: "contradicted",
+    score: 18,
+    refs: [
+      { factId: "EM-07", rel: "conflicts" },
+      { factId: "BANK-02", rel: "conflicts" },
+      { factId: "AGR-01", rel: "conflicts" },
+    ],
+  },
+  {
+    id: "c3",
+    type: "fact",
+    state: "tension",
+    score: 46,
+    refs: [
+      { factId: "MSG-02", rel: "supports" },
+      { factId: "EM-09", rel: "conflicts" },
+      { factId: "BANK-03", rel: "supports" },
+    ],
+  },
+  {
+    id: "c4",
+    type: "fact",
+    state: "contradicted",
+    score: 24,
+    refs: [{ factId: "MSG-05", rel: "conflicts" }],
+  },
+  {
+    id: "c5",
+    type: "fact",
+    state: "tension",
+    score: 52,
+    timeConflict: true,
+    refs: [
+      { factId: "CAL-08", rel: "supports" },
+      { factId: "EM-12", rel: "conflicts" },
+    ],
+  },
+  {
+    id: "c6",
+    type: "fact",
+    state: "nocover",
+    score: null,
+    recalled: true,
+    refs: [],
+  },
+  {
+    id: "c7",
+    type: "fact",
+    state: "supported",
+    score: 92,
+    refs: [{ factId: "DOC-01", rel: "supports" }],
+  },
+  {
+    id: "c8",
+    type: "fact",
+    state: "supported",
+    score: 95,
+    recalled: true,
+    refs: [{ factId: "BANK-03", rel: "supports" }],
+  },
+  {
+    id: "c9",
+    type: "fact",
+    state: "contradicted",
+    score: 16,
+    refs: [{ factId: "BANK-05", rel: "conflicts" }],
+  },
+  {
+    id: "c10",
+    type: "fact",
+    state: "nocover",
+    score: null,
+    refs: [],
+  },
+  {
+    id: "c11",
+    type: "fact",
+    state: "tension",
+    score: 58,
+    // Superseded by Whitfield's SECOND statement (§4): she revised "in
+    // person" -> "by dial-in", bringing her account into line with
+    // HAND-01 and the other witnesses. Single-view build: keep the S1
+    // account and its tension verdict, flag the revision.
+    superseded: {
+      by: "her second statement (§4)",
+      note: 'Whitfield withdrew this account in her second statement, revising her 3 May attendance from "in person" to "by dial-in" — which brings it into line with the attendance sheet (HAND-01) and with the other witnesses. The earlier account is kept and dated, not deleted.',
+    },
+    refs: [
+      { factId: "CAL-06", rel: "supports" },
+      { factId: "HAND-01", rel: "conflicts" },
+    ],
+  },
+  {
+    id: "c14",
+    type: "opinion",
+    state: "notverifiable",
+    score: null,
+    refs: [],
+  },
+  {
+    id: "c15",
+    type: "unverifiable",
+    state: "notverifiable",
+    score: null,
+    refs: [],
+  },
+  {
+    id: "c12",
+    type: "fact",
+    state: "recordconflict",
+    score: null,
+    recordConflict: {
+      subject: "the amount of the 23 August payment",
+      factIds: ["BANK-05", "LEDG-01"],
+      values: ["£40,000", "£45,000"],
+      governingStates: ["supported", "contradicted"],
+    },
+    refs: [
+      { factId: "BANK-05", rel: "record" },
+      { factId: "LEDG-01", rel: "record" },
+    ],
+  },
+  {
+    id: "c13",
+    type: "fact",
+    state: "recordconflict",
+    score: null,
+    recordConflict: {
+      subject: "the date compliance was notified",
+      kind: "date",
+      factIds: ["EM-15", "LOG-01"],
+      values: ["10 Aug 2021", "17 Aug 2021"],
+      governingStates: ["supported", "contradicted"],
+      dates: [10, 17],
+      month: "Aug",
+      boundary: {
+        day: 14,
+        label: "Board meeting — disclosure due by this date",
+        before: {
+          verdict: "supported",
+          note: "disclosure reaches compliance before the board meeting — in time.",
+        },
+        after: {
+          verdict: "contradicted",
+          note: "disclosure only logged after the board meeting — out of time.",
+        },
+      },
+    },
+    refs: [
+      { factId: "EM-15", rel: "record" },
+      { factId: "LOG-01", rel: "record" },
+    ],
+  },
+];
+
+export const CLAIM_TEXT: Readonly<Record<string, string>> = {
+  c1: "I first met Mr Harrow in March 2021.",
+  c2: "I had no involvement whatsoever in the Brightwater transaction.",
+  c3: "The payment of £40,000 was a loan repayment, not a consultancy fee.",
+  c4: "I never discussed the matter with Ms Vance.",
+  c5: "I was on annual leave for the whole of August 2021.",
+  c6: "To my knowledge, the board was never informed of the arrangement.",
+  c7: "I signed the engagement letter on 14 June 2021.",
+  c8: "I recall the sum involved was approximately £40,000",
+  c9: "I did not receive any personal benefit from the arrangement.",
+  c10: "The instruction to proceed came verbally from senior management.",
+  c11: "I attended the meeting on 3 May 2021 in person",
+  c12: "the amount transferred to my account was £40,000",
+  c13: "I notified compliance of the arrangement on 10 August 2021.",
+  c14: "the whole arrangement was entirely proper and unremarkable",
+  c15: "Had it been raised at board level, I would have expected to see it minuted.",
+};
+
+export const DOCUMENT: CaseDocument = {
+  title: "Witness Statement of Eleanor Whitfield",
+  meta: "First statement · 13 paragraphs · signed 26 May 2026",
+  paragraphs: [
+    {
+      id: "p1",
+      segments: [
+        "I, Eleanor Whitfield, am a former director of Meridian Capital Partners LLP. I make this statement in response to the matters raised by the Inquiry. The facts set out below are within my own knowledge and are true to the best of my recollection.",
+      ],
+    },
+    {
+      id: "p2",
+      segments: [
+        { claimId: "c1" },
+        " He was introduced to me by a mutual contact at a portfolio event, and our dealings from that point were limited and professional in nature.",
+      ],
+    },
+    {
+      id: "p3",
+      segments: [
+        { claimId: "c2" },
+        " The mandate was run by the structured-finance desk, and decisions of that kind sat well outside my remit at the relevant time.",
+      ],
+    },
+    {
+      id: "p4",
+      segments: [
+        "On the question of the August payment, I should be clear. ",
+        { claimId: "c3" },
+        " ",
+        { claimId: "c14" },
+        ", and it was documented in the ordinary way.",
+      ],
+    },
+    {
+      id: "p5",
+      segments: [
+        { claimId: "c4" },
+        " To the extent the Inquiry has been told otherwise, I do not accept that characterisation.",
+      ],
+    },
+    {
+      id: "p6",
+      segments: [
+        { claimId: "c5" },
+        " I was abroad with my family and had no access to work systems during that period.",
+      ],
+    },
+    { id: "p7", segments: [{ claimId: "c6" }, " ", { claimId: "c15" }] },
+    {
+      id: "p8",
+      segments: [
+        { claimId: "c7" },
+        " I read the letter carefully before signing and understood its terms.",
+      ],
+    },
+    {
+      id: "p9",
+      segments: [
+        "As to the figures, ",
+        { claimId: "c8" },
+        ", although I could not now give an exact amount without the papers in front of me.",
+      ],
+    },
+    {
+      id: "p10",
+      segments: [
+        { claimId: "c9" },
+        " Any suggestion that I gained financially from these events is simply wrong.",
+      ],
+    },
+    {
+      id: "p11",
+      segments: [
+        { claimId: "c10" },
+        " I acted on that instruction in good faith and ",
+        { claimId: "c11" },
+        ", as my diary for that day records.",
+      ],
+    },
+    {
+      id: "p12",
+      segments: [
+        "For completeness on the sums, ",
+        { claimId: "c12" },
+        " and that figure is borne out by the bank record for my account.",
+      ],
+    },
+    {
+      id: "p13",
+      segments: [
+        { claimId: "c13" },
+        " The disclosure was made in good time and the correspondence bears that out.",
+      ],
+    },
+  ],
+};

--- a/apps/web/src/routes/dev/-components/avt/shared-primitives.test.ts
+++ b/apps/web/src/routes/dev/-components/avt/shared-primitives.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+
+import type {
+  CLAIM_TEXT,
+  DOCUMENT,
+} from "@/routes/dev/-components/avt/sample-data";
+import type {
+  ConfBadge,
+  InterpNote,
+  MatchStepper,
+  MatchStepperState,
+  MediumChip,
+  RECORD_CONFLICT_BG_VAR,
+  RECORD_CONFLICT_FG_VAR,
+  RECORD_CONFLICT_VAR,
+  STATE_COLOR,
+  StateChip,
+  StateSwatch,
+  TypeChip,
+} from "@/routes/dev/-components/avt/state-chip";
+import type {
+  CONFIDENCE_LEVELS,
+  CLAIM_TYPE_META,
+  STATE_META,
+  ClaimFactRelation,
+  RecordConflictBoundary,
+} from "@/routes/dev/-components/avt/types";
+import type {
+  DispositionTone,
+  confirmLabel,
+  countClaims,
+  dispositionGuidance,
+  isContested,
+  isSettled,
+  needsAttention,
+  resolveClaimView,
+} from "@/routes/dev/-components/avt/verdict";
+
+type SharedPrimitiveExports = [
+  typeof CLAIM_TEXT,
+  typeof DOCUMENT,
+  typeof ConfBadge,
+  typeof InterpNote,
+  typeof MatchStepper,
+  MatchStepperState,
+  typeof MediumChip,
+  typeof RECORD_CONFLICT_BG_VAR,
+  typeof RECORD_CONFLICT_FG_VAR,
+  typeof RECORD_CONFLICT_VAR,
+  typeof STATE_COLOR,
+  typeof StateChip,
+  typeof StateSwatch,
+  typeof TypeChip,
+  typeof CONFIDENCE_LEVELS,
+  typeof CLAIM_TYPE_META,
+  typeof STATE_META,
+  ClaimFactRelation,
+  RecordConflictBoundary,
+  DispositionTone,
+  typeof confirmLabel,
+  typeof countClaims,
+  typeof dispositionGuidance,
+  typeof isContested,
+  typeof isSettled,
+  typeof needsAttention,
+  typeof resolveClaimView,
+];
+
+test("exposes the primitives consumed by later AVT layers", () => {
+  const exports: SharedPrimitiveExports | undefined = undefined;
+  expect(exports).toBeUndefined();
+});

--- a/apps/web/src/routes/dev/-components/avt/state-chip.tsx
+++ b/apps/web/src/routes/dev/-components/avt/state-chip.tsx
@@ -1,0 +1,275 @@
+/**
+ * AVT — shared verdict/type/confidence chips, reused across the
+ * anchor-facts panel, the document view, and the detail panel. Ported
+ * from the prototype's `app/ui.jsx` (StateChip/TypeChip/ConfBadge/
+ * MediumChip/InterpNote) onto Stella's real semantic color tokens
+ * instead of bespoke CSS variables.
+ */
+
+import type * as React from "react";
+
+import {
+  AlertTriangleIcon,
+  BanIcon,
+  CheckCircle2Icon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  CircleDashedIcon,
+  PenIcon,
+  ScaleIcon,
+  SplitIcon,
+  XCircleIcon,
+} from "lucide-react";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
+
+import {
+  CLAIM_TYPE_META,
+  STATE_META,
+  type ClaimState,
+  type ClaimType,
+  type ConfidenceLevel,
+} from "@/routes/dev/-components/avt/types";
+
+/**
+ * Record conflict has no equivalent in Stella's semantic token triad
+ * (success/warning/destructive) — it isn't a claim verdict, it's the
+ * record disagreeing with itself, so it needs its own hue. Stella's
+ * `--primary` token is a near-black ink color (used for primary
+ * buttons), not a distinct accent, so it can't serve here. Stella's
+ * actual mechanism for an extra category color is the `--option-*`
+ * swatch system (see packages/ui/src/styles/globals.css) — the same
+ * one `cell-metadata-flags.tsx` uses via inline `style`, since these
+ * aren't registered as Tailwind `@theme` utility classes.
+ */
+export const RECORD_CONFLICT_VAR = "var(--option-purple)";
+export const RECORD_CONFLICT_BG_VAR = "var(--option-purple-bg)";
+export const RECORD_CONFLICT_FG_VAR = "var(--option-purple-fg)";
+
+type StateColor = {
+  icon: typeof CheckCircle2Icon;
+  chipClass: string;
+  chipStyle?: React.CSSProperties;
+  textClass: string;
+  textStyle?: React.CSSProperties;
+  decorationClass: string;
+  decorationStyle?: React.CSSProperties;
+  swatchStyle: React.CSSProperties;
+  /** Background wash for a claim span that matches the active filter — makes it pop against dimmed non-matches. */
+  highlightClass: string;
+  highlightStyle?: React.CSSProperties;
+};
+
+const STATE_COLOR: Record<ClaimState, StateColor> = {
+  supported: {
+    icon: CheckCircle2Icon,
+    chipClass: "text-success border-success/32 bg-success/10",
+    textClass: "text-success",
+    decorationClass: "decoration-success",
+    swatchStyle: { backgroundColor: "var(--success)" },
+    highlightClass: "bg-success/15",
+  },
+  tension: {
+    icon: AlertTriangleIcon,
+    chipClass: "text-warning border-warning/32 bg-warning/10",
+    textClass: "text-warning",
+    decorationClass: "decoration-warning",
+    swatchStyle: { backgroundColor: "var(--warning)" },
+    highlightClass: "bg-warning/15",
+  },
+  contradicted: {
+    icon: XCircleIcon,
+    chipClass:
+      "text-destructive-foreground border-destructive/32 bg-destructive/10",
+    textClass: "text-destructive-foreground",
+    decorationClass: "decoration-destructive",
+    swatchStyle: { backgroundColor: "var(--destructive)" },
+    highlightClass: "bg-destructive/15",
+  },
+  nocover: {
+    icon: CircleDashedIcon,
+    chipClass: "text-muted-foreground border-border bg-muted",
+    textClass: "text-muted-foreground",
+    decorationClass:
+      "text-muted-foreground decoration-muted-foreground decoration-dotted",
+    swatchStyle: { backgroundColor: "var(--muted-foreground)" },
+    highlightClass: "bg-muted",
+  },
+  recordconflict: {
+    icon: SplitIcon,
+    chipClass: "border-transparent",
+    chipStyle: {
+      color: RECORD_CONFLICT_FG_VAR,
+      backgroundColor: RECORD_CONFLICT_BG_VAR,
+      borderColor: RECORD_CONFLICT_VAR,
+    },
+    textClass: "",
+    textStyle: { color: RECORD_CONFLICT_VAR },
+    decorationClass: "decoration-wavy",
+    decorationStyle: { textDecorationColor: RECORD_CONFLICT_VAR },
+    swatchStyle: { backgroundColor: RECORD_CONFLICT_VAR },
+    highlightClass: "",
+    highlightStyle: { backgroundColor: RECORD_CONFLICT_BG_VAR },
+  },
+  notverifiable: {
+    icon: BanIcon,
+    chipClass: "text-muted-foreground border-border bg-muted italic",
+    textClass: "text-muted-foreground",
+    decorationClass:
+      "text-muted-foreground decoration-muted-foreground decoration-dotted italic",
+    swatchStyle: { backgroundColor: "var(--muted-foreground)" },
+    highlightClass: "bg-muted",
+  },
+};
+
+/**
+ * Full per-state color definition (text/chip/decoration classes plus
+ * the record-conflict inline-style overrides). Exported directly so
+ * consumers pull exactly the field they need — e.g.
+ * `STATE_COLOR[state].textClass` — rather than deriving separate maps.
+ */
+export { STATE_COLOR };
+
+/** Small solid-color square — matches the prototype's `.stat .k .sw` legend swatch. */
+export function StateSwatch({ state }: { state: ClaimState }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block size-2 shrink-0 rounded-[2px]"
+      style={STATE_COLOR[state].swatchStyle}
+    />
+  );
+}
+
+export function StateChip({ state }: { state: ClaimState }) {
+  const color = STATE_COLOR[state];
+  const Icon = color.icon;
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 items-center gap-1.5 rounded-full border px-2.5 text-xs font-semibold",
+        color.chipClass,
+      )}
+      style={color.chipStyle}
+    >
+      <Icon aria-hidden="true" className="size-3.5" />
+      {STATE_META[state].chip}
+    </span>
+  );
+}
+
+export function TypeChip({ type }: { type: ClaimType }) {
+  const meta = CLAIM_TYPE_META[type];
+  return (
+    <span className="bg-muted text-foreground border-border inline-flex h-6 items-center gap-1.5 rounded-md border px-2.5 text-xs font-semibold">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "size-2 shrink-0 rounded-full",
+          type === "fact" ? "bg-primary" : "bg-warning",
+        )}
+      />
+      {meta.label}
+      {!meta.verifiable && (
+        <span className="border-border text-muted-foreground border-s ps-1.5 text-[11px] font-medium normal-case">
+          set aside
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function ConfBadge({ level }: { level: ConfidenceLevel }) {
+  const low = level === "Low";
+  return (
+    <span
+      className={cn(
+        "border-border bg-muted text-muted-foreground inline-flex h-5.5 items-center gap-1.5 rounded-md border px-2 text-[11px] font-semibold",
+        low && "text-warning border-warning/32 bg-warning/10",
+      )}
+      title="Interpretive confidence — how unambiguous this evidence's meaning is. Independent of the source medium (handwriting, scan, etc.)."
+    >
+      Interpretation <span className="font-bold">{level}</span>
+    </span>
+  );
+}
+
+/** Neutral descriptor of the source carrier (handwritten / scanned). Informational only. */
+export function MediumChip({ medium }: { medium: string | undefined }) {
+  if (!medium) {
+    return null;
+  }
+  return (
+    <span
+      className="bg-muted text-muted-foreground border-border inline-flex h-5.5 items-center gap-1.5 rounded-md border px-2 text-[11px] font-semibold whitespace-nowrap"
+      title="Source medium — a neutral descriptor. It does not lower confidence on its own."
+    >
+      <PenIcon aria-hidden="true" className="size-3" />
+      {medium}
+    </span>
+  );
+}
+
+/** Substantive interpretation caveat — shown where the MEANING of the evidence is contested. */
+export function InterpNote({ note }: { note: string | undefined }) {
+  if (!note) {
+    return null;
+  }
+  return (
+    <div className="text-warning-foreground bg-warning/10 border-warning/32 flex items-start gap-1.5 rounded-md border px-2.5 py-2 text-[11.5px] leading-relaxed">
+      <ScaleIcon
+        aria-hidden="true"
+        className="text-warning mt-0.5 size-3.5 shrink-0"
+      />
+      <span>{note}</span>
+    </div>
+  );
+}
+
+export type MatchStepperState = {
+  current: number | null;
+  total: number;
+  onPrev: (() => void) | null;
+  onNext: (() => void) | null;
+};
+
+/**
+ * "N/M" position among the active filter's matches, with prev/next —
+ * lets a reviewer step through matches without scanning the document
+ * by eye. Shown next to the current claim in the document (sticky, so
+ * it doesn't fight inline text flow) and mirrored in the detail panel,
+ * since a reviewer stepping through matches doesn't always care about
+ * any one claim's detail. Lives here (not in verification-view.tsx)
+ * so both it and claim-detail-panel.tsx can import it without a cycle.
+ */
+export function MatchStepper({ stepper }: { stepper: MatchStepperState }) {
+  if (stepper.total === 0) {
+    return null;
+  }
+  return (
+    <div className="text-muted-foreground inline-flex items-center gap-1 text-xs tabular-nums">
+      {stepper.current !== null
+        ? `${stepper.current}/${stepper.total}`
+        : `${stepper.total} matches`}
+      <Button
+        aria-label="Previous match"
+        disabled={!stepper.onPrev}
+        onClick={stepper.onPrev ?? undefined}
+        size="icon-xs"
+        variant="ghost"
+      >
+        <ChevronUpIcon />
+      </Button>
+      <Button
+        aria-label="Next match"
+        disabled={!stepper.onNext}
+        onClick={stepper.onNext ?? undefined}
+        size="icon-xs"
+        variant="ghost"
+      >
+        <ChevronDownIcon />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/routes/dev/-components/avt/types.ts
+++ b/apps/web/src/routes/dev/-components/avt/types.ts
@@ -1,0 +1,251 @@
+/**
+ * AVT (Anchor Verification Tool) — core domain types.
+ *
+ * Ported 1:1 from the standalone prototype's data model
+ * (`app/data.js`, `app/icons.jsx`, `app/verification.jsx`) — the
+ * anchor-fact schema, the claim/scoring shape, and the review-queue
+ * states are Sam's investigative-methodology design, not invented
+ * here. This file only gives that design real TypeScript types.
+ */
+
+export const CONFIDENCE_LEVELS = ["High", "Medium", "Low"] as const;
+export type ConfidenceLevel = (typeof CONFIDENCE_LEVELS)[number];
+
+/**
+ * A curated piece of hard evidence (email, bank record, agreed fact,
+ * etc.) that claims are checked against. `confidence` is INTERPRETIVE
+ * — how unambiguous the evidence's meaning is — and is never derived
+ * from `medium` (a neutral carrier descriptor like "Handwritten").
+ * `interpNote` is set only where the meaning is genuinely contested;
+ * `flag` holds a fact out of scoring pending reviewer confirmation.
+ */
+export type AnchorFact = {
+  id: string;
+  fact: string;
+  source: string;
+  page: string;
+  date: string;
+  kind: string;
+  confidence: ConfidenceLevel;
+  period: string;
+  medium?: string;
+  interpNote?: string;
+  flag?: boolean;
+  accepted?: boolean;
+};
+
+const CLAIM_TYPES = ["fact", "opinion", "unverifiable"] as const;
+export type ClaimType = (typeof CLAIM_TYPES)[number];
+
+const CLAIM_STATES = [
+  "supported",
+  "tension",
+  "contradicted",
+  "nocover",
+  "recordconflict",
+  "notverifiable",
+] as const;
+export type ClaimState = (typeof CLAIM_STATES)[number];
+
+/** States backed by a real 0-100 support score, computed against the record. */
+const SCORED_CLAIM_STATES = ["supported", "tension", "contradicted"] as const;
+type ScoredClaimState = (typeof SCORED_CLAIM_STATES)[number];
+
+/** States with no score by definition — nothing to check against, or the verdict is withheld. */
+const UNSCORED_CLAIM_STATES = [
+  "nocover",
+  "recordconflict",
+  "notverifiable",
+] as const;
+type UnscoredClaimState = (typeof UNSCORED_CLAIM_STATES)[number];
+
+const CLAIM_FACT_RELATIONS = ["supports", "conflicts", "record"] as const;
+export type ClaimFactRelation = (typeof CLAIM_FACT_RELATIONS)[number];
+
+type ClaimRef = {
+  factId: string;
+  rel: ClaimFactRelation;
+};
+
+/** A claim withdrawn/revised by a later statement — kept and dated, not deleted. */
+type ClaimSupersession = {
+  by: string;
+  note: string;
+  link?: string;
+};
+
+export type RecordConflictBoundary = {
+  day: number;
+  label: string;
+  before: { verdict: ClaimState; note: string };
+  after: { verdict: ClaimState; note: string };
+};
+
+/**
+ * Two anchor facts disagree with each other on the same point. The
+ * claim's verdict is withheld (never scored) until a human decides
+ * which record governs, or flags it for the evidence team.
+ */
+type RecordConflict = {
+  subject: string;
+  factIds: readonly [string, string];
+  values: readonly [string, string];
+  /** Verdict produced when the corresponding record in `factIds` governs. */
+  governingStates: readonly [ScoredClaimState, ScoredClaimState];
+  kind?: "date";
+  dates?: readonly [number, number];
+  month?: string;
+  boundary?: RecordConflictBoundary;
+};
+
+type ClaimBase = {
+  id: string;
+  type: ClaimType;
+  refs: readonly ClaimRef[];
+  /** Framed as the witness's own recollection ("I recall..."). Neutral — never affects state/score. */
+  recalled?: boolean;
+  /** Supporting and conflicting facts cover different dates; reconcile "as at" a chosen date. */
+  timeConflict?: boolean;
+  superseded?: ClaimSupersession;
+};
+
+/**
+ * `state` and `score` are a discriminated union, not two independent
+ * fields — a scored state always carries a real 0-100 number, an
+ * unscored state always carries `null`. This makes the invalid
+ * combination (e.g. "supported" with no score) impossible to construct,
+ * rather than merely a convention comments ask you to respect.
+ */
+export type Claim =
+  | (ClaimBase & {
+      state: ScoredClaimState;
+      score: number;
+      recordConflict?: never;
+    })
+  | (ClaimBase & {
+      state: Exclude<UnscoredClaimState, "recordconflict">;
+      score: null;
+      recordConflict?: never;
+    })
+  | (ClaimBase & {
+      state: "recordconflict";
+      score: null;
+      recordConflict: RecordConflict;
+    });
+
+type DocumentSegment = string | { claimId: string };
+
+type DocumentParagraph = {
+  id: string;
+  segments: readonly DocumentSegment[];
+};
+
+export type CaseDocument = {
+  title: string;
+  meta: string;
+  paragraphs: readonly DocumentParagraph[];
+};
+
+const REVIEW_STATUSES = ["reviewed", "disputed"] as const;
+export type ReviewStatus = (typeof REVIEW_STATUSES)[number];
+export type ReviewerOverrideState = Exclude<ClaimState, "recordconflict">;
+
+/**
+ * How a human resolved a record conflict: either picked which anchor
+ * fact governs (the claim is re-scored against it, the other stays on
+ * file marked superseded), or escalated it to the evidence team
+ * without picking a side.
+ */
+export type RecordConflictResolution =
+  | { kind: "governed"; factId: string }
+  | { kind: "escalated" };
+
+/** Per-claim human-review disposition. Independent of `override` and `note`. */
+export type ClaimReview = {
+  status: ReviewStatus | null;
+  override: ReviewerOverrideState | null;
+  note: string;
+  savedAt: string | null;
+  /** ISO instant of the latest review decision; note timestamps remain separate. */
+  decisionAt: string | null;
+  /** Set when this claim was cleared via the "accept N routine" bulk action. */
+  bulk?: boolean;
+  /** Set once a set-aside claim has been re-opened and re-checked against the record. */
+  reopened?: boolean;
+  recordConflictResolution?: RecordConflictResolution | null;
+};
+
+export const EMPTY_REVIEW: ClaimReview = {
+  status: null,
+  override: null,
+  note: "",
+  savedAt: null,
+  decisionAt: null,
+};
+
+type StateMeta = {
+  state: ClaimState;
+  label: string;
+  chip: string;
+};
+
+export const STATE_META: Record<ClaimState, StateMeta> = {
+  supported: {
+    state: "supported",
+    label: "Supported by the record",
+    chip: "Supported",
+  },
+  tension: {
+    state: "tension",
+    label: "In tension with the record",
+    chip: "In tension",
+  },
+  contradicted: {
+    state: "contradicted",
+    label: "Contradicted by the record",
+    chip: "Contradicted",
+  },
+  nocover: {
+    state: "nocover",
+    label: "No anchor fact covers this claim",
+    chip: "No coverage",
+  },
+  recordconflict: {
+    state: "recordconflict",
+    label: "Anchor facts disagree with each other",
+    chip: "Record conflict",
+  },
+  notverifiable: {
+    state: "notverifiable",
+    label: "Not a checkable factual claim",
+    chip: "Not verifiable",
+  },
+};
+
+type ClaimTypeMeta = {
+  type: ClaimType;
+  label: string;
+  verifiable: boolean;
+  hint: string;
+};
+
+export const CLAIM_TYPE_META: Record<ClaimType, ClaimTypeMeta> = {
+  fact: {
+    type: "fact",
+    label: "Fact",
+    verifiable: true,
+    hint: "Objective, checkable assertion — scored against the record. Includes claims framed as admissions or denials: judged on the underlying proposition, not the bare words.",
+  },
+  opinion: {
+    type: "opinion",
+    label: "Opinion",
+    verifiable: false,
+    hint: "A value judgement or characterisation — no document can confirm or contradict it, so it is set aside, not scored.",
+  },
+  unverifiable: {
+    type: "unverifiable",
+    label: "Not verifiable",
+    verifiable: false,
+    hint: "An assertion no document could ever settle — a counterfactual, a prediction, a statement of intent or belief, a legal conclusion, or a claim too vague to check. Set aside, not scored. Distinct from No coverage, which is a checkable fact the record is merely silent on.",
+  },
+};

--- a/apps/web/src/routes/dev/-components/avt/verdict.test.ts
+++ b/apps/web/src/routes/dev/-components/avt/verdict.test.ts
@@ -1,0 +1,63 @@
+import { panic } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { CLAIMS } from "@/routes/dev/-components/avt/sample-data";
+import type { ClaimReview } from "@/routes/dev/-components/avt/types";
+import { EMPTY_REVIEW } from "@/routes/dev/-components/avt/types";
+import { effectiveState } from "@/routes/dev/-components/avt/verdict";
+
+const claimById = (id: string) =>
+  CLAIMS.find((claim) => claim.id === id) ?? panic(`Missing claim ${id}`);
+
+const review = (patch: Partial<ClaimReview>): ClaimReview => ({
+  ...EMPTY_REVIEW,
+  ...patch,
+});
+
+describe("AVT displayed verdict", () => {
+  test("keeps an override separate from the tool verdict", () => {
+    const claim = claimById("c2");
+
+    expect(effectiveState(claim, review({ override: "supported" }))).toBe(
+      claim.state,
+    );
+  });
+
+  test("keeps unresolved and escalated record conflicts open", () => {
+    const claim = claimById("c12");
+
+    expect(effectiveState(claim, review({ override: "supported" }))).toBe(
+      "recordconflict",
+    );
+    expect(
+      effectiveState(
+        claim,
+        review({
+          override: "supported",
+          recordConflictResolution: { kind: "escalated" },
+        }),
+      ),
+    ).toBe("recordconflict");
+  });
+
+  test("uses the outcome attached to the governing record", () => {
+    const claim = claimById("c12");
+
+    expect(
+      effectiveState(
+        claim,
+        review({
+          recordConflictResolution: { kind: "governed", factId: "BANK-05" },
+        }),
+      ),
+    ).toBe("supported");
+    expect(
+      effectiveState(
+        claim,
+        review({
+          recordConflictResolution: { kind: "governed", factId: "LEDG-01" },
+        }),
+      ),
+    ).toBe("contradicted");
+  });
+});

--- a/apps/web/src/routes/dev/-components/avt/verdict.ts
+++ b/apps/web/src/routes/dev/-components/avt/verdict.ts
@@ -1,0 +1,247 @@
+/**
+ * AVT — pure verdict/triage logic. No React, no I/O.
+ *
+ * Ported from the prototype's `verification.jsx` / `detail.jsx`
+ * triage model: which claims warrant a human (conflicts + contested
+ * interpretations) versus which are routine (bulk-acceptable, no
+ * individual sign-off needed). This is Sam's decided methodology —
+ * kept verbatim, not redesigned.
+ */
+
+import { panic } from "better-result";
+
+import type {
+  AnchorFact,
+  Claim,
+  ClaimReview,
+  ClaimState,
+} from "@/routes/dev/-components/avt/types";
+
+const CONFLICT_STATES: ReadonlySet<ClaimState> = new Set([
+  "contradicted",
+  "tension",
+  "recordconflict",
+]);
+
+const isConflictState = (state: ClaimState): boolean =>
+  CONFLICT_STATES.has(state);
+
+/** True when any anchor fact this claim cites carries a genuine interpretation caveat. */
+export const isContested = (
+  claim: Pick<Claim, "refs">,
+  factById: (id: string) => AnchorFact | undefined,
+): boolean =>
+  claim.refs.some((ref) => factById(ref.factId)?.interpNote !== undefined);
+
+/**
+ * A claim NEEDS ATTENTION if its verdict is a conflict (contradicted /
+ * in tension / record conflict) OR its interpretation is contested.
+ * Everything else — cleanly supported, no coverage, or set aside — is
+ * ROUTINE: the per-claim review controls stay available for the audit
+ * trail, but it needs no individual sign-off.
+ */
+export const needsAttention = (
+  claim: Pick<Claim, "state" | "refs">,
+  factById: (id: string) => AnchorFact | undefined,
+): boolean =>
+  claim.state !== "notverifiable" &&
+  (isConflictState(claim.state) || isContested(claim, factById));
+
+/** A claim is SETTLED once a human dispositions it either way (reviewed OR disputed). */
+export const isSettled = (review: ClaimReview | undefined): boolean =>
+  review?.status === "reviewed" || review?.status === "disputed";
+
+/**
+ * Resolve the analysis verdict. Reviewer overrides remain annotations; a
+ * governed record conflict adopts the outcome attached to the selected fact.
+ */
+export const effectiveState = (
+  claim: Pick<Claim, "recordConflict" | "state">,
+  review: ClaimReview | undefined,
+): ClaimState => {
+  if (claim.state !== "recordconflict") {
+    return claim.state;
+  }
+  const resolution = review?.recordConflictResolution;
+  if (resolution?.kind !== "governed") {
+    return "recordconflict";
+  }
+  const conflict =
+    claim.recordConflict ?? panic("Record-conflict claim has no conflict data");
+  const index = conflict.factIds.indexOf(resolution.factId);
+  const state = conflict.governingStates.at(index);
+  return (
+    state ??
+    panic(`Governing fact ${resolution.factId} is not part of the conflict`)
+  );
+};
+
+/**
+ * Resolve the claim as it should be DISPLAYED.
+ *
+ * Re-opening a set-aside claim reclassifies it as a checkable fact and
+ * re-scores it — offline in this build, so it always lands on `nocover`
+ * with no refs, matching the prototype's own offline fallback.
+ *
+ * A plain `review.override` deliberately does NOT affect this, matching
+ * the prototype's `view()`: an override is a reviewer annotation shown
+ * alongside the tool's own verdict (the "Overridden" badge by the
+ * Override control), never a replacement for it. Only `reopened`
+ * legitimately changes the underlying analysis, because it represents an
+ * actual re-classification and re-check rather than a manual override of
+ * an existing score.
+ *
+ * Anything deriving state, counts or filtering from a claim should
+ * resolve through this once and use the result, rather than branching on
+ * the raw immutable `Claim` — resolving at only some call sites is what
+ * previously let the detail panel disagree with the document, the stat
+ * tiles and the filters about the same claim.
+ */
+export const resolveClaimView = (
+  claim: Claim,
+  review: ClaimReview | undefined,
+): Claim => {
+  if (review?.reopened && claim.state === "notverifiable") {
+    return {
+      ...claim,
+      type: "fact",
+      state: "nocover",
+      score: null,
+      refs: [],
+    };
+  }
+  return claim;
+};
+
+export type DispositionTone = "ready" | "manual" | "escalate" | "routine";
+
+type DispositionGuidance = {
+  tone: DispositionTone;
+  guide: string;
+  ask: string;
+};
+
+const DISP_COPY: Record<ClaimState, string> = {
+  supported:
+    "The record affirms this. Your sign-off confirms the tool read it correctly — no judgement call needed.",
+  tension:
+    "The record only partly supports this. Weigh the supporting and conflicting facts above before the verdict stands.",
+  contradicted:
+    "The record departs from this claim. A human call is needed before this verdict stands.",
+  recordconflict:
+    "Two exhibits in the record disagree. Resolve which governs above, or flag the evidence team — the tool won't pick for you.",
+  nocover:
+    "No anchor fact addresses this claim, so there's nothing to confirm it against. Sign-off is optional.",
+  notverifiable:
+    "Set aside as not verifiable — sign-off is optional. Re-open below if it's actually checkable.",
+};
+
+/**
+ * State-aware disposition steer: what KIND of call a verdict is
+ * asking the reviewer for, not just a generic "review/dispute" pair.
+ */
+export const dispositionGuidance = (
+  claim: Pick<Claim, "state" | "refs">,
+  factById: (id: string) => AnchorFact | undefined,
+): DispositionGuidance => {
+  if (claim.state === "recordconflict") {
+    return {
+      tone: "escalate",
+      guide: "Escalate",
+      ask: DISP_COPY.recordconflict,
+    };
+  }
+  if (claim.state === "contradicted" || claim.state === "tension") {
+    return {
+      tone: "manual",
+      guide: "Manual judgement",
+      ask: DISP_COPY[claim.state],
+    };
+  }
+  if (isContested(claim, factById)) {
+    return {
+      tone: "manual",
+      guide: "Manual judgement",
+      ask: "The verdict is clean, but a contributing fact's interpretation is contested — worth your eyes before sign-off.",
+    };
+  }
+  if (claim.state === "supported") {
+    return {
+      tone: "ready",
+      guide: "Ready to confirm",
+      ask: DISP_COPY.supported,
+    };
+  }
+  return { tone: "routine", guide: "Optional", ask: DISP_COPY[claim.state] };
+};
+
+export const confirmLabel = (state: ClaimState): string => {
+  if (state === "supported") {
+    return "Confirm — ready";
+  }
+  if (state === "nocover" || state === "notverifiable") {
+    return "Acknowledge";
+  }
+  if (state === "recordconflict") {
+    return "Confirm resolution";
+  }
+  return "Confirm verdict";
+};
+
+type ClaimCounts = {
+  total: number;
+  byState: Record<ClaimState, number>;
+  attnTotal: number;
+  attnSettled: number;
+  attnOpen: number;
+  routineTotal: number;
+  routineUnsettled: number;
+};
+
+export const countClaims = (
+  claims: readonly Claim[],
+  reviews: Readonly<Record<string, ClaimReview>>,
+  factById: (id: string) => AnchorFact | undefined,
+): ClaimCounts => {
+  const byState: Record<ClaimState, number> = {
+    supported: 0,
+    tension: 0,
+    contradicted: 0,
+    nocover: 0,
+    recordconflict: 0,
+    notverifiable: 0,
+  };
+  let attnTotal = 0;
+  let attnSettled = 0;
+  let routineUnsettled = 0;
+
+  for (const rawClaim of claims) {
+    const review = reviews[rawClaim.id];
+    // Count the claim as it is currently displayed, not as it was
+    // declared: reopening reclassifies a claim to `nocover` with no refs,
+    // so counting the raw claim would tally a reopened claim under its
+    // original state and judge `needsAttention` on refs it no longer has.
+    const claim = resolveClaimView(rawClaim, review);
+    const state = effectiveState(claim, review);
+    byState[state] += 1;
+    const settled = isSettled(review);
+    if (needsAttention({ state, refs: claim.refs }, factById)) {
+      attnTotal += 1;
+      if (settled) {
+        attnSettled += 1;
+      }
+    } else if (!settled) {
+      routineUnsettled += 1;
+    }
+  }
+
+  return {
+    total: claims.length,
+    byState,
+    attnTotal,
+    attnSettled,
+    attnOpen: attnTotal - attnSettled,
+    routineTotal: claims.length - attnTotal,
+    routineUnsettled,
+  };
+};


### PR DESCRIPTION
First of five stacked PRs adding the **Anchor Verification Tool (AVT)** — a dev-only harness for reviewing whether the claims in a document are actually supported by the underlying evidence record.

This PR is the foundation the other four build on. It adds no UI and no route; nothing is reachable until 5/5.

### What's here

| File | Purpose |
|---|---|
| `types.ts` | The domain model |
| `avt-store.ts` | In-memory store for reviewer actions |
| `verdict.ts` | Pure helpers — settled vs contested, reviewer guidance |
| `state-chip.tsx` | Shared presentational primitives |
| `sample-data.ts` | The mock record this harness runs against |

### One design note worth flagging

A claim's `state` and `score` are a discriminated union: a scored state always carries a real number, an unscored state always carries `null`. This came out of a real bug during the port — an overridden verdict could display a state alongside a score that had been computed for a *different* state. Making the pair a union means that combination can't be constructed anywhere, rather than being avoided by one careful code path.

### Scope, stated plainly

This is a UI harness on mock data. There is **no scoring engine and no retrieval** behind it, nothing is persisted, and it's gated to development builds. It exists to prove out the review mechanics and interaction model before any of that gets built. The in-app banner says the same thing to anyone who opens it.

### Review order

1. **→ this PR** — domain model and primitives
2. claim review panel
3. document view and claim linking
4. anchor facts panel
5. composition and the `/dev/avt` route

Each builds on the previous; 4/5 depends only on 1/5 and is stacked purely to keep review linear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AVT prototype for reviewing case claims against supporting facts and documents.
  * Added sample case content, including claims, witness statements, source references and document sections.
  * Added controls for assessing facts, editing review details, marking claims as reviewed, reopening them and resolving record conflicts.
  * Added visual indicators for claim status, type, confidence, source medium and interpretation notes.
  * Added verdict summaries, attention indicators and disposition guidance to support claim triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->