### PR TITLE
fix: dismiss search dialog in staging smoke

### DIFF
--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -169,6 +169,12 @@ test.describe("public hydration", () => {
       page.locator('[role="gridcell"][aria-current="date"]'),
     ).toHaveAttribute("data-date", expectedToday);
     await page.keyboard.press("Escape");
+    const customRangeButton = page.getByRole("button", {
+      name: /custom range|vlastní rozsah/iu,
+    });
+    await expect(customRangeButton).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(customRangeButton).toBeHidden();
     await firstDecision.click();
     await expect(page).toHaveURL(/\/law\/[a-z]{2,3}\/cases\//u);
 


### PR DESCRIPTION
The staging hydration smoke opened a date picker inside global search, then dismissed only the picker before clicking a decision behind the still-open search dialog. Close both overlay levels and wait for the dialog control to disappear before navigating.

Validation: affected web lint and type checks, repository type check, formatting, and i18n checks passed in the pre-push hook.
