### PR TITLE
fix: restore case law inspector dock contract

### DIFF
--- a/apps/web/src/components/authenticated-case-law-workspace.tsx
+++ b/apps/web/src/components/authenticated-case-law-workspace.tsx
@@ -122,6 +122,7 @@ const CaseLawInspector = ({
       <div
         className="text-sidebar-foreground hidden md:block"
         data-side="right"
+        data-slot="inspector-dock"
         data-state={showPaneContent ? "expanded" : "collapsed"}
       >
         <div className="bg-sidebar relative" style={{ width: widthPx }} />


### PR DESCRIPTION
The authenticated case-law inspector is a custom dock but lost the canonical `data-slot` during its refactor. Restore the slot so shared inspector invariants and the staging hydration smoke address the expanded dock.

Validation: pre-commit and pre-push checks passed (affected lint/typecheck, repository typecheck, format, and i18n).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added an identifying attribute to the case-law workspace’s inspector dock for improved interface consistency and tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->