### PR TITLE
fix(api): buy every word its stem leaves before expanding any

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-query.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.test.ts
@@ -1,10 +1,14 @@
 import { expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
 
 import {
   CORPUS_QUERY_LEAF_BUDGET,
   caseLawCorpusQuery,
   type CorpusStemming,
   corpusFreeTextClause,
+  type CorpusTermExpander,
   quoteCorpusValue,
   tokenizeCorpusFreeText,
 } from "@/api/lib/legal-search/corpus-query";
@@ -384,4 +388,121 @@ test("the leaf budget counts stem leaves too", () => {
   expect(clause).not.toBeNull();
   const leaves = [...(clause ?? "").matchAll(/"/gu)].length / 2;
   expect(leaves).toBeLessThanOrEqual(CORPUS_QUERY_LEAF_BUDGET);
+});
+
+/** Quoted values in a clause, which is what the leaf budget counts. */
+const countLeaves = (clause: string): number =>
+  [...clause.matchAll(/"/gu)].length / 2;
+
+/** The AND-ed groups of a free-text clause, outer parentheses removed. */
+const clauseGroups = (clause: string): string[] =>
+  clause.slice(1, -1).split(" AND ");
+
+/** Field-scoped leaves of a clause, e.g. `text_stem:"nájemn"`. */
+const fieldLeaves = (clause: string): string[] =>
+  [...clause.matchAll(/[a-z_]+:"[^"]*"/gu)].map(([leaf]) => leaf);
+
+// Every group is AND-ed, so a word the corpus carries only in another case
+// form empties the whole result set on its own. Spending the budget left to
+// right starved exactly the words a reader adds to narrow a search: the last
+// ones.
+test("a long query's later words still carry their stems", () => {
+  const expansions = new Map([
+    ["nájemní", ["nájemního", "nájemnímu", "nájemním"]],
+    ["smlouva", ["smlouvy", "smlouvě", "smlouvou"]],
+    ["výpověď", ["výpovědi", "výpovědí", "výpovědím"]],
+    ["bytu", ["byt", "bytem", "byty"]],
+    ["důvod", ["důvodu", "důvody", "důvodem"]],
+  ]);
+  const expand: CorpusTermExpander = (term) => expansions.get(term) ?? [];
+
+  const clause = corpusFreeTextClause(
+    "nájemní smlouva výpověď bytu důvod přiměřenosti",
+    { expand, stemming: CS_STEMMING },
+  );
+
+  expect(clause).not.toBeNull();
+  const groups = clauseGroups(clause ?? "");
+  expect(groups).toHaveLength(6);
+  for (const group of groups) {
+    expect(group).toContain('text_stem:"');
+    expect(group).toContain('headnote_stem:"');
+  }
+  // The last word is the one the corpus writes as `přiměřenost`; nothing but
+  // its stem leaf reaches that judgment, and it has no dictionary forms here.
+  expect(groups.at(-1)).toStartWith('("přiměřenosti" OR text_stem:"');
+  expect(countLeaves(clause ?? "")).toBeLessThanOrEqual(
+    CORPUS_QUERY_LEAF_BUDGET,
+  );
+});
+
+const STEM_FIELDS = ["text_stem", "headnote_stem"] as const;
+
+const wordArbitrary = fc
+  .array(fc.constantFrom(...Array.from("aeioumnprstvzáéíýčřšž")), {
+    minLength: 3,
+    maxLength: 10,
+  })
+  .map((letters) => letters.join(""));
+
+const queryArbitrary = fc.record({
+  fields: fc.subarray([...STEM_FIELDS], { minLength: 1 }),
+  words: fc.array(
+    fc.record({
+      extras: fc.integer({ max: 4, min: 0 }),
+      word: wordArbitrary,
+    }),
+    { maxLength: 12, minLength: 1 },
+  ),
+});
+
+/**
+ * A word's stem leaves are what makes it reachable at all in an inflected
+ * corpus, so the budget must buy every word's before it buys any word's
+ * dictionary forms. The baseline is what the same word gets as a query of its
+ * own, where the budget cannot bind: deriving it from the builder rather than
+ * restemming here keeps the property from re-encoding the stemmer.
+ *
+ * The condition is the stem pass's own cost: one surface leaf per word, plus
+ * one stem leaf per word per stem field.
+ */
+test("every word keeps its stem leaves while the stem pass fits", () => {
+  fc.assert(
+    fc.property(queryArbitrary, ({ fields, words }) => {
+      const stemming: CorpusStemming = { fields, language: "cs" };
+      const forms = new Map(
+        words.map(({ extras, word }) => [
+          word,
+          Array.from(
+            { length: extras },
+            (_unused, index) => `${word}x${index}`,
+          ),
+        ]),
+      );
+      const expand: CorpusTermExpander = (term) => forms.get(term) ?? [];
+
+      const clause = corpusFreeTextClause(
+        words.map(({ word }) => word).join(" "),
+        { expand, stemming },
+      );
+      expect(clause).not.toBeNull();
+      const groups = clauseGroups(clause ?? "");
+      expect(groups).toHaveLength(words.length);
+      expect(countLeaves(clause ?? "")).toBeLessThanOrEqual(
+        CORPUS_QUERY_LEAF_BUDGET,
+      );
+
+      if (words.length * (1 + fields.length) > CORPUS_QUERY_LEAF_BUDGET) {
+        return;
+      }
+      for (const [index, { word }] of words.entries()) {
+        const alone = corpusFreeTextClause(word, { stemming }) ?? "";
+        const group = groups[index] ?? "";
+        for (const leaf of fieldLeaves(alone)) {
+          expect(group).toContain(leaf);
+        }
+      }
+    }),
+    propertyConfig(),
+  );
 });

--- a/apps/api/src/lib/legal-search/corpus-query.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.test.ts
@@ -354,6 +354,23 @@ test("stem clauses compose with expansion rather than replacing it", () => {
   );
 });
 
+// Every leaf group the budget can grant reaches the clause, exactly once and
+// in the written order: the group union is the pass list itself, so a group no
+// pass spends cannot exist, and a group spent twice would repeat its leaves
+// here. The stem leaves are last though the budget buys them first.
+test("each leaf group is granted once, in the order a group is written", () => {
+  expect(
+    corpusFreeTextClause("nájemné", {
+      expand: () => ["nájemného"],
+      stemming: CS_STEMMING,
+      surfaceFields: ["headnote"],
+    }),
+  ).toBe(
+    '(("nájemné" OR "nájemného" OR headnote:"nájemné"' +
+      ' OR text_stem:"nájemn" OR headnote_stem:"nájemn"))',
+  );
+});
+
 test("a generation without extra fields gets the query it gets today", () => {
   for (const text of [
     "náhrada škody",

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -143,8 +143,8 @@ const TOKEN_EXPANSION_POLICY = {
 /**
  * Quoted leaves one query may carry. Expansion multiplies leaves per term, so
  * without a ceiling a long query would hand the engine a clause whose cost is
- * quadratic in what the reader typed. Terms are expanded left to right until
- * the next group would cross the ceiling; the rest stay single leaves.
+ * quadratic in what the reader typed. `spendLeafBudget` decides which of a
+ * token's alternatives the ceiling pays for.
  */
 export const CORPUS_QUERY_LEAF_BUDGET = 24;
 
@@ -223,6 +223,82 @@ const expansionLeaves = (
   }
 };
 
+/**
+ * How the budget pays for one token's alternatives. `stem` is the
+ * generation's stem fields, one leaf each; `surface` is every alternative
+ * spelling of the word as written — the dictionary's other inflections and
+ * the extra surface fields.
+ */
+type LeafGroup = "stem" | "surface";
+
+/**
+ * The order the budget is spent in, which is deliberately not the order a
+ * group is written in.
+ *
+ * Stems come first because they are the alternatives an AND clause cannot do
+ * without. Every token is AND-ed, so a word the corpus carries only in
+ * another case form matches nothing as a bare surface leaf and empties the
+ * whole result set on its own; in an inflected language the most selective
+ * word of a long query is routinely the last one, which is exactly the token
+ * a single left-to-right pass starves. The stem pass costs tokens × stem
+ * fields, so it is bounded by what the reader typed.
+ *
+ * Dictionary expansion then spends what is left, left to right. Rarest first
+ * would be the better order and no frequency signal reaches this builder to
+ * give it: the dictionary payload carries a per-bucket document frequency,
+ * but the loader keeps only the forms and `CorpusTermExpander` hands over
+ * surface forms alone. Ordering by selectivity means retaining that column at
+ * load and exposing it on the expander.
+ */
+const LEAF_BUDGET_PASSES = [
+  "stem",
+  "surface",
+] as const satisfies readonly LeafGroup[];
+
+type TokenLeaves = {
+  alternatives: Record<LeafGroup, readonly string[]>;
+  typed: string;
+};
+
+type BudgetedToken = {
+  granted: Record<LeafGroup, readonly string[]>;
+  token: TokenLeaves;
+};
+
+/**
+ * Which of each token's alternatives the ceiling could pay for.
+ *
+ * Both passes run the same rule: a group is granted whole or skipped, never
+ * truncated into a clause asking for an arbitrary subset of a word's forms,
+ * and a token no pass reaches keeps the surface leaf it always had. So a
+ * query long enough that the stem pass alone would cross the ceiling
+ * allocates stems left to right and leaves the remaining tokens bare, which
+ * is what every token got before this pass existed.
+ */
+const spendLeafBudget = (tokens: readonly TokenLeaves[]): BudgetedToken[] => {
+  const budgeted: BudgetedToken[] = tokens.map((token) => ({
+    granted: { stem: [], surface: [] },
+    token,
+  }));
+  let leaves = tokens.length;
+
+  for (const pass of LEAF_BUDGET_PASSES) {
+    for (const entry of budgeted) {
+      const extras = entry.token.alternatives[pass];
+      if (
+        extras.length === 0 ||
+        leaves + extras.length > CORPUS_QUERY_LEAF_BUDGET
+      ) {
+        continue;
+      }
+      leaves += extras.length;
+      entry.granted[pass] = extras;
+    }
+  }
+
+  return budgeted;
+};
+
 export type CorpusFreeTextOptions = {
   expand?: CorpusTermExpander | undefined;
   stemming?: CorpusStemming | null | undefined;
@@ -271,25 +347,27 @@ export const corpusFreeTextClause = (
     return null;
   }
 
-  let leaves = tokens.length;
-  const clauses = tokens.map((token) => {
-    const typed = quoteCorpusValue(token.value);
-    const extras = [
-      ...expansionLeaves(token, expand),
-      ...surfaceFieldLeaves(token.value, surfaceFields),
-      ...stemLeaves(token.value, stemming),
-    ];
-    // The budget is spent left to right: a token whose group would cross it
-    // stays a single leaf rather than truncating a group into a clause that
-    // asks for something narrower than either alternative.
-    if (
-      extras.length === 0 ||
-      leaves + extras.length > CORPUS_QUERY_LEAF_BUDGET
-    ) {
-      return typed;
+  const budgeted = spendLeafBudget(
+    tokens.map((token) => ({
+      alternatives: {
+        stem: stemLeaves(token.value, stemming),
+        surface: [
+          ...expansionLeaves(token, expand),
+          ...surfaceFieldLeaves(token.value, surfaceFields),
+        ],
+      },
+      typed: quoteCorpusValue(token.value),
+    })),
+  );
+
+  const clauses = budgeted.map(({ granted, token }) => {
+    // Surface alternatives before stems, the order a group has always been
+    // written in; only which of them the budget bought is new.
+    const extras = [...granted.surface, ...granted.stem];
+    if (extras.length === 0) {
+      return token.typed;
     }
-    leaves += extras.length;
-    return `(${[typed, ...extras].join(" OR ")})`;
+    return `(${[token.typed, ...extras].join(" OR ")})`;
   });
 
   return `(${clauses.join(" AND ")})`;

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -224,14 +224,6 @@ const expansionLeaves = (
 };
 
 /**
- * How the budget pays for one token's alternatives. `stem` is the
- * generation's stem fields, one leaf each; `surface` is every alternative
- * spelling of the word as written — the dictionary's other inflections and
- * the extra surface fields.
- */
-type LeafGroup = "stem" | "surface";
-
-/**
  * The order the budget is spent in, which is deliberately not the order a
  * group is written in.
  *
@@ -250,10 +242,37 @@ type LeafGroup = "stem" | "surface";
  * surface forms alone. Ordering by selectivity means retaining that column at
  * load and exposing it on the expander.
  */
-const LEAF_BUDGET_PASSES = [
-  "stem",
-  "surface",
-] as const satisfies readonly LeafGroup[];
+const LEAF_BUDGET_PASSES = ["stem", "surface"] as const;
+
+/**
+ * How the budget pays for one token's alternatives. `stem` is the
+ * generation's stem fields, one leaf each; `surface` is every alternative
+ * spelling of the word as written — the dictionary's other inflections and
+ * the extra surface fields.
+ *
+ * Derived from the passes rather than declared beside them: a group exists
+ * because a pass spends it, so there is no way to add one the budget never
+ * grants, and every `Record<LeafGroup, …>` below is total over that same list.
+ */
+type LeafGroup = (typeof LEAF_BUDGET_PASSES)[number];
+
+/**
+ * Where a granted group is written inside its OR group, lowest first.
+ *
+ * A group has always been written surface alternatives first, stems last,
+ * which is not the order the budget is spent in. A rank per group keeps the
+ * two orders independent without a second hand-listed sequence to drift from
+ * the first: the map is total over `LeafGroup`, so a new group has to choose
+ * its place rather than inherit one.
+ */
+const LEAF_EMIT_RANK = {
+  stem: 1,
+  surface: 0,
+} as const satisfies Record<LeafGroup, number>;
+
+const LEAF_EMIT_ORDER = [...LEAF_BUDGET_PASSES].sort(
+  (left, right) => LEAF_EMIT_RANK[left] - LEAF_EMIT_RANK[right],
+);
 
 type TokenLeaves = {
   alternatives: Record<LeafGroup, readonly string[]>;
@@ -361,9 +380,7 @@ export const corpusFreeTextClause = (
   );
 
   const clauses = budgeted.map(({ granted, token }) => {
-    // Surface alternatives before stems, the order a group has always been
-    // written in; only which of them the budget bought is new.
-    const extras = [...granted.surface, ...granted.stem];
+    const extras = LEAF_EMIT_ORDER.flatMap((group) => granted[group]);
     if (extras.length === 0) {
       return token.typed;
     }


### PR DESCRIPTION
## What

`corpusFreeTextClause` spent `CORPUS_QUERY_LEAF_BUDGET` left to right over one group per token: the typed surface leaf plus that token's extras (dictionary forms, extra surface fields, stem leaves). A long query exhausted the ceiling on its first few words, so every later word stayed a bare surface leaf and had to appear in the corpus exactly as typed. The groups are AND-ed, so one starved word matches nothing and empties the whole clause; in an inflected language the word a reader adds to narrow a search is routinely the last one.

## How

Two passes over the same ceiling, in `spendLeafBudget`:

1. **Stems.** Every token gets its stem leaves first, one per stem field. The pass costs tokens × stem fields, so it is bounded by what the reader typed.
2. **Everything else.** What is left buys dictionary forms and extra surface fields, left to right, exactly the previous rule.

Invariants kept:

- A group is granted whole or skipped, never truncated into an arbitrary subset of a word's forms; a token no pass reaches keeps the surface leaf it always had.
- A query long enough that the stem pass alone would cross the ceiling allocates stems left to right and leaves the remaining tokens bare, which is the pre-change behaviour.
- A generation with no stem fields (`stemming: null`) gets a byte-identical clause: the stem pass then allocates nothing and the second pass is the old rule. Within a group, alternatives are still written surface-first, then stems.

Ordering the second pass by selectivity (rarest word first) would be better and is not available: the dictionary payload carries a per-bucket document frequency, but `parseExpansionDictionary` keeps only the forms and `CorpusTermExpander` hands the builder surface forms alone. Doing it means retaining that column at load and exposing it on the expander; not in this PR.

## Tests

`apps/api/src/lib/legal-search/corpus-query.test.ts`:

- A property over 1–12 word queries with mixed extras and one or two stem fields: whenever the stem pass fits the ceiling, every word keeps the stem leaves it gets as a query of its own, the group count matches the word count, and the clause never exceeds the budget. The per-word baseline comes from the builder rather than from restemming in the test.
- A six-word regression whose last word is reachable only by stem, with dictionary forms on the earlier words.

Both fail against the previous allocation; the rest of the file, the expansion suites and the read-contract/query-guard suites pass unchanged.
