### PR TITLE
fix(api): read the NSS pagination state as a JavaScript literal

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -47,6 +47,9 @@ const reconciliation = requireReconciliation(czNssAdapter);
 
 const BASE_URL = "https://vyhledavac.nssoud.cz";
 
+/** One backslash, for fixtures that must carry a literal escape. */
+const BACKSLASH = String.fromCodePoint(92);
+
 // ── Portal-shaped fixtures ───────────────────────────────
 
 /**
@@ -129,9 +132,22 @@ const CURR_PARAMS_DECODED =
   '[{"Id":19,"TechnickyNazev":"datumvydanirozhodnuti","vyhledavaciPodminkaHodnota":[{"HodnotaDatumACasOd":"2026-06-10T00:00:00","HodnotaDatumACasDo":"2026-06-10T00:00:00"}]}]';
 const CURR_SORT = " order by  zvht38.Hodnota NOOR , zvhdt1.Hodnota DESC ";
 
-const scriptBlock = `<script type="text/javascript">
+/**
+ * The same state for a search whose condition comes from a codelist, captured
+ * verbatim from the portal. Its `ciselnikTreeData` states the condition's own
+ * options as JSON inside the JSON, so each title is wrapped in an escaped
+ * backslash followed by the escape for a double quote. Resolving the second
+ * without consuming the first leaves text that no longer parses as JSON, and
+ * the endpoint answers a body carrying it with 200 and nothing in it.
+ */
+const CURR_PARAMS_CODELIST_JSON =
+  "[{\\u0022Id\\u0022:308,\\u0022ZobrazovanyNazevSekce\\u0022:null,\\u0022TechnickyNazev\\u0022:\\u0022pravnivetaanv\\u0022,\\u0022ZobrazovanyNazev\\u0022:\\u0022Pr\\u00E1vn\\u00ED v\\u011Bta\\u0022,\\u0022DatovyTyp\\u0022:\\u0022FIELD_DIAL\\u0022,\\u0022VazbaKDotazu\\u0022:0,\\u0022vyhledavaciPodminkaHodnota\\u0022:[{\\u0022DatovyTyp\\u0022:\\u0022FIELD_DIAL\\u0022,\\u0022TechnickyNazev\\u0022:\\u0022pravnivetaanv\\u0022,\\u0022ZobrazovanyNazev\\u0022:\\u0022Pr\\u00E1vn\\u00ED v\\u011Bta\\u0022,\\u0022HodnotaText\\u0022:null,\\u0022HodnotaCislo\\u0022:null,\\u0022HodnotaDatumACasOd\\u0022:null,\\u0022HodnotaDatumACasDo\\u0022:null,\\u0022HodnotaCiselnikPolozky\\u0022:null,\\u0022HodnotaCiselnikPolozkySelected\\u0022:\\u00228240\\u0022,\\u0022ciselnikTreeData\\u0022:\\u0022[{id:8240,title:\\\\\\u0022ano\\\\\\u0022},{id:8241,title:\\\\\\u0022ne\\\\\\u0022}]\\u0022,\\u0022ciselnikPolozky\\u0022:[],\\u0022cisPolEnum\\u0022:[],\\u0022JeNastavena\\u0022:true,\\u0022NapovedaNazev\\u0022:null,\\u0022NapovedaHtml\\u0022:null}],\\u0022Visible\\u0022:true}]";
+const CURR_PARAMS_CODELIST_DECODED =
+  '[{"Id":308,"ZobrazovanyNazevSekce":null,"TechnickyNazev":"pravnivetaanv","ZobrazovanyNazev":"Pr\u00e1vn\u00ed v\u011bta","DatovyTyp":"FIELD_DIAL","VazbaKDotazu":0,"vyhledavaciPodminkaHodnota":[{"DatovyTyp":"FIELD_DIAL","TechnickyNazev":"pravnivetaanv","ZobrazovanyNazev":"Pr\u00e1vn\u00ed v\u011bta","HodnotaText":null,"HodnotaCislo":null,"HodnotaDatumACasOd":null,"HodnotaDatumACasDo":null,"HodnotaCiselnikPolozky":null,"HodnotaCiselnikPolozkySelected":"8240","ciselnikTreeData":"[{id:8240,title:\\"ano\\"},{id:8241,title:\\"ne\\"}]","ciselnikPolozky":[],"cisPolEnum":[],"JeNastavena":true,"NapovedaNazev":null,"NapovedaHtml":null}],"Visible":true}]';
+
+const scriptBlock = (params: string): string => `<script type="text/javascript">
     var moreRowsUrl = '/Home/MyResTRowsCont';
-    var currParams = '${CURR_PARAMS_JSON}';
+    var currParams = '${params}';
     var currViewId = '1';
     var currSort = '${CURR_SORT}';
 </script>`;
@@ -140,18 +156,21 @@ type SearchPageOptions = {
   statedCount: number;
   rows: readonly RowFixture[];
   withScript?: boolean;
+  /** The literal the page's own script hands its pagination state over in. */
+  scriptParams?: string;
 };
 
 const searchPage = ({
   rows,
   statedCount,
   withScript = true,
+  scriptParams = CURR_PARAMS_JSON,
 }: SearchPageOptions): string => `<html><body>
   <div id="contenttable"><div class="col-12"><div class="row justify-content-left">
     <h6>Počet nalezených záznamů: ${statedCount}</h6>
   </div></div></div>
   <table class="infinite-scroll">${rows.map(rowBlock).join("\n")}</table>
-  ${withScript ? scriptBlock : ""}
+  ${withScript ? scriptBlock(scriptParams) : ""}
 </body></html>`;
 
 /** The landing page, which only hands out an antiforgery token. */
@@ -757,11 +776,12 @@ describe("cz-nss listSlicePage", () => {
       continuation: [htmlResponse("")],
     });
 
-    expect(
-      await rejectionOf(
-        reconciliation.listSlicePage({ slice: SLICE, page: 1 }),
-      ),
-    ).toBeInstanceOf(Error);
+    const error = await rejectionOf(
+      reconciliation.listSlicePage({ slice: SLICE, page: 1 }),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain("answered no rows for page 1");
   });
 
   test("asks the portal's own continuation endpoint for a later page", async () => {
@@ -788,12 +808,67 @@ describe("cz-nss listSlicePage", () => {
     // The field names infiniteScroll.js posts, and the query decoded out of
     // the page's JavaScript string literal.
     expect(body.get("vyhledavaciPodminky")).toBe(CURR_PARAMS_DECODED);
+    // The date-range condition carries no nested quoting, so this is the byte
+    // string the endpoint has always been posted, unchanged.
     expect(body.get("zobrazeniVysledkuId")).toBe("1");
     expect(body.get("pageNum")).toBe("1");
     expect(body.get("resultOrder")).toBe(CURR_SORT);
     expect(listed.items.map(({ identity }) => identity)).toEqual([
       { type: "document", sourceDocumentId: REGIONAL_ROW.documentId },
     ]);
+  });
+
+  test("a codelist condition reaches the endpoint as the JSON the portal wrote", async () => {
+    const { requests } = installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: CZ_NSS_FIRST_PAGE_ROWS + 1,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+            scriptParams: CURR_PARAMS_CODELIST_JSON,
+          }),
+        ),
+      ],
+      continuation: [htmlResponse(rowBlock(REGIONAL_ROW))],
+    });
+
+    await reconciliation.listSlicePage({ slice: SLICE, page: 1 });
+
+    const posted = new URLSearchParams(requests.at(-1)?.body ?? "").get(
+      "vyhledavaciPodminky",
+    );
+    expect(posted).toBe(CURR_PARAMS_CODELIST_DECODED);
+    // The endpoint reconstructs the search by parsing this, so the assertion
+    // that matters is not the byte string but that it is still JSON: the
+    // escaped backslashes around each codelist title are exactly what a
+    // reader resolving `\\uXXXX` on its own destroys.
+    expect(() => JSON.parse(posted ?? "")).not.toThrow();
+  });
+
+  test("a literal ending at an escaped apostrophe is not truncated", async () => {
+    // The portal quotes these literals with apostrophes, so a value holding
+    // one escapes it. Ending the literal at any apostrophe posts a prefix of
+    // the query, which the endpoint does not recognise.
+    const { requests } = installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: CZ_NSS_FIRST_PAGE_ROWS + 1,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+            scriptParams: `[{${BACKSLASH}u0022Nazev${BACKSLASH}u0022:${BACKSLASH}u0022d${BACKSLASH}'Artagnan${BACKSLASH}u0022}]`,
+          }),
+        ),
+      ],
+      continuation: [htmlResponse(rowBlock(REGIONAL_ROW))],
+    });
+
+    await reconciliation.listSlicePage({ slice: SLICE, page: 1 });
+
+    expect(
+      new URLSearchParams(requests.at(-1)?.body ?? "").get(
+        "vyhledavaciPodminky",
+      ),
+    ).toBe('[{"Nazev":"d\'Artagnan"}]');
   });
 
   test("a day the court states no records for is empty, not short", async () => {
@@ -921,6 +996,50 @@ describe("cz-nss fetchPage", () => {
     expect(Result.isError(page) ? null : page.value.nextCursor).toBe(
       `${SLICE}:2`,
     );
+  }, 30_000);
+
+  test("an empty continuation body fails the page instead of ending the day", async () => {
+    // Case-law rule 14. The crawl read a 200 with no body as "no more rows",
+    // moved its cursor to the next day and never came back, so a query the
+    // endpoint refused cost the whole day past its first page. Failing holds
+    // the cursor and retries the page.
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: 68,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+          }),
+        ),
+      ],
+      continuation: [htmlResponse("")],
+    });
+
+    const page = await czNssAdapter.fetchPage(`${SLICE}:1`, {});
+
+    expect(Result.isError(page)).toBe(true);
+  }, 30_000);
+
+  test("a page past the day's last record is allowed to come back empty", async () => {
+    // The same empty body, and this time it is the answer: the day states
+    // sixty records, the first two pages carry all of them, and page two is
+    // past the end. Refusing this would wedge every day whose record count
+    // lands on a page boundary.
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: CZ_NSS_FIRST_PAGE_ROWS + CZ_NSS_CONTINUATION_PAGE_ROWS,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+          }),
+        ),
+      ],
+      continuation: [htmlResponse("")],
+    });
+
+    const page = await czNssAdapter.fetchPage(`${SLICE}:2`, {});
+
+    expect(Result.isError(page)).toBe(false);
   }, 30_000);
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -278,26 +278,77 @@ const extractFormFields = (html: string): Map<string, string> => {
 const extractAntiforgeryToken = (html: string): string | undefined =>
   extractHiddenField(html, "__RequestVerificationToken");
 
+/** The four hex digits a `\uXXXX` escape is made of. */
+const HEX_QUAD_PATTERN = /^[0-9a-fA-F]{4}$/u;
+
+/** The single-character escapes a JavaScript string literal may carry. */
+const SINGLE_CHARACTER_ESCAPES = new Map([
+  ["n", "\n"],
+  ["r", "\r"],
+  ["t", "\t"],
+  ["b", "\b"],
+  ["f", "\f"],
+  ["v", "\v"],
+]);
+
 /**
- * Decode the `\uXXXX` escapes a JavaScript string literal carries.
+ * Decode a JavaScript string literal the way the interpreter reads it.
  *
  * The results page hands its pagination state to `infiniteScroll.js` inside
  * single-quoted literals in which every double quote is escaped. The browser
  * posts the decoded value; anything else posts a query the server does not
- * recognise and answers with an empty body, which reads as a finished day.
+ * recognise and answers with an empty body.
+ *
+ * The escapes have to be consumed left to right, the backslash first. A
+ * reader that resolved `\uXXXX` wherever it appeared would treat the second
+ * half of an escaped backslash as the start of an escape, and any condition
+ * whose value is itself quoted JSON carries one: a codelist condition states
+ * its options in `ciselnikTreeData`, whose titles are wrapped in `\\` plus
+ * the escape for a double quote. The date-range search the crawl runs has no
+ * such condition, which is why the simpler reader stood; a single codelist
+ * condition decodes into text that is no longer JSON.
  */
-const unescapeJsStringLiteral = (value: string): string =>
-  value.replace(/\\u(?<hex>[0-9a-fA-F]{4})/gu, (_match, hex: string) =>
-    String.fromCodePoint(Number.parseInt(hex, 16)),
-  );
+const unescapeJsStringLiteral = (value: string): string => {
+  let decoded = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character !== "\\") {
+      decoded += character;
+      continue;
+    }
+    const escape = value[index + 1];
+    index += 1;
+    if (escape === "u") {
+      const hex = value.slice(index + 1, index + 5);
+      if (HEX_QUAD_PATTERN.test(hex)) {
+        decoded += String.fromCodePoint(Number.parseInt(hex, 16));
+        index += 4;
+        continue;
+      }
+    }
+    // `\\`, `\'`, `\"` and anything else stand for the character they escape;
+    // a backslash ending the literal stands for itself.
+    decoded +=
+      escape === undefined
+        ? "\\"
+        : (SINGLE_CHARACTER_ESCAPES.get(escape) ?? escape);
+  }
+  return decoded;
+};
 
-/** Read a `var name = '...';` initializer out of the page's inline script. */
+/**
+ * Read a `var name = '...';` initializer out of the page's inline script.
+ *
+ * The literal ends at the first *unescaped* quote. Ending it at any quote
+ * would truncate a value containing an escaped apostrophe and post a prefix
+ * of the query, which the endpoint does not recognise.
+ */
 const extractScriptString = (
   html: string,
   name: string,
 ): string | undefined => {
   const match = new RegExp(
-    `var\\s+${name}\\s*=\\s*'(?<value>[^']*)'`,
+    `var\\s+${name}\\s*=\\s*'(?<value>(?:\\\\.|[^'\\\\])*)'`,
     "u",
   ).exec(html);
   const value = match?.groups?.["value"];
@@ -1210,6 +1261,12 @@ type FetchResultPageOptions = {
   date: string;
   /** 0-indexed page within the day. */
   page: number;
+  /**
+   * What the day's results page said the search matched, or `null` where it
+   * said nothing. It is the only thing that tells a page past the day's last
+   * record from a query the endpoint refused.
+   */
+  statedCount: number | null;
   signal: AbortSignal;
 };
 
@@ -1223,6 +1280,7 @@ const fetchResultPage = async ({
   continuation,
   date,
   page,
+  statedCount,
   session,
   signal,
 }: FetchResultPageOptions): Promise<string> => {
@@ -1256,7 +1314,30 @@ const fetchResultPage = async ({
     });
   }
 
-  return await response.text();
+  const html = await response.text();
+  // Case-law rule 14: a day ends when the source says there is nothing more.
+  // This endpoint answers 200 with an empty body for two different things —
+  // a page past the day's last record, and a query it did not recognise —
+  // and only the stated count tells them apart. Reading the second as the
+  // first settles a day the walk saw a fraction of, and a forward-only
+  // cursor never comes back to it. A day whose count the page did not state
+  // is refused for the same reason: nothing here can say the day is over.
+  const requiredRows =
+    statedCount === null ? null : czNssExpectedRows({ page, statedCount });
+  if (html.trim() === "" && requiredRows !== 0) {
+    invalidateSession();
+    throw new AdapterFetchError({
+      message:
+        `NSS pagination for ${date} answered no rows for page ${page}, which ${ 
+        requiredRows === null
+          ? "the day's unstated record count cannot show is past its last record"
+          : `its stated count of ${statedCount} requires ${requiredRows} of`}`,
+      adapterKey: ADAPTER_KEYS.CZ_NSS,
+      cursor: `${date}:${page}`,
+    });
+  }
+
+  return html;
 };
 
 // ── Shared build path ────────────────────────────────────
@@ -1496,6 +1577,7 @@ const listCzNssSlicePage = async ({
             continuation,
             date: slice,
             page,
+            statedCount: search.statedCount,
             session,
             signal: effectiveSignal,
           }),
@@ -1739,6 +1821,7 @@ export const czNssAdapter = defineSourceAdapter({
                 continuation,
                 date,
                 page,
+                statedCount: searchResult.statedCount,
                 session,
                 signal: effectiveSignal,
               });


### PR DESCRIPTION
The NSS results page hands its pagination state to `infiniteScroll.js` in
single-quoted JavaScript literals, and the walk decodes them and posts the
value back to reach the pages after the first. Two things about that reader
were wrong. Both are invisible to the date-range search the crawl runs, and
both are fatal to any other one.

## The decoder

`unescapeJsStringLiteral` resolved `\uXXXX` wherever it appeared instead of
consuming escapes left to right, so the second half of an escaped backslash
started an escape of its own. Any condition whose value is itself quoted JSON
carries one: a condition drawn from a codelist states its options in
`ciselnikTreeData`, and each title there is wrapped in a backslash pair around
the escape for a double quote.

Decoding a captured codelist query with the old reader produces text that no
longer parses as JSON, which is then what the endpoint is asked for a page
with. The date-range condition has no nested quoting, which is why the simpler
reader stood.

The reader is now a left-to-right pass that consumes the backslash first and
handles the single-character escapes as well.

## The literal's boundary

`extractScriptString` matched `'[^']*'`, ending the literal at the first
apostrophe rather than the first unescaped one, so a value containing an
escaped apostrophe was posted truncated. It now matches `(?:\\.|[^'\\])*`.

## The empty 200

Both of the above make the endpoint answer 200 with an empty body, and so does
asking for a page past the day's last record. The walk could not tell them
apart and read either as the day being over.

That is case-law rule 14 from the wrong side. The crawl moved its cursor to the
next day, and being forward-only it never came back, so a refused query cost
every record past that day's first page, permanently and silently. The
signature is a day whose stored count stops at exactly 40.

`fetchResultPage` now refuses an empty body unless the day's stated record
count shows the page is past its last record, which is the one case where
emptiness is the answer. It throws `AdapterFetchError`, the same error the
function already throws for a non-ok status, with the day and page as its
cursor, and it invalidates the session as the other failure paths do. Throwing
holds the cursor, so the page is retried rather than skipped.

A day whose record count the page did not state is refused too: nothing
available at that point can show the day is over.

The reconciliation path already caught this indirectly, through the row-count
check that compares a page against the stated count. It now fails on the empty
body itself and names what it refused, rather than reporting a short page.

## Tests

Four new tests, each of which fails against the code before this change and
passes after it (verified by reverting the source alone):

- The codelist query is a verbatim capture from the portal, so the decoder is
  checked against the publisher's own bytes rather than against a restated
  expectation. The assertion that matters is not the byte string but that what
  gets posted still parses as JSON, since the endpoint reconstructs the search
  by parsing it.
- A literal ending at an escaped apostrophe is posted whole. This one is a
  constructed literal: the portal's own pages carry no apostrophe in these
  variables, so there are no real bytes to capture for it.
- An empty continuation body fails the crawl's page instead of ending the day.
- A page genuinely past the day's last record is still allowed to come back
  empty, so a day whose record count lands on a page boundary does not wedge.

The existing test that asserts the date-range query's posted byte string is
unchanged, and now says so explicitly: that path is byte-identical.

`bun scripts/run-tests.ts src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts` from
`apps/api`: 95 pass, 0 fail.
