### PR TITLE
fix: remount browser context after public hydration

### DIFF
--- a/apps/web/e2e/helpers/global-search.ts
+++ b/apps/web/e2e/helpers/global-search.ts
@@ -1,0 +1,37 @@
+import { expect, type Page } from "@playwright/test";
+
+const INTERACTION_TIMEOUT_MS = 1000;
+const HYDRATION_TIMEOUT_MS = 30_000;
+
+/** Opens the global-search date picker despite a public route's hydration remount. */
+export const openGlobalSearchDatePicker = async (page: Page) => {
+  const searchButton = page
+    .locator('[data-slot="sidebar"]')
+    .getByRole("button", { name: /search|hledat/iu });
+  const customRangeButton = page.getByRole("button", {
+    name: /custom range|vlastní rozsah/iu,
+  });
+  const datePickerTrigger = page
+    .getByRole("button", { name: /select date|vybrat datum/iu })
+    .first();
+  const dayGrid = page.locator('[role="gridcell"]').first();
+
+  // Public routes expose SSR controls before React has attached handlers. The
+  // browser-context remount can also close a dialog opened during hydration,
+  // so retry the whole interaction instead of only the final popover click.
+  await expect(async () => {
+    if (await dayGrid.isVisible()) {
+      return;
+    }
+    if (await datePickerTrigger.isVisible()) {
+      if ((await datePickerTrigger.getAttribute("aria-expanded")) !== "true") {
+        await datePickerTrigger.click({ timeout: INTERACTION_TIMEOUT_MS });
+      }
+    } else if (await customRangeButton.isVisible()) {
+      await customRangeButton.click({ timeout: INTERACTION_TIMEOUT_MS });
+    } else {
+      await searchButton.click({ timeout: INTERACTION_TIMEOUT_MS });
+    }
+    await expect(dayGrid).toBeVisible({ timeout: INTERACTION_TIMEOUT_MS });
+  }).toPass({ timeout: HYDRATION_TIMEOUT_MS });
+};

--- a/apps/web/e2e/specs/law-authenticated-sidebar.spec.ts
+++ b/apps/web/e2e/specs/law-authenticated-sidebar.spec.ts
@@ -1,5 +1,10 @@
+import { openGlobalSearchDatePicker } from "../helpers/global-search";
 import { expect, test } from "../helpers/test";
 import { createTestWorkspace, deleteTestWorkspace } from "../helpers/workspace";
+
+const MACOS_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36";
 
 test("authenticated law pages retain the user's recent matters", async ({
   page,
@@ -22,4 +27,38 @@ test("authenticated law pages retain the user's recent matters", async ({
   } finally {
     await deleteTestWorkspace(request, workspace.id);
   }
+});
+
+test.describe("public law hydration", () => {
+  test.use({
+    locale: "pt-PT",
+    timezoneId: "America/Los_Angeles",
+    userAgent: MACOS_USER_AGENT,
+  });
+
+  test("persisted locale activates without hydration errors", async ({
+    page,
+  }) => {
+    const fixedBrowserDate = new Date();
+    fixedBrowserDate.setUTCHours(2, 0, 0, 0);
+    const expectedToday = new Date(fixedBrowserDate.getTime() - 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    await page.clock.setFixedTime(fixedBrowserDate);
+    await page.addInitScript({
+      content: `window.localStorage.setItem(
+        "stella-i18n",
+        JSON.stringify({ state: { lang: "cs" }, version: 0 }),
+      );`,
+    });
+
+    await page.goto("/law?country=cze", { waitUntil: "commit" });
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.locator("html")).toHaveAttribute("lang", "cs");
+    await openGlobalSearchDatePicker(page);
+
+    await expect(
+      page.locator('[role="gridcell"][aria-current="date"]'),
+    ).toHaveAttribute("data-date", expectedToday);
+  });
 });

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 import { appShellNavigationLink } from "../helpers/app-shell";
+import { openGlobalSearchDatePicker } from "../helpers/global-search";
 
 const MACOS_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
@@ -162,23 +163,8 @@ test.describe("public hydration", () => {
     const firstDecision = page.locator('a[href*="/cases/"]').first();
 
     await expect(firstDecision).toBeVisible();
-    const datePickerTrigger = page
-      .getByRole("button", { name: /select date|vybrat datum/iu })
-      .first();
-    // The route is SSR'd, so the trigger is visible just before React has
-    // attached its handler and a too-early click is dropped (same gotcha as
-    // public-tools.spec.ts). Retry the open until hydration has accepted it.
-    // The re-click guard reads the trigger's aria-expanded, which the
-    // popover flips synchronously with its state: a successful click whose
-    // grid is still mounting is not toggled shut, while the dead SSR markup
-    // keeps it "false" so the pre-hydration case still retries.
-    const dayGrid = page.locator('[role="gridcell"]').first();
-    await expect(async () => {
-      if ((await datePickerTrigger.getAttribute("aria-expanded")) !== "true") {
-        await datePickerTrigger.click();
-      }
-      await expect(dayGrid).toBeVisible({ timeout: 1000 });
-    }).toPass({ timeout: 15_000 });
+    await expect(page.locator("html")).toHaveAttribute("lang", "cs");
+    await openGlobalSearchDatePicker(page);
     await expect(
       page.locator('[role="gridcell"][aria-current="date"]'),
     ).toHaveAttribute("data-date", expectedToday);

--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -99,9 +99,15 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
       });
 
   const messageLocale = preHydrationEnglish ? "en" : locale;
+  // The provider can finish hydrating while a nested Suspense boundary still
+  // holds server markup. Remount the context subtree when browser formatting
+  // becomes active so that deferred descendants mount from one coherent
+  // locale and time zone instead of hydrating against changed context.
+  const hydrationPhase = preHydrationEnglish ? "server" : "browser";
 
   return (
     <IntlProvider
+      key={hydrationPhase}
       locale={messageLocale}
       messages={activeMessages}
       timeZone={timeZone}


### PR DESCRIPTION
Public law pages could change locale and time-zone context while nested Suspense boundaries were still hydrating, producing React hydration mismatches and making the staging smoke fail. Remount the provider subtree once browser formatting becomes active, add a local regression for persisted Czech state on a macOS/Los Angeles browser, and complete the staging smoke's search/date-picker interaction before asserting browser-local dates.

Validation:
- regression fails on `origin/main` with React hydration mismatch errors and passes with this change
- pre-push affected checks: web lint, web typecheck, formatting, i18n
- full local verification completed all earlier stages; the all-repository typed lint was killed by local memory pressure, so required GitHub CI is the final gate
