### PR TITLE
fix(ci): admit fork pull requests to the merge queue once their head passed CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
     permissions:
       contents: read
       # The merge-group trust check reads the queued pull request's head
-      # repository.
+      # and the pull_request runs recorded for it.
       pull-requests: read
+      actions: read
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
       agent_sandbox_docker_required: ${{ steps.changed-files.outputs.agent_sandbox_docker_required }}
@@ -69,24 +70,44 @@ jobs:
           # the Actions UI (repository policy: approval required for
           # first-time contributors).
           #
-          # A merge group runs with the base repository's secrets and
-          # carries no per-push approval. Only a same-repo pull
-          # request is trusted there; the group's head ref names it
-          # as gh-readonly-queue/<base>/pr-<number>-<sha>.
-          if [[ "$EVENT_NAME" == "merge_group" ]]; then
-            if [[ "$MERGE_GROUP_HEAD_REF" =~ /pr-([0-9]+)-[0-9a-f]+$ ]]; then
-              queued_head_repo=$(gh api "repos/$BASE_REPO/pulls/${BASH_REMATCH[1]}" --jq '.head.repo.full_name')
-            else
-              queued_head_repo=""
-            fi
-            if [[ "$queued_head_repo" == "$BASE_REPO" ]]; then
-              echo "trusted=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "trusted=false" >> "$GITHUB_OUTPUT"
-              echo "::error::Merge group for a fork pull request (head ${queued_head_repo:-unknown}). Land fork changes from a same-repo branch."
-            fi
-          else
+          # A merge group runs with the base repository's secrets. The
+          # group's head ref names the queued pull request as
+          # gh-readonly-queue/<base>/pr-<number>-<sha>. A same-repo pull
+          # request is trusted outright. A fork pull request is trusted
+          # when its head passed a pull_request run of this workflow:
+          # that run cleared the fork gate above, GitHub enqueues only
+          # after `ci-result` passed on the head and only for a user
+          # with write access, and a later push drops the entry. So the
+          # group holds exactly the code a maintainer chose to merge
+          # after CI passed on it, and the enqueue is the approval to
+          # run it with this repository's secrets.
+          if [[ "$EVENT_NAME" != "merge_group" ]]; then
             echo "trusted=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ ! "$MERGE_GROUP_HEAD_REF" =~ /pr-([0-9]+)-[0-9a-f]+$ ]]; then
+            echo "trusted=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Merge group head ref does not name a pull request: $MERGE_GROUP_HEAD_REF"
+            exit 0
+          fi
+          queued_number="${BASH_REMATCH[1]}"
+          read -r queued_head_repo queued_head_sha < <(
+            gh api "repos/$BASE_REPO/pulls/$queued_number" --jq '.head.repo.full_name + " " + .head.sha'
+          )
+          if [[ "$queued_head_repo" == "$BASE_REPO" ]]; then
+            echo "trusted=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          passed_runs=$(
+            gh api "repos/$BASE_REPO/actions/workflows/ci.yml/runs?event=pull_request&status=success&head_sha=$queued_head_sha" \
+              --jq '.total_count'
+          )
+          if [[ "${passed_runs:-0}" -gt 0 ]]; then
+            echo "Fork pull request #$queued_number: head $queued_head_sha passed a pull_request run. Trusted."
+            echo "trusted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "trusted=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Merge group for fork pull request #$queued_number (head $queued_head_repo@$queued_head_sha) with no successful pull_request run on that head. Let CI pass on the pull request, then enqueue it again."
           fi
 
       - name: Checkout
@@ -2719,7 +2740,7 @@ jobs:
           fi
 
           if [[ "$TRUSTED" != "true" ]]; then
-            echo "::error::CI did not run: the merge group carries a fork pull request. Land fork changes from a same-repo branch."
+            echo "::error::CI did not run: the merge group carries a fork pull request whose head has no successful pull_request run."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2740,7 +2740,7 @@ jobs:
           fi
 
           if [[ "$TRUSTED" != "true" ]]; then
-            echo "::error::CI did not run: the merge group carries a fork pull request whose head has no successful pull_request run."
+            echo "::error::CI did not run: the merge group failed the trust check; see the ci-plan job for the reason."
             exit 1
           fi
 

--- a/docs/policies/access-control.md
+++ b/docs/policies/access-control.md
@@ -77,10 +77,13 @@ operations runbook (private).
    its author and the actor who pushed have had a commit or pull
    request merged into the repository (repository policy: approval
    required for first-time contributors), so code from an unknown
-   contributor never executes in CI before review.
-   The CI workflow (`.github/workflows/ci.yml`) also fails a merge
-   group that carries a fork pull request; fork changes land from a
-   same-repo branch.
+   contributor never executes in CI before review. The merge queue
+   admits a pull request only when a user with write access enqueues
+   it after `ci-result` passed on its head, and drops the entry when
+   the head moves. The CI workflow (`.github/workflows/ci.yml`)
+   trusts a merge group that carries a fork pull request only when a
+   `pull_request` run of the workflow succeeded on that head, and
+   fails the group otherwise.
 
 9. **Ruleset audit.** A weekly workflow
    (`audit-branch-protection.yml`) compares the live GitHub


### PR DESCRIPTION
## Problem

The merge-group trust check in `ci.yml` refused every fork pull request: `ci-plan` reported `trusted=false`, every job was skipped, and `ci-result` failed with "the merge group carries a fork pull request". A maintainer could land a fork pull request only by re-opening it from a same-repo branch or by bypassing the queue (#3045 landed that way after its queue run failed).

The gate was written when a merge group carried no per-push approval. The queue itself now supplies one: GitHub adds an entry only when a user with write access enqueues it, only after `ci-result` passed on the pull request head, and it drops the entry when the head moves. The `pull_request` run that produced that `ci-result` cleared the Actions fork gate (approval for first-time contributors).

## Change

- `ci-plan` trusts a merge group that carries a fork pull request when a `pull_request` run of this workflow succeeded on the queued head, and reports `trusted=false` with the head and the missing run otherwise. Same-repo pull requests stay trusted outright. The job gains `actions: read` to list those runs.
- `ci-result` names the new condition in its failure message.
- The "Fork trust gate" item in `docs/policies/access-control.md` describes the queue invariant and the check.

Stacked on #3098, which rewrites the same comment and policy paragraph for the first-time-contributor approval policy.

## Verification

The trust step was run locally against real merge-group head refs: a fork pull request with a green `pull_request` run (trusted), two fork pull requests without one (refused, with head and reason), a same-repo pull request (trusted), a malformed head ref (refused), and a `pull_request` event (trusted). `actionlint` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved merge queue validation for pull requests from the same repository and forks.
  - Fork pull requests are accepted only when the relevant workflow has completed successfully on the current commit.
  - Invalid merge-group references are rejected, with trust-check failures directing users to the CI planning job for details.

- **Documentation**
  - Updated access-control guidance to explain merge queue admission, head changes, and fork pull request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->