### PR TITLE
fix(api): classify a document review's model failure instead of answering 500

### DIFF
--- a/apps/api/src/handlers/document-reviews/parties.test.ts
+++ b/apps/api/src/handlers/document-reviews/parties.test.ts
@@ -1,17 +1,27 @@
 /**
  * The launcher's first-screen call: a document version that already has a
  * cached party detection answers from that row alone, with no model call and
- * no write.
+ * no write; a version that does not reaches the model, and a provider failure
+ * there answers with the status that names it rather than an opaque 500.
  */
 
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
+import type { OrgAIConfig } from "@/api/lib/ai-config";
 import { toSafeId } from "@/api/lib/branded-types";
+import type { detectReviewParties } from "@/api/lib/document-review/parties";
+import type { fetchAndPrepareReviewFiles } from "@/api/lib/document-review/prepare-review-files";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import {
+  modelStepFailure,
+  PROVIDER_FAILURE_CASES,
+} from "@/api/tests/helpers/provider-failure-cases";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-import reviewParties from "./parties";
+import reviewParties, { createReviewParties } from "./parties";
 
 type ReviewPartiesCtx = Parameters<typeof reviewParties.handler>[0];
 
@@ -51,7 +61,20 @@ const cachedParties = [
   { role: "Seller", name: null },
 ];
 
-const createHarness = () => {
+/** A BYOK org whose `pdf` role resolves, so the availability guard passes. */
+const orgAIConfig = {
+  providers: [{ provider: "openai", apiKey: "test-api-key" }],
+  overrideModels: {
+    chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+    fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+    pdf: { provider: "openai", modelId: "gpt-5.4" },
+    reasoning: { provider: "openai", modelId: "gpt-5.4" },
+  },
+} satisfies OrgAIConfig;
+
+const createHarness = ({
+  cachedRows = [{ parties: cachedParties }],
+}: { cachedRows?: { parties: unknown }[] } = {}) => {
   let insertCalled = false;
   const { safeDb, scopedDb } = createScopedDbMock({
     query: {
@@ -60,7 +83,7 @@ const createHarness = () => {
     select: () => ({
       from: () => ({
         where: () => ({
-          limit: async () => [{ parties: cachedParties }],
+          limit: async () => cachedRows,
         }),
       }),
     }),
@@ -70,9 +93,8 @@ const createHarness = () => {
     },
   });
 
-  const context = asTestRaw<ReviewPartiesCtx>({
+  const context = createTestHandlerContext<ReviewPartiesCtx>({
     body: { target: { entityId: ENTITY_ID, fileFieldId: FIELD_ID } },
-    memberRole: { role: "owner" },
     workspaceId: WORKSPACE_ID,
     safeDb,
     scopedDb,
@@ -80,12 +102,22 @@ const createHarness = () => {
       activeOrganizationId: toSafeId<"organization">("org_test_parties"),
     },
     user: { id: USER_ID },
-    orgAIConfig: null,
+    orgAIConfig,
     promptCachingEnabled: false,
   });
 
   return { context, insertCalled: () => insertCalled };
 };
+
+/** A prepared DOCX target: the detection fake never reads it. */
+const prepareReviewFilesFake = asTestRaw<typeof fetchAndPrepareReviewFiles>(
+  async () => await Promise.resolve([{ kind: "docx" }]),
+);
+
+const partiesFailingWith = (cause: unknown): typeof detectReviewParties =>
+  asTestRaw<typeof detectReviewParties>(
+    async () => await Promise.resolve(Result.err(modelStepFailure(cause))),
+  );
 
 describe("reviewParties", () => {
   test("answers from the cached row without a model call or a write", async () => {
@@ -99,4 +131,25 @@ describe("reviewParties", () => {
     });
     expect(insertCalled()).toBe(false);
   });
+
+  for (const { cause, message, name, status } of PROVIDER_FAILURE_CASES) {
+    test(`answers ${name} with the status that names it`, async () => {
+      const { context, insertCalled } = createHarness({ cachedRows: [] });
+      const handler = createReviewParties({
+        detectParties: partiesFailingWith(cause),
+        prepareReviewFiles: prepareReviewFilesFake,
+      });
+
+      const result = await handler.handler(context);
+
+      if (!("code" in result)) {
+        throw new Error("Expected the provider failure to return a status");
+      }
+      expect(result.code).toBe(status);
+      expect(result.response).toMatchObject({ message });
+      // A failed detection has nothing to cache: the row would answer every
+      // later call for this version with a result no model produced.
+      expect(insertCalled()).toBe(false);
+    });
+  }
 });

--- a/apps/api/src/handlers/document-reviews/parties.ts
+++ b/apps/api/src/handlers/document-reviews/parties.ts
@@ -46,168 +46,177 @@ const config = {
   body: documentReviewPartiesBodySchema,
 } satisfies HandlerConfig;
 
-const reviewParties = createSafeHandler(
-  config,
-  async function* ({
-    safeDb,
-    workspaceId,
-    body,
-    session,
-    orgAIConfig,
-    orgAIConfigStatus,
-    promptCachingEnabled,
-    user,
-  }) {
-    const organizationId = session.activeOrganizationId;
-    const targetRef = { ...body.target, workspaceId };
+export const createReviewParties = ({
+  detectParties = detectReviewParties,
+  prepareReviewFiles = fetchAndPrepareReviewFiles,
+}: {
+  /** External model-dispatch boundary; supplied by focused handler tests. */
+  detectParties?: typeof detectReviewParties | undefined;
+  /** External file-store boundary; supplied by focused handler tests. */
+  prepareReviewFiles?: typeof fetchAndPrepareReviewFiles | undefined;
+} = {}) =>
+  createSafeHandler(
+    config,
+    async function* ({
+      safeDb,
+      workspaceId,
+      body,
+      session,
+      orgAIConfig,
+      orgAIConfigStatus,
+      promptCachingEnabled,
+      user,
+    }) {
+      const organizationId = session.activeOrganizationId;
+      const targetRef = { ...body.target, workspaceId };
 
-    const loadedEntities = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.entities.findMany({
-          where: { id: { in: [targetRef.entityId] } },
-          columns: { id: true, workspaceId: true },
-          limit: 1,
-          with: {
-            currentVersion: {
-              columns: { id: true },
-              with: {
-                fields: { columns: { id: true, content: true } },
+      const loadedEntities = yield* Result.await(
+        safeDb((tx) =>
+          tx.query.entities.findMany({
+            where: { id: { in: [targetRef.entityId] } },
+            columns: { id: true, workspaceId: true },
+            limit: 1,
+            with: {
+              currentVersion: {
+                columns: { id: true },
+                with: {
+                  fields: { columns: { id: true, content: true } },
+                },
               },
             },
-          },
-        }),
-      ),
-    );
-    const selection = resolveReviewSelection({
-      target: targetRef,
-      references: [],
-      entities: loadedEntities,
-    });
-    if (Result.isError(selection)) {
-      return Result.err(selection.error);
-    }
-    const { entityId, entityVersionId, file } = selection.value.target;
+          }),
+        ),
+      );
+      const selection = resolveReviewSelection({
+        target: targetRef,
+        references: [],
+        entities: loadedEntities,
+      });
+      if (Result.isError(selection)) {
+        return Result.err(selection.error);
+      }
+      const { entityId, entityVersionId, file } = selection.value.target;
 
-    const cached = yield* Result.await(
-      safeDb((tx) =>
-        tx
-          .select({ parties: documentReviewParties.parties })
-          .from(documentReviewParties)
-          .where(
-            and(
-              eq(documentReviewParties.workspaceId, workspaceId),
-              eq(documentReviewParties.entityVersionId, entityVersionId),
-              eq(
-                documentReviewParties.promptVersion,
-                REVIEW_PARTIES_PROMPT_VERSION,
+      const cached = yield* Result.await(
+        safeDb((tx) =>
+          tx
+            .select({ parties: documentReviewParties.parties })
+            .from(documentReviewParties)
+            .where(
+              and(
+                eq(documentReviewParties.workspaceId, workspaceId),
+                eq(documentReviewParties.entityVersionId, entityVersionId),
+                eq(
+                  documentReviewParties.promptVersion,
+                  REVIEW_PARTIES_PROMPT_VERSION,
+                ),
               ),
-            ),
-          )
-          .limit(1),
-      ),
-    );
-    const cachedRow = cached.at(0);
-    if (cachedRow !== undefined) {
-      return Result.ok({ entityVersionId, parties: cachedRow.parties });
-    }
+            )
+            .limit(1),
+        ),
+      );
+      const cachedRow = cached.at(0);
+      if (cachedRow !== undefined) {
+        return Result.ok({ entityVersionId, parties: cachedRow.parties });
+      }
 
-    yield* requireTanStackAIAvailableForRole({
-      configStatus: orgAIConfigStatus,
-      orgConfig: orgAIConfig,
-      role: "pdf",
-    });
+      yield* requireTanStackAIAvailableForRole({
+        configStatus: orgAIConfigStatus,
+        orgConfig: orgAIConfig,
+        role: "pdf",
+      });
 
-    const preflightError = await assertUsageAvailableForHandler({
-      metering: { actionType: "chat", modelRole: "pdf" },
-      organizationId,
-      orgAIConfig,
-      workspaceId,
-      userId: user.id,
-      safeDb,
-    });
-    if (preflightError) {
-      return Result.err(preflightError);
-    }
-
-    const preparedResult = await Result.tryPromise({
-      try: async () => await fetchAndPrepareReviewFiles([file], organizationId),
-      catch: (cause) =>
-        new HandlerError({
-          status: 500,
-          message: "Internal server error",
-          cause,
-        }),
-    });
-    if (Result.isError(preparedResult)) {
-      return Result.err(preparedResult.error);
-    }
-    const target = preparedResult.value.at(0);
-    if (target?.kind !== "docx") {
-      return panic("DOCX review target was not prepared as DOCX blocks");
-    }
-
-    const serviceTier = "standard" as const;
-    const detected = await detectReviewParties({
-      target,
-      targetEntityVersionId: entityVersionId,
-      organizationId,
-      workspaceId,
-      orgAIConfig,
-      promptCachingEnabled,
-      serviceTier,
-      usageMetering: {
-        actionType: "chat",
+      const preflightError = await assertUsageAvailableForHandler({
+        metering: { actionType: "chat", modelRole: "pdf" },
         organizationId,
-        safeDb,
-        serviceTier,
-        userId: user.id,
+        orgAIConfig,
         workspaceId,
-      },
-      abortSignal: AbortSignal.timeout(TIMEOUT_MS),
-    });
-    if (Result.isError(detected)) {
-      // `WorkflowIntegrationError.cause` carries the provider's own failure —
-      // classify against that so an exhausted quota or a rejected key answers
-      // with the status that names it instead of an opaque 500.
-      return Result.err(
-        aiHandlerError(detected.error.cause, {
-          status: 502,
-          message: "Party detection failed",
+        userId: user.id,
+        safeDb,
+      });
+      if (preflightError) {
+        return Result.err(preflightError);
+      }
+
+      const preparedResult = await Result.tryPromise({
+        try: async () => await prepareReviewFiles([file], organizationId),
+        catch: (cause) =>
+          new HandlerError({
+            status: 500,
+            message: "Internal server error",
+            cause,
+          }),
+      });
+      if (Result.isError(preparedResult)) {
+        return Result.err(preparedResult.error);
+      }
+      const target = preparedResult.value.at(0);
+      if (target?.kind !== "docx") {
+        return panic("DOCX review target was not prepared as DOCX blocks");
+      }
+
+      const serviceTier = "standard" as const;
+      const detected = await detectParties({
+        target,
+        targetEntityVersionId: entityVersionId,
+        organizationId,
+        workspaceId,
+        orgAIConfig,
+        promptCachingEnabled,
+        serviceTier,
+        usageMetering: {
+          actionType: "chat",
+          organizationId,
+          safeDb,
+          serviceTier,
+          userId: user.id,
+          workspaceId,
+        },
+        abortSignal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+      if (Result.isError(detected)) {
+        // `WorkflowIntegrationError.cause` carries the provider's own failure —
+        // classify against that so an exhausted quota or a rejected key answers
+        // with the status that names it instead of an opaque 500.
+        return Result.err(
+          aiHandlerError(detected.error.cause, {
+            status: 502,
+            message: "Party detection failed",
+          }),
+        );
+      }
+      const parties = detected.value;
+
+      yield* Result.await(
+        safeDb(async (tx) => {
+          // audit: skip — derived AI cache keyed by entity version;
+          // recomputable from the document's current content, never surfaces
+          // as an audited mutation on its own.
+          await tx
+            .insert(documentReviewParties)
+            .values({
+              id: createSafeId<"documentReviewParty">(),
+              organizationId,
+              workspaceId,
+              entityId,
+              entityVersionId,
+              promptVersion: REVIEW_PARTIES_PROMPT_VERSION,
+              parties,
+              createdAt: new Date(),
+            })
+            .onConflictDoUpdate({
+              target: documentReviewParties.entityVersionId,
+              set: {
+                promptVersion: sql`excluded.prompt_version`,
+                parties: sql`excluded.parties`,
+                createdAt: sql`excluded.created_at`,
+              },
+            });
         }),
       );
-    }
-    const parties = detected.value;
 
-    yield* Result.await(
-      safeDb(async (tx) => {
-        // audit: skip — derived AI cache keyed by entity version;
-        // recomputable from the document's current content, never surfaces
-        // as an audited mutation on its own.
-        await tx
-          .insert(documentReviewParties)
-          .values({
-            id: createSafeId<"documentReviewParty">(),
-            organizationId,
-            workspaceId,
-            entityId,
-            entityVersionId,
-            promptVersion: REVIEW_PARTIES_PROMPT_VERSION,
-            parties,
-            createdAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: documentReviewParties.entityVersionId,
-            set: {
-              promptVersion: sql`excluded.prompt_version`,
-              parties: sql`excluded.parties`,
-              createdAt: sql`excluded.created_at`,
-            },
-          });
-      }),
-    );
+      return Result.ok({ entityVersionId, parties });
+    },
+  );
 
-    return Result.ok({ entityVersionId, parties });
-  },
-);
-
-export default reviewParties;
+export default createReviewParties();

--- a/apps/api/src/handlers/document-reviews/parties.ts
+++ b/apps/api/src/handlers/document-reviews/parties.ts
@@ -16,6 +16,7 @@ import { t } from "elysia";
 import { documentReviewParties } from "@/api/db/schema";
 import { resolveReviewSelection } from "@/api/handlers/document-reviews/review-selection";
 import { documentReviewTargetSchema } from "@/api/handlers/document-reviews/schemas";
+import { aiHandlerError } from "@/api/lib/ai-error";
 import {
   assertUsageAvailableForHandler,
   createSafeHandler,
@@ -165,11 +166,13 @@ const reviewParties = createSafeHandler(
       abortSignal: AbortSignal.timeout(TIMEOUT_MS),
     });
     if (Result.isError(detected)) {
+      // `WorkflowIntegrationError.cause` carries the provider's own failure —
+      // classify against that so an exhausted quota or a rejected key answers
+      // with the status that names it instead of an opaque 500.
       return Result.err(
-        new HandlerError({
-          status: 500,
-          message: "Internal server error",
-          cause: detected.error,
+        aiHandlerError(detected.error.cause, {
+          status: 502,
+          message: "Party detection failed",
         }),
       );
     }

--- a/apps/api/src/handlers/document-reviews/propose-positions.test.ts
+++ b/apps/api/src/handlers/document-reviews/propose-positions.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The proposal call's model failure. The endpoint's own preparation and model
+ * steps are injected, so what runs here is the branch that turns the step's
+ * `WorkflowIntegrationError` into an answer: a provider that refused for a
+ * reason the caller can act on must not arrive as an opaque 500.
+ */
+
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import type { prepareReferenceProposal } from "@/api/handlers/document-reviews/prepare-proposal";
+import type { proposeReferencePositions } from "@/api/handlers/document-reviews/reference-positions";
+import { toSafeId } from "@/api/lib/branded-types";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import {
+  modelStepFailure,
+  PROVIDER_FAILURE_CASES,
+} from "@/api/tests/helpers/provider-failure-cases";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+import type proposePositions from "./propose-positions";
+import { createProposePositions } from "./propose-positions";
+
+type ProposePositionsCtx = Parameters<typeof proposePositions.handler>[0];
+
+const WORKSPACE_ID = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000001",
+);
+const ENTITY_ID = toSafeId<"entity">("00000000-0000-0000-0000-000000000002");
+const ENTITY_VERSION_ID = toSafeId<"entityVersion">(
+  "00000000-0000-0000-0000-000000000003",
+);
+const FIELD_ID = toSafeId<"field">("00000000-0000-0000-0000-000000000004");
+const REFERENCE_ENTITY_ID = toSafeId<"entity">(
+  "00000000-0000-0000-0000-000000000006",
+);
+
+const body = {
+  target: { entityId: ENTITY_ID, fileFieldId: FIELD_ID },
+  references: [{ entityId: REFERENCE_ENTITY_ID, fileFieldId: FIELD_ID }],
+  seededPositions: [],
+  perspective: { role: "Purchaser", name: "Example Holdings a.s." },
+};
+
+/**
+ * Preparation succeeds: the failure under test is the model step's, and a
+ * request that never reached a provider would not exercise the branch.
+ */
+const prepareProposalFake = asTestRaw<typeof prepareReferenceProposal>(
+  async function* () {
+    return Result.ok({
+      target: { kind: "docx" },
+      references: [],
+      targetEntityVersionId: ENTITY_VERSION_ID,
+    });
+  },
+);
+
+const proposalFailingWith = (
+  cause: unknown,
+): typeof proposeReferencePositions =>
+  asTestRaw<typeof proposeReferencePositions>(
+    async () => await Promise.resolve(Result.err(modelStepFailure(cause))),
+  );
+
+describe("proposePositions", () => {
+  for (const { cause, message, name, status } of PROVIDER_FAILURE_CASES) {
+    test(`answers ${name} with the status that names it`, async () => {
+      const handler = createProposePositions({
+        prepareProposal: prepareProposalFake,
+        proposePositions: proposalFailingWith(cause),
+      });
+
+      const result = await handler.handler(
+        createTestHandlerContext<ProposePositionsCtx>({
+          body,
+          workspaceId: WORKSPACE_ID,
+        }),
+      );
+
+      if (!("code" in result)) {
+        throw new Error("Expected the provider failure to return a status");
+      }
+      expect(result.code).toBe(status);
+      expect(result.response).toMatchObject({ message });
+    });
+  }
+});

--- a/apps/api/src/handlers/document-reviews/propose-positions.ts
+++ b/apps/api/src/handlers/document-reviews/propose-positions.ts
@@ -21,80 +21,89 @@ const config = {
   body: proposeReviewPositionsBodySchema,
 } satisfies HandlerConfig;
 
-const proposePositions = createSafeHandler(
-  config,
-  async function* ({
-    safeDb,
-    workspaceId,
-    body,
-    session,
-    orgAIConfig,
-    orgAIConfigStatus,
-    promptCachingEnabled,
-    user,
-  }) {
-    const organizationId = session.activeOrganizationId;
-    const prepared = yield* yield* prepareReferenceProposal({
+export const createProposePositions = ({
+  prepareProposal = prepareReferenceProposal,
+  proposePositions = proposeReferencePositions,
+}: {
+  /** External document-preparation boundary; supplied by focused handler tests. */
+  prepareProposal?: typeof prepareReferenceProposal | undefined;
+  /** External model-dispatch boundary; supplied by focused handler tests. */
+  proposePositions?: typeof proposeReferencePositions | undefined;
+} = {}) =>
+  createSafeHandler(
+    config,
+    async function* ({
+      safeDb,
+      workspaceId,
       body,
+      session,
       orgAIConfig,
       orgAIConfigStatus,
-      organizationId,
-      safeDb,
-      userId: user.id,
-      workspaceId,
-    });
-
-    const serviceTier = "standard" as const;
-    const proposal = await proposeReferencePositions({
-      target: prepared.target,
-      references: prepared.references,
-      seededPositions: body.seededPositions,
-      perspective: body.perspective,
-      positionsMax: DOCUMENT_REVIEW_LIMITS.positionsMax,
-      targetEntityVersionId: prepared.targetEntityVersionId,
-      organizationId,
-      workspaceId,
-      orgAIConfig,
       promptCachingEnabled,
-      serviceTier,
-      usageMetering: {
-        actionType: "chat",
+      user,
+    }) {
+      const organizationId = session.activeOrganizationId;
+      const prepared = yield* yield* prepareProposal({
+        body,
+        orgAIConfig,
+        orgAIConfigStatus,
         organizationId,
         safeDb,
-        serviceTier,
         userId: user.id,
         workspaceId,
-      },
-      abortSignal: AbortSignal.timeout(TIMEOUT_MS),
-    });
-    if (Result.isError(proposal)) {
-      // `WorkflowIntegrationError.cause` carries the provider's own failure —
-      // classify against that so an exhausted quota or a rejected key answers
-      // with the status that names it instead of an opaque 500.
-      return Result.err(
-        aiHandlerError(proposal.error.cause, {
-          status: 502,
-          message: "Position proposal failed",
-        }),
-      );
-    }
-    // The words leave through their own rows, never through this answer: the
-    // proposed positions are pinned first and answered as ids. Seeds lead the
-    // list, as the caller already holds them.
-    const pinned = yield* Result.await(
-      safeDb(
-        async (tx) =>
-          await pinProposedPositions(tx, {
-            organizationId,
-            positions: proposal.value.positions,
-          }),
-      ),
-    );
-    return Result.ok({
-      ...proposal.value,
-      positions: [...body.seededPositions, ...pinned],
-    });
-  },
-);
+      });
 
-export default proposePositions;
+      const serviceTier = "standard" as const;
+      const proposal = await proposePositions({
+        target: prepared.target,
+        references: prepared.references,
+        seededPositions: body.seededPositions,
+        perspective: body.perspective,
+        positionsMax: DOCUMENT_REVIEW_LIMITS.positionsMax,
+        targetEntityVersionId: prepared.targetEntityVersionId,
+        organizationId,
+        workspaceId,
+        orgAIConfig,
+        promptCachingEnabled,
+        serviceTier,
+        usageMetering: {
+          actionType: "chat",
+          organizationId,
+          safeDb,
+          serviceTier,
+          userId: user.id,
+          workspaceId,
+        },
+        abortSignal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+      if (Result.isError(proposal)) {
+        // `WorkflowIntegrationError.cause` carries the provider's own failure —
+        // classify against that so an exhausted quota or a rejected key answers
+        // with the status that names it instead of an opaque 500.
+        return Result.err(
+          aiHandlerError(proposal.error.cause, {
+            status: 502,
+            message: "Position proposal failed",
+          }),
+        );
+      }
+      // The words leave through their own rows, never through this answer: the
+      // proposed positions are pinned first and answered as ids. Seeds lead the
+      // list, as the caller already holds them.
+      const pinned = yield* Result.await(
+        safeDb(
+          async (tx) =>
+            await pinProposedPositions(tx, {
+              organizationId,
+              positions: proposal.value.positions,
+            }),
+        ),
+      );
+      return Result.ok({
+        ...proposal.value,
+        positions: [...body.seededPositions, ...pinned],
+      });
+    },
+  );
+
+export default createProposePositions();

--- a/apps/api/src/handlers/document-reviews/propose-positions.ts
+++ b/apps/api/src/handlers/document-reviews/propose-positions.ts
@@ -5,10 +5,10 @@ import { DOCUMENT_REVIEW_LIMITS } from "@stll/api-contract";
 import { prepareReferenceProposal } from "@/api/handlers/document-reviews/prepare-proposal";
 import { proposeReferencePositions } from "@/api/handlers/document-reviews/reference-positions";
 import { proposeReviewPositionsBodySchema } from "@/api/handlers/document-reviews/schemas";
+import { aiHandlerError } from "@/api/lib/ai-error";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { pinProposedPositions } from "@/api/lib/document-review/reference-passages";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 const TIMEOUT_MS = 120_000;
 
@@ -68,11 +68,13 @@ const proposePositions = createSafeHandler(
       abortSignal: AbortSignal.timeout(TIMEOUT_MS),
     });
     if (Result.isError(proposal)) {
+      // `WorkflowIntegrationError.cause` carries the provider's own failure —
+      // classify against that so an exhausted quota or a rejected key answers
+      // with the status that names it instead of an opaque 500.
       return Result.err(
-        new HandlerError({
-          status: 500,
-          message: "Internal server error",
-          cause: proposal.error,
+        aiHandlerError(proposal.error.cause, {
+          status: 502,
+          message: "Position proposal failed",
         }),
       );
     }

--- a/apps/api/src/tests/helpers/provider-failure-cases.ts
+++ b/apps/api/src/tests/helpers/provider-failure-cases.ts
@@ -1,0 +1,70 @@
+/**
+ * Provider failures a handler has to name, with the answer each one owes.
+ *
+ * Shared because more than one endpoint maps the same `WorkflowIntegrationError`
+ * cause through `aiHandlerError`. A per-file copy of this table agrees with the
+ * mapping right up to the day one endpoint's copy is updated and the other's is
+ * not, which is the divergence the mapping exists to prevent.
+ *
+ * The status and the copy are written out rather than read back from
+ * `aiHandlerError`: a test that asks the mapping what the mapping does passes
+ * whatever the mapping says.
+ */
+
+import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
+
+export type ProviderFailureCase = {
+  /** Reads into the test name: "answers <name> with the status that names it". */
+  name: string;
+  /** The provider's own failure, in the shape an adapter surfaces it. */
+  cause: unknown;
+  status: number;
+  message: string;
+};
+
+export const PROVIDER_FAILURE_CASES = [
+  {
+    name: "an exhausted quota",
+    cause: Object.assign(new Error("Rate limit reached for requests"), {
+      statusCode: 429,
+    }),
+    status: 429,
+    message:
+      "The AI provider's quota is exhausted. Try again shortly, or contact your workspace admin.",
+  },
+  {
+    name: "an upstream billing stop",
+    cause: Object.assign(new Error("Insufficient credit balance"), {
+      statusCode: 402,
+    }),
+    status: 402,
+    message:
+      "The AI provider reported a billing or credit problem. An administrator should check the provider account.",
+  },
+  {
+    // The response body alone, with no status: how a provider's rejected key
+    // reaches the classifier when the adapter cannot preserve the 401.
+    name: "a rejected credential",
+    cause: {
+      error: {
+        code: "invalid_api_key",
+        message: "Incorrect API key provided.",
+        type: "invalid_request_error",
+      },
+    },
+    status: 502,
+    message:
+      "The AI provider rejected the configured credentials. An administrator should check the provider API key in organization settings.",
+  },
+] as const satisfies readonly ProviderFailureCase[];
+
+/**
+ * The failure a document-review model step returns: the step's own error, with
+ * the provider's underneath it. Reading the cause is the whole point of the
+ * classification, so the fixture must be caused rather than bare.
+ */
+export const modelStepFailure = (cause: unknown): WorkflowIntegrationError =>
+  new WorkflowIntegrationError({
+    message: "The model step did not complete",
+    cause,
+  });


### PR DESCRIPTION
## Proposed change

`document-reviews/parties` and `document-reviews/propose-positions` turn any failure of their model call into a flat `500 Internal server error`. Both receive a `WorkflowIntegrationError` whose `cause` is the provider's own failure, and both discard it, so an exhausted provider quota, a billing problem and a rejected API key all reach the caller as the same unattributable server fault, with no message the caller can act on.

`aiHandlerError` (`apps/api/src/lib/ai-error.ts`) exists for this: it maps the known kinds to 429, 402 and 502 with a message naming what to do about each, and returns the caller's own fallback for a shape it does not recognise, so an unrelated bug is not masked as "AI unavailable". The other handlers that answer a model failure with a status classify through it; these two are the exceptions.

Both now classify against `WorkflowIntegrationError.cause`, with 502 as the fallback so an upstream failure is no longer reported as a fault in this service, matching `properties/preview` and `workspaces/generate-bounding-boxes`.

The streaming sibling `propose-positions-stream` is unaffected: everything it can refuse is decided before the response starts, and a failure once bytes are flowing arrives as a stream event rather than a status.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DPbT9ko7smoExfKpALNmzc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when party detection fails, including clearer provider-related failure details.
  - Improved error reporting when position proposals fail, replacing generic server errors with more informative responses.
  - These failures now return the appropriate gateway error status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->