### PR TITLE
fix(api): lock corpus index count buckets in a fixed order

### DIFF
--- a/apps/api/drizzle/20260907120000_case_law_corpus_index_count_lock_order/migration.sql
+++ b/apps/api/drizzle/20260907120000_case_law_corpus_index_count_lock_order/migration.sql
@@ -1,0 +1,202 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The count triggers update one bucket per (generation, index_id) a statement
+-- touches. `UPDATE ... FROM deltas` leaves the row-lock order to the plan, so
+-- two transactions whose statements touch the same buckets in different orders
+-- can each hold a lock the other needs and deadlock. Every writer of
+-- case_law_corpus_index_projections is exposed: one decision update cascades
+-- into several buckets.
+--
+-- The buckets are now locked in primary-key order before the update, the same
+-- order in every transaction, so concurrent writers queue instead. The deltas
+-- are aggregated once into an array (one element per bucket, a small set
+-- whatever the statement's row count) and reused by the seed insert, the lock,
+-- and the update; the previous shape re-derived them per statement.
+-- `text` rather than the columns' varchar widths: the cast into this type is
+-- how a bucket key is carried, and a narrower width would truncate a widened
+-- key into the wrong bucket instead of failing.
+CREATE TYPE case_law_corpus_index_count_delta AS (
+  generation text,
+  index_id text,
+  delta bigint
+);--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION add_inserted_case_law_corpus_index_counts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  bucket_deltas case_law_corpus_index_count_delta[];
+BEGIN
+  SELECT array_agg(
+    (generation, index_id, delta)::case_law_corpus_index_count_delta
+    ORDER BY generation, index_id
+  )
+  INTO bucket_deltas
+  FROM (
+    SELECT generation, accounted_index_id AS index_id, count(*)::bigint AS delta
+    FROM new_projections
+    WHERE accounted_index_id IS NOT NULL
+    GROUP BY generation, accounted_index_id
+  ) AS changes;
+
+  IF bucket_deltas IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO case_law_corpus_index_counts (
+    generation,
+    index_id,
+    marked_indexed,
+    updated_at
+  )
+  SELECT deltas.generation, deltas.index_id, 0, clock_timestamp()
+  FROM unnest(bucket_deltas) AS deltas
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_counts_pk DO NOTHING;
+
+  -- After the seed insert, which keeps no row lock of its own, and before the
+  -- update, which would otherwise lock the buckets in plan order.
+  PERFORM 1
+  FROM case_law_corpus_index_counts AS counts
+  WHERE (counts.generation, counts.index_id) IN (
+    SELECT deltas.generation, deltas.index_id
+    FROM unnest(bucket_deltas) AS deltas
+  )
+  ORDER BY counts.generation, counts.index_id
+  FOR UPDATE;
+
+  UPDATE case_law_corpus_index_counts AS counts
+  SET marked_indexed = counts.marked_indexed + deltas.delta,
+      updated_at = clock_timestamp()
+  FROM unnest(bucket_deltas) AS deltas
+  WHERE counts.generation = deltas.generation
+    AND counts.index_id = deltas.index_id;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION apply_updated_case_law_corpus_index_counts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  bucket_deltas case_law_corpus_index_count_delta[];
+BEGIN
+  SELECT array_agg(
+    (generation, index_id, delta)::case_law_corpus_index_count_delta
+    ORDER BY generation, index_id
+  )
+  INTO bucket_deltas
+  FROM (
+    SELECT generation, index_id, sum(delta)::bigint AS delta
+    FROM (
+      SELECT generation, accounted_index_id AS index_id, -count(*)::bigint AS delta
+      FROM old_projections
+      WHERE accounted_index_id IS NOT NULL
+      GROUP BY generation, accounted_index_id
+      UNION ALL
+      SELECT generation, accounted_index_id AS index_id, count(*)::bigint AS delta
+      FROM new_projections
+      WHERE accounted_index_id IS NOT NULL
+      GROUP BY generation, accounted_index_id
+    ) AS changes
+    GROUP BY generation, index_id
+    HAVING sum(delta) <> 0
+  ) AS bucket_changes;
+
+  IF bucket_deltas IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Materialize a zero bucket first. A negative delta without an existing
+  -- bucket then violates the nonnegative CHECK instead of disappearing.
+  INSERT INTO case_law_corpus_index_counts (
+    generation,
+    index_id,
+    marked_indexed,
+    updated_at
+  )
+  SELECT deltas.generation, deltas.index_id, 0, clock_timestamp()
+  FROM unnest(bucket_deltas) AS deltas
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_counts_pk DO NOTHING;
+
+  PERFORM 1
+  FROM case_law_corpus_index_counts AS counts
+  WHERE (counts.generation, counts.index_id) IN (
+    SELECT deltas.generation, deltas.index_id
+    FROM unnest(bucket_deltas) AS deltas
+  )
+  ORDER BY counts.generation, counts.index_id
+  FOR UPDATE;
+
+  UPDATE case_law_corpus_index_counts AS counts
+  SET marked_indexed = counts.marked_indexed + deltas.delta,
+      updated_at = clock_timestamp()
+  FROM unnest(bucket_deltas) AS deltas
+  WHERE counts.generation = deltas.generation
+    AND counts.index_id = deltas.index_id;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION subtract_deleted_case_law_corpus_index_counts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  bucket_deltas case_law_corpus_index_count_delta[];
+BEGIN
+  SELECT array_agg(
+    (generation, index_id, delta)::case_law_corpus_index_count_delta
+    ORDER BY generation, index_id
+  )
+  INTO bucket_deltas
+  FROM (
+    SELECT generation, accounted_index_id AS index_id, count(*)::bigint AS delta
+    FROM old_projections
+    WHERE accounted_index_id IS NOT NULL
+    GROUP BY generation, accounted_index_id
+  ) AS changes;
+
+  IF bucket_deltas IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  PERFORM 1
+  FROM case_law_corpus_index_counts AS counts
+  WHERE (counts.generation, counts.index_id) IN (
+    SELECT deltas.generation, deltas.index_id
+    FROM unnest(bucket_deltas) AS deltas
+  )
+  ORDER BY counts.generation, counts.index_id
+  FOR UPDATE;
+
+  UPDATE case_law_corpus_index_counts AS counts
+  SET marked_indexed = counts.marked_indexed - deltas.delta,
+      updated_at = clock_timestamp()
+  FROM unnest(bucket_deltas) AS deltas
+  WHERE counts.generation = deltas.generation
+    AND counts.index_id = deltas.index_id;
+
+  IF EXISTS (
+    SELECT 1
+    FROM old_projections AS deleted
+    WHERE deleted.accounted_index_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_backfills AS generation
+        WHERE generation.generation = deleted.generation
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_counts AS counts
+        WHERE counts.generation = deleted.generation
+          AND counts.index_id = deleted.accounted_index_id
+      )
+  ) THEN
+    RAISE EXCEPTION 'case-law corpus index accounting bucket is missing';
+  END IF;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint

--- a/apps/api/src/lib/corpus-index/census-counts.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-counts.db.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { asc, eq } from "drizzle-orm";
+import { asc, eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
@@ -45,6 +45,16 @@ const insertedDecisionId = toSafeId<"caseLawDecision">(
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
 let scopedDb: ScopedDb;
+
+// The statement triggers touch one bucket per (generation, index_id) a
+// statement changes. Without a fixed lock order, concurrent writers can take
+// those row locks in opposite orders and deadlock, so every one of them must
+// lock its buckets in primary-key order before the update reaches them. The
+// set is discovered from the catalog rather than listed here, so a trigger
+// added or renamed later is held to the same invariant.
+const ORDERED_BUCKET_LOCK =
+  /FROM case_law_corpus_index_counts AS counts\s+WHERE[\s\S]*?ORDER BY counts\.generation, counts\.index_id\s+FOR UPDATE/u;
+const BUCKET_UPDATE = "UPDATE case_law_corpus_index_counts AS counts";
 
 const countRows = async () =>
   await db
@@ -137,6 +147,50 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await client.close();
+});
+
+test("count triggers lock their buckets in primary-key order before updating", async () => {
+  // Every trigger function on the projection table that writes a count
+  // bucket, whatever it is called.
+  const installed = await db.execute(sql`
+    SELECT proc.proname AS "name", pg_get_functiondef(proc.oid) AS "definition"
+    FROM pg_catalog.pg_trigger AS projection_trigger
+    JOIN pg_catalog.pg_class AS projection_table
+      ON projection_table.oid = projection_trigger.tgrelid
+    JOIN pg_catalog.pg_proc AS proc
+      ON proc.oid = projection_trigger.tgfoid
+    WHERE projection_table.relname = 'case_law_corpus_index_projections'
+      AND NOT projection_trigger.tgisinternal
+      AND pg_get_functiondef(proc.oid)
+        ~ '(UPDATE|INSERT INTO)\\s+case_law_corpus_index_counts'
+    ORDER BY proc.proname
+  `);
+
+  // The catalog columns arrive untyped; naming each function in the result
+  // makes a failure report which definition regressed.
+  const lockOrder = installed.rows.map((row) => {
+    const definition = String(row["definition"]);
+    const lockIndex = ORDERED_BUCKET_LOCK.exec(definition)?.index ?? -1;
+    return {
+      locksBeforeUpdating: definition.indexOf(BUCKET_UPDATE) > lockIndex,
+      locksBucketsInOrder: lockIndex >= 0,
+      name: String(row["name"]),
+    };
+  });
+  // Naming the writers keeps a discovery that returned nothing from
+  // satisfying the invariant vacuously, and makes adding one a decision. The
+  // invariant below is checked against whatever the catalog returned.
+  expect(lockOrder.map(({ name }) => name)).toEqual([
+    "add_inserted_case_law_corpus_index_counts",
+    "apply_updated_case_law_corpus_index_counts",
+    "subtract_deleted_case_law_corpus_index_counts",
+  ]);
+  expect(
+    lockOrder.filter(
+      ({ locksBeforeUpdating, locksBucketsInOrder }) =>
+        !locksBucketsInOrder || !locksBeforeUpdating,
+    ),
+  ).toEqual([]);
 });
 
 test("exact accounting converges across replay, races, and valid projection transitions", async () => {

--- a/apps/api/src/tests/helpers/case-law-projection-trigger.ts
+++ b/apps/api/src/tests/helpers/case-law-projection-trigger.ts
@@ -24,10 +24,8 @@ const PROJECTION_TRIGGER =
   "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection";
 const PROJECTION_TRIGGER_STATEMENT =
   /\b(?:CREATE|DROP) TRIGGER (?:IF EXISTS )?case_law_decisions_enqueue_corpus_index_projection\b/u;
-const ACCOUNTING_FUNCTION =
-  "CREATE OR REPLACE FUNCTION derive_case_law_corpus_index_accounting()";
 const ACCOUNTING_OBJECT =
-  /(?:INSERT INTO "case_law_corpus_index_count_backfills"|derive_case_law_corpus_index_accounting|add_inserted_case_law_corpus_index_counts|apply_updated_case_law_corpus_index_counts|subtract_deleted_case_law_corpus_index_counts|seed_case_law_corpus_index_count_backfill|case_law_corpus_index_projection_(?:derive_accounting|count_(?:insert|update|delete))|case_law_corpus_index_backfill_seed_count)/u;
+  /(?:INSERT INTO "case_law_corpus_index_count_backfills"|derive_case_law_corpus_index_accounting|add_inserted_case_law_corpus_index_counts|apply_updated_case_law_corpus_index_counts|subtract_deleted_case_law_corpus_index_counts|seed_case_law_corpus_index_count_backfill|case_law_corpus_index_count_delta|case_law_corpus_index_projection_(?:derive_accounting|count_(?:insert|update|delete))|case_law_corpus_index_backfill_seed_count)/u;
 
 /** Statements of a migration file, in order, comments included. */
 export const migrationStatements = (path: string): string[] =>
@@ -36,12 +34,17 @@ export const migrationStatements = (path: string): string[] =>
     .map((statement) => statement.trim())
     .filter((statement) => statement.length > 0);
 
+/** Every migration path, in the order the migrator applies them. */
+const migrationPaths = (): string[] =>
+  [...new Bun.Glob("*/migration.sql").scanSync(DRIZZLE_DIR)]
+    .sort()
+    .map((file) => nodePath.join(DRIZZLE_DIR, file));
+
 /** Path of the last migration whose text contains `marker`. */
 export const latestMigrationContaining = (marker: string): string => {
-  const path = [...new Bun.Glob("*/migration.sql").scanSync(DRIZZLE_DIR)]
-    .sort()
-    .map((file) => nodePath.join(DRIZZLE_DIR, file))
-    .findLast((file) => readFileSync(file, "utf-8").includes(marker));
+  const path = migrationPaths().findLast((file) =>
+    readFileSync(file, "utf-8").includes(marker),
+  );
   return path ?? panic(`no migration contains ${marker}`);
 };
 
@@ -86,9 +89,24 @@ export const installCaseLawProjectionTrigger = async (
   }
 };
 
-/** The seed statement and triggers that maintain exact projection counts. */
-export const caseLawProjectionAccountingStatements = (): string[] =>
-  latestStatements(ACCOUNTING_FUNCTION, ACCOUNTING_OBJECT);
+/**
+ * The seed statement, functions, and triggers that maintain exact projection
+ * counts, replayed from every migration that defines one, in migration order.
+ * Taking them from a single migration would pin the test to that migration's
+ * definitions and silently miss a later redefinition; replaying leaves the test
+ * database with what a migrated database converges to.
+ */
+export const caseLawProjectionAccountingStatements = (): string[] => {
+  const statements = migrationPaths().flatMap((path) =>
+    migrationStatements(path).filter((statement) =>
+      ACCOUNTING_OBJECT.test(statement),
+    ),
+  );
+  if (statements.length === 0) {
+    panic("no migration defines case-law corpus index projection accounting");
+  }
+  return statements;
+};
 
 /** Install exact projection accounting in a schema-built test database. */
 export const installCaseLawProjectionAccounting = async (


### PR DESCRIPTION
## Defect

The statement triggers that maintain `case_law_corpus_index_counts` update one
bucket per `(generation, index_id)` a statement touches, through
`UPDATE case_law_corpus_index_counts AS counts ... FROM deltas`. Nothing in that
statement fixes the order the row locks are taken in, so two transactions whose
statements touch the same buckets in different orders can each hold a lock the
other needs, and one of them is aborted as a deadlock victim.

Any concurrent writer of `case_law_corpus_index_projections` is exposed: a
single decision change cascades into projection rows across several buckets, so
the multi-row update is the ordinary case, not an edge case.

`add_inserted_case_law_corpus_index_counts` had the same exposure through
`ON CONFLICT ... DO UPDATE`, which locks the conflicting rows in the order the
insert produces them.

## Fix

A migration redefines the three functions. Each one now:

1. aggregates its deltas once into an array (one element per bucket, a small
   set whatever the statement's row count) instead of re-deriving them per
   statement,
2. seeds the zero buckets with `ON CONFLICT ... DO NOTHING`, which keeps no row
   lock of its own,
3. locks the buckets with `ORDER BY counts.generation, counts.index_id FOR
   UPDATE`, the same order in every transaction,
4. applies the update.

Concurrent writers now queue on the first contended bucket instead of
deadlocking. The counts, the nonnegative `CHECK`, and the missing-bucket guard
are unchanged.

## Tests

The accounting test helper replayed the statements of the single migration that
last defined the accounting trigger function, so a later migration redefining
only some of those objects would have been installed nowhere and tested never.
It now replays every migration that defines one of the accounting objects, in
migration order, which is what a migrated database converges to.

`census-counts.db.test.ts` gains a test that reads the installed definitions
back with `pg_get_functiondef` and asserts each of the three locks its buckets
in primary-key order before the update. The existing test continues to cover
the count invariants across insert, update, and delete of projections.

Reproducing the deadlock itself needs two concurrent sessions, which the PGlite
test database cannot host, so the lock order is asserted structurally and the
counts behaviorally. Removing the migration makes the new test fail on all
three functions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when updating case-law corpus index counts concurrently.
  - Reduced the risk of database deadlocks during insert, update and delete operations.
  - Added safeguards to ensure missing count buckets are handled consistently.
  - Improved error reporting when expected count data is unavailable.

- **Tests**
  - Added coverage to verify consistent update ordering and safer concurrent processing across case-law corpus counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->