### PR TITLE
fix(desktop): native strings follow the chosen language, localised dialogs, CLDR plurals

### DIFF
--- a/apps/desktop/src-tauri/src/command_manifest.rs
+++ b/apps/desktop/src-tauri/src/command_manifest.rs
@@ -17,6 +17,8 @@ macro_rules! with_stella_commands {
       commands::open_edit_root => "open_edit_root",
       commands::is_autostart_enabled => "is_autostart_enabled",
       commands::set_autostart => "set_autostart",
+      i18n::get_desktop_language => "get_desktop_language",
+      i18n::set_desktop_language => "set_desktop_language",
       clipboard_commands::clipboard_get_snapshot => "clipboard_get_snapshot",
       clipboard_commands::clipboard_complete_welcome => "clipboard_complete_welcome",
       clipboard_commands::clipboard_set_capture_status => "clipboard_set_capture_status",

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -259,10 +259,16 @@ async fn show_self_host_connect_dialog(
     return Err("A self-host connection dialog is already open.".to_string());
   }
 
+  // The dialog holds no strings of its own; its wording travels in the hash
+  // with the origins, so it renders in the language the rest of the app runs
+  // in.
   let hash = format!(
-    "webOrigin={}&apiBaseUrl={}",
+    "webOrigin={}&apiBaseUrl={}&strings={}&lang={}&dir={}",
     percent_encode(web_origin),
-    percent_encode(api_base_url)
+    percent_encode(api_base_url),
+    percent_encode(&crate::i18n::namespace_json("dialog")),
+    percent_encode(crate::i18n::active_locale()),
+    percent_encode(crate::i18n::text_direction()),
   );
 
   let builder = tauri::WebviewWindowBuilder::new(
@@ -270,7 +276,7 @@ async fn show_self_host_connect_dialog(
     "selfhost-connect-dialog",
     tauri::WebviewUrl::App(format!("selfhost-connect-dialog.html#{hash}").into()),
   )
-  .title("Connect self-hosted Stella")
+  .title(crate::i18n::t("dialog.selfHostWindowTitle"))
   .inner_size(420.0, 320.0)
   .resizable(false);
   let builder = crate::window_placement::centered_on_target_screen(

--- a/apps/desktop/src-tauri/src/i18n.rs
+++ b/apps/desktop/src-tauri/src/i18n.rs
@@ -340,7 +340,7 @@ pub fn t_plural(key: &str, count: usize) -> String {
   let template = t(key);
 
   // Parse ICU plural: {count, plural, one {…} few {…} other {…}}
-  if let Some(start) = template.find("{count, plural,") {
+  if let Some(start) = template.find(PLURAL_PREFIX) {
     let rest = &template[start..];
     let form = select_plural_form(count);
 
@@ -359,37 +359,189 @@ pub fn t_plural(key: &str, count: usize) -> String {
 
 /// CLDR plural category for Arabic, whose six categories the branch probe
 /// below cannot express: it knows only one/few/other.
-fn arabic_plural_form(count: usize) -> &'static str {
-  match count {
-    0 => "zero",
-    1 => "one",
-    2 => "two",
-    _ => match count % 100 {
-      3..=10 => "few",
-      11..=99 => "many",
-      _ => "other",
-    },
+/// CLDR plural rules, for whole numbers. The tray formats counts, never
+/// fractions, so the categories a fraction can select (`many` in Czech, in
+/// Lithuanian) are outside every rule here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PluralRule {
+  /// One for exactly 1: en, de, es, et, hu.
+  One,
+  /// One for 0 and 1 as well: fr, pt.
+  OneWithZero,
+  /// One for 1, few for 2 to 4: cs, sk.
+  OneFew,
+  Polish,
+  Lithuanian,
+  Latvian,
+  Arabic,
+}
+
+/// A rule per shipped locale. A test asserts this covers `LOCALES` exactly, so
+/// a locale cannot arrive without someone answering how it counts.
+const PLURAL_RULES: &[(&str, PluralRule)] = &[
+  ("en", PluralRule::One),
+  ("ar", PluralRule::Arabic),
+  ("cs", PluralRule::OneFew),
+  ("de", PluralRule::One),
+  ("es", PluralRule::One),
+  ("et", PluralRule::One),
+  ("fr", PluralRule::OneWithZero),
+  ("hu", PluralRule::One),
+  ("lt", PluralRule::Lithuanian),
+  ("lv", PluralRule::Latvian),
+  ("pl", PluralRule::Polish),
+  ("pt-BR", PluralRule::OneWithZero),
+  ("sk", PluralRule::OneFew),
+];
+
+fn plural_rule(locale: &str) -> Option<PluralRule> {
+  PLURAL_RULES
+    .iter()
+    .find(|(l, _)| *l == locale)
+    .map(|(_, rule)| *rule)
+}
+
+impl PluralRule {
+  fn category(self, count: usize) -> &'static str {
+    let by_ten = count % 10;
+    let by_hundred = count % 100;
+    match self {
+      Self::One => {
+        if count == 1 {
+          "one"
+        } else {
+          "other"
+        }
+      }
+      Self::OneWithZero => {
+        if count <= 1 {
+          "one"
+        } else {
+          "other"
+        }
+      }
+      Self::OneFew => match count {
+        1 => "one",
+        2..=4 => "few",
+        _ => "other",
+      },
+      // Polish leaves nothing for `other`: every whole number is one, few or
+      // many. `other` stays in the catalogues because ICU requires it.
+      Self::Polish => {
+        if count == 1 {
+          "one"
+        } else if (2..=4).contains(&by_ten) && !(12..=14).contains(&by_hundred) {
+          "few"
+        } else {
+          "many"
+        }
+      }
+      Self::Lithuanian => {
+        if (11..=19).contains(&by_hundred) {
+          "other"
+        } else if by_ten == 1 {
+          "one"
+        } else if (2..=9).contains(&by_ten) {
+          "few"
+        } else {
+          "other"
+        }
+      }
+      Self::Latvian => {
+        if by_ten == 0 || (11..=19).contains(&by_hundred) {
+          "zero"
+        } else if by_ten == 1 {
+          "one"
+        } else {
+          "other"
+        }
+      }
+      Self::Arabic => match count {
+        0 => "zero",
+        1 => "one",
+        2 => "two",
+        _ => match by_hundred {
+          3..=10 => "few",
+          11..=99 => "many",
+          _ => "other",
+        },
+      },
+    }
+  }
+
+  /// The branches a catalogue must spell out: every category the rule selects,
+  /// plus `other`, which ICU requires even where nothing selects it. This is
+  /// what the catalogues are checked against; nothing reads it at run time.
+  #[cfg(test)]
+  fn categories(self) -> &'static [&'static str] {
+    match self {
+      Self::One | Self::OneWithZero => &["one", "other"],
+      Self::OneFew => &["one", "few", "other"],
+      Self::Polish => &["one", "few", "many", "other"],
+      Self::Lithuanian => &["one", "few", "other"],
+      Self::Latvian => &["zero", "one", "other"],
+      Self::Arabic => &["zero", "one", "two", "few", "many", "other"],
+    }
   }
 }
 
-/// Select the ICU plural form based on the active locale and count.
-/// Covers CLDR plural rules for supported languages.
 fn select_plural_form(count: usize) -> &'static str {
-  let tr = active();
-  if tr.locale == "ar" {
-    return arabic_plural_form(count);
-  }
+  plural_rule(active().locale).map_or("other", |rule| rule.category(count))
+}
 
-  // Check if this locale has a "few" branch by testing a known key
-  let has_few = tr.messages.values().any(|v| v.contains("few {"));
+const PLURAL_PREFIX: &str = "{count, plural,";
 
-  if count == 1 {
-    "one"
-  } else if has_few && (2..=4).contains(&count) {
-    "few"
-  } else {
-    "other"
+/// Length of the `{…}` group `s` starts with, braces balanced.
+fn balanced_group_len(s: &str) -> Option<usize> {
+  let mut depth = 0usize;
+  for (index, character) in s.char_indices() {
+    match character {
+      '{' => depth += 1,
+      '}' => {
+        depth -= 1;
+        if depth == 0 {
+          return Some(index + character.len_utf8());
+        }
+      }
+      _ => {}
+    }
   }
+  None
+}
+
+/// The branch names an ICU plural message spells out, in order. Empty for a
+/// message that is not a plural. Only the catalogue guard reads this: at run
+/// time a branch is looked up by name, never enumerated.
+#[cfg(test)]
+fn plural_branch_names(icu: &str) -> Vec<String> {
+  let Some(start) = icu.find(PLURAL_PREFIX) else {
+    return Vec::new();
+  };
+
+  let mut rest = &icu[start + PLURAL_PREFIX.len()..];
+  let mut names = Vec::new();
+  loop {
+    let trimmed = rest.trim_start();
+    let Some(brace) = trimmed.find('{') else {
+      break;
+    };
+    let name = trimmed[..brace].trim();
+    // Anything else is the text after the plural argument, not a branch.
+    if name.is_empty()
+      || !name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '=')
+    {
+      break;
+    }
+    let body = &trimmed[brace..];
+    let Some(length) = balanced_group_len(body) else {
+      break;
+    };
+    names.push(name.to_string());
+    rest = &body[length..];
+  }
+  names
 }
 
 /// Extract a branch from an ICU plural pattern.
@@ -398,36 +550,17 @@ fn select_plural_form(count: usize) -> &'static str {
 fn extract_plural_branch(icu: &str, form: &str) -> Option<String> {
   let needle = format!("{form} {{");
   let branch_start = icu.find(&needle)?;
-  let content_start = branch_start + needle.len();
-  let rest = &icu[content_start..];
-
-  // Find the matching closing brace (handle nested `{count}`)
-  let mut depth = 1;
-  let mut end = 0;
-  for (i, ch) in rest.char_indices() {
-    match ch {
-      '{' => depth += 1,
-      '}' => {
-        depth -= 1;
-        if depth == 0 {
-          end = i;
-          break;
-        }
-      }
-      _ => {}
-    }
-  }
-
-  if end > 0 {
-    Some(rest[..end].to_string())
-  } else {
-    None
-  }
+  // Start at the branch's opening brace so the nested `{count}` is balanced
+  // rather than read as the end of the branch.
+  let body = &icu[branch_start + needle.len() - 1..];
+  let length = balanced_group_len(body)?;
+  Some(body[1..length - 1].to_string())
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::collections::BTreeSet;
 
   fn ensure_init() {
     init_en();
@@ -606,20 +739,173 @@ mod tests {
     assert_eq!(resolve_locale("ja-JP"), None);
   }
 
-  // -- arabic_plural_form --
+  // -- plural rules --
+
+  /// The counts each rule family is checked at: a singular, a small plural,
+  /// the teens Slavic and Baltic rules treat apart, and the same shapes again
+  /// past 100, where a rule that reads the whole number instead of its last
+  /// two digits gives itself away.
+  const PLURAL_COUNTS: [usize; 11] = [0, 1, 2, 5, 11, 21, 22, 25, 101, 111, 112];
+
+  fn categories_at(rule: PluralRule) -> Vec<&'static str> {
+    PLURAL_COUNTS
+      .iter()
+      .map(|count| rule.category(*count))
+      .collect()
+  }
 
   #[test]
-  fn test_arabic_plural_form_covers_every_category() {
-    assert_eq!(arabic_plural_form(0), "zero");
-    assert_eq!(arabic_plural_form(1), "one");
-    assert_eq!(arabic_plural_form(2), "two");
-    assert_eq!(arabic_plural_form(3), "few");
-    assert_eq!(arabic_plural_form(10), "few");
-    assert_eq!(arabic_plural_form(11), "many");
-    assert_eq!(arabic_plural_form(99), "many");
-    assert_eq!(arabic_plural_form(100), "other");
-    assert_eq!(arabic_plural_form(102), "other");
-    assert_eq!(arabic_plural_form(103), "few");
+  fn one_other_rule_matches_cldr() {
+    assert_eq!(
+      categories_at(PluralRule::One),
+      [
+        "other", "one", "other", "other", "other", "other", "other", "other", "other",
+        "other", "other"
+      ]
+    );
+  }
+
+  #[test]
+  fn one_with_zero_rule_matches_cldr() {
+    assert_eq!(
+      categories_at(PluralRule::OneWithZero),
+      [
+        "one", "one", "other", "other", "other", "other", "other", "other", "other",
+        "other", "other"
+      ]
+    );
+  }
+
+  #[test]
+  fn one_few_rule_matches_cldr() {
+    assert_eq!(
+      categories_at(PluralRule::OneFew),
+      [
+        "other", "one", "few", "other", "other", "other", "other", "other", "other",
+        "other", "other"
+      ]
+    );
+  }
+
+  #[test]
+  fn polish_rule_matches_cldr() {
+    assert_eq!(
+      categories_at(PluralRule::Polish),
+      [
+        "many", "one", "few", "many", "many", "many", "few", "many", "many", "many",
+        "many"
+      ]
+    );
+  }
+
+  #[test]
+  fn lithuanian_rule_matches_cldr() {
+    assert_eq!(
+      categories_at(PluralRule::Lithuanian),
+      [
+        "other", "one", "few", "few", "other", "one", "few", "few", "one", "other",
+        "other"
+      ]
+    );
+  }
+
+  #[test]
+  fn latvian_rule_matches_cldr() {
+    assert_eq!(
+      categories_at(PluralRule::Latvian),
+      [
+        "zero", "one", "other", "other", "zero", "one", "other", "other", "one",
+        "zero", "zero"
+      ]
+    );
+  }
+
+  #[test]
+  fn arabic_rule_matches_cldr() {
+    assert_eq!(
+      categories_at(PluralRule::Arabic),
+      [
+        "zero", "one", "two", "few", "many", "many", "many", "many", "other", "many",
+        "many"
+      ]
+    );
+  }
+
+  #[test]
+  fn every_shipped_locale_has_a_plural_rule() {
+    let mut declared: Vec<&str> = LOCALES.iter().map(|(l, _)| *l).collect();
+    declared.sort_unstable();
+    let mut ruled: Vec<&str> = PLURAL_RULES.iter().map(|(l, _)| *l).collect();
+    ruled.sort_unstable();
+    assert_eq!(ruled, declared);
+  }
+
+  #[test]
+  fn a_rule_only_selects_categories_it_declares() {
+    for (_, rule) in PLURAL_RULES {
+      let declared: BTreeSet<&str> = rule.categories().iter().copied().collect();
+      let mut selected: BTreeSet<&str> = BTreeSet::new();
+      for count in 0..=1200usize {
+        let category = rule.category(count);
+        assert!(declared.contains(category), "{rule:?} selected {category}");
+        selected.insert(category);
+      }
+      // Everything but ICU's mandatory `other` has to be reachable, otherwise
+      // the catalogues are asked for a branch nothing renders.
+      for category in declared.iter().filter(|category| **category != "other") {
+        assert!(
+          selected.contains(category),
+          "{rule:?} never selects {category}"
+        );
+      }
+    }
+  }
+
+  // -- plural_branch_names --
+
+  #[test]
+  fn plural_branch_names_reads_every_branch() {
+    let icu = "{count, plural, zero {none} one {1 item} other {{count} items}}";
+    assert_eq!(plural_branch_names(icu), ["zero", "one", "other"]);
+  }
+
+  #[test]
+  fn plural_branch_names_stops_at_the_end_of_the_argument() {
+    let icu = "{count, plural, one {1 item} other {{count} items}} in {folder}";
+    assert_eq!(plural_branch_names(icu), ["one", "other"]);
+  }
+
+  #[test]
+  fn plural_branch_names_is_empty_for_a_plain_message() {
+    assert_eq!(plural_branch_names("Open file").len(), 0);
+  }
+
+  /// Every plural message spells out exactly the categories its locale's rule
+  /// can select, so a count never falls through to a branch written for
+  /// another number. Fails on a new plural message, a new locale, or a rule
+  /// that gains a category.
+  #[test]
+  fn every_plural_message_names_its_locale_s_categories() {
+    for (locale, source) in LOCALES {
+      let rule = plural_rule(locale).expect("plural rule for a shipped locale");
+      let expected: BTreeSet<String> = rule
+        .categories()
+        .iter()
+        .map(|category| (*category).to_string())
+        .collect();
+
+      let mut checked = 0usize;
+      for (key, message) in parse_locale(source) {
+        if !message.contains(PLURAL_PREFIX) {
+          continue;
+        }
+        let named: BTreeSet<String> =
+          plural_branch_names(&message).into_iter().collect();
+        assert_eq!(named, expected, "{locale} {key}");
+        checked += 1;
+      }
+      assert!(checked > 0, "{locale} has no plural messages to check");
+    }
   }
 
   // -- flatten_json --

--- a/apps/desktop/src-tauri/src/i18n.rs
+++ b/apps/desktop/src-tauri/src/i18n.rs
@@ -1,12 +1,27 @@
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock, RwLock};
 
-static TRANSLATIONS: OnceLock<Translations> = OnceLock::new();
+use crate::config::APP_DATA_DIR_NAME;
+
+/// The locale the native strings render in. It lives here rather than in
+/// Tauri's managed state because `t` is called from places that hold no
+/// `AppHandle`: the session manager, the retry loop, the tray builder.
+static ACTIVE: RwLock<Option<&'static Translations>> = RwLock::new(None);
+
+/// Catalogues parsed so far, kept for the process lifetime so `t` can hand out
+/// a `&str` that outlives a locale change. Bounded by the shipped locales.
+static PARSED: Mutex<Vec<&'static Translations>> = Mutex::new(Vec::new());
+
+/// The saved language, one locale tag. Absent means "follow the system", which
+/// is also what an unreadable or unrecognised file means.
+const LANGUAGE_FILE_NAME: &str = "language";
 
 struct Translations {
   locale: &'static str,
   messages: HashMap<String, String>,
-  fallback: HashMap<String, String>,
+  fallback: &'static HashMap<String, String>,
 }
 
 /// Every locale the app ships, in the picker's order. A test asserts this
@@ -85,47 +100,189 @@ fn resolve_locale(tag: &str) -> Option<&'static str> {
   None
 }
 
-fn detect_locale() -> &'static str {
-  sys_locale::get_locale()
-    .and_then(|tag| resolve_locale(&tag))
-    .unwrap_or("en")
+fn english_messages() -> &'static HashMap<String, String> {
+  static ENGLISH: OnceLock<HashMap<String, String>> = OnceLock::new();
+  ENGLISH.get_or_init(|| {
+    parse_locale(locale_source("en").map_or("{}", |(_, source)| source))
+  })
+}
+
+fn translations_for(
+  locale: &'static str,
+  source: &'static str,
+) -> &'static Translations {
+  let mut parsed = PARSED.lock().expect("i18n catalogue cache");
+  if let Some(cached) = parsed.iter().copied().find(|t| t.locale == locale) {
+    return cached;
+  }
+
+  let built: &'static Translations = Box::leak(Box::new(Translations {
+    locale,
+    messages: parse_locale(source),
+    fallback: english_messages(),
+  }));
+  parsed.push(built);
+  built
+}
+
+fn active() -> &'static Translations {
+  let guard = ACTIVE.read().expect("i18n active locale");
+  guard.expect("i18n not initialized; call i18n::init() first")
+}
+
+/// The locale the native strings currently render in.
+pub fn active_locale() -> &'static str {
+  active().locale
+}
+
+/// Renders the native strings in `tag`'s locale from here on. Returns the
+/// locale that was resolved, or `None` when the app ships nothing for `tag`.
+pub fn set_active_locale(tag: &str) -> Option<&'static str> {
+  let locale = resolve_locale(tag)?;
+  let (locale, source) = locale_source(locale)?;
+  let translations = translations_for(locale, source);
+  *ACTIVE.write().expect("i18n active locale") = Some(translations);
+  Some(locale)
+}
+
+/// The saved language wins over the system's: it is the one the user picked in
+/// this app, and it must survive a system whose locale says otherwise.
+fn choose_startup_locale(
+  saved: Option<&'static str>,
+  system: Option<&'static str>,
+) -> &'static str {
+  saved.or(system).unwrap_or("en")
+}
+
+fn system_locale() -> Option<&'static str> {
+  sys_locale::get_locale().and_then(|tag| resolve_locale(&tag))
 }
 
 /// Initialize the translation system. Call once at startup.
 pub fn init() {
-  init_with_locale(detect_locale());
+  let saved = saved_language_path()
+    .as_deref()
+    .and_then(read_language_file)
+    .and_then(|tag| resolve_locale(&tag));
+  set_active_locale(choose_startup_locale(saved, system_locale()));
 }
 
-/// Initialize with a specific locale. Useful for tests.
+/// Initialize with English. Tests read the source catalogue, never the saved
+/// language, so a developer's own preference cannot change what they assert.
 #[cfg(test)]
 pub fn init_en() {
-  init_with_locale("en");
+  set_active_locale("en");
 }
 
-fn init_with_locale(locale: &str) {
-  TRANSLATIONS.get_or_init(|| {
-    let fallback = parse_locale(locale_source("en").map(|(_, s)| s).unwrap_or("{}"));
+fn saved_language_path() -> Option<PathBuf> {
+  dirs::data_dir()
+    .map(|data_dir| data_dir.join(APP_DATA_DIR_NAME).join(LANGUAGE_FILE_NAME))
+}
 
-    match locale_source(locale) {
-      Some((locale, source)) => Translations {
-        locale,
-        messages: parse_locale(source),
-        fallback,
-      },
-      None => Translations {
-        locale: "en",
-        messages: fallback.clone(),
-        fallback,
-      },
+/// Reads the saved locale tag. Only a regular file counts: a directory or a
+/// symlink at the path is never read, as with the app-data marker files.
+fn read_language_file(path: &Path) -> Option<String> {
+  if !fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_file()) {
+    return None;
+  }
+  let raw = fs::read_to_string(path).ok()?;
+  let tag = raw.trim();
+  (!tag.is_empty()).then(|| tag.to_string())
+}
+
+fn write_language_file(path: &Path, locale: &str) -> Result<(), String> {
+  match fs::symlink_metadata(path) {
+    Ok(meta) if !meta.file_type().is_file() => {
+      return Err("saved language path is not a regular file".to_string());
     }
-  });
+    _ => {}
+  }
+
+  let parent = path
+    .parent()
+    .ok_or_else(|| "saved language path is invalid".to_string())?;
+  fs::create_dir_all(parent)
+    .map_err(|error| format!("saved language directory failed: {error}"))?;
+
+  // Written beside the target and renamed into place, as the clipboard store
+  // does: the rename replaces whatever sits at the path in one step instead
+  // of following a link planted there after the check above.
+  let temp_path = path.with_extension(format!(
+    "{}.{}.tmp",
+    std::process::id(),
+    uuid::Uuid::new_v4()
+  ));
+  if let Err(error) = fs::write(&temp_path, locale) {
+    let _ = fs::remove_file(&temp_path);
+    return Err(format!("saved language write failed: {error}"));
+  }
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Err(error) =
+      fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600))
+    {
+      let _ = fs::remove_file(&temp_path);
+      return Err(format!("saved language permissions failed: {error}"));
+    }
+  }
+  if let Err(error) = fs::rename(&temp_path, path) {
+    let _ = fs::remove_file(&temp_path);
+    return Err(format!("saved language replace failed: {error}"));
+  }
+  Ok(())
+}
+
+/// Saves `locale` so the next launch renders native strings in it before any
+/// window exists. Writing only on a change keeps a window's start-up
+/// reconciliation from touching the disk on every launch.
+fn persist_language(locale: &str) -> Result<(), String> {
+  let path = saved_language_path()
+    .ok_or_else(|| "app data directory is unavailable".to_string())?;
+  if read_language_file(&path).as_deref() == Some(locale) {
+    return Ok(());
+  }
+  write_language_file(&path, locale)
+}
+
+/// The locale the native strings render in, for a window that has to agree
+/// with them.
+#[tauri::command]
+pub fn get_desktop_language() -> String {
+  active_locale().to_string()
+}
+
+/// Switches the native strings to `language` and saves the choice. The tray
+/// menu is the one native string that is built once and cached, so it is
+/// rebuilt here; notifications and dialogs render when they are shown.
+#[tauri::command]
+pub async fn set_desktop_language(
+  language: String,
+  app: tauri::AppHandle,
+  state: tauri::State<'_, crate::commands::AppState>,
+) -> Result<String, String> {
+  let unshipped = || format!("stella desktop does not ship the language {language}.");
+  let locale = resolve_locale(&language).ok_or_else(unshipped)?;
+  // Saved before it goes live: a choice the disk refused must not become the
+  // locale the notifications already render in while the tray and the
+  // windows stay behind, and the next launch would revert it anyway.
+  persist_language(locale)?;
+
+  let previous = active_locale();
+  let locale = set_active_locale(locale).ok_or_else(unshipped)?;
+
+  if locale != previous {
+    let snapshot = state.lock().await.get_snapshot();
+    crate::tray::refresh(&app, &snapshot);
+  }
+
+  Ok(locale.to_string())
 }
 
 /// Look up a translation key. Falls back to English, then returns the key itself.
 pub fn t(key: &str) -> &str {
-  let tr = TRANSLATIONS
-    .get()
-    .expect("i18n not initialized; call i18n::init() first");
+  let tr = active();
   tr.messages
     .get(key)
     .or_else(|| tr.fallback.get(key))
@@ -185,7 +342,7 @@ fn arabic_plural_form(count: usize) -> &'static str {
 /// Select the ICU plural form based on the active locale and count.
 /// Covers CLDR plural rules for supported languages.
 fn select_plural_form(count: usize) -> &'static str {
-  let tr = TRANSLATIONS.get().expect("i18n not initialized");
+  let tr = active();
   if tr.locale == "ar" {
     return arabic_plural_form(count);
   }
@@ -271,6 +428,63 @@ mod tests {
     declared.sort();
 
     assert_eq!(declared, on_disk);
+  }
+
+  // -- startup resolution --
+
+  fn unique_path() -> PathBuf {
+    std::env::temp_dir().join(format!("stella-language-{}", uuid::Uuid::new_v4()))
+  }
+
+  #[test]
+  fn saved_language_beats_the_system_locale() {
+    assert_eq!(choose_startup_locale(Some("cs"), Some("de")), "cs");
+  }
+
+  #[test]
+  fn system_locale_applies_when_nothing_is_saved() {
+    assert_eq!(choose_startup_locale(None, Some("de")), "de");
+  }
+
+  #[test]
+  fn english_applies_when_neither_resolves() {
+    assert_eq!(choose_startup_locale(None, None), "en");
+  }
+
+  #[test]
+  fn a_saved_language_round_trips() {
+    let path = unique_path();
+    assert_eq!(read_language_file(&path), None);
+
+    write_language_file(&path, "pt-BR").unwrap();
+    assert_eq!(read_language_file(&path).as_deref(), Some("pt-BR"));
+
+    write_language_file(&path, "ar").unwrap();
+    assert_eq!(read_language_file(&path).as_deref(), Some("ar"));
+
+    fs::remove_file(&path).unwrap();
+  }
+
+  #[test]
+  fn a_directory_is_never_a_saved_language() {
+    let path = unique_path();
+    fs::create_dir(&path).unwrap();
+
+    assert_eq!(read_language_file(&path), None);
+    assert!(write_language_file(&path, "cs").is_err());
+
+    fs::remove_dir(&path).unwrap();
+  }
+
+  #[test]
+  fn an_unrecognised_saved_language_is_ignored() {
+    let path = unique_path();
+    write_language_file(&path, "kl-GL").unwrap();
+
+    let saved = read_language_file(&path).and_then(|tag| resolve_locale(&tag));
+    assert_eq!(choose_startup_locale(saved, Some("de")), "de");
+
+    fs::remove_file(&path).unwrap();
   }
 
   // -- resolve_locale --

--- a/apps/desktop/src-tauri/src/i18n.rs
+++ b/apps/desktop/src-tauri/src/i18n.rs
@@ -246,6 +246,39 @@ fn persist_language(locale: &str) -> Result<(), String> {
   write_language_file(&path, locale)
 }
 
+/// Right-to-left locales, as the shared direction map the web app reads
+/// declares them. A test pins this list to that map.
+const RTL_LOCALES: &[&str] = &["ar"];
+
+/// The direction the active locale lays out in, for a window that has no
+/// bundle of its own to read it from.
+pub fn text_direction() -> &'static str {
+  if RTL_LOCALES.contains(&active_locale()) {
+    "rtl"
+  } else {
+    "ltr"
+  }
+}
+
+/// The catalogue entries under `namespace`, keyed by their leaf name, as a
+/// JSON object. The dialog windows render from this rather than carrying
+/// their own copies of the strings, so their keys live in the catalogues with
+/// everything else and the parity test covers them.
+pub fn namespace_json(namespace: &str) -> String {
+  let tr = active();
+  let prefix = format!("{namespace}.");
+  let mut entries = serde_json::Map::new();
+  // English first so a locale that is missing a key still renders something.
+  for source in [tr.fallback, &tr.messages] {
+    for (key, value) in source {
+      if let Some(leaf) = key.strip_prefix(&prefix) {
+        entries.insert(leaf.to_string(), serde_json::Value::String(value.clone()));
+      }
+    }
+  }
+  serde_json::Value::Object(entries).to_string()
+}
+
 /// The locale the native strings render in, for a window that has to agree
 /// with them.
 #[tauri::command]
@@ -428,6 +461,68 @@ mod tests {
     declared.sort();
 
     assert_eq!(declared, on_disk);
+  }
+
+  /// The web app reads its directions from `packages/locales`; a dialog window
+  /// has no bundle to read them from, so the list here is a second copy. This
+  /// reads the shared map so the copy cannot quietly disagree with it, and
+  /// fails if a shipped locale is missing from the map altogether.
+  #[test]
+  fn rtl_locales_match_the_shared_direction_map() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+      .join("../../../packages/locales/src/directions.ts");
+    let source = std::fs::read_to_string(&path).expect("shared direction map");
+
+    let mut mapped: Vec<(String, String)> = Vec::new();
+    for line in source.lines() {
+      let Some((left, right)) = line.split_once(':') else {
+        continue;
+      };
+      let locale = left.trim().trim_matches('"');
+      let Some(direction) = right.trim().strip_prefix('"') else {
+        continue;
+      };
+      let Some(direction) = direction.split('"').next() else {
+        continue;
+      };
+      if direction == "ltr" || direction == "rtl" {
+        mapped.push((locale.to_string(), direction.to_string()));
+      }
+    }
+
+    let mut declared: Vec<String> =
+      LOCALES.iter().map(|(l, _)| (*l).to_string()).collect();
+    declared.sort();
+    let mut mapped_locales: Vec<String> =
+      mapped.iter().map(|(locale, _)| locale.clone()).collect();
+    mapped_locales.sort();
+    assert_eq!(declared, mapped_locales);
+
+    let mut shared_rtl: Vec<&str> = mapped
+      .iter()
+      .filter(|(_, direction)| direction == "rtl")
+      .map(|(locale, _)| locale.as_str())
+      .collect();
+    shared_rtl.sort_unstable();
+    let mut ours = RTL_LOCALES.to_vec();
+    ours.sort_unstable();
+    assert_eq!(ours, shared_rtl);
+  }
+
+  #[test]
+  fn dialog_strings_come_from_the_catalogue() {
+    ensure_init();
+    let strings: serde_json::Value =
+      serde_json::from_str(&namespace_json("dialog")).unwrap();
+
+    assert_eq!(strings["deny"], "Deny");
+    assert_eq!(
+      strings["takeoverTitle"],
+      "{requester} wants to take over editing"
+    );
+    // The namespace prefix is stripped and nothing outside it leaks in.
+    assert!(strings.get("dialog.deny").is_none());
+    assert!(strings.get("settings").is_none());
   }
 
   // -- startup resolution --

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -205,12 +205,7 @@ pub fn run() {
             mgr.ensure_sse_listener(&manager, sid);
           }
 
-          let snapshot = mgr.get_snapshot();
-          if let Ok(menu) = tray::build_tray_menu(&handle, &snapshot)
-            && let Some(tray) = handle.tray_by_id("main")
-          {
-            let _ = tray.set_menu(Some(menu));
-          }
+          tray::refresh(&handle, &mgr.get_snapshot());
         });
       }
 

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -2125,12 +2125,7 @@ impl SessionManager {
       let snapshot = self.get_snapshot();
       let _ = handle.emit_to("main", "state-changed", &snapshot);
 
-      // Rebuild tray menu to reflect new state
-      if let Ok(menu) = crate::tray::build_tray_menu(handle, &snapshot)
-        && let Some(tray) = handle.tray_by_id("main")
-      {
-        let _ = tray.set_menu(Some(menu));
-      }
+      crate::tray::refresh(handle, &snapshot);
     }
   }
 

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -2476,11 +2476,16 @@ async fn show_takeover_dialog(
   requested_by: &str,
   file_name: &str,
 ) -> bool {
-  // Pass dynamic data via URL hash — the static HTML reads it via JS.
+  // Pass dynamic data via URL hash — the static HTML reads it via JS. The
+  // dialog's own wording travels the same way: it holds no strings of its own,
+  // so it renders in the language the rest of the app runs in.
   let hash = format!(
-    "requester={}&fileName={}",
+    "requester={}&fileName={}&strings={}&lang={}&dir={}",
     urlencode(requested_by),
     urlencode(file_name),
+    urlencode(&crate::i18n::namespace_json("dialog")),
+    urlencode(crate::i18n::active_locale()),
+    urlencode(crate::i18n::text_direction()),
   );
 
   let builder = tauri::WebviewWindowBuilder::new(
@@ -2488,7 +2493,7 @@ async fn show_takeover_dialog(
     "takeover-dialog",
     tauri::WebviewUrl::App(format!("takeover-dialog.html#{hash}").into()),
   )
-  .title("stella desktop")
+  .title(crate::i18n::t("dialog.takeoverWindowTitle"))
   .inner_size(400.0, 260.0)
   .resizable(false)
   .always_on_top(true);

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -86,6 +86,17 @@ fn get_tray_status_label(snapshot: &AppSnapshot) -> String {
   t("tray.noActiveEdits").to_string()
 }
 
+/// Rebuilds the tray menu from `snapshot`. The menu is the one native string
+/// the app caches, so both state changes and a language change come through
+/// here. A failed rebuild leaves the previous menu in place.
+pub fn refresh(app: &AppHandle, snapshot: &AppSnapshot) {
+  if let Ok(menu) = build_tray_menu(app, snapshot)
+    && let Some(tray) = app.tray_by_id("main")
+  {
+    let _ = tray.set_menu(Some(menu));
+  }
+}
+
 pub fn build_tray_menu(
   app: &AppHandle,
   snapshot: &AppSnapshot,

--- a/apps/desktop/src/i18n/index.tsx
+++ b/apps/desktop/src/i18n/index.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import { IntlProvider } from "use-intl";
 
@@ -87,23 +88,50 @@ const catalogueModules = {
 
 export const detectedLanguage = detectLanguage();
 
-export const getPreferredLanguage = (): SupportedLanguage => {
+const storedLanguage = (): SupportedLanguage | null => {
   try {
-    const storedLanguage = localStorage.getItem(DESKTOP_LANGUAGE_STORAGE_KEY);
-    if (storedLanguage && isSupportedLanguage(storedLanguage)) {
-      return storedLanguage;
-    }
+    const stored = localStorage.getItem(DESKTOP_LANGUAGE_STORAGE_KEY);
+    return stored !== null && isSupportedLanguage(stored) ? stored : null;
   } catch {
-    return detectedLanguage;
+    return null;
   }
-
-  return detectedLanguage;
 };
 
+export const getPreferredLanguage = (): SupportedLanguage =>
+  storedLanguage() ?? detectedLanguage;
+
 export const setPreferredLanguage = async (language: SupportedLanguage) => {
+  // The tray, the menus and the notifications render from the locale the
+  // backend holds, so the choice has to reach it, not only this window. It
+  // is stored only once the backend accepted it: a refused choice left in
+  // storage would come back on the next window as if it had gone through.
+  await invoke("set_desktop_language", { language });
   localStorage.setItem(DESKTOP_LANGUAGE_STORAGE_KEY, language);
   await emit(DESKTOP_LANGUAGE_CHANGED_EVENT, { language });
 };
+
+/**
+ * Settles the one language the app runs in when a window starts.
+ *
+ * A stored choice wins: the backend may predate it, and adopting the
+ * backend's own resolution would silently discard what the user picked.
+ * With nothing stored, the backend's resolution is adopted instead of
+ * detecting a second time here, so the tray and the windows cannot start
+ * out in different languages.
+ */
+export const synchronizeDesktopLanguage =
+  async (): Promise<SupportedLanguage> => {
+    const stored = storedLanguage();
+    if (stored) {
+      await invoke("set_desktop_language", { language: stored });
+      return stored;
+    }
+
+    const native = await invoke<string>("get_desktop_language");
+    const language = isSupportedLanguage(native) ? native : detectedLanguage;
+    localStorage.setItem(DESKTOP_LANGUAGE_STORAGE_KEY, language);
+    return language;
+  };
 
 /** Lays the window out in the language's own direction, so an RTL locale
  *  mirrors the whole UI rather than only its text. */

--- a/apps/desktop/src/i18n/langs/ar.json
+++ b/apps/desktop/src/i18n/langs/ar.json
@@ -51,6 +51,22 @@
     "takenOverTitle": "انتقل التحرير إلى جهاز آخر",
     "takenOverLocalError": "انتقل التحرير على سطح المكتب إلى جهاز آخر. هذه النسخة المحلية محفوظة."
   },
+  "dialog": {
+    "allow": "السماح",
+    "apiUrl": "عنوان API",
+    "cancel": "إلغاء",
+    "connect": "الاتصال",
+    "deny": "الرفض",
+    "selfHostSubtitle": "السماح لموقع stella هذا بفتح المستندات في stella desktop.",
+    "selfHostTitle": "هل تريد الاتصال بنسخة stella المستضافة ذاتياً هذه؟",
+    "selfHostWindowTitle": "الاتصال بنسخة stella المستضافة ذاتياً",
+    "takeoverFile": "ملف Office",
+    "takeoverRequester": "شخص ما",
+    "takeoverSubtitle": "سيتابع من آخر نقطة حفظ لديك.",
+    "takeoverTitle": "يريد {requester} تولي التحرير",
+    "takeoverWindowTitle": "طلب تولي التحرير",
+    "webOrigin": "أصل الويب"
+  },
   "settings": {
     "about": "حول",
     "connected": "متصل",

--- a/apps/desktop/src/i18n/langs/cs.json
+++ b/apps/desktop/src/i18n/langs/cs.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Úpravy na desktopu přesunuty na jiné zařízení. Tato lokální kopie je zachována.",
     "takenOverTitle": "Úpravy přesunuty na jiné zařízení"
   },
+  "dialog": {
+    "allow": "Povolit",
+    "apiUrl": "Adresa API",
+    "cancel": "Zrušit",
+    "connect": "Připojit",
+    "deny": "Odepřít",
+    "selfHostSubtitle": "Povolit tomuto webu stella otevírat dokumenty v aplikaci stella desktop.",
+    "selfHostTitle": "Připojit tuto vlastní instalaci stella?",
+    "selfHostWindowTitle": "Připojit vlastní instalaci stella",
+    "takeoverFile": "Soubor Office",
+    "takeoverRequester": "Někdo",
+    "takeoverSubtitle": "Bude pokračovat od vašeho posledního uloženého kontrolního bodu.",
+    "takeoverTitle": "{requester} chce převzít úpravy",
+    "takeoverWindowTitle": "Žádost o převzetí",
+    "webOrigin": "Původ webu"
+  },
   "settings": {
     "about": "O aplikaci",
     "connected": "Připojeno",

--- a/apps/desktop/src/i18n/langs/de.json
+++ b/apps/desktop/src/i18n/langs/de.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Desktop-Bearbeitung auf anderes Gerät verschoben. Diese lokale Kopie bleibt erhalten.",
     "takenOverTitle": "Bearbeitung auf anderes Gerät verschoben"
   },
+  "dialog": {
+    "allow": "Zulassen",
+    "apiUrl": "API-URL",
+    "cancel": "Abbrechen",
+    "connect": "Verbinden",
+    "deny": "Ablehnen",
+    "selfHostSubtitle": "Dieser stella-Website erlauben, Dokumente in stella desktop zu öffnen.",
+    "selfHostTitle": "Diese selbst gehostete stella verbinden?",
+    "selfHostWindowTitle": "Selbst gehostete stella verbinden",
+    "takeoverFile": "Office-Datei",
+    "takeoverRequester": "Jemand",
+    "takeoverSubtitle": "Die Bearbeitung wird ab Ihrem zuletzt gespeicherten Checkpoint fortgesetzt.",
+    "takeoverTitle": "{requester} möchte die Bearbeitung übernehmen",
+    "takeoverWindowTitle": "Übernahmeanfrage",
+    "webOrigin": "Web-Origin"
+  },
   "settings": {
     "about": "Über",
     "connected": "Verbunden",

--- a/apps/desktop/src/i18n/langs/en.json
+++ b/apps/desktop/src/i18n/langs/en.json
@@ -53,6 +53,22 @@
     "takenOverTitle": "Editing moved to another device",
     "takenOverLocalError": "Desktop editing moved to another device. This local copy is preserved."
   },
+  "dialog": {
+    "allow": "Allow",
+    "apiUrl": "API URL",
+    "cancel": "Cancel",
+    "connect": "Connect",
+    "deny": "Deny",
+    "selfHostSubtitle": "Allow this stella site to open documents in stella desktop.",
+    "selfHostTitle": "Connect this self-hosted stella?",
+    "selfHostWindowTitle": "Connect self-hosted stella",
+    "takeoverFile": "Office file",
+    "takeoverRequester": "Someone",
+    "takeoverSubtitle": "They'll continue from your latest saved checkpoint.",
+    "takeoverTitle": "{requester} wants to take over editing",
+    "takeoverWindowTitle": "Takeover request",
+    "webOrigin": "Web origin"
+  },
   "settings": {
     "about": "About",
     "connected": "Connected",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "La edición de escritorio se movió a otro dispositivo. Esta copia local se mantiene preservada.",
     "takenOverTitle": "Edición movida a otro dispositivo"
   },
+  "dialog": {
+    "allow": "Permitir",
+    "apiUrl": "URL de la API",
+    "cancel": "Cancelar",
+    "connect": "Conectar",
+    "deny": "Denegar",
+    "selfHostSubtitle": "Permitir que este sitio de stella abra documentos en stella desktop.",
+    "selfHostTitle": "¿Conectar esta stella autoalojada?",
+    "selfHostWindowTitle": "Conectar stella autoalojada",
+    "takeoverFile": "Archivo de Office",
+    "takeoverRequester": "Alguien",
+    "takeoverSubtitle": "Continuará desde tu último punto de control guardado.",
+    "takeoverTitle": "{requester} quiere tomar el control de la edición",
+    "takeoverWindowTitle": "Solicitud de control",
+    "webOrigin": "Origen web"
+  },
   "settings": {
     "about": "Acerca de",
     "connected": "Conectado",

--- a/apps/desktop/src/i18n/langs/et.json
+++ b/apps/desktop/src/i18n/langs/et.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Töölaua muutmine teisaldatud teise seadmesse. See kohalik koopia on säilitatud.",
     "takenOverTitle": "Muutmine teisaldatud teise seadmesse"
   },
+  "dialog": {
+    "allow": "Luba",
+    "apiUrl": "API aadress",
+    "cancel": "Loobu",
+    "connect": "Ühenda",
+    "deny": "Keela",
+    "selfHostSubtitle": "Luba sellel stella saidil avada dokumente rakenduses stella desktop.",
+    "selfHostTitle": "Kas ühendada see ise majutatud stella?",
+    "selfHostWindowTitle": "Ühenda ise majutatud stella",
+    "takeoverFile": "Office'i fail",
+    "takeoverRequester": "Keegi",
+    "takeoverSubtitle": "Ta jätkab teie viimasest salvestatud kontrollpunktist.",
+    "takeoverTitle": "{requester} soovib redigeerimise üle võtta",
+    "takeoverWindowTitle": "Ülevõtmistaotlus",
+    "webOrigin": "Veebi päritolu"
+  },
   "settings": {
     "about": "Teave",
     "connected": "Ühendatud",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -1,8 +1,8 @@
 {
   "tray": {
-    "activeEdits": "{count, plural, one {1 modification active} other {{count} modifications actives}}",
+    "activeEdits": "{count, plural, one {{count} modification active} other {{count} modifications actives}}",
     "clipboard": "Historique du presse-papiers",
-    "documentsSyncing": "{count, plural, one {1 document en synchronisation} other {{count} documents en synchronisation}}",
+    "documentsSyncing": "{count, plural, one {{count} document en synchronisation} other {{count} documents en synchronisation}}",
     "needsAttention": "Nécessite une attention",
     "noActiveEdits": "Aucune modification active",
     "updateReady": "Mise à jour prête",
@@ -156,7 +156,7 @@
     "groupColor": "Couleur du groupe",
     "groupName": "Nom du groupe",
     "groups": "Groupes",
-    "itemCount": "{count, plural, one {1 élément} other {{count} éléments}}",
+    "itemCount": "{count, plural, one {{count} élément} other {{count} éléments}}",
     "keyboardNavigate": "← → naviguer",
     "link": "Lien",
     "local": "Local",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "La modification sur le bureau a été déplacée vers un autre appareil. Cette copie locale est préservée.",
     "takenOverTitle": "Modification déplacée vers un autre appareil"
   },
+  "dialog": {
+    "allow": "Autoriser",
+    "apiUrl": "URL de l’API",
+    "cancel": "Annuler",
+    "connect": "Connecter",
+    "deny": "Refuser",
+    "selfHostSubtitle": "Autoriser ce site stella à ouvrir des documents dans stella desktop.",
+    "selfHostTitle": "Connecter cette instance stella auto-hébergée ?",
+    "selfHostWindowTitle": "Connecter une instance stella auto-hébergée",
+    "takeoverFile": "Fichier Office",
+    "takeoverRequester": "Quelqu’un",
+    "takeoverSubtitle": "La modification reprendra à votre dernier point de contrôle enregistré.",
+    "takeoverTitle": "{requester} souhaite reprendre la modification",
+    "takeoverWindowTitle": "Demande de reprise",
+    "webOrigin": "Origine web"
+  },
   "settings": {
     "about": "À propos",
     "connected": "Connecté",

--- a/apps/desktop/src/i18n/langs/hu.json
+++ b/apps/desktop/src/i18n/langs/hu.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Az asztali szerkesztés másik eszközre lett áthelyezve. Ez a helyi másolat megőrzésre kerül.",
     "takenOverTitle": "Szerkesztés másik eszközre áthelyezve"
   },
+  "dialog": {
+    "allow": "Engedélyezés",
+    "apiUrl": "API-cím",
+    "cancel": "Mégse",
+    "connect": "Csatlakozás",
+    "deny": "Elutasítás",
+    "selfHostSubtitle": "Engedélyezi, hogy ez a stella webhely dokumentumokat nyisson meg a stella desktop alkalmazásban.",
+    "selfHostTitle": "Csatlakoztatja ezt a saját üzemeltetésű stella példányt?",
+    "selfHostWindowTitle": "Saját üzemeltetésű stella csatlakoztatása",
+    "takeoverFile": "Office-fájl",
+    "takeoverRequester": "Valaki",
+    "takeoverSubtitle": "A szerkesztés a legutóbb mentett ellenőrzőponttól folytatódik.",
+    "takeoverTitle": "{requester} át szeretné venni a szerkesztést",
+    "takeoverWindowTitle": "Átvételi kérés",
+    "webOrigin": "Webes forrás"
+  },
   "settings": {
     "about": "Névjegy",
     "connected": "Csatlakozva",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Darbalaukio redagavimas perkeltas į kitą įrenginį. Ši vietinė kopija yra išsaugota.",
     "takenOverTitle": "Redagavimas perkeltas į kitą įrenginį"
   },
+  "dialog": {
+    "allow": "Leisti",
+    "apiUrl": "API adresas",
+    "cancel": "Atšaukti",
+    "connect": "Prijungti",
+    "deny": "Neleisti",
+    "selfHostSubtitle": "Leisti šiai stella svetainei atverti dokumentus programoje stella desktop.",
+    "selfHostTitle": "Prijungti šią savarankiškai talpinamą stella?",
+    "selfHostWindowTitle": "Prijungti savarankiškai talpinamą stella",
+    "takeoverFile": "Office failas",
+    "takeoverRequester": "Kažkas",
+    "takeoverSubtitle": "Redagavimas bus tęsiamas nuo paskutinio išsaugoto kontrolinio taško.",
+    "takeoverTitle": "{requester} nori perimti redagavimą",
+    "takeoverWindowTitle": "Perėmimo prašymas",
+    "webOrigin": "Žiniatinklio kilmė"
+  },
   "settings": {
     "about": "Apie",
     "connected": "Prisijungta",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -1,8 +1,8 @@
 {
   "tray": {
-    "activeEdits": "{count, plural, one {1 aktyvus redagavimas} few {{count} aktyvūs redagavimai} other {{count} aktyvių redagavimų}}",
+    "activeEdits": "{count, plural, one {{count} aktyvus redagavimas} few {{count} aktyvūs redagavimai} other {{count} aktyvių redagavimų}}",
     "clipboard": "Iškarpinės istorija",
-    "documentsSyncing": "{count, plural, one {1 dokumentas sinchronizuojamas} few {{count} dokumentai sinchronizuojami} other {{count} dokumentų sinchronizuojama}}",
+    "documentsSyncing": "{count, plural, one {{count} dokumentas sinchronizuojamas} few {{count} dokumentai sinchronizuojami} other {{count} dokumentų sinchronizuojama}}",
     "needsAttention": "Reikia dėmesio",
     "noActiveEdits": "Nėra aktyvių redagavimų",
     "updateReady": "Naujinimas paruoštas",
@@ -156,7 +156,7 @@
     "groupColor": "Grupės spalva",
     "groupName": "Grupės pavadinimas",
     "groups": "Grupės",
-    "itemCount": "{count, plural, one {1 elementas} few {{count} elementai} other {{count} elementų}}",
+    "itemCount": "{count, plural, one {{count} elementas} few {{count} elementai} other {{count} elementų}}",
     "keyboardNavigate": "← → naršyti",
     "link": "Nuoroda",
     "local": "Vietinė",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Darbvirsmas rediģēšana pārvietota uz citu ierīci. Šī lokālā kopija ir saglabāta.",
     "takenOverTitle": "Rediģēšana pārvietota uz citu ierīci"
   },
+  "dialog": {
+    "allow": "Atļaut",
+    "apiUrl": "API adrese",
+    "cancel": "Atcelt",
+    "connect": "Savienot",
+    "deny": "Liegt",
+    "selfHostSubtitle": "Atļaut šai stella vietnei atvērt dokumentus lietotnē stella desktop.",
+    "selfHostTitle": "Vai savienot šo pašmitināto stella?",
+    "selfHostWindowTitle": "Savienot pašmitināto stella",
+    "takeoverFile": "Office fails",
+    "takeoverRequester": "Kāds",
+    "takeoverSubtitle": "Rediģēšana turpināsies no jūsu pēdējā saglabātā kontrolpunkta.",
+    "takeoverTitle": "{requester} vēlas pārņemt rediģēšanu",
+    "takeoverWindowTitle": "Pārņemšanas pieprasījums",
+    "webOrigin": "Tīmekļa izcelsme"
+  },
   "settings": {
     "about": "Par",
     "connected": "Savienots",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -1,8 +1,8 @@
 {
   "tray": {
-    "activeEdits": "{count, plural, one {1 aktīvs labojums} other {{count} aktīvi labojumi}}",
+    "activeEdits": "{count, plural, zero {{count} aktīvu labojumu} one {{count} aktīvs labojums} other {{count} aktīvi labojumi}}",
     "clipboard": "Starpliktuves vēsture",
-    "documentsSyncing": "{count, plural, one {1 dokuments tiek sinhronizēts} other {{count} dokumenti tiek sinhronizēti}}",
+    "documentsSyncing": "{count, plural, zero {{count} dokumentu tiek sinhronizēts} one {{count} dokuments tiek sinhronizēts} other {{count} dokumenti tiek sinhronizēti}}",
     "needsAttention": "Nepieciešama uzmanība",
     "noActiveEdits": "Nav aktīvu labojumu",
     "updateReady": "Atjauninājums gatavs",
@@ -156,7 +156,7 @@
     "groupColor": "Grupas krāsa",
     "groupName": "Grupas nosaukums",
     "groups": "Grupas",
-    "itemCount": "{count, plural, one {1 vienums} other {{count} vienumi}}",
+    "itemCount": "{count, plural, zero {{count} vienumu} one {{count} vienums} other {{count} vienumi}}",
     "keyboardNavigate": "← → pārvietoties",
     "link": "Saite",
     "local": "Lokāli",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Edycja pulpitu przeniesiona na inne urządzenie. Ta lokalna kopia jest zachowana.",
     "takenOverTitle": "Edycja przeniesiona na inne urządzenie"
   },
+  "dialog": {
+    "allow": "Zezwól",
+    "apiUrl": "Adres API",
+    "cancel": "Anuluj",
+    "connect": "Połącz",
+    "deny": "Odmów",
+    "selfHostSubtitle": "Zezwól tej witrynie stella na otwieranie dokumentów w aplikacji stella desktop.",
+    "selfHostTitle": "Połączyć tę samodzielnie hostowaną instancję stella?",
+    "selfHostWindowTitle": "Połącz samodzielnie hostowaną instancję stella",
+    "takeoverFile": "Plik pakietu Office",
+    "takeoverRequester": "Ktoś",
+    "takeoverSubtitle": "Edycja będzie kontynuowana od ostatniego zapisanego punktu kontrolnego.",
+    "takeoverTitle": "{requester} chce przejąć edycję",
+    "takeoverWindowTitle": "Prośba o przejęcie",
+    "webOrigin": "Źródło witryny"
+  },
   "settings": {
     "about": "Informacje",
     "connected": "Połączono",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -1,8 +1,8 @@
 {
   "tray": {
-    "activeEdits": "{count, plural, one {1 aktywna edycja} few {{count} aktywne edycje} other {{count} aktywnych edycji}}",
+    "activeEdits": "{count, plural, one {1 aktywna edycja} few {{count} aktywne edycje} many {{count} aktywnych edycji} other {{count} aktywnych edycji}}",
     "clipboard": "Historia schowka",
-    "documentsSyncing": "{count, plural, one {1 dokument synchronizowany} few {{count} dokumenty synchronizowane} other {{count} dokumentów synchronizowanych}}",
+    "documentsSyncing": "{count, plural, one {1 dokument synchronizowany} few {{count} dokumenty synchronizowane} many {{count} dokumentów synchronizowanych} other {{count} dokumentów synchronizowanych}}",
     "needsAttention": "Wymaga uwagi",
     "noActiveEdits": "Brak aktywnych edycji",
     "updateReady": "Aktualizacja gotowa",
@@ -156,7 +156,7 @@
     "groupColor": "Kolor grupy",
     "groupName": "Nazwa grupy",
     "groups": "Grupy",
-    "itemCount": "{count, plural, one {1 element} few {{count} elementy} other {{count} elementów}}",
+    "itemCount": "{count, plural, one {1 element} few {{count} elementy} many {{count} elementów} other {{count} elementów}}",
     "keyboardNavigate": "← → nawigacja",
     "link": "Link",
     "local": "Lokalnie",

--- a/apps/desktop/src/i18n/langs/pt-BR.json
+++ b/apps/desktop/src/i18n/langs/pt-BR.json
@@ -51,6 +51,22 @@
     "takenOverTitle": "A edição foi movida para outro dispositivo",
     "takenOverLocalError": "A edição no desktop foi movida para outro dispositivo. Esta cópia local está preservada."
   },
+  "dialog": {
+    "allow": "Permitir",
+    "apiUrl": "URL da API",
+    "cancel": "Cancelar",
+    "connect": "Conectar",
+    "deny": "Negar",
+    "selfHostSubtitle": "Permitir que este site da stella abra documentos no stella desktop.",
+    "selfHostTitle": "Conectar esta stella auto-hospedada?",
+    "selfHostWindowTitle": "Conectar stella auto-hospedada",
+    "takeoverFile": "Arquivo do Office",
+    "takeoverRequester": "Alguém",
+    "takeoverSubtitle": "A edição continuará a partir do seu último ponto de controle salvo.",
+    "takeoverTitle": "{requester} quer assumir a edição",
+    "takeoverWindowTitle": "Solicitação de transferência",
+    "webOrigin": "Origem web"
+  },
   "settings": {
     "about": "Sobre",
     "connected": "Conectado",

--- a/apps/desktop/src/i18n/langs/sk.json
+++ b/apps/desktop/src/i18n/langs/sk.json
@@ -51,6 +51,22 @@
     "takenOverLocalError": "Úpravy na desktope presunuté na iné zariadenie. Táto lokálna kópia je zachovaná.",
     "takenOverTitle": "Úpravy presunuté na iné zariadenie"
   },
+  "dialog": {
+    "allow": "Povoliť",
+    "apiUrl": "Adresa API",
+    "cancel": "Zrušiť",
+    "connect": "Pripojiť",
+    "deny": "Odmietnuť",
+    "selfHostSubtitle": "Povoliť tejto stránke stella otvárať dokumenty v aplikácii stella desktop.",
+    "selfHostTitle": "Pripojiť túto vlastnú inštaláciu stella?",
+    "selfHostWindowTitle": "Pripojiť vlastnú inštaláciu stella",
+    "takeoverFile": "Súbor Office",
+    "takeoverRequester": "Niekto",
+    "takeoverSubtitle": "Bude pokračovať od vášho posledného uloženého kontrolného bodu.",
+    "takeoverTitle": "{requester} chce prevziať úpravy",
+    "takeoverWindowTitle": "Žiadosť o prevzatie",
+    "webOrigin": "Pôvod webu"
+  },
   "settings": {
     "about": "O aplikácii",
     "connected": "Pripojené",

--- a/apps/desktop/src/mainview/main.tsx
+++ b/apps/desktop/src/mainview/main.tsx
@@ -1,4 +1,4 @@
-import { lazy, StrictMode, Suspense, useEffect, useState } from "react";
+import { lazy, StrictMode, Suspense, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import type { Root as ReactRoot } from "react-dom/client";
 
@@ -14,6 +14,7 @@ import {
   getPreferredLanguage,
   isSupportedLanguage,
   loadMessages,
+  synchronizeDesktopLanguage,
 } from "../i18n";
 import type { DesktopMessages } from "../i18n";
 import { subscribeDesktopEvent } from "../shared/desktop-events";
@@ -55,6 +56,30 @@ const Root = () => {
     applyDocumentLanguage(language);
   }, [language]);
 
+  // A language event that lands while start-up synchronisation is still
+  // awaiting the backend carries the newer choice; the synchronisation
+  // result must not roll it back.
+  const languageEvents = useRef(0);
+
+  useEffect(() => {
+    const eventsAtStart = languageEvents.current;
+    void synchronizeDesktopLanguage()
+      .then((desktopLanguage) => {
+        if (languageEvents.current === eventsAtStart) {
+          setLanguage(desktopLanguage);
+        }
+        return;
+      })
+      .catch((error: unknown) => {
+        reportDesktopError({
+          code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+          detail: describeError(error),
+          operation: DESKTOP_TELEMETRY_OPERATIONS.runtime,
+          window: telemetryWindow,
+        });
+      });
+  }, []);
+
   useEffect(() => {
     let disposed = false;
     void loadMessages(language).then((nextMessages) => {
@@ -75,6 +100,7 @@ const Root = () => {
         event: DESKTOP_LANGUAGE_CHANGED_EVENT,
         handler: ({ payload }) => {
           if (isSupportedLanguage(payload.language)) {
+            languageEvents.current += 1;
             setLanguage(payload.language);
           }
         },

--- a/apps/desktop/src/mainview/selfhost-connect-dialog.html
+++ b/apps/desktop/src/mainview/selfhost-connect-dialog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <title>Connect self-hosted Stella</title>
+    <title>stella desktop</title>
     <style>
       * {
         box-sizing: border-box;
@@ -137,30 +137,48 @@
   <body>
     <main class="dialog">
       <div class="mark">§</div>
-      <h1 class="title">Connect this self-hosted Stella?</h1>
-      <p class="subtitle">
-        Allow this Stella site to open documents in stella desktop.
-      </p>
+      <h1 class="title" id="title"></h1>
+      <p class="subtitle" id="subtitle"></p>
       <div class="details">
         <p>
-          <span class="label">Web origin</span>
+          <span class="label" id="webOriginLabel"></span>
           <span class="value" id="webOrigin"></span>
         </p>
         <p>
-          <span class="label">API URL</span>
+          <span class="label" id="apiBaseUrlLabel"></span>
           <span class="value" id="apiBaseUrl"></span>
         </p>
       </div>
       <div class="actions">
-        <button class="cancel" id="cancelBtn">Cancel</button>
-        <button class="connect" id="connectBtn">Connect</button>
+        <button class="cancel" id="cancelBtn"></button>
+        <button class="connect" id="connectBtn"></button>
       </div>
     </main>
     <script>
+      // Origins and wording both arrive in the URL hash, set by Rust when it
+      // opens the window: the dialog carries no strings of its own, so it
+      // speaks whatever language the rest of the app is running in.
       const params = new URLSearchParams(window.location.hash.slice(1));
+      const strings = JSON.parse(params.get("strings") || "{}");
       const webOrigin = params.get("webOrigin") || "";
       const apiBaseUrl = params.get("apiBaseUrl") || "";
 
+      document.documentElement.lang = params.get("lang") || "en";
+      document.documentElement.dir = params.get("dir") || "ltr";
+      document.title = strings.selfHostWindowTitle || "";
+
+      document.getElementById("title").textContent = strings.selfHostTitle;
+      document.getElementById("subtitle").textContent =
+        strings.selfHostSubtitle;
+      document.getElementById("webOriginLabel").textContent = strings.webOrigin;
+      document.getElementById("apiBaseUrlLabel").textContent = strings.apiUrl;
+      document.getElementById("cancelBtn").textContent = strings.cancel;
+      document.getElementById("connectBtn").textContent = strings.connect;
+
+      // The origins stay left-to-right whichever way the dialog reads: a URL
+      // reordered by the bidi algorithm is a different URL to the eye.
+      document.getElementById("webOrigin").dir = "ltr";
+      document.getElementById("apiBaseUrl").dir = "ltr";
       document.getElementById("webOrigin").textContent = webOrigin;
       document.getElementById("apiBaseUrl").textContent = apiBaseUrl;
 

--- a/apps/desktop/src/mainview/takeover-dialog.html
+++ b/apps/desktop/src/mainview/takeover-dialog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <title>Takeover Request</title>
+    <title>stella desktop</title>
     <style>
       * {
         margin: 0;
@@ -128,25 +128,28 @@
   </head>
   <body>
     <div class="dialog">
-      <div class="avatar" id="avatar">??</div>
-      <div class="title">
-        <span class="requester" id="requester">Someone</span> wants to take over
-        editing
-      </div>
-      <div class="subtitle">
-        They'll continue from your latest saved checkpoint.
-      </div>
-      <div class="file-name" id="fileName">Office file</div>
+      <div class="avatar" id="avatar"></div>
+      <div class="title" id="title"></div>
+      <div class="subtitle" id="subtitle"></div>
+      <div class="file-name" id="fileName"></div>
       <div class="actions">
-        <button class="deny" id="denyBtn">Deny</button>
-        <button class="allow" id="allowBtn">Allow</button>
+        <button class="deny" id="denyBtn"></button>
+        <button class="allow" id="allowBtn"></button>
       </div>
     </div>
     <script>
-      // Read params from URL hash (set by Rust when opening the window)
+      // Params and wording both arrive in the URL hash, set by Rust when it
+      // opens the window: the dialog carries no strings of its own, so it
+      // speaks whatever language the rest of the app is running in.
       const params = new URLSearchParams(window.location.hash.slice(1));
-      const requester = params.get("requester") || "Someone";
-      const fileName = params.get("fileName") || "Office file";
+      const strings = JSON.parse(params.get("strings") || "{}");
+
+      document.documentElement.lang = params.get("lang") || "en";
+      document.documentElement.dir = params.get("dir") || "ltr";
+      document.title = strings.takeoverWindowTitle || "";
+
+      const requester = params.get("requester") || strings.takeoverRequester;
+      const fileName = params.get("fileName") || strings.takeoverFile;
       const initials = requester
         .split(" ")
         .map((w) => w[0])
@@ -155,8 +158,28 @@
         .toUpperCase();
 
       document.getElementById("avatar").textContent = initials;
-      document.getElementById("requester").textContent = requester;
-      document.getElementById("fileName").textContent = fileName;
+      document.getElementById("subtitle").textContent =
+        strings.takeoverSubtitle;
+      // Names and file names arrive in whichever script they were written
+      // in; isolating them keeps the bidi algorithm from reordering their
+      // punctuation into the surrounding sentence.
+      const fileNameElement = document.getElementById("fileName");
+      fileNameElement.textContent = fileName;
+      fileNameElement.dir = "auto";
+      document.getElementById("denyBtn").textContent = strings.deny;
+      document.getElementById("allowBtn").textContent = strings.allow;
+
+      // The name is highlighted inside the sentence, and languages put it in
+      // different places, so the translated sentence is split at its
+      // placeholder rather than assembled from fragments here.
+      const title = document.getElementById("title");
+      const parts = (strings.takeoverTitle || "{requester}").split(
+        "{requester}",
+      );
+      const highlighted = document.createElement("bdi");
+      highlighted.className = "requester";
+      highlighted.textContent = requester;
+      title.append(parts[0] || "", highlighted, parts[1] || "");
 
       function respond(approved) {
         if (window.__TAURI_INTERNALS__) {

--- a/apps/desktop/tests/i18n-language-preference.test.ts
+++ b/apps/desktop/tests/i18n-language-preference.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const invokeMock = mock();
+const emitMock = mock(async () => undefined);
+
+await mock.module("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+// The module registry is shared across test files, so the replacement has to
+// carry every export the event module is imported for, not only `emit`.
+await mock.module("@tauri-apps/api/event", () => ({
+  emit: emitMock,
+  listen: mock(async () => () => undefined),
+}));
+
+const store = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string) => store.get(key) ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  },
+});
+
+const { setPreferredLanguage, synchronizeDesktopLanguage } =
+  await import("../src/i18n/index");
+
+const STORAGE_KEY = "stella-desktop-language";
+
+beforeEach(() => {
+  store.clear();
+  invokeMock.mockReset();
+  emitMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
+  emitMock.mockResolvedValue(undefined);
+});
+
+describe("setPreferredLanguage", () => {
+  test("hands the choice to the backend, not only to this window", async () => {
+    await setPreferredLanguage("cs");
+
+    expect(invokeMock).toHaveBeenCalledWith("set_desktop_language", {
+      language: "cs",
+    });
+    expect(store.get(STORAGE_KEY)).toBe("cs");
+    expect(emitMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates a backend that refused the change", async () => {
+    invokeMock.mockRejectedValue(new Error("language unavailable"));
+
+    // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+    // type-aware lint; capture the rejection explicitly instead.
+    const rejection: unknown = await setPreferredLanguage("ar").then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(
+      rejection instanceof Error ? rejection.message : String(rejection),
+    ).toBe("language unavailable");
+    // The event is what re-renders the windows; a backend that did not switch
+    // must not leave them claiming it did, nor leave the refused choice in
+    // storage for the next window to pick up.
+    expect(emitMock).not.toHaveBeenCalled();
+    expect(store.has(STORAGE_KEY)).toBe(false);
+  });
+});
+
+describe("synchronizeDesktopLanguage", () => {
+  test("pushes a stored choice down to a backend that predates it", async () => {
+    store.set(STORAGE_KEY, "pl");
+
+    expect(await synchronizeDesktopLanguage()).toBe("pl");
+
+    expect(invokeMock).toHaveBeenCalledWith("set_desktop_language", {
+      language: "pl",
+    });
+  });
+
+  test("adopts the backend's locale when nothing is stored", async () => {
+    invokeMock.mockResolvedValue("pt-BR");
+
+    expect(await synchronizeDesktopLanguage()).toBe("pt-BR");
+
+    expect(invokeMock).toHaveBeenCalledWith("get_desktop_language");
+    expect(store.get(STORAGE_KEY)).toBe("pt-BR");
+  });
+
+  test("ignores a backend locale the windows do not ship", async () => {
+    invokeMock.mockResolvedValue("kl-GL");
+
+    const language = await synchronizeDesktopLanguage();
+
+    expect(language).not.toBe("kl-GL");
+    expect(store.get(STORAGE_KEY)).toBe(language);
+  });
+});


### PR DESCRIPTION
Three defects the locale-parity work left behind: the native strings
ignored the chosen language, the two HTML dialogs were English whatever
the app ran in, and plural forms were picked by a heuristic rather than
by CLDR.

## The tray follows the chosen language

`setPreferredLanguage` wrote localStorage and emitted a frontend event.
The native strings were built once at startup from `sys_locale` and never
rebuilt, so choosing a language changed the windows and left the tray, the
menus and the notifications in whatever language the OS reported.

The choice is now saved natively, in a file alongside the other app-data
preferences, and the active catalogue sits behind a lock that a Tauri
command swaps. Startup prefers the saved language over the system's, so
the tray comes up in the chosen language before any window exists.

A window reconciles the two when it starts: a stored choice is pushed down
(it can predate the saved file), and with nothing stored the backend's own
resolution is adopted rather than detected a second time, so a first run
cannot start the tray and the windows in different languages.

The active locale lives in the i18n module rather than in Tauri's managed
state because `t` is called from the session manager, the retry loop and
the tray builder, none of which hold an `AppHandle`. Catalogues are parsed
once and kept, so `t` still hands out a `&str` that outlives a switch.

The tray rebuild that state changes and language changes share is now one
helper instead of three copies.

## The dialogs speak the app's language

`takeover-dialog.html` and `selfhost-connect-dialog.html` carried their
strings in their markup. They now carry none: the wording travels in the
URL hash beside the data they already received, so their keys sit in the
message catalogues and the existing parity test covers them. Both take
their `lang` and `dir` from the active locale.

The takeover sentence highlights the requester's name inside it and
languages place that name differently, so the dialog splits the translated
sentence at its placeholder rather than assembling it from fragments. In a
right-to-left dialog the self-host origins stay left-to-right: a URL
reordered by the bidi algorithm is a different URL to the eye.

The right-to-left list a dialog needs has no bundle to read it from, so a
test pins it to the shared direction map in `packages/locales`, which must
also cover every shipped locale.

## Plural forms follow CLDR

The selector looked for a `few` branch anywhere in the catalogue and
treated 2 to 4 as few for every language that had one. Consequences:
Polish read 22 as `other` rather than `few`; Lithuanian and Latvian read
21 as a plural rather than a singular; Latvian had no `zero` form at all.

Each shipped locale now names the rule it counts by, with two guards: the
rule table must cover the locale list exactly, and each rule is pinned to
CLDR at 0, 1, 2, 5, 11, 21, 22, 25, 101, 111 and 112 — the counts that
separate the families, including past 100, where a rule that reads the
whole number instead of its last two digits gives itself away.

The catalogues follow. Polish gains the `many` branch that carries every
count it never called `few`; Latvian gains `zero`; and the branches a
corrected selector now reaches for 21 (lt, lv) or for 0 (fr) interpolate
the count instead of spelling out `1`. A fixed-point test holds that line:
every plural message names exactly the categories its locale's rule can
select, plus the `other` ICU requires.

## Tests

`bun --filter @stll/desktop test` and
`cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml i18n`, plus
`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Arabic and Brazilian Portuguese language support, including installer options.
  - Added runtime language selection, persistence, system-locale fallback, and right-to-left layout support.
  - Localised self-host connection and takeover dialogs across supported languages.

- **Bug Fixes**
  - Improved pluralised messages for multiple languages.
  - Corrected clipboard keyboard navigation and scrolling in right-to-left layouts.
  - Improved tray menu refresh during session restoration and state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
