### PR TITLE
fix(ci): require Actions approval for first-time contributors only

### DIFF
--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -39,10 +39,11 @@ jobs:
       BRANCH_PROTECTION_APP_ID: ${{ secrets.BRANCH_PROTECTION_APP_ID }}
       BRANCH_PROTECTION_APP_KEY: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}
 
-  # Fork pull requests run CI only after a maintainer approves the push
-  # (`docs/policies/access-control.md`, "Fork trust gate"). That gate is
-  # a repository setting rather than workflow code, so drift would not
-  # show up in review; fail when it is loosened.
+  # A first-time contributor's fork pull request runs CI only after a
+  # maintainer approves the push (`docs/policies/access-control.md`,
+  # "Fork trust gate"). That gate is a repository setting rather than
+  # workflow code, so drift would not show up in review; fail when it
+  # is loosened.
   audit-fork-approval:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -59,7 +60,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
-          EXPECTED_POLICY: all_external_contributors
+          EXPECTED_POLICY: first_time_contributors
         shell: bash --noprofile --norc -eo pipefail {0}
         run: |
           LIVE_POLICY=$(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,10 @@ jobs:
         run: |
           # A pull_request run is trusted once it starts. Same-repo
           # authors have write access to push branches, and a fork
-          # run only starts after a maintainer approves that exact
-          # push in the Actions UI (repository policy: approval
-          # required for all external contributors).
+          # run starts only for an author with a merged pull request
+          # here, or after a maintainer approves that exact push in
+          # the Actions UI (repository policy: approval required for
+          # first-time contributors).
           #
           # A merge group runs with the base repository's secrets and
           # carries no per-push approval. Only a same-repo pull

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,11 @@ jobs:
         run: |
           # A pull_request run is trusted once it starts. Same-repo
           # authors have write access to push branches, and a fork
-          # run starts only for an author whose commit or pull
-          # request has merged here, or after a maintainer approves
-          # that exact push in the Actions UI (repository policy:
-          # approval required for first-time contributors).
+          # run starts only when the pull request author and the
+          # pushing actor each have a merged commit or pull request
+          # here, or after a maintainer approves that exact push in
+          # the Actions UI (repository policy: approval required for
+          # first-time contributors).
           #
           # A merge group runs with the base repository's secrets and
           # carries no per-push approval. Only a same-repo pull

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
         run: |
           # A pull_request run is trusted once it starts. Same-repo
           # authors have write access to push branches, and a fork
-          # run starts only for an author with a merged pull request
-          # here, or after a maintainer approves that exact push in
-          # the Actions UI (repository policy: approval required for
-          # first-time contributors).
+          # run starts only for an author whose commit or pull
+          # request has merged here, or after a maintainer approves
+          # that exact push in the Actions UI (repository policy:
+          # approval required for first-time contributors).
           #
           # A merge group runs with the base repository's secrets and
           # carries no per-push approval. Only a same-repo pull

--- a/docs/policies/access-control.md
+++ b/docs/policies/access-control.md
@@ -73,19 +73,20 @@ operations runbook (private).
    authentication, dependency manifests, and privileged desktop code.
 
 8. **Fork trust gate.** GitHub Actions requires a maintainer to
-   approve every workflow run for a pull request from a fork
-   (repository policy: approval required for all external
-   contributors), so untrusted code never executes in CI before
-   review. The CI workflow (`.github/workflows/ci.yml`) also fails a
-   merge group that carries a fork pull request; fork changes land
-   from a same-repo branch.
+   approve every workflow run for a fork pull request until its
+   author has a merged pull request in the repository (repository
+   policy: approval required for first-time contributors), so code
+   from an unknown contributor never executes in CI before review.
+   The CI workflow (`.github/workflows/ci.yml`) also fails a merge
+   group that carries a fork pull request; fork changes land from a
+   same-repo branch.
 
 9. **Ruleset audit.** A weekly workflow
    (`audit-branch-protection.yml`) compares the live GitHub
    ruleset against the checked-in expected configuration and
    alerts on drift. The same workflow fails when the Actions
-   fork approval policy no longer requires approval for all
-   external contributors.
+   fork approval policy no longer requires approval for
+   first-time contributors.
 
 ## Enforcement
 

--- a/docs/policies/access-control.md
+++ b/docs/policies/access-control.md
@@ -73,11 +73,11 @@ operations runbook (private).
    authentication, dependency manifests, and privileged desktop code.
 
 8. **Fork trust gate.** GitHub Actions requires a maintainer to
-   approve every workflow run for a fork pull request until the
-   author has had a commit or pull request merged into the
-   repository (repository policy: approval required for first-time
-   contributors), so code from an unknown contributor never
-   executes in CI before review.
+   approve every workflow run for a fork pull request until both
+   its author and the actor who pushed have had a commit or pull
+   request merged into the repository (repository policy: approval
+   required for first-time contributors), so code from an unknown
+   contributor never executes in CI before review.
    The CI workflow (`.github/workflows/ci.yml`) also fails a merge
    group that carries a fork pull request; fork changes land from a
    same-repo branch.

--- a/docs/policies/access-control.md
+++ b/docs/policies/access-control.md
@@ -73,10 +73,11 @@ operations runbook (private).
    authentication, dependency manifests, and privileged desktop code.
 
 8. **Fork trust gate.** GitHub Actions requires a maintainer to
-   approve every workflow run for a fork pull request until its
-   author has a merged pull request in the repository (repository
-   policy: approval required for first-time contributors), so code
-   from an unknown contributor never executes in CI before review.
+   approve every workflow run for a fork pull request until the
+   author has had a commit or pull request merged into the
+   repository (repository policy: approval required for first-time
+   contributors), so code from an unknown contributor never
+   executes in CI before review.
    The CI workflow (`.github/workflows/ci.yml`) also fails a merge
    group that carries a fork pull request; fork changes land from a
    same-repo branch.


### PR DESCRIPTION
## Change

The Actions fork approval policy is now `first_time_contributors`: a fork pull request runs CI without approval once its author has a merged pull request in the repository. Until then every push still needs a maintainer's approval. The setting is already applied.

- `audit-branch-protection.yml` expects `first_time_contributors` for the weekly drift check.
- The trust comment in `ci.yml` and the "Fork trust gate" item in `docs/policies/access-control.md` describe the new gate.

A `pull_request` run from a fork gets a read-only token and no secrets regardless of the policy, and `ci.yml` still fails a merge group that carries a fork pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated access-control guidance to clarify that approval is required for fork pull requests from contributors without a previously merged commit or pull request.
  - Clarified that contributors with a previously merged commit or pull request may trigger fork workflows without additional approval.

- **Chores**
  - Updated policy checks and workflow comments to reflect the first-time-contributor approval requirement.
  - Clarified that approval of the exact push can also allow a fork pull-request workflow to run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->