### PR TITLE
fix(ci): gate fork pull requests with Actions approval, not a label

### DIFF
--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -41,7 +41,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {

--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -38,3 +38,36 @@ jobs:
     secrets:
       BRANCH_PROTECTION_APP_ID: ${{ secrets.BRANCH_PROTECTION_APP_ID }}
       BRANCH_PROTECTION_APP_KEY: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}
+
+  # Fork pull requests run CI only after a maintainer approves the push
+  # (`docs/policies/access-control.md`, "Fork trust gate"). That gate is
+  # a repository setting rather than workflow code, so drift would not
+  # show up in review; fail when it is loosened.
+  audit-fork-approval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.BRANCH_PROTECTION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}
+
+      - name: Check fork approval policy
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          EXPECTED_POLICY: all_external_contributors
+        shell: bash --noprofile --norc -eo pipefail {0}
+        run: |
+          LIVE_POLICY=$(
+            gh api "repos/${REPO}/actions/permissions/fork-pr-contributor-approval" \
+              --jq '.approval_policy'
+          )
+          echo "Fork approval policy: ${LIVE_POLICY}"
+          if [ "${LIVE_POLICY}" != "${EXPECTED_POLICY}" ]; then
+            echo "::error::Actions fork approval policy is '${LIVE_POLICY}', expected '${EXPECTED_POLICY}'. Restore it under Settings > Actions > General."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI Checks
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   # The merge queue builds main plus one pull request and merges only if this
   # workflow reports `ci-result` success on that commit, so every check below
   # also runs on the tree that will actually land.
@@ -11,18 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Non-run-ci label events intentionally skip below. Keep them out of
-  # the main CI concurrency group so an incidental label cannot cancel
-  # real checks. The ci-result job also changes its check name for
-  # those events so it cannot replace the required status with a pass.
-  group: >-
-    ${{ github.workflow }}-${{ github.ref }}-${{
-      github.event_name == 'pull_request'
-      && github.event.action == 'labeled'
-      && github.event.label.name != 'run-ci'
-      && format('label-{0}-{1}', github.event.label.name, github.run_id)
-      || 'checks'
-    }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: {}
@@ -32,12 +21,9 @@ jobs:
     # Decide trust before checkout, then compute every changed-file scope in
     # the same runner so downstream work starts after one scheduling wave.
     # Skip draft PRs (CI runs when marked ready for review via `reopened`).
-    # Also skip irrelevant label events: only the "run-ci" label matters.
     if: >-
       github.event_name == 'workflow_dispatch'
-      || (github.event.pull_request.draft != true
-          && (github.event.action != 'labeled'
-              || github.event.label.name == 'run-ci'))
+      || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -72,20 +58,19 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
-          HAS_RUN_CI_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-ci') }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
-          # Same-repo PRs are trusted: the author has write access
-          # to push branches. Fork PRs need a maintainer to add
-          # the "run-ci" label after reviewing the code.
+          # A pull_request run is trusted once it starts. Same-repo
+          # authors have write access to push branches, and a fork
+          # run only starts after a maintainer approves that exact
+          # push in the Actions UI (repository policy: approval
+          # required for all external contributors).
           #
-          # A merge group runs with the base repository's secrets, and
-          # the "run-ci" label survives pushes made after the reviewed
-          # commit, so the label cannot vouch for it. Only a same-repo
-          # pull request is trusted there; the group's head ref names
-          # it as gh-readonly-queue/<base>/pr-<number>-<sha>.
+          # A merge group runs with the base repository's secrets and
+          # carries no per-push approval. Only a same-repo pull
+          # request is trusted there; the group's head ref names it
+          # as gh-readonly-queue/<base>/pr-<number>-<sha>.
           if [[ "$EVENT_NAME" == "merge_group" ]]; then
             if [[ "$MERGE_GROUP_HEAD_REF" =~ /pr-([0-9]+)-[0-9a-f]+$ ]]; then
               queued_head_repo=$(gh api "repos/$BASE_REPO/pulls/${BASH_REMATCH[1]}" --jq '.head.repo.full_name')
@@ -98,13 +83,8 @@ jobs:
               echo "trusted=false" >> "$GITHUB_OUTPUT"
               echo "::error::Merge group for a fork pull request (head ${queued_head_repo:-unknown}). Land fork changes from a same-repo branch."
             fi
-          elif [[ "$HEAD_REPO" == "$BASE_REPO" ]]; then
-            echo "trusted=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$HAS_RUN_CI_LABEL" == "true" ]]; then
-            echo "trusted=true" >> "$GITHUB_OUTPUT"
           else
-            echo "trusted=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Fork PR without 'run-ci' label — CI skipped. A maintainer must review the code and add the 'run-ci' label to run checks."
+            echo "trusted=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout
@@ -394,8 +374,8 @@ jobs:
   # The agent sandbox must be exercised before the standalone protected
   # canary can exist on the default branch. This job is safe for draft PRs: it
   # receives no secrets, keeps the token read-only, and runs on an ephemeral
-  # hosted runner. Same-repository branches run immediately; forks retain the
-  # repository's explicit run-ci approval gate.
+  # hosted runner. Same-repository branches run immediately; forks wait for
+  # the repository's Actions approval gate.
   agent-sandbox-docker:
     name: Agent sandbox Docker isolation and lifecycle
     needs: ci-plan
@@ -2608,14 +2588,7 @@ jobs:
   # this check to pass, which ensures untrusted PRs cannot be
   # merged without CI and trusted PRs must pass all checks.
   ci-result:
-    name: >-
-      ${{
-        github.event_name == 'pull_request'
-        && github.event.action == 'labeled'
-        && github.event.label.name != 'run-ci'
-        && format('ci-result-ignored-label-{0}', github.run_id)
-        || 'ci-result'
-      }}
+    name: ci-result
     if: always()
     needs:
       [
@@ -2675,9 +2648,9 @@ jobs:
           WEB_IMAGE_SMOKE_REQUIRED: ${{ needs.ci-plan.outputs.web_image_smoke_required }}
           WINDOWS_SCRIPTS_RESULT: ${{ needs.windows-scripts.result }}
         run: |
-          # When the CI plan was skipped (draft PR or
-          # irrelevant label event), all downstream jobs are also
-          # skipped. This is expected and should not block the PR.
+          # When the CI plan was skipped (draft PR), all downstream
+          # jobs are also skipped. This is expected and should not
+          # block the PR.
           if [[ "$PLAN_RESULT" == "skipped" ]]; then
             echo "CI plan skipped. Passing."
             exit 0
@@ -2730,7 +2703,7 @@ jobs:
           fi
 
           if [[ "$TRUSTED" != "true" ]]; then
-            echo "::error::CI was not run. A maintainer must review the code and add the 'run-ci' label."
+            echo "::error::CI did not run: the merge group carries a fork pull request. Land fork changes from a same-repo branch."
             exit 1
           fi
 

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -2,9 +2,10 @@ name: PR Lint
 
 on:
   pull_request_target:
-    # Run once when the PR opens, then only when a maintainer explicitly
-    # trusts a fork with "run-ci" or requests a rerun with "run-pr-lint".
-    # This metadata-only workflow must never check out or execute PR code.
+    # Run once when a same-repo PR opens, then only when a maintainer
+    # requests a run with "run-pr-lint" (a rerun, or the first run for a
+    # fork). This metadata-only workflow must never check out or execute
+    # PR code.
     types: [opened, labeled]
 
 concurrency:
@@ -25,11 +26,10 @@ jobs:
   pr-lint:
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]'
-      && (github.event.pull_request.head.repo.full_name == github.repository
-          || contains(github.event.pull_request.labels.*.name, 'run-ci'))
-      && (github.event.action != 'labeled'
-          || github.event.label.name == 'run-ci'
-          || github.event.label.name == 'run-pr-lint')
+      && ((github.event.action == 'opened'
+           && github.event.pull_request.head.repo.full_name == github.repository)
+          || (github.event.action == 'labeled'
+              && github.event.label.name == 'run-pr-lint'))
     # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
     # Do not switch to `secrets: inherit` — that widens the blast radius
     # if the reusable ever starts touching named secrets.

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -2,10 +2,10 @@ name: PR Lint
 
 on:
   pull_request_target:
-    # Run once when a same-repo PR opens, then only when a maintainer
-    # requests a run with "run-pr-lint" (a rerun, or the first run for a
-    # fork). This metadata-only workflow must never check out or execute
-    # PR code.
+    # Run once when a PR opens, then only when a maintainer requests a
+    # rerun with "run-pr-lint". This metadata-only workflow reads the
+    # title and must never check out or execute PR code, so it is safe
+    # to run for forks without approval.
     types: [opened, labeled]
 
 concurrency:
@@ -26,10 +26,8 @@ jobs:
   pr-lint:
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]'
-      && ((github.event.action == 'opened'
-           && github.event.pull_request.head.repo.full_name == github.repository)
-          || (github.event.action == 'labeled'
-              && github.event.label.name == 'run-pr-lint'))
+      && (github.event.action == 'opened'
+          || github.event.label.name == 'run-pr-lint')
     # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
     # Do not switch to `secrets: inherit` — that widens the blast radius
     # if the reusable ever starts touching named secrets.

--- a/docs/policies/access-control.md
+++ b/docs/policies/access-control.md
@@ -83,7 +83,9 @@ operations runbook (private).
 9. **Ruleset audit.** A weekly workflow
    (`audit-branch-protection.yml`) compares the live GitHub
    ruleset against the checked-in expected configuration and
-   alerts on drift.
+   alerts on drift. The same workflow fails when the Actions
+   fork approval policy no longer requires approval for all
+   external contributors.
 
 ## Enforcement
 

--- a/docs/policies/access-control.md
+++ b/docs/policies/access-control.md
@@ -72,10 +72,13 @@ operations runbook (private).
    paths, including CI/release automation, database code and migrations,
    authentication, dependency manifests, and privileged desktop code.
 
-8. **Fork trust gate.** The CI workflow
-   (`.github/workflows/ci.yml`) skips checks on fork PRs
-   until a maintainer applies the `run-ci` label, preventing
-   untrusted code from executing in CI.
+8. **Fork trust gate.** GitHub Actions requires a maintainer to
+   approve every workflow run for a pull request from a fork
+   (repository policy: approval required for all external
+   contributors), so untrusted code never executes in CI before
+   review. The CI workflow (`.github/workflows/ci.yml`) also fails a
+   merge group that carries a fork pull request; fork changes land
+   from a same-repo branch.
 
 9. **Ruleset audit.** A weekly workflow
    (`audit-branch-protection.yml`) compares the live GitHub


### PR DESCRIPTION
## Problem

CI ran on every `pull_request` `labeled` event. For labels other than `run-ci` it skipped all jobs and renamed the aggregator to `ci-result-ignored-label-<run id>`, so a label could not pass the required check by skipping. The rename leaves the newest check suite on the commit without `ci-result`, and GitHub's merge gate then reports `Required status check "ci-result" is expected`.

Dependabot labels each pull request right after pushing, and its label events start workflows, so no Dependabot pull request could enter the merge queue (#3068, #3069, #3070 today). Any label added by a person after a pull request's last push has the same effect.

## Change

- Drop the `labeled` trigger, the aggregator rename, and the concurrency special-case from `ci.yml`. `ci-result` is always named `ci-result`.
- Fork pull requests are gated by the repository's Actions policy instead: approval is required for all external contributors, so each push is approved rather than a label that survives later pushes. The policy is already set. The merge-group check for fork pull requests stays.
- `pr-lint` runs on open for same-repo pull requests, and on the `run-pr-lint` label otherwise (rerun, or first run for a fork).
- The checked-in ruleset drops strict status checks to match the live ruleset. The merge queue rebuilds `main` plus the pull request and re-runs the required checks on that commit, so requiring the branch to be up to date only forced a second CI run.
- Policy doc updated.

## After merge

- Delete the `run-ci` label. Open fork pull requests that carry it move to the Actions approval prompt on their next push.
