### PR TITLE
fix(api): capture the Czech supreme courts' published headnote

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -23,6 +23,7 @@ import {
 import type { CzNsListingRow } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
 import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 const reconciliation = requireReconciliation(czNsAdapter);
@@ -100,14 +101,47 @@ const DECISION_BODY =
   "takto: Dovolání se odmítá. Odůvodnění: Soud prvního stupně rozsudkem zamítl žalobu. " +
   "JUDr. Pavel Horák, Ph.D.\npředseda senátu";
 
-const detailPageHtml = (docket: string): string => {
+/**
+ * The headnote row, which the page carries for every decision: a spacer image
+ * where the court wrote none, and its own words where it did. Unlike the rows
+ * above, the value is not a `<font>` run, so it runs to the cell's close.
+ */
+const legalSentenceRowHtml = (value: string | undefined): string => {
+  const cell =
+    value === undefined
+      ? `<img width="1" height="1" src="/icons/ecblank.gif" border="0" alt="">`
+      : `<b>${value}</b>`;
+  return (
+    `<tr valign="top"><td class="left-part" width="17%"><b><font face="Times New Roman">Právní věta:</font></b></td>` +
+    `<td class="right-part" style="text-align: justify;" width="83%">${cell}</td></tr>`
+  );
+};
+
+/** The annotation row, printed only where the court wrote one. */
+const abstractRowHtml = (value: string): string =>
+  `<tr valign="top"><td class="left-part" width="17%"><b><font face="Times New Roman">Anotace:</font></b></td>` +
+  `<td class="right-part" width="83%"><details><summary></summary><p>${value}</p></details></td></tr>`;
+
+type DetailPageOptions = {
+  /** The court's headnote, for a decision it selected for its collection. */
+  legalSentence?: string | undefined;
+  /** The court's case annotation, printed beside the headnote. */
+  abstract?: string | undefined;
+};
+
+const detailPageHtml = (
+  docket: string,
+  { abstract, legalSentence }: DetailPageOptions = {},
+): string => {
   const rows = [
+    legalSentenceRowHtml(legalSentence),
     detailRowHtml("Datum rozhodnutí", "28. 5. 2026"),
     detailRowHtml("Spisová značka", docket),
     detailRowHtml("ECLI", "ECLI:CZ:NS:2026:30.CDO.3000.2025.1"),
     detailRowHtml("Typ rozhodnutí", "ROZSUDEK"),
     detailRowHtml("Heslo", "Dovolání"),
     detailRowHtml("Kategorie rozhodnutí", "E"),
+    ...(abstract === undefined ? [] : [abstractRowHtml(abstract)]),
   ].join("");
   return `<!DOCTYPE HTML><html><body><table>${rows}</table><font face="Times New Roman">${DECISION_BODY}</font></body></html>`;
 };
@@ -120,11 +154,18 @@ type MockOptions = {
   listing?: { body: string; status?: number | undefined } | undefined;
   detailStatus?: number | undefined;
   printStatus?: number | undefined;
+  /** What the detail page's headnote and annotation rows state. */
+  summary?: DetailPageOptions | undefined;
 };
 
 const requestedUrls: string[] = [];
 
-const mockFetch = ({ detailStatus, listing, printStatus }: MockOptions) => {
+const mockFetch = ({
+  detailStatus,
+  listing,
+  printStatus,
+  summary,
+}: MockOptions) => {
   globalThis.fetch = asFetchMock((input: string | URL | Request) => {
     const url = input instanceof Request ? input.url : String(input);
     requestedUrls.push(url);
@@ -146,7 +187,7 @@ const mockFetch = ({ detailStatus, listing, printStatus }: MockOptions) => {
     }
     if (url.includes("/WebSearch/")) {
       return Promise.resolve(
-        new Response(detailPageHtml(DOCKET.FIRST), {
+        new Response(detailPageHtml(DOCKET.FIRST, summary), {
           status: detailStatus ?? 200,
           headers: { "Content-Type": "text/html" },
         }),
@@ -588,6 +629,63 @@ describe("cz-ns buildDecision", () => {
     expect(built.decision.legacySourceUrls).toEqual([
       built.decision.sourceUrl ?? "",
     ]);
+  });
+
+  /** The court's own words, as it writes them under `Právní věta:`. */
+  const HEADNOTE =
+    "Uloží-li soud rodičům povinnost účastnit se mimosoudního smírčího nebo " +
+    "mediačního jednání, jde o rozhodnutí, jímž se upravuje řízení, a proti " +
+    "takovému rozhodnutí není odvolání přípustné.";
+
+  /** The court's own annotation, as it writes it under `Anotace:`. */
+  const ANNOTATION =
+    "Okresní soud uložil rodičům povinnost účastnit se mediačního jednání. " +
+    "Krajský soud odvolání matky odmítl jako nepřípustné.";
+
+  /** Crawl one decision whose detail page states these summary rows. */
+  const crawledWithSummary = async (summary: DetailPageOptions) => {
+    mockFetch({ printStatus: 404, summary });
+    const built = await reconciliation.buildDecision({
+      unid: UNID.FIRST,
+      caseNumber: DOCKET.FIRST,
+    });
+    if (built.type !== "built") {
+      throw new TypeError("Expected the fixture decision to build");
+    }
+    return built.decision;
+  };
+
+  test("the court's headnote and annotation reach the row's publisher summary", async () => {
+    const decision = await crawledWithSummary({
+      abstract: ANNOTATION,
+      legalSentence: HEADNOTE,
+    });
+
+    expect(decision.metadata["legalSentence"]).toBe(HEADNOTE);
+    expect(decision.metadata["abstract"]).toBe(ANNOTATION);
+    // The keys are worth writing only where the summary reader looks, and the
+    // headnote is the more specific of the two, so it is what a reader gets.
+    expect(
+      publisherSummaryOf({ documentAst: null, metadata: decision.metadata }),
+    ).toBe(HEADNOTE);
+  });
+
+  test("an annotation the court wrote no headnote for is still a summary", async () => {
+    const decision = await crawledWithSummary({ abstract: ANNOTATION });
+
+    expect(decision.metadata["legalSentence"]).toBeUndefined();
+    expect(
+      publisherSummaryOf({ documentAst: null, metadata: decision.metadata }),
+    ).toBe(ANNOTATION);
+  });
+
+  test("the spacer the court prints for a decision it wrote neither for is not a summary", async () => {
+    const decision = await crawledWithSummary({});
+
+    // The headnote row is on every page; where the court wrote nothing it
+    // holds a one-pixel spacer image, which must not be stored as a sentence.
+    expect(decision.metadata["legalSentence"]).toBeUndefined();
+    expect(decision.metadata["abstract"]).toBeUndefined();
   });
 
   test("a detail page that does not come back is reported, never written", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
 import type { CzNsListingRow } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
 import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
+import { hashContent } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
@@ -686,6 +687,39 @@ describe("cz-ns buildDecision", () => {
     // holds a one-pixel spacer image, which must not be stored as a sentence.
     expect(decision.metadata["legalSentence"]).toBeUndefined();
     expect(decision.metadata["abstract"]).toBeUndefined();
+  });
+
+  test("a headnote or annotation the court adds later moves the source hash", async () => {
+    // Sequentially: each crawl installs its own fetch stub on the global.
+    const hashes: string[] = [];
+    for (const summary of [
+      {},
+      { legalSentence: HEADNOTE },
+      { abstract: ANNOTATION },
+      { abstract: ANNOTATION, legalSentence: HEADNOTE },
+      { legalSentence: `${HEADNOTE} Věta druhá.` },
+    ] satisfies DetailPageOptions[]) {
+      hashes.push((await crawledWithSummary(summary)).rawHash);
+    }
+
+    // The refresh check skips a row whose source hash stands still. The court
+    // writes both after publishing the decision and edits them later, so a row
+    // stored before that has to hash differently once the page states the new
+    // text; otherwise the update never lands. The two are hashed in fixed
+    // positions, so a headnote alone and an annotation alone cannot collide.
+    expect(new Set(hashes).size).toBe(hashes.length);
+  });
+
+  test("a decision the court wrote neither for hashes as it did before", async () => {
+    const decision = await crawledWithSummary({});
+
+    // The literal is the hash's pre-existing input, so re-hashing the rows the
+    // court wrote neither for cannot happen without editing this line.
+    expect(decision.rawHash).toBe(
+      hashContent(
+        `${DOCKET.FIRST}|ECLI:CZ:NS:2026:30.CDO.3000.2025.1|28. 5. 2026`,
+      ),
+    );
   });
 
   test("a detail page that does not come back is reported, never written", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -353,7 +353,18 @@ export const buildCzNsDecision = async (
   const printHtml = printResponse.ok ? await printResponse.text() : "";
 
   const meta = parseDetailPage(webHtml);
-  const raw = `${caseNumber}|${meta["ecli"] ?? ""}|${meta["decisionDate"] ?? ""}`;
+  // The court writes a headnote and an annotation when it selects an already
+  // published decision for its collection, and edits them afterwards. Left out
+  // of the source hash, the refresh check would read such a row as unchanged
+  // and skip the update for good. They are appended only where the court
+  // states one, so a decision that has neither hashes exactly as it did and is
+  // not rewritten for this; both positions are then present, so a headnote
+  // alone and an annotation alone cannot hash alike.
+  const summary =
+    meta["legalSentence"] === undefined && meta["abstract"] === undefined
+      ? ""
+      : `|${meta["legalSentence"] ?? ""}|${meta["abstract"] ?? ""}`;
+  const raw = `${caseNumber}|${meta["ecli"] ?? ""}|${meta["decisionDate"] ?? ""}${summary}`;
 
   // Parse AST from the print page (rich HTML)
   let documentAst: DocumentAst | EmptyAst = EMPTY_AST;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -144,6 +144,13 @@ const LABEL_PATTERNS: Record<string, RegExp> = {
     /Kategorie rozhodnutí:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>(?<value>[\s\S]*?)<\/font>/iu,
   legalSentence:
     /Právní věta:<\/font><\/b><\/td><td[^>]*>(?<value>[\s\S]*?)<\/td>/iu,
+  /**
+   * The court's own case annotation, which it prints under `Anotace:` beside
+   * the headnote for part of its collection. Unlike every other row on this
+   * page the cell holds a `<details>` disclosure rather than a `<font>` run,
+   * so the value runs to the cell's close.
+   */
+  abstract: /Anotace:<\/font><\/b><\/td><td[^>]*>(?<value>[\s\S]*?)<\/td>/iu,
 };
 
 /**
@@ -405,6 +412,7 @@ export const buildCzNsDecision = async (
         ...sourceMetadata,
         judge,
         legalSentence: meta["legalSentence"],
+        abstract: meta["abstract"],
         keywords: meta["keywords"]?.split("\n").flatMap((s) => {
           const trimmed = s.trim();
           return trimmed ? [trimmed] : [];

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -37,6 +37,7 @@ import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-ns
 import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { hashContent } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { publisherSummaryOf } from "@/api/lib/case-law/publisher-summary";
 import {
   listingIdentityKey,
   SOURCE_DOCUMENT_ID_MAX_LENGTH,
@@ -168,11 +169,38 @@ const DOCUMENT_HTML = `<html><body>
   řízení o kasační stížnosti.</p>
 </body></html>`;
 
-const detailPage = (ecli: string): string => `<html><body>
-  <div id="ecli"><span class="det-textitle">ECLI:</span><span class="det-textval" title="${ecli}">${ecli}</span></div>
-  <div id="druhdokumentuavyrokrozhodnuti"><span class="det-textval">Rozsudek</span></div>
-  <div id="datumvydanirozhodnuti"><span class="det-textval">10.06.2026</span></div>
-</body></html>`;
+/**
+ * One field of the detail page, in the portal's own markup: a `data-field-id`
+ * div whose label and value are two spans told apart by their class, and
+ * whose value the portal repeats in a `title` attribute.
+ */
+const detailField = (fieldId: string, value: string): string =>
+  `<div class="col-md-12 col-lg-12 col-xl-12 detcard mt-1 d-flex justify-content-between" data-nss="nssview" data-field-id="${fieldId}">` +
+  `<span class="det-textitle" data-toggle="tooltip" title="${fieldId}">${fieldId} :</span>` +
+  `<span class="det-textval" data-toggle="tooltip" title="${value}"> ${value}</span></div>`;
+
+type DetailPageOptions = {
+  ecli: string;
+  /**
+   * The court's headnote, which the portal prints only for the decisions it
+   * selects for its collection. `pravnivetaanv` states ano/ne for every
+   * decision either way, so the fixture always carries both.
+   */
+  legalSentence?: string | undefined;
+};
+
+const detailPage = ({ ecli, legalSentence }: DetailPageOptions): string => {
+  const fields = [
+    detailField("ecli", ecli),
+    detailField("druhdokumentuavyrokrozhodnuti", "Rozsudek"),
+    detailField("datumvydanirozhodnuti", "10.06.2026"),
+    ...(legalSentence === undefined
+      ? []
+      : [detailField("pravnivetaupravena", legalSentence)]),
+    detailField("pravnivetaanv", legalSentence === undefined ? "ne" : "ano"),
+  ].join("");
+  return `<html><body>${fields}</body></html>`;
+};
 
 // ── Fetch stub ───────────────────────────────────────────
 
@@ -187,6 +215,8 @@ type StubOptions = {
   documentStatus?: number;
   /** Status for the detail page alone; defaults to `documentStatus`. */
   detailStatus?: number;
+  /** The headnote the detail page states, if the court wrote one. */
+  legalSentence?: string | undefined;
 };
 
 const htmlResponse = (body: string, status = 200): Response =>
@@ -199,6 +229,7 @@ const installStub = ({
   continuation = [],
   documentStatus = 200,
   detailStatus = documentStatus,
+  legalSentence,
   search = [],
 }: StubOptions): { requests: RecordedRequest[] } => {
   const requests: RecordedRequest[] = [];
@@ -230,7 +261,12 @@ const installStub = ({
         }
         if (url.pathname.startsWith("/DokumentDetail/Index/")) {
           return detailStatus === 200
-            ? htmlResponse(detailPage("ECLI:CZ:MSPH:2026:1.Az.4.2026.79"))
+            ? htmlResponse(
+                detailPage({
+                  ecli: "ECLI:CZ:MSPH:2026:1.Az.4.2026.79",
+                  legalSentence,
+                }),
+              )
             : htmlResponse("", detailStatus);
         }
         if (url.pathname.startsWith("/DokumentOriginal/Html/")) {
@@ -1245,6 +1281,101 @@ describe("cz-nss buildDecision", () => {
     // buys this row no sheet.
     expect(outcome.result.sheetNumber).toBeUndefined();
     expect(outcome.result.metadata["publishedCaseNumber"]).toBe("1 Az 4/2026");
+  });
+
+  /** The court's own words, as it writes them under `Právní věta (text)`. */
+  const HEADNOTE =
+    "Rozhodnutí v místním referendu, která jsou ze zákona neplatná " +
+    "(§ 48 odst. 1 zákona č. 22/2004 Sb., o místním referendu), správní soudy " +
+    "z hlediska dalších vad způsobujících neplatnost rozhodnutí nepřezkoumávají.";
+
+  /** Crawl one decision the portal states this headnote for, or none. */
+  const crawledWithHeadnote = async (legalSentence?: string) => {
+    installStub({
+      legalSentence,
+      search: [
+        htmlResponse(searchPage({ statedCount: 1, rows: [MUNICIPAL_ROW] })),
+      ],
+    });
+    const listed = await reconciliation.listSlicePage({
+      slice: SLICE,
+      page: 0,
+    });
+    installStub({ legalSentence, search: [] });
+    const built = await reconciliation.buildDecision(
+      throughJsonb(listed.items.at(0)?.payload),
+    );
+    if (built.type !== "built") {
+      throw new TypeError("Expected the fixture decision to build");
+    }
+    return built.decision;
+  };
+
+  test("the court's headnote reaches the row's publisher summary", async () => {
+    const decision = await crawledWithHeadnote(HEADNOTE);
+
+    expect(decision.metadata["legalSentence"]).toBe(HEADNOTE);
+    // The key is worth writing only where the summary reader looks, so the
+    // reader answers here rather than the spelling being trusted on its own.
+    expect(
+      publisherSummaryOf({ documentAst: null, metadata: decision.metadata }),
+    ).toBe(HEADNOTE);
+  });
+
+  test("the ano/ne flag beside the headnote is not the headnote", async () => {
+    const withHeadnote = await crawledWithHeadnote(HEADNOTE);
+    const without = await crawledWithHeadnote();
+
+    // `pravnivetaanv` states ano/ne for every decision and sits beside
+    // `pravnivetaupravena`; a reader keyed on the shared prefix would store
+    // "ne" as the sentence for the whole corpus.
+    expect(withHeadnote.metadata["legalSentence"]).toBe(HEADNOTE);
+    expect(without.metadata["legalSentence"]).toBeUndefined();
+    expect(
+      publisherSummaryOf({ documentAst: null, metadata: without.metadata }),
+    ).not.toBe("ne");
+  });
+
+  test("a replay carries the headnote the crawl read, and cannot add one", async () => {
+    const decision = await crawledWithHeadnote(HEADNOTE);
+    const reparse = czNssAdapter.reparseStoredRaw;
+    if (reparse === undefined) {
+      throw new TypeError("Expected cz-nss to implement stored-raw replay");
+    }
+    globalThis.fetch = asFetchMock(() => {
+      throw new TypeError("Stored-raw replay must not contact the publisher");
+    });
+
+    const replayed = async (metadata: Record<string, unknown>) =>
+      await reparse({
+        raw: new TextEncoder().encode(decision.sourceRaw ?? ""),
+        contentType: decision.sourceRawContentType ?? null,
+        caseNumber: decision.caseNumber,
+        sourceDocumentId: decision.sourceDocumentId ?? null,
+        language: decision.language,
+        court: decision.court,
+        ecli: decision.ecli ?? null,
+        decisionDate: decision.decisionDate ?? null,
+        decisionType: decision.decisionType ?? null,
+        sourceUrl: decision.sourceUrl ?? null,
+        documentUrl: decision.documentUrl ?? null,
+        metadata,
+      } satisfies StoredRawReparseInput);
+
+    const carried = await replayed(decision.metadata);
+    // The stored payload is the decision document; the headnote is a field of
+    // the detail page. A replay therefore keeps what the crawl wrote and
+    // cannot recover the sentence for a row stored without it.
+    const { legalSentence: _dropped, ...withoutHeadnote } = decision.metadata;
+    const bare = await replayed(withoutHeadnote);
+
+    expect(carried.type).toBe("parsed");
+    expect(bare.type).toBe("parsed");
+    if (carried.type !== "parsed" || bare.type !== "parsed") {
+      return;
+    }
+    expect(carried.result.metadata["legalSentence"]).toBe(HEADNOTE);
+    expect(bare.result.metadata["legalSentence"]).toBeUndefined();
   });
 
   test("refuses to write a row whose document the court did not serve", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -1376,6 +1376,33 @@ describe("cz-nss buildDecision", () => {
     }
     expect(carried.result.metadata["legalSentence"]).toBe(HEADNOTE);
     expect(bare.result.metadata["legalSentence"]).toBeUndefined();
+    // Crawl and replay have to agree on the hash, or every replayed row would
+    // read as changed to the crawl that next re-reads it, and back again.
+    expect(carried.result.rawHash).toBe(decision.rawHash);
+    expect(bare.result.rawHash).not.toBe(decision.rawHash);
+  });
+
+  test("a headnote the court adds or edits moves the source hash", async () => {
+    const none = await crawledWithHeadnote();
+    const headnoted = await crawledWithHeadnote(HEADNOTE);
+    const edited = await crawledWithHeadnote(`${HEADNOTE} Věta druhá.`);
+
+    // The refresh check skips a row whose source hash stands still. The court
+    // writes its headnote after publishing the decision and edits it later,
+    // so a row stored before either has to hash differently once the portal
+    // states the new text; otherwise the update never lands.
+    expect(headnoted.rawHash).not.toBe(none.rawHash);
+    expect(edited.rawHash).not.toBe(headnoted.rawHash);
+  });
+
+  test("a decision the court states no headnote for hashes as it did before", async () => {
+    const none = await crawledWithHeadnote();
+
+    // The literal is the hash's pre-existing input, so re-hashing the rows the
+    // court wrote no headnote for cannot happen without editing this line.
+    expect(none.rawHash).toBe(
+      hashContent("1 Az 4/2026-79|2026-06-10|rozsudek"),
+    );
   });
 
   test("refuses to write a row whose document the court did not serve", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -705,6 +705,7 @@ type DetailMetadata = {
   caseStatus: string | undefined;
   administrativeAuthority: string | undefined;
   citation: string | undefined;
+  legalSentence: string | undefined;
 };
 
 /** Extract a div's value text by its ID, skipping the label span. */
@@ -752,6 +753,7 @@ const EMPTY_DETAIL: DetailMetadata = {
   caseStatus: undefined,
   administrativeAuthority: undefined,
   citation: undefined,
+  legalSentence: undefined,
 };
 
 /**
@@ -809,6 +811,12 @@ const fetchDetailMetadata = async (
         caseStatus: extractDivText(html, "stavrizeni"),
         administrativeAuthority: extractDivText(html, "nazevspravnihoorganu"),
         citation: extractDivText(html, "citace"),
+        // The headnote the court writes for a decision it selects into its
+        // collection, under `pravnivetaupravena` ("Právní věta (text)"). The
+        // neighbouring `pravnivetaanv` is the ano/ne flag, not the sentence,
+        // and the field is on the detail page alone: neither document
+        // endpoint carries it.
+        legalSentence: extractDivText(html, "pravnivetaupravena"),
       },
     };
   } catch {
@@ -893,6 +901,7 @@ const rowToResult = (
       caseStatus: detail.caseStatus,
       administrativeAuthority: detail.administrativeAuthority,
       citation: detail.citation,
+      legalSentence: detail.legalSentence,
     },
     // Fulltext is parser output, not publisher identity. Keeping it out makes
     // crawl and replay converge on the same source hash after parser changes.

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -560,6 +560,7 @@ type CzNssSourceHashOptions = {
   sheetNumber: string | undefined;
   decisionDate: string | undefined;
   decisionType: string | undefined;
+  legalSentence: string | undefined;
 };
 
 /**
@@ -576,19 +577,29 @@ type CzNssSourceHashOptions = {
  * carries ` - 66`, or through a court that re-spaces its own citations.
  * Spacing is typography, not a document changing, and a hash that tracked it
  * would rewrite rows for it and would leave crawl and replay disagreeing.
+ *
+ * The headnote is here for the same reason as the sheet, and its timing is
+ * why: the court writes it when it selects an already published decision for
+ * its collection, and edits it afterwards. Left out, a row stored before that
+ * would be skipped as unchanged for good. It is appended only where the court
+ * states one, so a decision that has none hashes exactly as it did and is not
+ * rewritten for this. The replay hashes the value off the row's own metadata,
+ * which is where the crawl put it, so the two agree.
  */
 const czNssSourceHash = ({
   caseNumber,
   sheetNumber,
   decisionDate,
   decisionType,
+  legalSentence,
 }: CzNssSourceHashOptions): string => {
   const { caseNumber: docket, sheetNumber: carried } =
     splitCaseReference(caseNumber);
   const sheet = sheetNumber ?? carried;
   const reference = sheet === undefined ? docket : `${docket}-${sheet}`;
+  const base = `${reference}|${decisionDate ?? ""}|${decisionType ?? ""}`;
   return hashContent(
-    `${reference}|${decisionDate ?? ""}|${decisionType ?? ""}`,
+    legalSentence === undefined ? base : `${base}|${legalSentence}`,
   );
 };
 
@@ -910,6 +921,7 @@ const rowToResult = (
       sheetNumber,
       decisionDate,
       decisionType,
+      legalSentence: detail.legalSentence,
     }),
     parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NSS],
     documentAst: content.documentAst ?? EMPTY_AST,
@@ -1042,6 +1054,7 @@ const reparseStoredRaw = (
         sheetNumber,
         decisionDate,
         decisionType,
+        legalSentence: nonEmptyString(stored.metadata["legalSentence"]),
       }),
       parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NSS],
       documentAst: parsed.documentAst,


### PR DESCRIPTION
Both Czech supreme courts publish a headnote ("právní věta") for the decisions they select for their collections. `publisherSummaryOf` (`apps/api/src/lib/case-law/publisher-summary.ts`) reads it from `metadata.legalSentence`, then `abstract`, then `summary`. Neither adapter stored everything its source states.

## Supreme Administrative Court (`cz-nss`)

`/DokumentDetail/Index/{id}` carries two adjacent fields:

- `pravnivetaanv` ("Právní věta"): `ano` / `ne`
- `pravnivetaupravena` ("Právní věta (text)"): the sentence itself

The adapter read neither. It now reads `pravnivetaupravena` through the same `extractDivText` every other detail field uses, and stores it as `metadata.legalSentence`. The name matters here: `pravnivetaanv` looks like the headnote field and holds only the flag, so a reader keyed on the shared prefix would store `"ne"` as the sentence for the whole corpus.

Across the detail pages checked against the live portal the two fields agree exactly: every page stating `ano` carries a text and every page stating `ne` carries none. A multi-part headnote ("I. … II. …") arrives inside that one field, so nothing has to be joined.

Neither document endpoint (`/DokumentOriginal/Html/{id}`, `/DokumentOriginal/Text/{id}`) carries the sentence; it is a detail-page field only.

## Supreme Court (`cz-ns`)

The detail page (`WebSearch/{unid}`) already had its `Právní věta:` row read into `metadata.legalSentence`, and that stands. The row is on every page and holds a one-pixel spacer image where the court wrote no headnote, which `stripHtml` already reduces to nothing.

What was dropped is the row beside it, `Anotace:`, the court's own case annotation, printed for part of the same set. Unlike every other row on the page its cell holds a `<details>` disclosure rather than a `<font>` run, so the pattern reads to the cell's close. It lands in `metadata.abstract`, the key the summary reader consults after `legalSentence`.

## Which decisions this covers

Both courts state these fields for the decisions they select for their collections, not for the whole corpus: the Supreme Court prints them for its category A decisions, and the Supreme Administrative Court for the ones its detail page flags `ano`, including decisions not yet issued in a volume. The adapters capture what the source states; where the court wrote nothing, nothing is stored.

Neither field belongs to the document AST, so neither can be a `headnotes` apparatus role: the NS AST is parsed from the print page and the NSS AST from the document endpoint, and both fields live on the metadata page instead. No new metadata key is introduced; both are keys `PUBLISHER_SUMMARY_SOURCES` already declares.

## Replay and parser versions

No parser version is bumped, and both reasons are specific:

- `cz-ns` implements no `reparseStoredRaw`, so it has no replay path a version could make eligible.
- `cz-nss` replays from the stored decision document plus the row's own metadata. The detail page is not part of the stored payload, so a replay carries forward the headnote the crawl wrote and cannot recover one for a row stored without it. Bumping the version would rewrite the NSS corpus without adding the field.

Existing rows therefore keep what they hold; documents read after this change carry the fields. A test pins both halves of the replay behaviour so the boundary is stated in the suite rather than only here.

## Tests

`cz-ns-reconciliation.test.ts` and `cz-nss.test.ts` gain source-shaped detail fixtures (`data-field-id` divs with `det-textitle`/`det-textval` spans for the NSS, `left-part`/`right-part` rows including the spacer-image cell and the `<details>` annotation cell for the NS) and assert through `publisherSummaryOf`, so the key each adapter writes is bound to the list the reader walks rather than trusted by spelling.

Every new test was run against the unfixed adapter first: reading `pravnivetaanv` instead of `pravnivetaupravena` fails the three NSS tests, dropping either field fails its court's tests.

From `apps/api`:

```
bun run test src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts \
  src/handlers/case-law/ingestion/adapters/cz-nss.test.ts \
  src/handlers/case-law/ingestion/adapters/nullish-optional-fields.test.ts \
  src/lib/case-law/publisher-summary.test.ts
```

118 pass, 0 fail. `pipeline.test.ts`, `pipeline-canonical.test.ts` and `corpus-ingestion-checkpoint.test.ts` also run green.

