### PR TITLE
feat(api): index a decision's classification in its own field

### DIFF
--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -555,6 +555,7 @@ const buildCorpusIndexQuery = ({
     expand,
     stemming: fields.stemming,
     surfaceFields: fields.surfaceFields,
+    keywordFields: fields.keywordFields,
   });
 
 type ResolveCorpusIndexQueryOptions = {

--- a/apps/api/src/lib/case-law/publisher-summary.test.ts
+++ b/apps/api/src/lib/case-law/publisher-summary.test.ts
@@ -6,7 +6,11 @@ import type {
   ParagraphRole,
 } from "@stll/legal-ast/document-ast";
 
-import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
+import {
+  publisherHeadnoteOf,
+  publisherKeywordsOf,
+  publisherSummaryOf,
+} from "@/api/lib/case-law/publisher-summary";
 
 const documentAst = (blocks: Block[]): DocumentAst => ({
   version: 1,
@@ -129,4 +133,42 @@ test("a summary opening with a one-letter word keeps it", () => {
       metadata: { legalArea: "  v likvidaci  " },
     }),
   ).toBe("v likvidaci");
+});
+
+test("a headnote is a sentence somebody wrote, never a classification", () => {
+  // The reading the corpus index writes into its headnote field. Every
+  // classification key at once, so the answer cannot be an accident of order:
+  // no source of this list holds one, so none can come back from it.
+  const classified = {
+    documentAst: null,
+    metadata: {
+      keywords: ["nájem", "výpověď"],
+      legalAreas: ["Občanské právo"],
+      legalArea: "Daně",
+    },
+  };
+
+  expect(publisherHeadnoteOf(classified)).toBeNull();
+  expect(publisherKeywordsOf(classified)).toBe("nájem · výpověď");
+  expect(
+    publisherHeadnoteOf({
+      documentAst: documentAst([paragraph("b1", "Právní věta", "headnotes")]),
+      metadata: { legalArea: "Daně" },
+    }),
+  ).toBe("Právní věta");
+});
+
+test("the line a reader sees falls back to the classification", () => {
+  // Display behaviour, unchanged: a decision whose publisher wrote no sentence
+  // reads better with the terms it was filed under than with an empty line.
+  // What the index must not do is score that fallback as a headnote.
+  const tagged = { documentAst: null, metadata: { legalArea: "Daně" } };
+
+  expect(publisherSummaryOf(tagged)).toBe("Daně");
+  expect(publisherSummaryOf(tagged)).toBe(publisherKeywordsOf(tagged));
+  const written = {
+    documentAst: null,
+    metadata: { legalSentence: "Právní věta", legalArea: "Daně" },
+  };
+  expect(publisherSummaryOf(written)).toBe(publisherHeadnoteOf(written));
 });

--- a/apps/api/src/lib/case-law/publisher-summary.ts
+++ b/apps/api/src/lib/case-law/publisher-summary.ts
@@ -5,16 +5,17 @@ import type { SQL, SQLWrapper } from "drizzle-orm";
 import type { ApparatusRole, DocumentAst } from "@stll/legal-ast/document-ast";
 
 /**
- * The publisher's own summary of a decision: the sentence a reader
- * recognises the case by, written by whoever published it rather than by the
- * court. Every jurisdiction the corpus covers has one under a different name
- * and in a different place, so the sources are declared once, in order, and
- * every consumer walks that one list.
+ * What a publisher says about a decision, in the two kinds it comes in: the
+ * headnote — the sentence a reader recognises the case by, written by whoever
+ * published it rather than by the court — and the keywords, the subject index
+ * and legal areas the decision was filed under. Every jurisdiction the corpus
+ * covers publishes both under different names and in different places, so the
+ * sources are declared once, in order, and every consumer walks these lists.
  *
- * Order is from the most to the least specific, and it is the same for every
- * court, so a decision's summary means the same thing across jurisdictions.
- * Adding a jurisdiction means adding a source here, never a branch anywhere
- * else.
+ * Order within a kind is from the most to the least specific, and it is the
+ * same for every court, so a decision's headnote means the same thing across
+ * jurisdictions. Adding a jurisdiction means adding a source here, never a
+ * branch anywhere else.
  */
 
 /**
@@ -23,36 +24,70 @@ import type { ApparatusRole, DocumentAst } from "@stll/legal-ast/document-ast";
  * publisher's own, in document order, with no key naming convention in
  * between.
  *
- * `apparatus` and `counsel` are apparatus too but are not summaries: the
+ * `apparatus` and `counsel` are apparatus too but are not headnotes: the
  * first is unnamed publisher matter, the second is who appeared.
  */
-const PUBLISHER_SUMMARY_AST_ROLES = [
+const PUBLISHER_HEADNOTE_AST_ROLES = [
   "headnotes",
   "syllabus",
   "summary",
 ] as const satisfies readonly ApparatusRole[];
 
-/** How one metadata value is read into summary text. */
+/** How one metadata value is read into text. */
 type PublisherSummaryValueShape = "text" | "list";
 
-type PublisherSummarySource =
-  | { origin: "ast"; roles: readonly ApparatusRole[] }
-  | { origin: "metadata"; key: string; shape: PublisherSummaryValueShape };
+/**
+ * What a source's value is. A headnote is a sentence somebody wrote about the
+ * decision; keywords are the terms it was indexed and filed under. Both are
+ * the publisher's, and a reader with no headnote is better served by the tags
+ * than by an empty line, but they are not the same kind of text: one is prose,
+ * the other a classification. The kind therefore travels with the source, and
+ * a consumer that has to keep them apart — the corpus index gives each its own
+ * field — asks for one list or the other instead of re-deciding per key.
+ */
+type PublisherSummaryKind = "headnote" | "keywords";
+
+type PublisherSummarySourceOf<Kind extends PublisherSummaryKind> =
+  | { kind: Kind; origin: "ast"; roles: readonly ApparatusRole[] }
+  | {
+      kind: Kind;
+      origin: "metadata";
+      key: string;
+      shape: PublisherSummaryValueShape;
+    };
+
+type PublisherSummarySource = PublisherSummarySourceOf<PublisherSummaryKind>;
 
 /**
- * Every place a publisher summary can live, best first. Each metadata key is
- * one an adapter records verbatim from its source; a key arrives here with the
+ * Every place a headnote can live, best first. Each metadata key is one an
+ * adapter records verbatim from its source; a key arrives here with the
  * adapter that writes it, never before one.
  */
+const PUBLISHER_HEADNOTE_SOURCES = [
+  { kind: "headnote", origin: "ast", roles: PUBLISHER_HEADNOTE_AST_ROLES },
+  { kind: "headnote", origin: "metadata", key: "legalSentence", shape: "text" },
+  { kind: "headnote", origin: "metadata", key: "abstract", shape: "text" },
+  { kind: "headnote", origin: "metadata", key: "summary", shape: "text" },
+] as const satisfies readonly PublisherSummarySourceOf<"headnote">[];
+
+/**
+ * Every place a decision's classification can live, best first: the subject
+ * index the publisher assigned, then the areas of law they filed it under.
+ */
+const PUBLISHER_KEYWORD_SOURCES = [
+  { kind: "keywords", origin: "metadata", key: "keywords", shape: "list" },
+  { kind: "keywords", origin: "metadata", key: "legalAreas", shape: "list" },
+  { kind: "keywords", origin: "metadata", key: "legalArea", shape: "text" },
+] as const satisfies readonly PublisherSummarySourceOf<"keywords">[];
+
+/**
+ * Both lists as one, headnotes first: the order the single line a reader sees
+ * resolves in, and the order the SQL reading below walks.
+ */
 export const PUBLISHER_SUMMARY_SOURCES = [
-  { origin: "ast", roles: PUBLISHER_SUMMARY_AST_ROLES },
-  { origin: "metadata", key: "legalSentence", shape: "text" },
-  { origin: "metadata", key: "abstract", shape: "text" },
-  { origin: "metadata", key: "summary", shape: "text" },
-  { origin: "metadata", key: "keywords", shape: "list" },
-  { origin: "metadata", key: "legalAreas", shape: "list" },
-  { origin: "metadata", key: "legalArea", shape: "text" },
-] as const satisfies readonly PublisherSummarySource[];
+  ...PUBLISHER_HEADNOTE_SOURCES,
+  ...PUBLISHER_KEYWORD_SOURCES,
+] as const;
 
 /** Items of a list-shaped source, as one line. */
 const LIST_SEPARATOR = " · ";
@@ -178,21 +213,17 @@ const astSummary = (
   return paragraphs.length === 0 ? null : paragraphs.join(PARAGRAPH_SEPARATOR);
 };
 
-type PublisherSummaryInput = {
+export type PublisherSummaryInput = {
   documentAst: DocumentAst | null;
   metadata: Record<string, unknown> | null;
 };
 
-/**
- * The first source that has something, over the full list. Null when the
- * publisher supplied nothing, so a consumer omits the line rather than
- * rendering an empty one.
- */
-export const publisherSummaryOf = ({
-  documentAst,
-  metadata,
-}: PublisherSummaryInput): string | null => {
-  for (const source of PUBLISHER_SUMMARY_SOURCES) {
+/** The first source of a list that has something, or null when none has. */
+const firstSourceText = (
+  sources: readonly PublisherSummarySource[],
+  { documentAst, metadata }: PublisherSummaryInput,
+): string | null => {
+  for (const source of sources) {
     switch (source.origin) {
       case "ast": {
         const text = astSummary(documentAst, source.roles);
@@ -216,6 +247,29 @@ export const publisherSummaryOf = ({
   }
   return null;
 };
+
+/**
+ * The publisher's own sentence about the decision, and only that: a
+ * classification cannot come back from here, because the list this walks holds
+ * no classification source. Null where no publisher wrote one.
+ */
+export const publisherHeadnoteOf = (
+  input: PublisherSummaryInput,
+): string | null => firstSourceText(PUBLISHER_HEADNOTE_SOURCES, input);
+
+/** The terms the publisher indexed and filed the decision under. */
+export const publisherKeywordsOf = (
+  input: PublisherSummaryInput,
+): string | null => firstSourceText(PUBLISHER_KEYWORD_SOURCES, input);
+
+/**
+ * One line for a reader: the headnote, or the classification where there is no
+ * headnote. Null when the publisher supplied neither, so a consumer omits the
+ * line rather than rendering an empty one.
+ */
+export const publisherSummaryOf = (
+  input: PublisherSummaryInput,
+): string | null => publisherHeadnoteOf(input) ?? publisherKeywordsOf(input);
 
 /**
  * The same list, as one SQL expression over a decision's `metadata`, and the

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
@@ -65,8 +65,11 @@ test("every deployable generation selects one explicit Quickwit cluster", () => 
   expect(corpusIndexClusterForGeneration("case_law", "case_law_v6")).toBe(
     "q09",
   );
+  expect(corpusIndexClusterForGeneration("case_law", "case_law_v7")).toBe(
+    "q09",
+  );
   expect(() =>
-    corpusIndexClusterForGeneration("case_law", "case_law_v7"),
+    corpusIndexClusterForGeneration("case_law", "case_law_v8"),
   ).toThrow("Unknown case_law corpus index generation");
 });
 

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -45,7 +45,7 @@ type FinalManifestGenerationByFamily = {
 };
 
 const FINAL_Q09_GENERATIONS = {
-  case_law: ["case_law_v5", "case_law_v6"],
+  case_law: ["case_law_v5", "case_law_v6", "case_law_v7"],
   legislation: ["legislation_v2"],
 } as const satisfies {
   [Family in CorpusFamily]: readonly FinalManifestGenerationByFamily[Family][];

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -349,12 +349,12 @@ export const DECISION_TIMESTAMP_FIELD = "decision_date_ts";
 export const UNDATED_DECISION_TIMESTAMP = "1800-01-01";
 
 /**
- * The index field carrying a decision's publisher summary: the publisher's
- * own sentence about the case, from `publisher-summary.ts`. Its own field
- * rather than a prefix of `text`, so a term matching the summary is a
- * document-level hit that ranks and reads as one, and so `heading_path`'s
- * problem cannot recur: it is written to the opening passage only, exactly
- * like `title`, and therefore answers once per document.
+ * The index field carrying a decision's headnote: the publisher's own sentence
+ * about the case, from `publisher-summary.ts`. Its own field rather than a
+ * prefix of `text`, so a term matching the headnote is a document-level hit
+ * that ranks and reads as one, and so `heading_path`'s problem cannot recur:
+ * it is written to the opening passage only, exactly like `title`, and
+ * therefore answers once per document.
  *
  * Not stored: the line a reader sees is read from Postgres, so a copy in the
  * docstore would pay object-storage bytes for nothing.
@@ -365,6 +365,24 @@ export const UNDATED_DECISION_TIMESTAMP = "1800-01-01";
  * arrives with a generation and never before one.
  */
 export const PUBLISHER_SUMMARY_FIELD = "headnote";
+
+/**
+ * The index field carrying a decision's classification: the subject-index
+ * terms and areas of law the publisher filed it under, from
+ * `publisher-summary.ts`. A separate field because it is a different kind of
+ * text: a headnote is a sentence somebody wrote about this decision, a
+ * classification is a handful of terms shared with every other decision filed
+ * the same way, and a term matching one should not score as if it had matched
+ * the other.
+ *
+ * Written to the opening passage only and never a default search field, like
+ * the headnote. Unlike the headnote it carries no fieldnorms: fieldnorms are
+ * what make BM25 length normalization work, and against a field this short
+ * they are amplification — a two-word tag list would outscore a paragraph a
+ * publisher wrote for the same term. A classification is worth matching, not
+ * worth winning on.
+ */
+export const PUBLISHER_KEYWORDS_FIELD = "keywords";
 
 /**
  * The stem companions of the two full-text fields a reader's words reach.

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -6,7 +6,7 @@ import {
   corpusIndexConfigFromManifest,
   corpusIndexIdFromManifest,
   corpusIndexManifestDigest,
-  corpusIndexPublisherSummaryField,
+  corpusIndexPublisherFields,
   corpusIndexStemFields,
   requireCorpusIndexIdForManifest,
   requireCorpusIndexManifest,
@@ -22,6 +22,8 @@ const EXPECTED_DIGESTS = {
     "7ee1e1bdbc0a1c746407333cac6eba21446d32b0eca461235569eac4197ed0ce",
   case_law_v6:
     "1fc5f09b5471e49a4e5588c9f59c3ce78c08a9aa54b55e5edef168bc315accc8",
+  case_law_v7:
+    "2de0dbda9f81c61968b0775f47dcbdb151aa1f3bfa2e982aa7272ce43238add4",
   legislation_v2:
     "dc252d8635081d8037e7f9b1aca6713181a27390e8eb6dda54139ae6a1e68583",
 } as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
@@ -30,6 +32,7 @@ test("the final-generation registry is exact and fails closed", () => {
   expect(Object.keys(CORPUS_INDEX_MANIFESTS).sort()).toEqual([
     "case_law_v5",
     "case_law_v6",
+    "case_law_v7",
     "legislation_v2",
   ]);
   expect(requireCorpusIndexManifest("case_law", "case_law_v5")).toBe(
@@ -37,6 +40,9 @@ test("the final-generation registry is exact and fails closed", () => {
   );
   expect(requireCorpusIndexManifest("case_law", "case_law_v6")).toBe(
     CORPUS_INDEX_MANIFESTS.case_law_v6,
+  );
+  expect(requireCorpusIndexManifest("case_law", "case_law_v7")).toBe(
+    CORPUS_INDEX_MANIFESTS.case_law_v7,
   );
   expect(requireCorpusIndexManifest("legislation", "legislation_v2")).toBe(
     CORPUS_INDEX_MANIFESTS.legislation_v2,
@@ -55,6 +61,9 @@ test("manifest digests pin every semantic array and ignore object key order", ()
   );
   expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.case_law_v6)).toBe(
     EXPECTED_DIGESTS.case_law_v6,
+  );
+  expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.case_law_v7)).toBe(
+    EXPECTED_DIGESTS.case_law_v7,
   );
   expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.legislation_v2)).toBe(
     EXPECTED_DIGESTS.legislation_v2,
@@ -420,26 +429,78 @@ test("v6 adds the publisher summary and nothing else", () => {
   );
 });
 
-test("only a generation that maps the field reports one", () => {
+test("v7 gives the publisher's classification a field of its own", () => {
+  const v6 = CORPUS_INDEX_MANIFESTS.case_law_v6.engine.indexConfig.doc_mapping;
+  const v7 = CORPUS_INDEX_MANIFESTS.case_law_v7.engine.indexConfig.doc_mapping;
+
+  expect(v7.field_mappings.map(({ name }) => name)).toEqual([
+    ...v6.field_mappings.map(({ name }) => name),
+    "keywords",
+  ]);
+  // The headnote's mapping, minus the fieldnorms BM25 length normalization
+  // runs on: a two-word tag list must not outscore a sentence a publisher
+  // wrote, for the same term, on brevity alone.
+  expect(v7.field_mappings.at(-1)).toEqual({
+    name: "keywords",
+    type: "text",
+    tokenizer: "folded",
+    record: "position",
+    fieldnorms: false,
+    indexed: true,
+    stored: false,
+    fast: false,
+  });
+  expect(v7.mode).toBe("strict");
+  expect(v7.tag_fields).toEqual(v6.tag_fields);
+  expect(v7.timestamp_field).toBe(v6.timestamp_field);
+  expect(CORPUS_INDEX_MANIFESTS.case_law_v7.projection.builderVersion).toBe(
+    "case-law-passages-v3",
+  );
+});
+
+test("only a generation that maps a publisher field reports one", () => {
   expect(
-    corpusIndexPublisherSummaryField(CORPUS_INDEX_MANIFESTS.case_law_v5),
-  ).toBeNull();
+    corpusIndexPublisherFields(CORPUS_INDEX_MANIFESTS.case_law_v5),
+  ).toEqual({ kind: "none" });
+  // v6 has one field for everything a publisher wrote, and keeps it: changing
+  // what a built generation writes would leave two readings of one field
+  // inside a single index.
   expect(
-    corpusIndexPublisherSummaryField(CORPUS_INDEX_MANIFESTS.case_law_v6),
-  ).toBe("headnote");
+    corpusIndexPublisherFields(CORPUS_INDEX_MANIFESTS.case_law_v6),
+  ).toEqual({ kind: "summary", summaryField: "headnote" });
   expect(
-    corpusIndexPublisherSummaryField(CORPUS_INDEX_MANIFESTS.legislation_v2),
-  ).toBeNull();
+    corpusIndexPublisherFields(CORPUS_INDEX_MANIFESTS.case_law_v7),
+  ).toEqual({
+    kind: "summary_and_keywords",
+    summaryField: "headnote",
+    keywordsField: "keywords",
+  });
+  expect(
+    corpusIndexPublisherFields(CORPUS_INDEX_MANIFESTS.legislation_v2),
+  ).toEqual({ kind: "none" });
   for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
-    const field = corpusIndexPublisherSummaryField(manifest);
-    if (field === null) {
-      continue;
-    }
-    expect(
-      manifest.engine.indexConfig.doc_mapping.field_mappings.some(
-        ({ name }) => name === field,
+    const publisher = corpusIndexPublisherFields(manifest);
+    const declared = new Set(
+      manifest.engine.indexConfig.doc_mapping.field_mappings.map(
+        ({ name }) => name,
       ),
-    ).toBe(true);
+    );
+    switch (publisher.kind) {
+      case "none":
+        break;
+      case "summary":
+        expect(declared.has(publisher.summaryField)).toBe(true);
+        break;
+      case "summary_and_keywords":
+        expect([
+          declared.has(publisher.summaryField),
+          declared.has(publisher.keywordsField),
+        ]).toEqual([true, true]);
+        break;
+      default:
+        publisher satisfies never;
+        throw new Error("Unhandled publisher fields");
+    }
   }
 });
 
@@ -450,20 +511,30 @@ test("v6 keeps the default search fields v5 has", () => {
   // only — the summary, or either stem — must never be reachable by a bare
   // term, or a summary-only match would answer with a passage whose text does
   // not carry the terms. The query builder names those fields explicitly.
-  const defaultsOf = (generation: "case_law_v5" | "case_law_v6") =>
+  const defaultsOf = (
+    generation: "case_law_v5" | "case_law_v6" | "case_law_v7",
+  ) =>
     CORPUS_INDEX_MANIFESTS[generation].engine.indexConfig.search_settings
       .default_search_fields;
 
   expect(defaultsOf("case_law_v6")).toEqual(["title", "text"]);
   expect(defaultsOf("case_law_v6")).toEqual(defaultsOf("case_law_v5"));
-  for (const absent of ["headnote", "text_stem", "headnote_stem"]) {
-    expect(defaultsOf("case_law_v6")).not.toContain(absent);
+  expect(defaultsOf("case_law_v7")).toEqual(defaultsOf("case_law_v6"));
+  for (const absent of ["headnote", "keywords", "text_stem", "headnote_stem"]) {
+    expect(defaultsOf("case_law_v7")).not.toContain(absent);
   }
 });
 
 test("only a generation that maps the stem fields reports them", () => {
   expect(corpusIndexStemFields(CORPUS_INDEX_MANIFESTS.case_law_v5)).toBeNull();
   expect(corpusIndexStemFields(CORPUS_INDEX_MANIFESTS.case_law_v6)).toEqual({
+    text: "text_stem",
+    publisherSummary: "headnote_stem",
+  });
+  // v7 stems the same two fields. The classification is a controlled
+  // vocabulary matched on the words it is written in, so it carries no stem
+  // companion; adding one is a mapping change and therefore a generation.
+  expect(corpusIndexStemFields(CORPUS_INDEX_MANIFESTS.case_law_v7)).toEqual({
     text: "text_stem",
     publisherSummary: "headnote_stem",
   });

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -15,6 +15,7 @@ import {
   CORPUS_INDEX_DATE_INPUT_FORMATS,
   DECISION_TIMESTAMP_FIELD,
   FOLDED_TOKENIZER,
+  PUBLISHER_KEYWORDS_FIELD,
   PUBLISHER_SUMMARY_FIELD,
   STEM_FIELD_OF,
   canonicalCorpusIndexMaturationPeriod,
@@ -83,6 +84,30 @@ type CaseLawV6Manifest = CaseLawManifestBase & {
   };
 };
 
+/**
+ * v6 with the publisher's classification in its own field. v6 has one field
+ * for everything a publisher wrote, so a decision with no headnote carries its
+ * subject-index terms there instead, and a query matching those terms scores
+ * against the field that stands for a written headnote. Splitting them is a
+ * mapping change, and the case-law doc mapping is `strict`, so it arrives as a
+ * generation: v6 keeps its exact bytes, its digest, and every projection
+ * fingerprint derived from it while v7 builds beside it.
+ */
+type CaseLawV7Manifest = CaseLawManifestBase & {
+  generation: "case_law_v7";
+  projection: CorpusIndexProjectionContract & {
+    layout: "passage";
+    builderVersion: "case-law-passages-v3";
+    yearFacetField: "decision_year";
+    publisherSummaryField: typeof PUBLISHER_SUMMARY_FIELD;
+    keywordsField: typeof PUBLISHER_KEYWORDS_FIELD;
+    stemFields: {
+      text: (typeof STEM_FIELD_OF)["text"];
+      publisherSummary: (typeof STEM_FIELD_OF)[typeof PUBLISHER_SUMMARY_FIELD];
+    };
+  };
+};
+
 type LegislationV2Manifest = CorpusIndexManifestBase & {
   family: "legislation";
   generation: "legislation_v2";
@@ -99,6 +124,7 @@ type LegislationV2Manifest = CorpusIndexManifestBase & {
 export type CorpusIndexManifest =
   | CaseLawV5Manifest
   | CaseLawV6Manifest
+  | CaseLawV7Manifest
   | LegislationV2Manifest;
 export type CorpusIndexManifestGeneration = CorpusIndexManifest["generation"];
 
@@ -335,6 +361,37 @@ const CASE_LAW_V6_INDEX_CONFIG = deepFreeze(
   ),
 );
 
+const caseLawV7Fields = (): CorpusIndexFieldMapping[] => {
+  const base = caseLawV6Fields();
+  const headnote =
+    base.find((field) => field.name === PUBLISHER_SUMMARY_FIELD) ??
+    panic("Case-law fields no longer map the headnote");
+  // The headnote's tokenizer and positions, so the same phrase matches the
+  // same way, minus the fieldnorms: a classification is a handful of terms and
+  // BM25 length normalization would let it outscore a sentence a publisher
+  // wrote for the same word. Not stored and not fast for the headnote's
+  // reasons: nothing reads it back, nothing filters or sorts on it.
+  return [
+    ...base,
+    { ...headnote, name: PUBLISHER_KEYWORDS_FIELD, fieldnorms: false },
+  ];
+};
+
+const CASE_LAW_V7_INDEX_CONFIG = deepFreeze(
+  structuredClone(
+    indexConfig({
+      fieldMappings: caseLawV7Fields(),
+      tagFields: [...CASE_LAW_TAG_FIELDS],
+      timestampField: DECISION_TIMESTAMP_FIELD,
+      // Unchanged from v6, for the reason stated there: a hit is a passage and
+      // its stored `text` is the excerpt that stands for the match, so a field
+      // written to the opening passage only is named by the query builder or
+      // not matched at all.
+      defaultSearchFields: ["title", "text"],
+    }),
+  ),
+);
+
 const LEGISLATION_V2_INDEX_CONFIG = deepFreeze(
   structuredClone(
     indexConfig({
@@ -408,6 +465,34 @@ export const CORPUS_INDEX_MANIFESTS = deepFreeze({
       byJurisdiction: { ...CASE_LAW_INDEX_GROUP_OF },
     },
   },
+  case_law_v7: {
+    schemaVersion: CORPUS_INDEX_MANIFEST_SCHEMA_VERSION,
+    family: "case_law",
+    generation: "case_law_v7",
+    cluster: "q09",
+    engine: {
+      binaryVersion: QUICKWIT_V09_BINARY_VERSION,
+      indexConfig: CASE_LAW_V7_INDEX_CONFIG,
+    },
+    projection: {
+      layout: "passage",
+      builderVersion: "case-law-passages-v3",
+      documentIdField: "document_id",
+      projectionRevisionField: "projection_revision",
+      openingField: "is_opening",
+      yearFacetField: "decision_year",
+      publisherSummaryField: PUBLISHER_SUMMARY_FIELD,
+      keywordsField: PUBLISHER_KEYWORDS_FIELD,
+      stemFields: {
+        text: STEM_FIELD_OF.text,
+        publisherSummary: STEM_FIELD_OF[PUBLISHER_SUMMARY_FIELD],
+      },
+    },
+    route: {
+      type: "case_law_group",
+      byJurisdiction: { ...CASE_LAW_INDEX_GROUP_OF },
+    },
+  },
   legislation_v2: {
     schemaVersion: CORPUS_INDEX_MANIFEST_SCHEMA_VERSION,
     family: "legislation",
@@ -442,6 +527,8 @@ export const requireCorpusIndexManifest = (
           return CORPUS_INDEX_MANIFESTS.case_law_v5;
         case "case_law_v6":
           return CORPUS_INDEX_MANIFESTS.case_law_v6;
+        case "case_law_v7":
+          return CORPUS_INDEX_MANIFESTS.case_law_v7;
         default:
           return panic(`Unknown case-law index manifest: ${generation}`);
       }
@@ -455,22 +542,50 @@ export const requireCorpusIndexManifest = (
 };
 
 /**
- * The index field a generation carries the publisher summary in, or null for
- * a generation whose indexes never mapped one. Total over every generation, so
- * a new one has to answer rather than inherit: writing the field into a
- * `strict` index that does not map it drops the whole document, and the engine
- * reports that as a successful ingest.
+ * How a generation's indexes hold what a publisher wrote, as the three shapes
+ * that exist rather than as a field name plus a convention:
+ *
+ * - `none`: the generation mapped neither field. Nothing publisher-authored is
+ *   written, because writing a field into a `strict` index that does not map
+ *   it drops the whole document, and the engine reports that as a successful
+ *   ingest.
+ * - `summary`: one field for everything a publisher wrote. A decision with no
+ *   headnote carries its classification there, which is the reading the
+ *   generation was built with and may not change under it.
+ * - `summary_and_keywords`: a field each. The headnote holds sentences and
+ *   nothing else; the classification has somewhere of its own to go.
+ *
+ * Total over every generation, so a new one answers rather than inherits, and
+ * the kind is what the writer, the fingerprint and the reader all branch on.
  */
-export const corpusIndexPublisherSummaryField = (
+export type CorpusIndexPublisherFields =
+  | { kind: "none" }
+  | { kind: "summary"; summaryField: typeof PUBLISHER_SUMMARY_FIELD }
+  | {
+      kind: "summary_and_keywords";
+      summaryField: typeof PUBLISHER_SUMMARY_FIELD;
+      keywordsField: typeof PUBLISHER_KEYWORDS_FIELD;
+    };
+
+export const corpusIndexPublisherFields = (
   manifest: CorpusIndexManifest,
-): typeof PUBLISHER_SUMMARY_FIELD | null => {
+): CorpusIndexPublisherFields => {
   switch (manifest.generation) {
     case "case_law_v5":
-      return null;
+      return { kind: "none" };
     case "case_law_v6":
-      return manifest.projection.publisherSummaryField;
+      return {
+        kind: "summary",
+        summaryField: manifest.projection.publisherSummaryField,
+      };
+    case "case_law_v7":
+      return {
+        kind: "summary_and_keywords",
+        summaryField: manifest.projection.publisherSummaryField,
+        keywordsField: manifest.projection.keywordsField,
+      };
     case "legislation_v2":
-      return null;
+      return { kind: "none" };
     default:
       manifest satisfies never;
       return panic(`Unhandled manifest: ${String(manifest)}`);
@@ -495,6 +610,7 @@ export const corpusIndexStemFields = (
     case "case_law_v5":
       return null;
     case "case_law_v6":
+    case "case_law_v7":
       return manifest.projection.stemFields;
     case "legislation_v2":
       return null;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
@@ -230,6 +230,60 @@ test("v6 writes the publisher summary on the opening passage only", () => {
   }
 });
 
+test("v7 keeps a classification out of the headnote field", () => {
+  const documents = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v7,
+    input: {
+      ...CASE_LAW_INPUT,
+      metadata: { keywords: ["nájem", "výpověď"], legalArea: "Daně" },
+    },
+    payload: {
+      text: `${"první ".repeat(400)}\n\n${"druhý ".repeat(400)}`,
+      ast: null,
+    },
+    revision: REVISION,
+  });
+
+  expect(documents.length).toBeGreaterThan(1);
+  // The publisher wrote no sentence about this decision, so it has no
+  // headnote: the terms it was indexed under are not one.
+  expect(documents.at(0)).toMatchObject({ keywords: "nájem · výpověď" });
+  for (const [index, document] of documents.entries()) {
+    expect("headnote" in document).toBe(false);
+    expect("headnote_stem" in document).toBe(false);
+    expect("keywords" in document).toBe(index === 0);
+    expect(
+      Object.keys(document).every((key) =>
+        manifestFields("case_law_v7").has(key),
+      ),
+    ).toBe(true);
+  }
+});
+
+test("v7 writes a headnote and a classification to their own fields", () => {
+  const [document] = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v7,
+    input: {
+      ...CASE_LAW_INPUT,
+      metadata: {
+        legalSentence: "Nájemního bytu se to netýká.",
+        legalAreas: ["Občanské právo", "Nájem"],
+      },
+    },
+    payload: { text: "Nájemního bytu se to netýká.", ast: null },
+    revision: REVISION,
+  });
+
+  expect(document).toMatchObject({
+    headnote: "Nájemního bytu se to netýká.",
+    keywords: "Občanské právo · Nájem",
+  });
+  // The headnote keeps its stem companion; the classification has none, so a
+  // field it could not fill is a field it does not emit.
+  expect("headnote_stem" in (document ?? {})).toBe(true);
+  expect("keywords_stem" in (document ?? {})).toBe(false);
+});
+
 test("v6 prefers a marked apparatus paragraph to a metadata key", () => {
   const [document] = buildCaseLawProjectionDocuments({
     manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
@@ -239,6 +293,21 @@ test("v6 prefers a marked apparatus paragraph to a metadata key", () => {
   });
 
   expect(document).toMatchObject({ headnote: "Právní věta" });
+});
+
+test("the summary a v6 index already holds keeps its fallback", () => {
+  // v6 maps one field for everything a publisher wrote. Splitting the two
+  // readings under it would leave one index holding both, so the generation
+  // that maps a second field is the one that stops using the fallback.
+  const [document] = buildCaseLawProjectionDocuments({
+    manifest: CORPUS_INDEX_MANIFESTS.case_law_v6,
+    input: { ...CASE_LAW_INPUT, metadata: { keywords: ["nájem"] } },
+    payload: { text: "Usnesení", ast: null },
+    revision: REVISION,
+  });
+
+  expect(document).toMatchObject({ headnote: "nájem" });
+  expect("keywords" in (document ?? {})).toBe(false);
 });
 
 test("v5 never emits a field its strict mapping does not declare", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
@@ -2,14 +2,20 @@ import { panic } from "better-result";
 
 import type { SafeId } from "@/api/lib/branded-types";
 import { hasUsableAst } from "@/api/lib/case-law/document-ast";
-import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
+import {
+  publisherHeadnoteOf,
+  publisherKeywordsOf,
+  publisherSummaryOf,
+  type PublisherSummaryInput,
+} from "@/api/lib/case-law/publisher-summary";
 import { chunkDocument } from "@/api/lib/corpus-index/chunking";
 import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
 import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
 import {
-  corpusIndexPublisherSummaryField,
+  corpusIndexPublisherFields,
   corpusIndexStemFields,
   type CorpusIndexManifest,
+  type CorpusIndexPublisherFields,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import {
   caseLawProjectionTitle,
@@ -42,6 +48,7 @@ type CaseLawProjectionDocument = SharedProjectionDocument & {
   decision_year?: number;
   ecli?: string;
   headnote?: string;
+  keywords?: string;
   text_stem?: string;
   headnote_stem?: string;
 };
@@ -96,6 +103,63 @@ type BuildCaseLawOptions = ProjectionBuildBase & {
 
 const CASE_LAW_DECISION_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 
+/** One index field and the text this decision fills it with. */
+type PublisherProjectionField = { field: string; value: string };
+
+type PublisherProjection = {
+  summary: PublisherProjectionField | null;
+  keywords: PublisherProjectionField | null;
+};
+
+const publisherField = (
+  field: string,
+  value: string | null,
+): PublisherProjectionField | null =>
+  value === null ? null : { field, value };
+
+/**
+ * What this decision writes into the generation's publisher fields. The full
+ * source list, AST roles included: this is the one place holding both a parsed
+ * document and its publisher metadata.
+ *
+ * Which reading fills the summary field is the generation's, not this
+ * function's: a generation with a field for the classification keeps sentences
+ * and tags apart, and one built before that field existed keeps the fallback
+ * its indexes already hold, because changing what a built generation writes
+ * would leave two readings of the same field inside one index.
+ */
+const publisherProjection = (
+  publisher: CorpusIndexPublisherFields,
+  input: PublisherSummaryInput,
+): PublisherProjection => {
+  switch (publisher.kind) {
+    case "none":
+      return { summary: null, keywords: null };
+    case "summary":
+      return {
+        summary: publisherField(
+          publisher.summaryField,
+          publisherSummaryOf(input),
+        ),
+        keywords: null,
+      };
+    case "summary_and_keywords":
+      return {
+        summary: publisherField(
+          publisher.summaryField,
+          publisherHeadnoteOf(input),
+        ),
+        keywords: publisherField(
+          publisher.keywordsField,
+          publisherKeywordsOf(input),
+        ),
+      };
+    default:
+      publisher satisfies never;
+      return panic(`Unhandled publisher fields: ${String(publisher)}`);
+  }
+};
+
 export const buildCaseLawProjectionDocuments = ({
   manifest,
   input,
@@ -122,15 +186,10 @@ export const buildCaseLawProjectionDocuments = ({
   const decisionYear =
     input.decisionDate === null ? null : Number(input.decisionDate.slice(0, 4));
   const ast = hasUsableAst(payload.ast) ? payload.ast : null;
-  // The full source list, AST roles included: this is the one place holding
-  // both a parsed document and its publisher metadata. The read path sees the
-  // metadata prefix of the same list, so the indexed line is never a different
-  // answer, only a better one.
-  const summaryField = corpusIndexPublisherSummaryField(manifest);
-  const summary =
-    summaryField === null
-      ? null
-      : publisherSummaryOf({ documentAst: ast, metadata: input.metadata });
+  const publisher = publisherProjection(corpusIndexPublisherFields(manifest), {
+    documentAst: ast,
+    metadata: input.metadata,
+  });
   // Stems come from the decision's own language, not its jurisdiction: an
   // index group spans several countries and a court may publish in more than
   // one language. A language with no stemmer writes no stem fields at all,
@@ -142,9 +201,9 @@ export const buildCaseLawProjectionDocuments = ({
       ? null
       : { fields: stemFields, language: stemLanguage };
   const summaryStem =
-    stemmed === null || summary === null
+    stemmed === null || publisher.summary === null
       ? null
-      : stemCorpusText(summary, stemmed.language);
+      : stemCorpusText(publisher.summary.value, stemmed.language);
   const chunks = chunkDocument({ ast, fallbackText: payload.text });
   const documents: CaseLawProjectionDocument[] = [];
   for (const chunk of chunks) {
@@ -161,9 +220,13 @@ export const buildCaseLawProjectionDocuments = ({
       // Opening passage only, like `title`: a document-level line repeated on
       // every passage would let one decision answer a broad query as many
       // times as it has passages. The summary's stem follows it, so the two
-      // are always written together or not at all.
-      ...(chunk.seq === 0 && summaryField !== null && summary !== null
-        ? { [summaryField]: summary }
+      // are always written together or not at all, and the classification
+      // sits beside them under the same rule.
+      ...(chunk.seq === 0 && publisher.summary !== null
+        ? { [publisher.summary.field]: publisher.summary.value }
+        : {}),
+      ...(chunk.seq === 0 && publisher.keywords !== null
+        ? { [publisher.keywords.field]: publisher.keywords.value }
         : {}),
       ...(chunk.seq === 0 && stemmed !== null && summaryStem !== null
         ? { [stemmed.fields.publisherSummary]: summaryStem }

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
@@ -138,6 +138,14 @@ test("manifest and projection families cannot be crossed", () => {
   ).toThrow("Corpus projection family mismatch");
 });
 
+const fingerprintOf = (
+  manifest: CorpusIndexManifest,
+  input: CaseLawProjectionInput,
+): string | null => {
+  const descriptor = deriveCorpusIndexProjectionDescriptor(manifest, input);
+  return descriptor.action === "upsert" ? descriptor.fingerprint : null;
+};
+
 test("only a generation that indexes the summary fingerprints it", () => {
   const withSummary = {
     ...CASE_LAW_INPUT,
@@ -193,27 +201,53 @@ const EXPECTED_FINGERPRINTS = {
     "67b6e403467118f9e7369c10b8f2de9d76d3297033926efb81b2cc47945d7acf",
   case_law_v6:
     "f52ff99433302ac499667cf09c3745046db4a5451bb5c46e218eb8bc8d8376f1",
+  case_law_v7:
+    "a9c3029fe0840d45d985de94edba5bd92c3bdac7bb76dc53e5449237802c92d9",
 } as const;
+
+test("v7 fingerprints the sentence and the classification apart", () => {
+  const tagged = {
+    ...CASE_LAW_INPUT,
+    metadata: { legalArea: "Daně" },
+  } as const satisfies CaseLawProjectionInput;
+  const written = {
+    ...CASE_LAW_INPUT,
+    metadata: { legalSentence: "Daně" },
+  } as const satisfies CaseLawProjectionInput;
+
+  // v6 reads both through one field, so the two decisions project the same
+  // way: the tag is written where the sentence would have been.
+  expect(fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v6, tagged)).toBe(
+    fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v6, written),
+  );
+  // v7 writes them to different fields, so they are different projections and
+  // a fingerprint that could not tell them apart would leave one of them
+  // holding the other's document.
+  expect(fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v7, tagged)).not.toBe(
+    fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v7, written),
+  );
+  // Both readings are covered, so editing either re-projects.
+  for (const input of [tagged, written]) {
+    expect(fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v7, input)).not.toBe(
+      fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v7, CASE_LAW_INPUT),
+    );
+  }
+});
 
 test("only a generation that writes stem fields fingerprints the stemmer set", () => {
   // Stems are content: the manifest digest pins the fields, not the algorithms
   // filling them, so a new language or a Snowball upgrade has to move v6's
   // fingerprint and re-project, and has to leave v5 — which writes no stem
   // field — exactly where it is.
-  const fingerprintOf = (manifest: CorpusIndexManifest) => {
-    const descriptor = deriveCorpusIndexProjectionDescriptor(
-      manifest,
-      CASE_LAW_INPUT,
-    );
-    return descriptor.action === "upsert" ? descriptor.fingerprint : null;
-  };
-
-  expect(fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v5)).toBe(
-    EXPECTED_FINGERPRINTS.case_law_v5,
-  );
-  expect(fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v6)).toBe(
-    EXPECTED_FINGERPRINTS.case_law_v6,
-  );
+  expect(
+    fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v5, CASE_LAW_INPUT),
+  ).toBe(EXPECTED_FINGERPRINTS.case_law_v5);
+  expect(
+    fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v6, CASE_LAW_INPUT),
+  ).toBe(EXPECTED_FINGERPRINTS.case_law_v6);
+  expect(
+    fingerprintOf(CORPUS_INDEX_MANIFESTS.case_law_v7, CASE_LAW_INPUT),
+  ).toBe(EXPECTED_FINGERPRINTS.case_law_v7);
   // Why the v6 pin moves: the version names the release and every language the
   // module dispatches, so either kind of change reaches the fingerprint.
   expect(MORPHOLOGY_VERSION).toContain(SNOWBALL_RELEASE);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
@@ -1,14 +1,19 @@
 import { panic } from "better-result";
 
-import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
+import {
+  publisherHeadnoteOf,
+  publisherKeywordsOf,
+  publisherSummaryOf,
+} from "@/api/lib/case-law/publisher-summary";
 import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
 import {
   corpusIndexContractDigest,
   corpusIndexIdFromManifest,
   corpusIndexManifestDigest,
-  corpusIndexPublisherSummaryField,
+  corpusIndexPublisherFields,
   corpusIndexStemFields,
   type CorpusIndexManifest,
+  type CorpusIndexPublisherFields,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
 import { MORPHOLOGY_VERSION } from "@/api/lib/legal-search/morphology/stem";
@@ -90,6 +95,38 @@ export const caseLawProjectionTitle = ({
   return `${reference} — ${court}`;
 };
 
+type PublisherFingerprintFields = {
+  publisherSummary?: string | null;
+  keywords?: string | null;
+};
+
+/**
+ * The publisher text a generation's fingerprint covers. Keyed by what the
+ * reading means rather than by the field it lands in, and derived from the
+ * same union the writer branches on, so a fingerprint cannot describe a
+ * reading the writer does not perform.
+ */
+const publisherFingerprintFields = (
+  publisher: CorpusIndexPublisherFields,
+  metadata: Record<string, unknown> | null,
+): PublisherFingerprintFields => {
+  const input = { documentAst: null, metadata };
+  switch (publisher.kind) {
+    case "none":
+      return {};
+    case "summary":
+      return { publisherSummary: publisherSummaryOf(input) };
+    case "summary_and_keywords":
+      return {
+        publisherSummary: publisherHeadnoteOf(input),
+        keywords: publisherKeywordsOf(input),
+      };
+    default:
+      publisher satisfies never;
+      return panic(`Unhandled publisher fields: ${String(publisher)}`);
+  }
+};
+
 export const deriveCorpusIndexProjectionDescriptor = (
   manifest: CorpusIndexManifest,
   input: CorpusIndexProjectionInput,
@@ -135,20 +172,16 @@ export const deriveCorpusIndexProjectionDescriptor = (
 
   switch (input.family) {
     case "case_law": {
-      // A fingerprint has to cover everything the generation writes. The
-      // summary's AST source is already covered through `contentHash`; its
-      // metadata source is not, so a generation carrying the field folds the
-      // metadata reading in and re-projects when a publisher edits it. A
-      // generation without the field keeps the fingerprints it already has.
-      const publisherSummary =
-        corpusIndexPublisherSummaryField(manifest) === null
-          ? {}
-          : {
-              publisherSummary: publisherSummaryOf({
-                documentAst: null,
-                metadata: input.metadata,
-              }),
-            };
+      // A fingerprint has to cover everything the generation writes, under the
+      // exact reading that generation writes it with. The AST source is
+      // already covered through `contentHash`; the metadata sources are not,
+      // so a generation carrying a publisher field folds its metadata reading
+      // in and re-projects when a publisher edits it. A generation without the
+      // fields keeps the fingerprints it already has.
+      const publisher = publisherFingerprintFields(
+        corpusIndexPublisherFields(manifest),
+        input.metadata,
+      );
       return {
         action: "upsert",
         indexId,
@@ -161,7 +194,7 @@ export const deriveCorpusIndexProjectionDescriptor = (
           decisionDateTimestamp:
             input.decisionDate ?? UNDATED_DECISION_TIMESTAMP,
           ecli: input.ecli,
-          ...publisherSummary,
+          ...publisher,
         }),
       };
     }

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -181,7 +181,7 @@ const searchResult = async (
   // resolver takes it separately from the clause.
   // The generation decides which fields exist to be named; the language
   // filter, then the jurisdiction, decides how the reader's words are stemmed.
-  const { surfaceFields, stemming } = caseLawCorpusQueryFields({
+  const { surfaceFields, keywordFields, stemming } = caseLawCorpusQueryFields({
     generation,
     jurisdiction: query.jurisdiction,
     language: query.language,
@@ -202,6 +202,7 @@ const searchResult = async (
         expand,
         stemming,
         surfaceFields,
+        keywordFields,
       }),
     jurisdiction: query.jurisdiction,
     mode: envBase.QUERY_EXPANSION_MODE,

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
@@ -13,6 +13,7 @@ test("legacy and final case-law reads use their declared schema", () => {
     yearFacetField: "year",
     stemFields: null,
     searchableFields: [],
+    keywordFields: [],
   });
   expect(corpusIndexReadContract("case_law", "case_law_v5")).toEqual({
     family: "case_law",
@@ -20,6 +21,7 @@ test("legacy and final case-law reads use their declared schema", () => {
     yearFacetField: "decision_year",
     stemFields: null,
     searchableFields: [],
+    keywordFields: [],
   });
   // What a *bare* term reaches is the index's decision, not the reader's, so
   // the summary changed nothing here; the stem fields did, because only a
@@ -30,6 +32,19 @@ test("legacy and final case-law reads use their declared schema", () => {
     yearFacetField: "decision_year",
     stemFields: { text: "text_stem", publisherSummary: "headnote_stem" },
     searchableFields: ["headnote"],
+    keywordFields: [],
+  });
+  // A generation that maps the classification separately answers with both:
+  // a reader's word reaches the tags where the publisher wrote no sentence,
+  // and the field it matched decides how the hit scores.
+  expect(corpusIndexReadContract("case_law", "case_law_v7")).toEqual({
+    family: "case_law",
+    openingPassageQuery: "is_opening:true",
+    yearFacetField: "decision_year",
+    stemFields: { text: "text_stem", publisherSummary: "headnote_stem" },
+    searchableFields: ["headnote"],
+    // Its own list, because the leaf budget pays for it last.
+    keywordFields: ["keywords"],
   });
 });
 
@@ -53,6 +68,18 @@ test("extra fields and stemming both need a generation that maps them", () => {
     }),
   ).toEqual({
     surfaceFields: ["headnote"],
+    keywordFields: [],
+    stemming: { language: "cs", fields: ["text_stem", "headnote_stem"] },
+  });
+  expect(
+    caseLawCorpusQueryFields({
+      generation: "case_law_v7",
+      jurisdiction: "CZE",
+      language: undefined,
+    }),
+  ).toEqual({
+    surfaceFields: ["headnote"],
+    keywordFields: ["keywords"],
     stemming: { language: "cs", fields: ["text_stem", "headnote_stem"] },
   });
   // Slovak has a stemmer but no published expansion dictionary; the two are
@@ -72,7 +99,7 @@ test("extra fields and stemming both need a generation that maps them", () => {
       jurisdiction: "CZE",
       language: undefined,
     }),
-  ).toEqual({ surfaceFields: [], stemming: null });
+  ).toEqual({ surfaceFields: [], keywordFields: [], stemming: null });
   // The European index carries 24 languages under one jurisdiction, so the
   // jurisdiction alone names none of them.
   expect(
@@ -142,4 +169,78 @@ test("a request filtered to German queries the German stems the projection wrote
   expect(corpusFreeTextClause("Mietverträge", { stemming })).toBe(
     '(("Mietverträge" OR text_stem:"mietvertrag" OR headnote_stem:"mietvertrag"))',
   );
+});
+
+/** One clause per token, each split into the leaves it offers the engine. */
+const leafGroups = (clause: string): string[][] =>
+  clause
+    .slice(1, -1)
+    .split(" AND ")
+    .map((group) =>
+      (group.startsWith("(") ? group.slice(1, -1) : group).split(" OR "),
+    );
+
+const clauseFor = (generation: "case_law_v6" | "case_law_v7", text: string) => {
+  const { surfaceFields, keywordFields, stemming } = caseLawCorpusQueryFields({
+    generation,
+    jurisdiction: "CZE",
+    language: undefined,
+  });
+  return corpusFreeTextClause(text, {
+    stemming,
+    surfaceFields,
+    keywordFields,
+  });
+};
+
+test("the classification field never costs a query the leaves it had", () => {
+  // Six words, and under the summary-only contract they fill the ceiling
+  // exactly: six typed leaves, two stems each, then one headnote leaf each.
+  // Every leaf the classification field could buy is one the budget has
+  // already spent, so it must buy none rather than evict any.
+  const words = [
+    "nájemní",
+    "smlouva",
+    "výpověď",
+    "nájemce",
+    "náhrada",
+    "škody",
+  ];
+
+  for (let count = 1; count <= words.length; count += 1) {
+    const text = words.slice(0, count).join(" ");
+    const withoutKeywords = clauseFor("case_law_v6", text) ?? "";
+    const withKeywords = clauseFor("case_law_v7", text) ?? "";
+    const before = leafGroups(withoutKeywords);
+    const after = leafGroups(withKeywords);
+
+    expect(after).toHaveLength(before.length);
+    for (const [index, leaves] of before.entries()) {
+      const granted = after.at(index) ?? [];
+      // Every leaf the older contract bought is still bought, in order, and
+      // anything the newer one adds is a classification leaf.
+      expect(granted.slice(0, leaves.length)).toEqual(leaves);
+      for (const extra of granted.slice(leaves.length)) {
+        expect(extra.startsWith('keywords:"')).toBe(true);
+      }
+    }
+  }
+
+  // The exactly-full case, stated as itself: nothing left to pay with.
+  expect(clauseFor("case_law_v7", words.join(" "))).toBe(
+    clauseFor("case_law_v6", words.join(" ")),
+  );
+  expect(clauseFor("case_law_v6", words.join(" "))).toContain(
+    'headnote:"škody"',
+  );
+});
+
+test("a query with budget to spare reaches the classification field", () => {
+  // The other half of the same rule: last in line is not never.
+  const clause = clauseFor("case_law_v7", "nájemní smlouva") ?? "";
+
+  expect(clause).toContain('keywords:"nájemní"');
+  expect(clause).toContain('headnote:"nájemní"');
+  expect(clause).toContain("headnote_stem:");
+  expect(clause).toContain('keywords:"smlouva"');
 });

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
@@ -3,9 +3,10 @@ import { panic } from "better-result";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
-  corpusIndexPublisherSummaryField,
+  corpusIndexPublisherFields,
   corpusIndexStemFields,
   requireCorpusIndexManifest,
+  type CorpusIndexPublisherFields,
   type CorpusIndexStemFields,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import type { CorpusStemming } from "@/api/lib/legal-search/corpus-query";
@@ -30,6 +31,48 @@ export type CaseLawIndexReadContract = {
    * reaches. Named explicitly by a query or not matched at all.
    */
   searchableFields: readonly string[];
+  /**
+   * The publisher's classification, kept apart from the fields above rather
+   * than listed with them: it is the newest and weakest of a query's
+   * alternatives, and the leaf budget pays for it only after every token's
+   * stems and older alternatives, so naming it can never cost a query the
+   * matches it had without it.
+   */
+  keywordFields: readonly string[];
+};
+
+type PublisherQueryFields = Pick<
+  CaseLawIndexReadContract,
+  "searchableFields" | "keywordFields"
+>;
+
+/**
+ * The publisher fields of a generation, as the lists a query may name them
+ * in. Both are matched only where a clause asks for them; what a bare term
+ * reaches is the index's own decision and neither is part of it. One switch
+ * answers for both, so the two lists cannot drift into disagreeing about what
+ * a generation maps.
+ */
+const publisherQueryFields = (
+  publisher: CorpusIndexPublisherFields,
+): PublisherQueryFields => {
+  switch (publisher.kind) {
+    case "none":
+      return { searchableFields: [], keywordFields: [] };
+    case "summary":
+      return {
+        searchableFields: [publisher.summaryField],
+        keywordFields: [],
+      };
+    case "summary_and_keywords":
+      return {
+        searchableFields: [publisher.summaryField],
+        keywordFields: [publisher.keywordsField],
+      };
+    default:
+      publisher satisfies never;
+      return panic(`Unhandled publisher fields: ${String(publisher)}`);
+  }
 };
 
 export type LegislationIndexReadContract = {
@@ -72,22 +115,21 @@ export function corpusIndexReadContract(
           yearFacetField: "year",
           stemFields: null,
           searchableFields: [],
+          keywordFields: [],
         }
       : { family, openingPassageQuery: "seq:0" };
   }
 
   const manifest = requireCorpusIndexManifest(family, generation);
   switch (manifest.family) {
-    case "case_law": {
-      const publisherSummary = corpusIndexPublisherSummaryField(manifest);
+    case "case_law":
       return {
         family: manifest.family,
         openingPassageQuery: `${manifest.projection.openingField}:true`,
         yearFacetField: manifest.projection.yearFacetField,
         stemFields: corpusIndexStemFields(manifest),
-        searchableFields: publisherSummary === null ? [] : [publisherSummary],
+        ...publisherQueryFields(corpusIndexPublisherFields(manifest)),
       };
-    }
     case "legislation":
       return {
         family: manifest.family,
@@ -109,6 +151,7 @@ type CaseLawCorpusQueryFieldsOptions = {
 
 export type CaseLawCorpusQueryFields = {
   surfaceFields: readonly string[];
+  keywordFields: readonly string[];
   stemming: CorpusStemming | null;
 };
 
@@ -137,16 +180,15 @@ export const caseLawCorpusQueryFields = ({
   jurisdiction,
   language,
 }: CaseLawCorpusQueryFieldsOptions): CaseLawCorpusQueryFields => {
-  const { stemFields, searchableFields } = corpusIndexReadContract(
-    "case_law",
-    generation,
-  );
+  const { stemFields, searchableFields, keywordFields } =
+    corpusIndexReadContract("case_law", generation);
   const stemLanguage =
     language === undefined
       ? corpusMorphologyLanguage(jurisdiction)
       : documentMorphologyLanguage(language);
   return {
     surfaceFields: searchableFields,
+    keywordFields,
     stemming:
       stemFields === null || stemLanguage === null
         ? null

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -235,20 +235,29 @@ const expansionLeaves = (
  * a single left-to-right pass starves. The stem pass costs tokens × stem
  * fields, so it is bounded by what the reader typed.
  *
- * Dictionary expansion then spends what is left, left to right. Rarest first
- * would be the better order and no frequency signal reaches this builder to
- * give it: the dictionary payload carries a per-bucket document frequency,
- * but the loader keeps only the forms and `CorpusTermExpander` hands over
- * surface forms alone. Ordering by selectivity means retaining that column at
- * load and exposing it on the expander.
+ * Dictionary expansion and the other surface fields then spend what is left,
+ * left to right. Rarest first would be the better order and no frequency
+ * signal reaches this builder to give it: the dictionary payload carries a
+ * per-bucket document frequency, but the loader keeps only the forms and
+ * `CorpusTermExpander` hands over surface forms alone. Ordering by
+ * selectivity means retaining that column at load and exposing it on the
+ * expander.
+ *
+ * The classification field comes last, and being last is the point: it is a
+ * generation's newest field and the weakest match on it — the terms a
+ * publisher filed a decision under, not what the decision says — so it may
+ * only spend what every token's stems and existing alternatives left behind.
+ * A generation that maps no such field contributes an empty group, so its
+ * clause is what it was before the field existed, leaf for leaf.
  */
-const LEAF_BUDGET_PASSES = ["stem", "surface"] as const;
+const LEAF_BUDGET_PASSES = ["stem", "surface", "keywords"] as const;
 
 /**
  * How the budget pays for one token's alternatives. `stem` is the
  * generation's stem fields, one leaf each; `surface` is every alternative
  * spelling of the word as written — the dictionary's other inflections and
- * the extra surface fields.
+ * the extra surface fields; `keywords` is the publisher's classification
+ * field, a different kind of match and the one paid for last.
  *
  * Derived from the passes rather than declared beside them: a group exists
  * because a pass spends it, so there is no way to add one the budget never
@@ -263,11 +272,14 @@ type LeafGroup = (typeof LEAF_BUDGET_PASSES)[number];
  * which is not the order the budget is spent in. A rank per group keeps the
  * two orders independent without a second hand-listed sequence to drift from
  * the first: the map is total over `LeafGroup`, so a new group has to choose
- * its place rather than inherit one.
+ * its place rather than inherit one. The classification leaves are written
+ * after both, so the group a generation without that field writes stays a
+ * prefix of the one it writes with it.
  */
 const LEAF_EMIT_RANK = {
   stem: 1,
   surface: 0,
+  keywords: 2,
 } as const satisfies Record<LeafGroup, number>;
 
 const LEAF_EMIT_ORDER = [...LEAF_BUDGET_PASSES].sort(
@@ -296,7 +308,7 @@ type BudgetedToken = {
  */
 const spendLeafBudget = (tokens: readonly TokenLeaves[]): BudgetedToken[] => {
   const budgeted: BudgetedToken[] = tokens.map((token) => ({
-    granted: { stem: [], surface: [] },
+    granted: { stem: [], surface: [], keywords: [] },
     token,
   }));
   let leaves = tokens.length;
@@ -327,6 +339,12 @@ export type CorpusFreeTextOptions = {
    * carries the terms.
    */
   surfaceFields?: readonly string[] | undefined;
+  /**
+   * Classification fields, matched the same way and last in line for the leaf
+   * budget, so naming one can never cost a token the alternatives it had
+   * without it.
+   */
+  keywordFields?: readonly string[] | undefined;
 };
 
 /**
@@ -343,11 +361,13 @@ export type CorpusFreeTextOptions = {
  * the grouping differs.
  *
  * A group mixes an unscoped leaf with field-scoped ones — `("slovo" OR
- * headnote:"slovo" OR text_stem:"slov")` — which the engine reads leaf by
- * leaf: the first is matched against the default fields and the rest against
- * the field each names. Every extra leaf is an alternative beside the surface
+ * headnote:"slovo" OR text_stem:"slov" OR keywords:"slovo")` — which the
+ * engine reads leaf by leaf: the first is matched against the default fields
+ * and the rest against the field each names. Every extra leaf is an alternative beside the surface
  * leaf, never instead of it, so a generation with more fields answers
- * everything the same query answered without them, plus the wider matches.
+ * everything the same query answered without them, plus the wider matches —
+ * a property the leaf budget has to preserve too, which is why its passes are
+ * ordered oldest alternative first.
  *
  * With no expander, no extra fields and no stemming this emits exactly what it
  * emitted before any of them existed, byte for byte; the wider forms differ
@@ -359,6 +379,7 @@ export const corpusFreeTextClause = (
     expand = noTermExpansion,
     stemming = null,
     surfaceFields = [],
+    keywordFields = [],
   }: CorpusFreeTextOptions = {},
 ): string | null => {
   const tokens = tokenizeCorpusFreeText(text);
@@ -374,6 +395,7 @@ export const corpusFreeTextClause = (
           ...expansionLeaves(token, expand),
           ...surfaceFieldLeaves(token.value, surfaceFields),
         ],
+        keywords: surfaceFieldLeaves(token.value, keywordFields),
       },
       typed: quoteCorpusValue(token.value),
     })),
@@ -414,6 +436,7 @@ export type CaseLawCorpusQueryOptions = {
   expand?: CorpusTermExpander | undefined;
   stemming?: CorpusStemming | null | undefined;
   surfaceFields?: readonly string[] | undefined;
+  keywordFields?: readonly string[] | undefined;
 };
 
 /**
@@ -429,11 +452,13 @@ export const caseLawCorpusQuery = ({
   expand,
   stemming,
   surfaceFields,
+  keywordFields,
 }: CaseLawCorpusQueryOptions): string | null => {
   const freeText = corpusFreeTextClause(text, {
     expand,
     stemming,
     surfaceFields,
+    keywordFields,
   });
   if (freeText === null) {
     return null;

--- a/apps/api/src/scripts/corpus-index-query-diff-report.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff-report.ts
@@ -116,7 +116,7 @@ export const goldenQueryRequest = (
   // The diff compares generations, so the query each one gets is the query
   // that generation's schema supports: a clause over a field an index never
   // mapped would compare an invalid query with a valid one.
-  const { surfaceFields, stemming } = caseLawCorpusQueryFields({
+  const { surfaceFields, keywordFields, stemming } = caseLawCorpusQueryFields({
     generation,
     jurisdiction: query.jurisdiction,
     language: query.filters?.language,
@@ -126,6 +126,7 @@ export const goldenQueryRequest = (
     filters: { ...query.filters, jurisdiction: jurisdictionClause },
     stemming,
     surfaceFields,
+    keywordFields,
   });
   return engineQuery === null ? null : { indexId, engineQuery };
 };


### PR DESCRIPTION
A headnote is a sentence a publisher wrote about a decision. Keywords and legal
areas are how they filed it. Both arrive as publisher metadata, and both fed the
one `headnote` index field, so a subject-index tag was indexed as a headnote and
scored as one. They are different kinds of text and belong in different fields.

## What changed

**One source list, split by kind.** `publisher-summary.ts` declared every place
publisher matter can live in a single ordered list. It is now two lists with
different types: `publisherHeadnoteOf` walks the sentence sources (parser-marked
apparatus paragraphs, then `legalSentence`, `abstract`, `summary`), and
`publisherKeywordsOf` walks the classification sources (`keywords`,
`legalAreas`, `legalArea`). A classification source does not compile into the
headnote list, so a tag cannot reach the headnote field by construction rather
than by a check somebody has to remember.

**The line a reader sees is unchanged.** `publisherSummaryOf` is still the
headnote, or the classification where there is no headnote, in exactly the order
it resolved before; the SQL reading behind the search, list and latest handlers
is untouched, and the binding test that holds the two implementations to the
same answer passes as it stands. A decision whose publisher wrote no sentence
still reads better with the terms it was filed under than with an empty line.
Only what the index does with them changes.

**`case_law_v7`** maps the split: `headnote` takes sentences, the new `keywords`
field takes the classification. `keywords` carries the headnote's tokenizer and
positions, so the same phrase matches the same way, and no fieldnorms, so a
two-word tag list does not outscore a paragraph on brevity. Like the headnote it
is written to the opening passage only and is not a default search field, so
only a query that names it can match it; the read contract adds it to the fields
a case-law query names for a generation that maps it.

## No built generation changes

A new field is a mapping change, and the case-law doc mapping is `strict`, so it
can only arrive with a generation. Which reading fills a generation's fields
therefore comes from its manifest, the way the stem fields already do:
`corpusIndexPublisherFields` is total over every generation and returns `none`,
`summary` (one field, classification as its fallback), or `summary_and_keywords`.
The writer, the projection fingerprint and the query builder all branch on that
one union, so a fingerprint cannot describe a reading the writer does not
perform.

v6 is `summary` and keeps writing exactly what its indexes already hold. The
pinned v5 and v6 manifest digests and projection fingerprints do not move, which
the existing tests assert. v7 is declared, not deployed: nothing serves it until
a generation row selects it.

## Deliberate scope

`keywords` has no stem companion. A classification is a controlled vocabulary
matched on the words it is written in, and adding a stem field is itself a
mapping change, so the generation that wants one can map it. Weighting lives in
the mapping rather than in the query because the engine's query language has no
boost operator.

## Tests

`bun test` over `publisher-summary`, `publisher-summary.db`,
`corpus-index-manifest`, `corpus-index-projection-builder`,
`corpus-index-projection-descriptor`, `corpus-index-read-contract`,
`corpus-generation-contract`, `corpus-query`, `corpus-index-config`,
`corpus-index-provider`, `corpus-index-projection-engine|executor|contract|scope`
and the case-law search handler. New coverage: a headnote reading that cannot
return a classification, v7 writing each to its own field, v6 keeping its
fallback, v7 fingerprinting the two readings apart where v6 cannot tell them
apart, and the read contract naming both fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `case_law_v7` search generation, separating publisher headnotes from classification keywords.
  - Case-law searches can now match classification keywords, including subject terms and areas of law.
  - Publisher-authored headnotes and classification keywords are now displayed and indexed separately where supported.
  - Search query budgeting prioritises existing content while using available capacity for keyword matches.

- **Bug Fixes**
  - Improved publisher summary selection so written headnotes are preferred, with classification keywords used as a fallback where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->