### PR TITLE
refactor(api): export the Czech supreme courts' detail-page parsers

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -246,8 +246,10 @@ const extractFulltext = (html: string): string | undefined => {
   return text.length > 100 ? text : undefined;
 };
 
-/** Parse metadata from a decision detail page. */
-const parseDetailPage = (html: string): Record<string, string | undefined> => {
+/** Read every labelled row of a detail page into its own key. */
+const parseDetailLabels = (
+  html: string,
+): Record<string, string | undefined> => {
   const result: Record<string, string | undefined> = {};
 
   for (const [key, pattern] of Object.entries(LABEL_PATTERNS)) {
@@ -260,10 +262,49 @@ const parseDetailPage = (html: string): Record<string, string | undefined> => {
     }
   }
 
-  result["fulltext"] = extractFulltext(html);
-
   return result;
 };
+
+/**
+ * What the court writes about a decision it selected into its collection:
+ * the headnote, the annotation beside it, and the category letter that says
+ * the decision is in the collection at all (`A`).
+ *
+ * Its own type because two readers want exactly these rows and no others —
+ * the crawl, which reads them off a page it fetched for the decision text,
+ * and a backfill, which fetches the page for these rows alone. Naming them
+ * once is what keeps the two reading the same keys.
+ */
+export type CzNsPublishedSummary = {
+  /** `Právní věta:`, the court's own headnote. */
+  legalSentence: string | undefined;
+  /** `Anotace:`, the court's own case annotation. */
+  abstract: string | undefined;
+  /** `Kategorie rozhodnutí:`; `A` is the published collection. */
+  category: string | undefined;
+};
+
+const summaryOfLabels = (
+  labels: Record<string, string | undefined>,
+): CzNsPublishedSummary => ({
+  legalSentence: labels["legalSentence"],
+  abstract: labels["abstract"],
+  category: labels["category"]?.trim(),
+});
+
+/**
+ * The summary rows of a detail page, without the decision text beneath them.
+ * The text is the expensive half of the page and a reader after the headnote
+ * alone has no use for it.
+ */
+export const parseCzNsDetailSummary = (html: string): CzNsPublishedSummary =>
+  summaryOfLabels(parseDetailLabels(html));
+
+/** Parse metadata from a decision detail page. */
+const parseDetailPage = (html: string): Record<string, string | undefined> => ({
+  ...parseDetailLabels(html),
+  fulltext: extractFulltext(html),
+});
 
 /** One decision as the publisher lists it, whichever listing named it. */
 export type CzNsListingRow = {
@@ -422,8 +463,7 @@ export const buildCzNsDecision = async (
         decisionType: meta["decisionType"]?.toLowerCase(),
         ...sourceMetadata,
         judge,
-        legalSentence: meta["legalSentence"],
-        abstract: meta["abstract"],
+        ...summaryOfLabels(meta),
         keywords: meta["keywords"]?.split("\n").flatMap((s) => {
           const trimmed = s.trim();
           return trimmed ? [trimmed] : [];
@@ -432,7 +472,6 @@ export const buildCzNsDecision = async (
           const trimmed = s.trim();
           return trimmed ? [trimmed] : [];
         }),
-        category: meta["category"]?.trim(),
       },
       rawHash: hashContent(raw),
       parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NS],

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -611,7 +611,7 @@ const czNssSourceHash = ({
 const fetchDecisionContent = async (
   documentId: string,
   row: ParsedRow,
-  detail: DetailMetadata,
+  detail: CzNssDetailMetadata,
   session: SessionState,
   signal: AbortSignal,
 ): Promise<DecisionContent> => {
@@ -703,7 +703,13 @@ const fetchDecisionContent = async (
   }
 };
 
-type DetailMetadata = {
+/**
+ * The fields the portal states on a document's own detail page, which no
+ * document endpoint carries. Exported under the adapter's name because a
+ * second reader — a backfill that fetches this page for the headnote alone —
+ * must bind to the same shape rather than restate its keys.
+ */
+export type CzNssDetailMetadata = {
   ecli: string | undefined;
   judge: string | undefined;
   senate: string | undefined;
@@ -747,11 +753,41 @@ const extractDivText = (html: string, divId: string): string | undefined => {
 };
 
 /**
+ * Read the detail page's fields out of its markup.
+ *
+ * Split from the fetch below so a caller that already holds the page — a
+ * backfill reading the headnote off it, its own tests — parses it through
+ * the adapter rather than through a second copy of these field names.
+ */
+export const parseCzNssDetailMetadata = (
+  html: string,
+): CzNssDetailMetadata => ({
+  ecli: extractDivText(html, "ecli"),
+  judge: extractDivText(html, "soudcezpravodaj"),
+  senate: extractDivText(html, "soudsenat"),
+  legalArea: extractDivText(html, "oblastupravy"),
+  decisionType: extractDivText(html, "druhdokumentuavyrokrozhodnuti"),
+  decisionDate: extractDivText(html, "datumvydanirozhodnuti"),
+  outcome: extractDivText(html, "vyrokrozhodnuti"),
+  caseType: extractDivText(html, "typrizeni"),
+  parties: extractDivText(html, "ucastnicirizeniz"),
+  caseStatus: extractDivText(html, "stavrizeni"),
+  administrativeAuthority: extractDivText(html, "nazevspravnihoorganu"),
+  citation: extractDivText(html, "citace"),
+  // The headnote the court writes for a decision it selects into its
+  // collection, under `pravnivetaupravena` ("Právní věta (text)"). The
+  // neighbouring `pravnivetaanv` is the ano/ne flag, not the sentence,
+  // and the field is on the detail page alone: neither document
+  // endpoint carries it.
+  legalSentence: extractDivText(html, "pravnivetaupravena"),
+});
+
+/**
  * Fetch structured metadata from /DokumentDetail/Index/{id}.
  * Extracts ECLI, judge, legal area, decision type, outcome,
  * case type, and parties.
  */
-const EMPTY_DETAIL: DetailMetadata = {
+const EMPTY_DETAIL: CzNssDetailMetadata = {
   ecli: undefined,
   judge: undefined,
   senate: undefined,
@@ -778,7 +814,7 @@ const EMPTY_DETAIL: DetailMetadata = {
  * a document not yet read and comes back for.
  */
 type DetailFetch =
-  | { type: "fetched"; detail: DetailMetadata }
+  | { type: "fetched"; detail: CzNssDetailMetadata }
   | { type: "unavailable" };
 
 const fetchDetailMetadata = async (
@@ -807,29 +843,7 @@ const fetchDetailMetadata = async (
 
     const html = await response.text();
 
-    return {
-      type: "fetched",
-      detail: {
-        ecli: extractDivText(html, "ecli"),
-        judge: extractDivText(html, "soudcezpravodaj"),
-        senate: extractDivText(html, "soudsenat"),
-        legalArea: extractDivText(html, "oblastupravy"),
-        decisionType: extractDivText(html, "druhdokumentuavyrokrozhodnuti"),
-        decisionDate: extractDivText(html, "datumvydanirozhodnuti"),
-        outcome: extractDivText(html, "vyrokrozhodnuti"),
-        caseType: extractDivText(html, "typrizeni"),
-        parties: extractDivText(html, "ucastnicirizeniz"),
-        caseStatus: extractDivText(html, "stavrizeni"),
-        administrativeAuthority: extractDivText(html, "nazevspravnihoorganu"),
-        citation: extractDivText(html, "citace"),
-        // The headnote the court writes for a decision it selects into its
-        // collection, under `pravnivetaupravena` ("Právní věta (text)"). The
-        // neighbouring `pravnivetaanv` is the ano/ne flag, not the sentence,
-        // and the field is on the detail page alone: neither document
-        // endpoint carries it.
-        legalSentence: extractDivText(html, "pravnivetaupravena"),
-      },
-    };
+    return { type: "fetched", detail: parseCzNssDetailMetadata(html) };
   } catch {
     return { type: "unavailable" };
   }
@@ -839,7 +853,7 @@ const fetchDetailMetadata = async (
 const rowToResult = (
   row: ParsedRow,
   content: DecisionContent,
-  detail: DetailMetadata,
+  detail: CzNssDetailMetadata,
 ): IngestionResult => {
   const sourceDocumentId = czNssSourceDocumentId(row);
   const court = courtFromEcli(detail.ecli);


### PR DESCRIPTION
The two Czech supreme courts print their published headnote on a decision's
detail page, and #3107 taught the adapters to read it during the crawl. Rows
stored before that read it from nowhere: `cz-nss` keeps the decision document
as its raw payload, so a stored-raw replay carries a sentence the crawl read
and cannot recover one it did not, and `cz-ns` implements no
`reparseStoredRaw` at all. Filling those rows means fetching the detail page
again — for the summary rows alone, not for the decision.

That reader needs the adapters' own parsing. None of it was importable, so it
could only restate the field names and drift from them the next time a court
renames a row.

- `cz-ns`: `parseCzNsDetailSummary` reads `Právní věta:`, `Anotace:` and
  `Kategorie rozhodnutí:` off a detail page without parsing the decision text
  beneath them, which is the expensive half of the page. The label loop is
  split out of `parseDetailPage`, and `buildCzNsDecision` now writes those
  three keys through the same `summaryOfLabels` the new export uses, so the
  crawl and any second reader cannot spell them differently.
- `cz-nss`: `parseCzNssDetailMetadata` is the field list `fetchDetailMetadata`
  held inline; `CzNssDetailMetadata` is the type named for it.

Both fetches keep their literal URLs. Routing them through a helper leaves the
outbound target with no statically provable origin and trips
`require-safe-outbound-target`.

No behaviour change. Based on `fix/cz-headnote-capture` (#3107) because the
`abstract` and `legalSentence` rows the exports carry are added there; it
retargets to main when that merges.

Tests: `cz-nss.test.ts` and `cz-ns-reconciliation.test.ts`, 97 pass / 0 fail.