### PR TITLE
feat(desktop): arrow between the clipboard search field and the group rail

### DIFF
--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -108,6 +108,7 @@ import {
   clipboardSourceTintIndex,
   clipboardSourceTitle,
   clipboardTimelineKeyAction,
+  clipboardGroupRailKeyAction,
   filterClipboardItems,
   formatClipboardAge,
   hasClipboardPrimaryModifier,
@@ -117,6 +118,7 @@ import {
   quickCopyIndex,
   shouldCopyFromClipboardInput,
   shouldReturnToTimelineFromInput,
+  shouldLeaveSearchForGroups,
 } from "./clipboard-logic";
 import type { ClipboardPointerPosition } from "./clipboard-logic";
 import {
@@ -1342,6 +1344,7 @@ const ClipboardApp = () => {
   const t = useTranslations("clipboard");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
+  const groupsRailRef = useRef<HTMLElement>(null);
   const timelineRailRef = useRef<HTMLDivElement>(null);
   const railPointerRef = useRef<ClipboardPointerPosition | null>(null);
   const contextMenuTriggerRef = useRef<HTMLElement>(null);
@@ -1824,6 +1827,36 @@ const ClipboardApp = () => {
     selectIndex(nextIndex);
   };
 
+  const handleGroupRailKeyDown = (
+    event: KeyboardEvent,
+    target: HTMLElement,
+  ) => {
+    const groupsRail = groupsRailRef.current;
+    const railAction = clipboardGroupRailKeyAction(event.key);
+    if (!groupsRail || !railAction) {
+      return;
+    }
+    if (railAction === "focusTimeline") {
+      if (activeItem) {
+        event.preventDefault();
+        selectIndex(activeIndex);
+      }
+      return;
+    }
+    event.preventDefault();
+    const controls = Array.from(
+      groupsRail.querySelectorAll<HTMLElement>("button:not([disabled])"),
+    );
+    const control = target.closest("button");
+    const index = control ? controls.indexOf(control) : -1;
+    const nextIndex = index + (railAction === "next" ? 1 : -1);
+    if (nextIndex < 0) {
+      searchInputRef.current?.focus();
+      return;
+    }
+    controls.at(nextIndex)?.focus();
+  };
+
   const handleKeyDown = (event: KeyboardEvent) => {
     if (dialog.type !== "closed" || welcomeOpen) {
       return;
@@ -1868,6 +1901,18 @@ const ClipboardApp = () => {
       } else if (activeItem && shouldReturnToTimelineFromInput(inputKey)) {
         event.preventDefault();
         selectIndex(activeIndex);
+      } else if (
+        shouldLeaveSearchForGroups({
+          ...inputKey,
+          selectionEnd: event.target.selectionEnd,
+          selectionStart: event.target.selectionStart,
+          valueLength: event.target.value.length,
+        })
+      ) {
+        event.preventDefault();
+        groupsRailRef.current
+          ?.querySelector<HTMLElement>("button[aria-pressed='true']")
+          ?.focus();
       }
       return;
     }
@@ -1892,6 +1937,10 @@ const ClipboardApp = () => {
       return;
     }
     const target = event.target instanceof HTMLElement ? event.target : null;
+    if (target && groupsRailRef.current?.contains(target)) {
+      handleGroupRailKeyDown(event, target);
+      return;
+    }
     const cardTrigger = target?.closest("[data-clipboard-card-trigger]");
     const interactiveTarget = target?.closest(
       "button, a, input, textarea, select, [contenteditable='true']",
@@ -2324,6 +2373,7 @@ const ClipboardApp = () => {
         </div>
         <nav
           aria-label={t("groups")}
+          ref={groupsRailRef}
           className="clipboard-groups-rail border-border flex min-w-0 scrollbar-none items-center gap-1 overflow-x-auto border-s ps-2"
         >
           <Button

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -233,6 +233,13 @@ const focusTimeline = (node: HTMLDivElement | null) => {
   }
 };
 
+/**
+ * The shared input carries `dir="auto"` once it holds text, so only the
+ * computed style says which side of the field its caret offsets sit on.
+ */
+const clipboardInputDirection = (input: HTMLInputElement) =>
+  getComputedStyle(input).direction === "rtl" ? "rtl" : "ltr";
+
 const focusCard = (rail: HTMLDivElement | null, id: string) => {
   requestAnimationFrame(() => {
     if (!rail) {
@@ -1904,6 +1911,7 @@ const ClipboardApp = () => {
       } else if (
         shouldLeaveSearchForGroups({
           ...inputKey,
+          direction: clipboardInputDirection(event.target),
           selectionEnd: event.target.selectionEnd,
           selectionStart: event.target.selectionStart,
           valueLength: event.target.value.length,

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1911,9 +1911,11 @@ const ClipboardApp = () => {
       } else if (
         shouldLeaveSearchForGroups({
           ...inputKey,
+          ...modifiers,
           direction: clipboardInputDirection(event.target),
           selectionEnd: event.target.selectionEnd,
           selectionStart: event.target.selectionStart,
+          shiftKey: event.shiftKey,
           valueLength: event.target.value.length,
         })
       ) {

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -126,29 +126,38 @@ export const shouldReturnToTimelineFromInput = ({
   !isClipboardNameInput(dataset) && key === "ArrowUp" && !isComposing;
 
 type ClipboardSearchArrowKey = ClipboardInputKey & {
+  direction: "ltr" | "rtl";
   selectionEnd: number | null;
   selectionStart: number | null;
   valueLength: number;
 };
 
 /**
- * ArrowRight with the caret at the end of the search text hands focus to the
- * group rail beside the search field (an empty field qualifies). With text to
- * the right of the caret, or a selection, the arrow keeps moving the caret.
+ * ArrowRight with the caret at the search field's visual right edge hands
+ * focus to the group rail beside the search field (an empty field qualifies).
+ * The field resolves its own direction from the query, so an Arabic or Hebrew
+ * query puts that edge at offset 0 and the end of the text on the left. With
+ * text still to the right of the caret, or a selection, the arrow keeps moving
+ * the caret.
  */
 export const shouldLeaveSearchForGroups = ({
   dataset,
+  direction,
   isComposing,
   key,
   selectionEnd,
   selectionStart,
   valueLength,
-}: ClipboardSearchArrowKey) =>
-  !isClipboardNameInput(dataset) &&
-  key === "ArrowRight" &&
-  !isComposing &&
-  selectionStart === valueLength &&
-  selectionEnd === valueLength;
+}: ClipboardSearchArrowKey) => {
+  const rightEdge = direction === "rtl" ? 0 : valueLength;
+  return (
+    !isClipboardNameInput(dataset) &&
+    key === "ArrowRight" &&
+    !isComposing &&
+    selectionStart === rightEdge &&
+    selectionEnd === rightEdge
+  );
+};
 
 /**
  * The group rail is the row below the timeline: left and right walk its

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -125,28 +125,36 @@ export const shouldReturnToTimelineFromInput = ({
 }: ClipboardInputKey) =>
   !isClipboardNameInput(dataset) && key === "ArrowUp" && !isComposing;
 
-type ClipboardSearchArrowKey = ClipboardInputKey & {
-  direction: "ltr" | "rtl";
-  selectionEnd: number | null;
-  selectionStart: number | null;
-  valueLength: number;
-};
+type ClipboardSearchArrowKey = ClipboardInputKey &
+  ClipboardModifiers & {
+    direction: "ltr" | "rtl";
+    selectionEnd: number | null;
+    selectionStart: number | null;
+    shiftKey: boolean;
+    valueLength: number;
+  };
 
 /**
  * ArrowRight with the caret at the search field's visual right edge hands
  * focus to the group rail beside the search field (an empty field qualifies).
  * The field resolves its own direction from the query, so an Arabic or Hebrew
  * query puts that edge at offset 0 and the end of the text on the left. With
- * text still to the right of the caret, or a selection, the arrow keeps moving
- * the caret.
+ * text still to the right of the caret the arrow keeps moving the caret, and
+ * any modifier leaves the platform's own word, line, and selection gestures
+ * alone.
  */
 export const shouldLeaveSearchForGroups = ({
+  altGraphKey,
+  altKey,
+  ctrlKey,
   dataset,
   direction,
   isComposing,
   key,
+  metaKey,
   selectionEnd,
   selectionStart,
+  shiftKey,
   valueLength,
 }: ClipboardSearchArrowKey) => {
   const rightEdge = direction === "rtl" ? 0 : valueLength;
@@ -154,6 +162,11 @@ export const shouldLeaveSearchForGroups = ({
     !isClipboardNameInput(dataset) &&
     key === "ArrowRight" &&
     !isComposing &&
+    !altGraphKey &&
+    !altKey &&
+    !ctrlKey &&
+    !metaKey &&
+    !shiftKey &&
     selectionStart === rightEdge &&
     selectionEnd === rightEdge
   );

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -125,6 +125,49 @@ export const shouldReturnToTimelineFromInput = ({
 }: ClipboardInputKey) =>
   !isClipboardNameInput(dataset) && key === "ArrowUp" && !isComposing;
 
+type ClipboardSearchArrowKey = ClipboardInputKey & {
+  selectionEnd: number | null;
+  selectionStart: number | null;
+  valueLength: number;
+};
+
+/**
+ * ArrowRight with the caret at the end of the search text hands focus to the
+ * group rail beside the search field (an empty field qualifies). With text to
+ * the right of the caret, or a selection, the arrow keeps moving the caret.
+ */
+export const shouldLeaveSearchForGroups = ({
+  dataset,
+  isComposing,
+  key,
+  selectionEnd,
+  selectionStart,
+  valueLength,
+}: ClipboardSearchArrowKey) =>
+  !isClipboardNameInput(dataset) &&
+  key === "ArrowRight" &&
+  !isComposing &&
+  selectionStart === valueLength &&
+  selectionEnd === valueLength;
+
+/**
+ * The group rail is the row below the timeline: left and right walk its
+ * controls, ArrowUp returns to the selected card. Stepping before the first
+ * control lands back in the search field, so the two arrows pair up.
+ */
+export const clipboardGroupRailKeyAction = (key: string) => {
+  switch (key) {
+    case "ArrowLeft":
+      return "previous";
+    case "ArrowRight":
+      return "next";
+    case "ArrowUp":
+      return "focusTimeline";
+    default:
+      return null;
+  }
+};
+
 /**
  * Command, or Control on Windows and Linux. Alt disqualifies the combination:
  * AltGr reports as Ctrl+Alt there, so a layout that produces a character with

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -7,6 +7,7 @@ import {
   clipboardDraggedItemId,
   clipboardItemLink,
   clipboardPointerMoved,
+  clipboardGroupRailKeyAction,
   clipboardTimelineKeyAction,
   clipboardRailScrollDelta,
   clipboardRailWindow,
@@ -20,6 +21,7 @@ import {
   isClipboardNameInput,
   quickCopyIndex,
   shouldCopyFromClipboardInput,
+  shouldLeaveSearchForGroups,
   shouldReturnToTimelineFromInput,
 } from "../src/clipboard/clipboard-logic";
 import type { ClipboardItem } from "../src/clipboard/clipboard-types";
@@ -330,6 +332,14 @@ describe("keyboard indexes", () => {
     expect(clipboardTimelineKeyAction("ArrowUp")).toBeNull();
   });
 
+  test("group rail arrows walk horizontally and Arrow Up returns to the timeline", () => {
+    expect(clipboardGroupRailKeyAction("ArrowLeft")).toBe("previous");
+    expect(clipboardGroupRailKeyAction("ArrowRight")).toBe("next");
+    expect(clipboardGroupRailKeyAction("ArrowUp")).toBe("focusTimeline");
+    expect(clipboardGroupRailKeyAction("ArrowDown")).toBeNull();
+    expect(clipboardGroupRailKeyAction("Enter")).toBeNull();
+  });
+
   test("timeline navigation has no target beyond either edge", () => {
     expect(adjacentClipboardIndex(0, "next", 2)).toBe(1);
     expect(adjacentClipboardIndex(1, "next", 2)).toBeNull();
@@ -516,6 +526,48 @@ describe("clipboard input keyboard handling", () => {
         dataset: {},
         isComposing: false,
         key: "ArrowDown",
+      }),
+    ).toBe(false);
+  });
+
+  test("ArrowRight leaves search for the groups only from the end of the text", () => {
+    const atEnd = {
+      dataset: {},
+      isComposing: false,
+      key: "ArrowRight",
+      selectionEnd: 3,
+      selectionStart: 3,
+      valueLength: 3,
+    };
+    expect(shouldLeaveSearchForGroups(atEnd)).toBe(true);
+    expect(
+      shouldLeaveSearchForGroups({
+        ...atEnd,
+        selectionEnd: 0,
+        selectionStart: 0,
+        valueLength: 0,
+      }),
+    ).toBe(true);
+    expect(shouldLeaveSearchForGroups({ ...atEnd, selectionStart: 2 })).toBe(
+      false,
+    );
+    expect(
+      shouldLeaveSearchForGroups({
+        ...atEnd,
+        selectionEnd: 1,
+        selectionStart: 1,
+      }),
+    ).toBe(false);
+    expect(shouldLeaveSearchForGroups({ ...atEnd, isComposing: true })).toBe(
+      false,
+    );
+    expect(shouldLeaveSearchForGroups({ ...atEnd, key: "ArrowLeft" })).toBe(
+      false,
+    );
+    expect(
+      shouldLeaveSearchForGroups({
+        ...atEnd,
+        dataset: { clipboardNameInput: "" },
       }),
     ).toBe(false);
   });

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -533,6 +533,7 @@ describe("clipboard input keyboard handling", () => {
   test("ArrowRight leaves search for the groups only from the end of the text", () => {
     const atEnd = {
       dataset: {},
+      direction: "ltr" as const,
       isComposing: false,
       key: "ArrowRight",
       selectionEnd: 3,
@@ -570,6 +571,27 @@ describe("clipboard input keyboard handling", () => {
         dataset: { clipboardNameInput: "" },
       }),
     ).toBe(false);
+  });
+
+  test("an RTL query puts the field's right edge at the start of the text", () => {
+    const rtl = {
+      dataset: {},
+      direction: "rtl" as const,
+      isComposing: false,
+      key: "ArrowRight",
+      selectionEnd: 0,
+      selectionStart: 0,
+      valueLength: 3,
+    };
+    expect(shouldLeaveSearchForGroups(rtl)).toBe(true);
+    expect(
+      shouldLeaveSearchForGroups({
+        ...rtl,
+        selectionEnd: 3,
+        selectionStart: 3,
+      }),
+    ).toBe(false);
+    expect(shouldLeaveSearchForGroups({ ...rtl, selectionEnd: 3 })).toBe(false);
   });
 });
 

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -532,12 +532,17 @@ describe("clipboard input keyboard handling", () => {
 
   test("ArrowRight leaves search for the groups only from the end of the text", () => {
     const atEnd = {
+      altGraphKey: false,
+      altKey: false,
+      ctrlKey: false,
       dataset: {},
       direction: "ltr" as const,
       isComposing: false,
       key: "ArrowRight",
+      metaKey: false,
       selectionEnd: 3,
       selectionStart: 3,
+      shiftKey: false,
       valueLength: 3,
     };
     expect(shouldLeaveSearchForGroups(atEnd)).toBe(true);
@@ -573,14 +578,47 @@ describe("clipboard input keyboard handling", () => {
     ).toBe(false);
   });
 
+  test("a modified ArrowRight keeps the platform's caret and selection gestures", () => {
+    const atEnd = {
+      altGraphKey: false,
+      altKey: false,
+      ctrlKey: false,
+      dataset: {},
+      direction: "ltr" as const,
+      isComposing: false,
+      key: "ArrowRight",
+      metaKey: false,
+      selectionEnd: 3,
+      selectionStart: 3,
+      shiftKey: false,
+      valueLength: 3,
+    };
+    for (const modifier of [
+      "altGraphKey",
+      "altKey",
+      "ctrlKey",
+      "metaKey",
+      "shiftKey",
+    ] as const) {
+      expect(shouldLeaveSearchForGroups({ ...atEnd, [modifier]: true })).toBe(
+        false,
+      );
+    }
+  });
+
   test("an RTL query puts the field's right edge at the start of the text", () => {
     const rtl = {
+      altGraphKey: false,
+      altKey: false,
+      ctrlKey: false,
       dataset: {},
       direction: "rtl" as const,
       isComposing: false,
       key: "ArrowRight",
+      metaKey: false,
       selectionEnd: 0,
       selectionStart: 0,
+      shiftKey: false,
       valueLength: 3,
     };
     expect(shouldLeaveSearchForGroups(rtl)).toBe(true);


### PR DESCRIPTION
## Summary

In the clipboard panel, ArrowDown from the timeline already lands in the search field, but the group chips beside it were reachable only by mouse or Tab. This wires the arrows through the footer row:

- **ArrowRight** in the search field, with the caret at the end of the text (an empty field qualifies), focuses the selected group chip. With text to the right of the caret, or a selection, the arrow keeps moving the caret. IME composition and the clip name editor are excluded, as for the existing ArrowUp handling.
- **ArrowLeft / ArrowRight** on a group rail control walk its buttons in DOM order (All clips, new group, chips). ArrowLeft before the first control returns to the search field.
- **ArrowUp** on a group rail control returns to the selected card, mirroring ArrowUp in the search field.

Escape, Enter and Space keep their native behaviour on the chips. The pure key decisions live in `clipboard-logic.ts` with unit tests; the panel handler gained one extracted `handleGroupRailKeyDown` to stay under the complexity limit.

## Test plan

- [x] `bun test apps/desktop/tests/clipboard-logic.test.ts`
- [ ] Open the panel, ArrowDown, ArrowRight: the active chip is focused; Left/Right walk chips; Enter selects; ArrowUp returns to the card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added keyboard navigation for clipboard groups, including moving between groups and returning focus to the timeline.
  * Pressing Arrow Right at the end of the search field moves focus to the active group.

* **Bug Fixes**
  * Improved keyboard focus handling while editing clip names and using input methods.

* **Tests**
  * Added coverage for clipboard keyboard navigation and focus transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->