### PR TITLE
fix(api): name a generated object's provider failure by its body

### DIFF
--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -56,7 +56,19 @@ const httpStatusFromString = (value: unknown): number | null => {
   return isHttpStatus(status) ? status : null;
 };
 
-const providerStatusCode = (error: unknown): number | null => {
+/**
+ * The provider HTTP status one link of an error chain carries, or `null` when
+ * that link carries none of its own.
+ *
+ * Exported because every decision taken on a provider status has to read it
+ * the same way: naming the failure here, and the service-tier retry predicate
+ * in `tanstack-ai-generate`. A second reader drifts, and it drifts silently,
+ * because both agree on the shape the tests happen to use and disagree on the
+ * one production sends. The `HandlerError` exclusion below is exactly such a
+ * disagreement: a reader without it names every wrapped failure 502 and reads
+ * a permanent credential, billing or retired-model answer as a server error.
+ */
+export const providerStatusCode = (error: unknown): number | null => {
   if (!isRecord(error)) {
     return null;
   }

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -784,6 +784,70 @@ describe("TanStack AI structured output generation", () => {
     expect(providerRequests).toHaveLength(1);
   });
 
+  // An adapter whose SDK exception reports the status as a plain field and
+  // stringifies the response body into the message keeps neither once the
+  // engine rebuilds the run error: the body in the message is the only
+  // evidence left of what the provider answered. The streaming seam recovers
+  // it, so this one has to as well; otherwise quota, billing, retired model
+  // and outage all reach the classifier as one unnamed failure.
+  test("classifies a generated object's failure whose only detail is the provider body", async () => {
+    queueRun(
+      throwingRun(
+        new Error(
+          JSON.stringify({
+            error: {
+              code: 429,
+              message: "Resource has been exhausted.",
+              status: "RESOURCE_EXHAUSTED",
+            },
+          }),
+        ),
+      ),
+    );
+
+    const caught = await generateObjectForTestModel({
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      outputSchema: v.strictObject({ answer: v.string() }),
+      prompt: "Extract the answer.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({ status: 502 });
+    expect(classifyAIError(caught)).toBe("quota_exhausted");
+    expect(isAnticipatedAIFailure(caught, classifyAIError(caught))).toBe(true);
+  });
+
+  test("leaves a generated object's plain-text failure unclassified", async () => {
+    const providerError = new Error("The model is currently overloaded.");
+    queueRun(throwingRun(providerError));
+
+    const caught = await generateObjectForTestModel({
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      outputSchema: v.strictObject({ answer: v.string() }),
+      prompt: "Extract the answer.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    // Nothing names this failure, so the engine's own wrapper stands rather
+    // than being replaced by a 502 that would claim a status it never had.
+    expect(caught).toHaveProperty("cause", providerError);
+    expect(classifyAIError(caught)).toBe("unknown");
+  });
+
   test("retries deferred structured streams after control-only chunks", async () => {
     queueRun(
       throwingRun(

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -11,6 +11,7 @@ import {
 
 import type { CachingDecision } from "@/api/lib/ai-config";
 import { classifyAIError, isAnticipatedAIFailure } from "@/api/lib/ai-error";
+import type { AIErrorKind } from "@/api/lib/ai-error";
 import { toSafeId } from "@/api/lib/branded-types";
 import { StructuredOutputBudgetError } from "@/api/lib/structured-output-budget";
 import {
@@ -300,6 +301,43 @@ const noCaching = {
   enabled: false,
   reason: "org-disabled",
 } satisfies CachingDecision;
+
+/**
+ * A provider answer whose only surviving detail is its response body: the
+ * adapter reported the status as a plain field on its SDK exception and
+ * stringified the body into the message, and the engine rebuilt the run error
+ * from the message alone.
+ */
+const providerBodyError = (status: number): Error =>
+  new Error(
+    JSON.stringify({
+      error: {
+        code: status,
+        message: `The provider answered ${status}.`,
+      },
+    }),
+  );
+
+// The statuses a body-only failure can name, and whether each justifies a
+// second attempt on the standard tier. A permanent answer (rejected
+// credentials, the upstream account's billing, a model the provider retired)
+// says the same thing however it is asked, so re-asking only costs a request.
+const PROVIDER_BODY_SERVICE_TIER_FALLBACK_MATRIX = [
+  {
+    kind: "provider_credentials_rejected",
+    retriesOnStandardTier: false,
+    status: 401,
+  },
+  { kind: "provider_billing", retriesOnStandardTier: false, status: 402 },
+  { kind: "model_unavailable", retriesOnStandardTier: false, status: 404 },
+  { kind: "quota_exhausted", retriesOnStandardTier: true, status: 429 },
+  { kind: "provider_unavailable", retriesOnStandardTier: true, status: 500 },
+  { kind: "provider_unavailable", retriesOnStandardTier: true, status: 503 },
+] as const satisfies readonly {
+  kind: AIErrorKind;
+  retriesOnStandardTier: boolean;
+  status: number;
+}[];
 
 let analytics: RecordingAnalytics;
 let logs: RecordingLogger;
@@ -847,6 +885,51 @@ describe("TanStack AI structured output generation", () => {
     expect(caught).toHaveProperty("cause", providerError);
     expect(classifyAIError(caught)).toBe("unknown");
   });
+
+  // A body-only failure reaches the service-tier retry predicate wrapped in
+  // the 502 `HandlerError` the recovery above built for it. That 502 is this
+  // service's own wrapper, not the provider's answer, so a predicate reading
+  // it grades every permanent failure as a server error and spends a second
+  // provider call on the standard tier to be told the same thing. The
+  // provider's status is one `cause` down; the retry is decided on that, which
+  // makes the decision agree with the name the same failure is given.
+  for (const {
+    kind,
+    retriesOnStandardTier,
+    status,
+  } of PROVIDER_BODY_SERVICE_TIER_FALLBACK_MATRIX) {
+    test(`${retriesOnStandardTier ? "retries" : "does not retry"} a deferred OpenAI object generation whose provider body is ${status}`, async () => {
+      // Queued twice so the retried and non-retried rows differ only in how
+      // many provider calls happened, never in whether the run failed.
+      queueRun(throwingRun(providerBodyError(status)));
+      queueRun(throwingRun(providerBodyError(status)));
+
+      const caught = await generateObjectForTestModel({
+        caching: noCaching,
+        organizationId: null,
+        orgAIConfig: null,
+        outputSchema: v.strictObject({ answer: v.string() }),
+        prompt: "Extract the answer.",
+        role: "chat",
+        serviceTier: "flex",
+        tenantWorkspaceIds: [],
+      }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      expect(classifyAIError(caught)).toBe(kind);
+      expect(providerRequests).toHaveLength(retriesOnStandardTier ? 2 : 1);
+      expect(providerRequests).toMatchObject(
+        retriesOnStandardTier
+          ? [
+              { modelOptions: { service_tier: "flex" } },
+              { modelOptions: { service_tier: "default" } },
+            ]
+          : [{ modelOptions: { service_tier: "flex" } }],
+      );
+    });
+  }
 
   test("retries deferred structured streams after control-only chunks", async () => {
     queueRun(

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -882,6 +882,10 @@ describe("TanStack AI structured output generation", () => {
 
     // Nothing names this failure, so the engine's own wrapper stands rather
     // than being replaced by a 502 that would claim a status it never had.
+    // The wrapper carries no status at all, which is what separates it from a
+    // recovery that fired: a `HandlerError` would answer 502 while classifying
+    // as `unknown` just the same, and would keep this same cause.
+    expect(caught).not.toHaveProperty("status");
     expect(caught).toHaveProperty("cause", providerError);
     expect(classifyAIError(caught)).toBe("unknown");
   });

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -26,7 +26,11 @@ import type {
   CachingDecision,
   OrgAIConfig,
 } from "@/api/lib/ai-config";
-import { classifyAIError, providerErrorBody } from "@/api/lib/ai-error";
+import {
+  classifyAIError,
+  providerErrorBody,
+  providerStatusCode,
+} from "@/api/lib/ai-error";
 import type { TanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
@@ -673,9 +677,12 @@ const shouldRetryWithStandardServiceTier = ({
 // `chat({ outputSchema })` does not rethrow the adapter's error: it records
 // the failure and throws `new Error(message, { cause: providerError })`, so
 // the status and retry hints live one `cause` down. The streaming paths throw
-// the provider error itself. Walk the chain to the first link that carries a
-// provider status and judge that link; the depth bound keeps a cyclic cause
-// from hanging the request.
+// the provider error itself, and a body-only failure arrives inside the
+// `HandlerError` `withRecoveredProviderStatus` built for it, whose own 502 is
+// this service's, not the provider's. Walk the chain to the first link that
+// carries a provider status, using the classifier's own reader so the status
+// the retry is decided on is the status the failure is named by; the depth
+// bound keeps a cyclic cause from hanging the request.
 const MAX_CAUSE_DEPTH = 8;
 
 const providerErrorInCauseChain = (
@@ -695,10 +702,27 @@ const providerErrorInCauseChain = (
   return null;
 };
 
+/**
+ * A run error the provider's own answer does not account for.
+ *
+ * The streaming seam's `RUN_ERROR` carries the provider's message and nothing
+ * else: the engine drops the status the adapter's exception held, so a flex or
+ * batch tier that was merely unavailable reaches this predicate with nothing
+ * to judge. That run still failed at the provider, which is the case the
+ * deferred-tier fallback exists for, so it retries once on the standard tier.
+ *
+ * The classifier decides "unaccounted for", not the absence of a number: an
+ * adapter can name a permanent answer through a provider-owned marker that
+ * carries no status at all (a rejected key), and a named answer is the
+ * provider's verdict however it was spelled.
+ */
+const isUnattributedRunError = (error: unknown): boolean =>
+  HandlerError.is(error) && classifyAIError(error) === "unknown";
+
 const isRetryableServiceTierFallbackError = (error: unknown): boolean => {
   const provider = providerErrorInCauseChain(error);
   if (provider === null) {
-    return false;
+    return isUnattributedRunError(error);
   }
 
   const isRetryable = provider.record["isRetryable"];
@@ -710,20 +734,6 @@ const isRetryableServiceTierFallbackError = (error: unknown): boolean => {
   }
 
   return provider.statusCode === 429 || provider.statusCode >= 500;
-};
-
-const providerStatusCode = (error: Record<string, unknown>): number | null => {
-  const statusCode = error["statusCode"];
-  if (typeof statusCode === "number" && Number.isInteger(statusCode)) {
-    return statusCode;
-  }
-
-  const status = error["status"];
-  if (typeof status === "number" && Number.isInteger(status)) {
-    return status;
-  }
-
-  return null;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -26,7 +26,7 @@ import type {
   CachingDecision,
   OrgAIConfig,
 } from "@/api/lib/ai-config";
-import { providerErrorBody } from "@/api/lib/ai-error";
+import { classifyAIError, providerErrorBody } from "@/api/lib/ai-error";
 import type { TanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
@@ -514,6 +514,13 @@ type StandardServiceTierFallbackOptions<TResult> = {
   run: (serviceTier: AIRequestServiceTier) => Promise<TResult>;
 };
 
+// The only exit a failed non-streaming run has, so it is where that run's
+// provider status is recovered. The retry decision reads the recovered error
+// too: a fallback the provider's own status justifies cannot be skipped for
+// want of a status the message still carries. The standard-tier attempt
+// answers through this same function (`isDeferredServiceTier("standard")` is
+// false, so it takes the throw), which leaves both attempts recovered without
+// a second exit to keep in step.
 const withStandardServiceTierFallback = async <TResult>({
   model,
   serviceTier,
@@ -522,11 +529,22 @@ const withStandardServiceTierFallback = async <TResult>({
   try {
     return await run(serviceTier);
   } catch (error) {
-    if (!shouldRetryWithStandardServiceTier({ error, model, serviceTier })) {
-      throw error;
+    const recovered = withRecoveredProviderStatus(error);
+    if (
+      !shouldRetryWithStandardServiceTier({
+        error: recovered,
+        model,
+        serviceTier,
+      })
+    ) {
+      throw recovered;
     }
 
-    return await run("standard");
+    return await withStandardServiceTierFallback({
+      model,
+      run,
+      serviceTier: "standard",
+    });
   }
 };
 
@@ -604,6 +622,39 @@ const tanStackRunError = (chunk: RunErrorEvent): HandlerError => {
     ...(chunk.code ? { code: chunk.code } : {}),
     ...(cause === undefined ? {} : { cause }),
   });
+};
+
+/**
+ * The same recovery as {@link tanStackRunError}, for the seam that does not
+ * stream.
+ *
+ * `chat({ outputSchema })` never yields the run error to its caller: it rebuilds
+ * it as `new Error(message)`, keeping the event's `code` only when the adapter
+ * set one and dropping its `rawEvent`. An adapter that reports the status as a
+ * plain field on its SDK exception and stringifies the response body into the
+ * message sets neither, so the rebuilt error reaches `classifyAIError` with no
+ * status at all and quota, billing, retired model and outage all read as one
+ * unnamed transport failure, while the identical provider answer classifies
+ * once streamed. Recover the body here so one answer is named one way
+ * whichever seam asked for it.
+ *
+ * The error passes through untouched unless the recovered body actually names
+ * the failure, so an engine-internal error keeps its own identity.
+ */
+const withRecoveredProviderStatus = (error: unknown): unknown => {
+  if (!(error instanceof Error) || classifyAIError(error) !== "unknown") {
+    return error;
+  }
+  const cause = providerErrorBody(error.message);
+  if (cause === undefined) {
+    return error;
+  }
+  const recovered = new HandlerError({
+    status: 502,
+    message: error.message,
+    cause,
+  });
+  return classifyAIError(recovered) === "unknown" ? error : recovered;
 };
 
 const shouldRetryWithStandardServiceTier = ({


### PR DESCRIPTION
## Proposed change

`chat({ outputSchema })` does not hand the caller the adapter's run error. It rebuilds it as `new Error(message)`, keeping the event's `code` only when the adapter set one and dropping its `rawEvent`. An adapter whose SDK exception reports the status as a plain field and stringifies the response body into the message sets neither, so the rebuilt error reaches `classifyAIError` with no status at all: quota, billing, a retired model and an outage all read as one unnamed transport failure, and `isAnticipatedAIFailure` grades each of them a defect rather than the operational state it is.

`tanStackRunError` already recovers that body from the message on the streaming seam. This applies the same recovery to the seam that does not stream, so one provider answer is named one way whichever seam asked for it.

The recovery sits in `withStandardServiceTierFallback`, the failed run's only exit. That also revives the deferred-tier retry: `shouldRetryWithStandardServiceTier` reads a status off the cause chain, so today a fallback the provider's own status justifies is skipped for want of a status the message still carries. The standard-tier attempt answers through that same function (`isDeferredServiceTier("standard")` is false, so it takes the throw), which keeps both attempts recovered without a second exit to hold in step.

The wrap stands only when the recovered body actually names the failure, so an engine-internal error (a finalization that produced no result, a schema validation failure) keeps its own identity.

### Tests

Two cases on the object seam, mirroring the pair the text seam already carries:

- a provider failure whose only detail is the response body classifies (`quota_exhausted`, and anticipated);
- a plain-text provider failure stays `unknown` and keeps the engine's own wrapper rather than gaining a 502 that claims a status it never had.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HAyFsTd4VVMt6bBKVEcJ8X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of AI provider errors when quota or rate limits are exceeded.
  - Provider responses with structured error details are now classified more accurately, with clearer status reporting.
  - Preserved the underlying provider error for unexpected failures, improving diagnostic information.
  - Standard fallback behaviour now responds more reliably when service-tier requests encounter provider errors.
  - Unattributed provider failures can now be retried on the standard service tier where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->