### PR TITLE
fix(api): keep a CJEU cell's own text when it sits beside an element

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
@@ -661,6 +661,8 @@ describe("parseEcjDecisionHtml", () => {
       "text around a paragraph": `${loose("before")} <p class="coj-normal">block</p> ${loose("after")}`,
       "text around a nested table": `${loose("before")} <table><tr><td><p>nested</p></td></tr></table> ${loose("after")}`,
       "text around an unknown element": `${loose("before")} <section>other</section> ${loose("after")}`,
+      "text across a break": `${loose("above")}<br>${loose("below")}`,
+      "spans across a break": `<span class="coj-italic">${loose("above")}</span><br><span class="coj-italic">${loose("below")}</span>`,
     };
 
     const rows = Object.values(arrangements)
@@ -676,7 +678,7 @@ describe("parseEcjDecisionHtml", () => {
       "</div></body></html>",
     ].join("");
 
-    const { fulltext, validationIssues } = parseEcjDecisionHtml({
+    const { documentAst, fulltext, validationIssues } = parseEcjDecisionHtml({
       caseNumber: "C-1/00",
       ecli: undefined,
       court: "Court of Justice",
@@ -696,6 +698,20 @@ describe("parseEcjDecisionHtml", () => {
     expect(dropped.map(([name]) => name)).toEqual([]);
     expect(validationIssues).not.toContain("CONTENT_LOSS");
     expect(validationIssues).not.toContain("MISSING_WORDS");
+
+    // `<br>` is the tag whose meaning is not in its contents, so a
+    // walker that reads contents sees nothing in it and the lines on
+    // either side weld into one word. Both arrangements keep the break:
+    // one paragraph per cell, the two lines still apart inside it.
+    const acrossABreak = documentAst.blocks.filter((block) =>
+      block.plainText.includes(loose("above")),
+    );
+    expect(acrossABreak).toHaveLength(2);
+    for (const block of acrossABreak) {
+      expect(block.plainText).toMatch(
+        /loose-above content\s*\n\s*loose-below content/u,
+      );
+    }
   });
 
   test("reads the keyword chain in a non-Latin script", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
@@ -647,6 +647,57 @@ describe("parseEcjDecisionHtml", () => {
     expect(missing).toEqual([]);
   });
 
+  test("keeps a cell's own text however it is arranged around its elements", () => {
+    // Cellar writes a quoted entry as loose text around the spans that
+    // emphasize part of it, so a cell's text and its elements interleave
+    // in every order. The text is the cell's content just as much as the
+    // elements are, and no arrangement may drop it.
+    const loose = (position: string) => `loose-${position} content`;
+    const arrangements = {
+      "text only": loose("only"),
+      "text then span": `${loose("before")} <span class="coj-italic">emph</span>`,
+      "span then text": `<span class="coj-italic">emph</span> ${loose("after")}`,
+      "text around a span": `${loose("before")} <span class="coj-italic">emph</span> ${loose("after")}`,
+      "text around a paragraph": `${loose("before")} <p class="coj-normal">block</p> ${loose("after")}`,
+      "text around a nested table": `${loose("before")} <table><tr><td><p>nested</p></td></tr></table> ${loose("after")}`,
+      "text around an unknown element": `${loose("before")} <section>other</section> ${loose("after")}`,
+    };
+
+    const rows = Object.values(arrangements)
+      .map(
+        (cell, index) =>
+          `<tr><td><span class="coj-count" id="point${index + 1}">${index + 1}</span></td><td>${cell}</td></tr>`,
+      )
+      .join("");
+    const html = [
+      "<html><body><div class='coj-normal' lang='en'>",
+      "<p class='coj-sum-title-1'>JUDGMENT OF THE COURT</p>",
+      `<table>${rows}</table>`,
+      "</div></body></html>",
+    ].join("");
+
+    const { fulltext, validationIssues } = parseEcjDecisionHtml({
+      caseNumber: "C-1/00",
+      ecli: undefined,
+      court: "Court of Justice",
+      decisionDate: undefined,
+      decisionType: undefined,
+      sourceUrl: undefined,
+      celex: "62000CJ0001",
+      html,
+    });
+
+    const dropped = Object.entries(arrangements).filter(
+      ([, cell]) =>
+        !(cell.match(/loose-\w+ content/gu) ?? []).every((text) =>
+          fulltext.includes(text),
+        ),
+    );
+    expect(dropped.map(([name]) => name)).toEqual([]);
+    expect(validationIssues).not.toContain("CONTENT_LOSS");
+    expect(validationIssues).not.toContain("MISSING_WORDS");
+  });
+
   test("reads the keyword chain in a non-Latin script", async () => {
     const html = await readFixture("62022CJ0128.el.html.gz");
     if (html === undefined) {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
@@ -663,6 +663,9 @@ describe("parseEcjDecisionHtml", () => {
       "text around an unknown element": `${loose("before")} <section>other</section> ${loose("after")}`,
       "text across a break": `${loose("above")}<br>${loose("below")}`,
       "spans across a break": `<span class="coj-italic">${loose("above")}</span><br><span class="coj-italic">${loose("below")}</span>`,
+      "text across an indented break": `${loose("above")} <br> ${loose("below")}`,
+      "text before trailing breaks": `${loose("edge")} <br> <br> `,
+      "text after leading breaks": ` <br> <br> ${loose("edge")}`,
     };
 
     const rows = Object.values(arrangements)
@@ -706,12 +709,83 @@ describe("parseEcjDecisionHtml", () => {
     const acrossABreak = documentAst.blocks.filter((block) =>
       block.plainText.includes(loose("above")),
     );
-    expect(acrossABreak).toHaveLength(2);
+    expect(acrossABreak).toHaveLength(3);
     for (const block of acrossABreak) {
       expect(block.plainText).toMatch(
         /loose-above content\s*\n\s*loose-below content/u,
       );
     }
+
+    // A break at an edge separates a line from nothing, and the source's
+    // indentation puts a blank text node on each side of it. Both are
+    // trivia: the paragraph opens and closes on its own words.
+    const atAnEdge = documentAst.blocks.filter((block) =>
+      block.plainText.includes(loose("edge")),
+    );
+    expect(atAnEdge).toHaveLength(2);
+    for (const block of atAnEdge) {
+      const inlines = hasBlockInlines(block) ? block.inlines : [];
+      expect(inlines).toEqual([{ type: "text", text: loose("edge") }]);
+      expect(block.plainText).toBe(loose("edge"));
+    }
+  });
+
+  test("anonymizes a cell's own text like the elements beside it", () => {
+    // `anon-block` marks content the publisher anonymized, and the flag
+    // covers everything inside the marked element. The cell walk starts
+    // below it, so a cell that carries the class has to seed the state
+    // itself or its loose text leaves the parser unmarked while the
+    // spans beside it are marked — the same text, protected or not by
+    // where the publisher happened to open a span.
+    const html = [
+      "<html><body><div class='coj-normal' lang='en'>",
+      "<p class='coj-sum-title-1'>JUDGMENT OF THE COURT</p>",
+      "<table><tr>",
+      `<td><span class="coj-count" id="point1">1</span></td>`,
+      `<td class="anon-block">applicant name <span class="coj-italic">and the mark</span> in the case</td>`,
+      "</tr></table>",
+      "</div></body></html>",
+    ].join("");
+
+    const { documentAst } = parseEcjDecisionHtml({
+      caseNumber: "C-1/00",
+      ecli: undefined,
+      court: "Court of Justice",
+      decisionDate: undefined,
+      decisionType: undefined,
+      sourceUrl: undefined,
+      celex: "62000CJ0001",
+      html,
+    });
+
+    const block = documentAst.blocks.find((candidate) =>
+      candidate.plainText.includes("applicant name"),
+    );
+    expect(block?.plainText).toBe("applicant name and the mark in the case");
+
+    const texts: Extract<Inline, { type: "text" }>[] = [];
+    const collectText = (inlines: readonly Inline[]): void => {
+      for (const inline of inlines) {
+        if (inline.type === "text") {
+          texts.push(inline);
+          continue;
+        }
+        if (hasInlineChildren(inline)) {
+          collectText(inline.children);
+        }
+      }
+    };
+    collectText(
+      block !== undefined && hasBlockInlines(block) ? block.inlines : [],
+    );
+
+    // The loose text is its own inline, so a flag carried only by the
+    // element beside it would leave the cell's own words unmarked.
+    expect(texts.length).toBeGreaterThan(1);
+    expect(texts.map((inline) => inline.text).join("")).toBe(
+      "applicant name and the mark in the case",
+    );
+    expect(texts.filter((inline) => inline.anonymized !== true)).toEqual([]);
   });
 
   test("reads the keyword chain in a non-Latin script", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
@@ -996,12 +996,12 @@ type CellContext =
  * Cellar's inline vocabulary inside a cell. Anything outside it opens a
  * block of its own, so each `<p class="coj-normal">` of a quoted passage
  * stays a separate paragraph and an unrecognised element keeps the
- * paragraph it used to get.
+ * paragraph it used to get. `<br>` is inline too, but it is empty and
+ * is handled before this set: see `visitCell`.
  */
 const INLINE_TAGS = new Set([
   "a",
   "b",
-  "br",
   "em",
   "i",
   "img",
@@ -1012,6 +1012,22 @@ const INLINE_TAGS = new Set([
   "sup",
   "u",
 ]);
+
+/**
+ * Drop the breaks at a run's edges. A break separates two lines, so one
+ * with nothing on the far side of it opens or closes the paragraph on an
+ * empty line — the whitespace `collapseWhitespace` trims, written as a
+ * tag. Nothing readable is lost: the break carries no text.
+ */
+const trimEdgeBreaks = (inlines: Inline[]): Inline[] => {
+  while (inlines[0]?.type === "line-break") {
+    inlines.shift();
+  }
+  while (inlines.at(-1)?.type === "line-break") {
+    inlines.pop();
+  }
+  return inlines;
+};
 
 const visitCell = (
   $: cheerio.CheerioAPI,
@@ -1030,7 +1046,7 @@ const visitCell = (
   // the loose run instead and close it whenever a block child starts.
   let run: Inline[] = [];
   const flushRun = (): void => {
-    const inlines = collapseWhitespace(run);
+    const inlines = trimEdgeBreaks(collapseWhitespace(run));
     run = [];
     const plainText = inlinesToPlainText(inlines).trim();
     if (!plainText) {
@@ -1065,6 +1081,16 @@ const visitCell = (
     if (tag === "div") {
       flushRun();
       visitCell($, builder, $child, undefined);
+      return;
+    }
+
+    // `walkInlines` reads a node's contents, and an empty element
+    // carries its meaning in the tag instead, so handing it a `<br>`
+    // yields nothing and welds the lines around the break together.
+    // Emit the break the walker emits for a `<br>` nested in a span,
+    // which keeps `A<br>B` two lines wherever the break sits.
+    if (tag === "br") {
+      run.push({ type: "line-break" });
       return;
     }
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
@@ -41,7 +41,7 @@
  */
 
 import * as cheerio from "cheerio";
-import { type AnyNode, type Element, isTag } from "domhandler";
+import { type AnyNode, type Element, isTag, isText } from "domhandler";
 
 import type {
   Block,
@@ -447,19 +447,18 @@ const classDepth = (
  * latter (`#fragment`) to text, which is what the reader wants: the
  * footnote targets are not part of the AST.
  */
+const ECJ_INLINE_OPTIONS = {
+  sanitizeHref: sanitizeUrl,
+  emphasisClasses: {
+    bold: [CLASS.bold, `${CLASS_PREFIX}${CLASS.bold}`],
+    italic: [CLASS.italic, `${CLASS_PREFIX}${CLASS.italic}`],
+  },
+};
+
 const walkEcjInlines = (
   $: cheerio.CheerioAPI,
   el: cheerio.Cheerio<AnyNode>,
-): Inline[] =>
-  collapseWhitespace(
-    walkInlines($, el, {
-      sanitizeHref: sanitizeUrl,
-      emphasisClasses: {
-        bold: [CLASS.bold, `${CLASS_PREFIX}${CLASS.bold}`],
-        italic: [CLASS.italic, `${CLASS_PREFIX}${CLASS.italic}`],
-      },
-    }),
-  );
+): Inline[] => collapseWhitespace(walkInlines($, el, ECJ_INLINE_OPTIONS));
 
 /**
  * The converter pretty-prints its output, so inline text arrives with
@@ -993,6 +992,27 @@ type CellContext =
   | { marker: string; number?: undefined }
   | undefined;
 
+/**
+ * Cellar's inline vocabulary inside a cell. Anything outside it opens a
+ * block of its own, so each `<p class="coj-normal">` of a quoted passage
+ * stays a separate paragraph and an unrecognised element keeps the
+ * paragraph it used to get.
+ */
+const INLINE_TAGS = new Set([
+  "a",
+  "b",
+  "br",
+  "em",
+  "i",
+  "img",
+  "small",
+  "span",
+  "strong",
+  "sub",
+  "sup",
+  "u",
+]);
+
 const visitCell = (
   $: cheerio.CheerioAPI,
   builder: BlockBuilder,
@@ -1001,21 +1021,61 @@ const visitCell = (
 ): void => {
   const before = builder.blocks.length;
   const signature = isSignature($, $cell);
-  const cellText = textOf($cell);
 
-  $cell.children().each((_, child) => {
+  // A cell mixes its own text with elements: Cellar writes a quoted
+  // entry as loose text around the spans that emphasize part of it.
+  // Walking `children()` alone reaches the elements and never the text
+  // between them, so that text was dropped whenever any element child
+  // produced a block — the one failure rule 10 does not allow. Collect
+  // the loose run instead and close it whenever a block child starts.
+  let run: Inline[] = [];
+  const flushRun = (): void => {
+    const inlines = collapseWhitespace(run);
+    run = [];
+    const plainText = inlinesToPlainText(inlines).trim();
+    if (!plainText) {
+      return;
+    }
+    pushParagraph(builder, {
+      ...roleOf(builder.zone, signature),
+      inlines,
+      plainText,
+    });
+  };
+
+  $cell.contents().each((_, child) => {
+    if (isText(child)) {
+      run.push({ type: "text", text: $(child).text() });
+      return;
+    }
+
+    if (!isTag(child)) {
+      return;
+    }
+
     const $child = $(child);
-    const tag = tagNameOf(child);
+    const tag = child.tagName.toLowerCase();
 
     if (tag === "table") {
+      flushRun();
       visitTable($, builder, $child);
       return;
     }
 
     if (tag === "div") {
+      flushRun();
       visitCell($, builder, $child, undefined);
       return;
     }
+
+    // Untrimmed: the run's edges are trimmed once, in `flushRun`, so a
+    // span's own leading space still separates it from the text before.
+    if (INLINE_TAGS.has(tag)) {
+      run.push(...walkInlines($, $child, ECJ_INLINE_OPTIONS));
+      return;
+    }
+
+    flushRun();
 
     // As in `visitChild`: anything else still contributes its text.
     const inlines = walkEcjInlines($, $child);
@@ -1031,15 +1091,7 @@ const visitCell = (
     });
   });
 
-  // A cell holding bare text rather than paragraphs would otherwise
-  // contribute nothing.
-  if (builder.blocks.length === before && cellText !== "") {
-    pushParagraph(builder, {
-      ...roleOf(builder.zone, signature),
-      inlines: [{ type: "text", text: cellText }],
-      plainText: cellText,
-    });
-  }
+  flushRun();
 
   const first = builder.blocks[before];
   if (!first || first.type !== "paragraph") {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
@@ -55,7 +55,13 @@ import { hasInlineChildren } from "@/api/handlers/case-law/document-ast";
 import { validateAndLog } from "@/api/lib/legal-search/parsers/validate-ast";
 import { sanitizeUrl } from "@/api/lib/sanitize-url";
 
-import { inlinesToPlainText, walkInlines } from "./shared-inlines";
+import {
+  ANONYMIZED_CLASS,
+  type WalkInlinesOptions,
+  appendTextInline,
+  inlinesToPlainText,
+  walkInlines,
+} from "./shared-inlines";
 
 // ── Public API ─────────────────────────────────────────────
 
@@ -458,7 +464,8 @@ const ECJ_INLINE_OPTIONS = {
 const walkEcjInlines = (
   $: cheerio.CheerioAPI,
   el: cheerio.Cheerio<AnyNode>,
-): Inline[] => collapseWhitespace(walkInlines($, el, ECJ_INLINE_OPTIONS));
+  options: WalkInlinesOptions = ECJ_INLINE_OPTIONS,
+): Inline[] => collapseWhitespace(walkInlines($, el, options));
 
 /**
  * The converter pretty-prints its output, so inline text arrives with
@@ -1014,16 +1021,23 @@ const INLINE_TAGS = new Set([
 ]);
 
 /**
- * Drop the breaks at a run's edges. A break separates two lines, so one
- * with nothing on the far side of it opens or closes the paragraph on an
- * empty line — the whitespace `collapseWhitespace` trims, written as a
- * tag. Nothing readable is lost: the break carries no text.
+ * Drop the breaks and blank text at a run's edges. A break separates two
+ * lines, so one with nothing on the far side of it opens or closes the
+ * paragraph on an empty line — the whitespace `collapseWhitespace` trims,
+ * written as a tag. The blank text goes with it: `A <br> ` puts an
+ * indentation gap on each side of the break, and stopping the walk at
+ * that gap would leave the break it surrounds. Nothing readable is lost;
+ * neither node carries a word.
  */
-const trimEdgeBreaks = (inlines: Inline[]): Inline[] => {
-  while (inlines[0]?.type === "line-break") {
+const trimEdgeTrivia = (inlines: Inline[]): Inline[] => {
+  const isTrivia = (node: Inline | undefined): boolean =>
+    node?.type === "line-break" ||
+    (node?.type === "text" && node.text.trim() === "");
+
+  while (isTrivia(inlines[0])) {
     inlines.shift();
   }
-  while (inlines.at(-1)?.type === "line-break") {
+  while (isTrivia(inlines.at(-1))) {
     inlines.pop();
   }
   return inlines;
@@ -1044,9 +1058,19 @@ const visitCell = (
   // between them, so that text was dropped whenever any element child
   // produced a block — the one failure rule 10 does not allow. Collect
   // the loose run instead and close it whenever a block child starts.
+
+  // The walker marks everything inside an `anon-block` element, but its
+  // walk starts at the node it is given: a cell (or a row) carrying the
+  // class itself is above every walk this function starts, so the state
+  // has to be read from the cell's ancestry and seeded into each of
+  // them. Loose text is the cell's content like the elements beside it
+  // and carries the same flag.
+  const anonymized = $cell.closest(`.${ANONYMIZED_CLASS}`).length > 0;
+  const inlineOptions = { ...ECJ_INLINE_OPTIONS, anonymized };
+
   let run: Inline[] = [];
   const flushRun = (): void => {
-    const inlines = trimEdgeBreaks(collapseWhitespace(run));
+    const inlines = collapseWhitespace(trimEdgeTrivia(run));
     run = [];
     const plainText = inlinesToPlainText(inlines).trim();
     if (!plainText) {
@@ -1061,7 +1085,7 @@ const visitCell = (
 
   $cell.contents().each((_, child) => {
     if (isText(child)) {
-      run.push({ type: "text", text: $(child).text() });
+      appendTextInline(run, $(child).text(), anonymized);
       return;
     }
 
@@ -1097,14 +1121,14 @@ const visitCell = (
     // Untrimmed: the run's edges are trimmed once, in `flushRun`, so a
     // span's own leading space still separates it from the text before.
     if (INLINE_TAGS.has(tag)) {
-      run.push(...walkInlines($, $child, ECJ_INLINE_OPTIONS));
+      run.push(...walkInlines($, $child, inlineOptions));
       return;
     }
 
     flushRun();
 
     // As in `visitChild`: anything else still contributes its text.
-    const inlines = walkEcjInlines($, $child);
+    const inlines = walkEcjInlines($, $child, inlineOptions);
     const plainText = inlinesToPlainText(inlines).trim();
     if (!plainText) {
       return;

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
@@ -66,6 +66,13 @@ export const appendTextInline = (
  */
 export const ASPOSE_SPACER_GAP = "\u00a0\u00a0";
 
+/**
+ * Class marking content the publisher anonymized. Everything inside the
+ * element carries the flag, so a parser reading a subtree whose walk
+ * starts below the marked element has to seed the state itself.
+ */
+export const ANONYMIZED_CLASS = "anon-block";
+
 export type WalkInlinesOptions = {
   /**
    * Map/validate `<a>` hrefs (e.g. `sanitizeUrl`, which returns
@@ -119,7 +126,7 @@ export const walkInlines = (
       }
 
       const $child = $(child);
-      const childAnon = anonymized || $child.hasClass("anon-block");
+      const childAnon = anonymized || $child.hasClass(ANONYMIZED_CLASS);
 
       if (tag === "br") {
         inlines.push({ type: "line-break" });

--- a/apps/api/src/lib/legal-search/ingestion-constants.ts
+++ b/apps/api/src/lib/legal-search/ingestion-constants.ts
@@ -52,7 +52,7 @@ export const PARSER_VERSIONS = {
   [ADAPTER_KEYS.AT_UMSE]: 2,
   [ADAPTER_KEYS.AT_BKS]: 2,
   [ADAPTER_KEYS.AT_FINDOK]: 2,
-  [ADAPTER_KEYS.EU_ECJ]: 4,
+  [ADAPTER_KEYS.EU_ECJ]: 5,
 } as const satisfies Record<AdapterKey, number>;
 
 /**


### PR DESCRIPTION
## Proposed change

`visitCell` in `parsers/eu-ecj.ts` walked `$cell.children()`. That reaches the
cell's element children and never the text nodes between them, so a cell's own
text only survived through the fallback underneath the loop:

```ts
if (builder.blocks.length === before && cellText !== "") { ... }
```

which runs only when the cell produced no block at all. A cell holding both text
and elements fails that condition as soon as one element child pushes a
paragraph, and the text is then dropped with nothing recording it.

Cellar writes a quoted entry that way whenever part of it is emphasized or
replaced by a figure: the spans are element children, and the rest of the
sentence is loose text around them. Because the shape is the converter's and not
any one language's, a document written this way loses the same words in every
language it is published in, while `retainedPct` stays high enough that the
document still reads as broadly complete.

This walks `contents()` instead and collects the loose run, closing it whenever
a block child starts, so text and elements keep their document order. Cellar's
inline vocabulary folds into the run; anything else still opens the paragraph of
its own it opened before, so the shape of a quoted passage is unchanged and each
`<p class="coj-normal">` stays its own paragraph. The bare-text fallback is
unreachable once the run exists and is removed.

The run's edges are trimmed once, when it is flushed, rather than per fragment,
so a span's own leading space still separates it from the text before it.

This is the completeness half of rule 10 in `handlers/case-law/CLAUDE.md`: text
the parser cannot place is emitted anyway, in document order, and never dropped.

### Test

`keeps a cell's own text however it is arranged around its elements` enumerates
the arrangements rather than one example: text alone, text before and after a
span, text around a paragraph, around a nested table, and around an element
outside the vocabulary. It asserts on the loss directly (no `CONTENT_LOSS` or
`MISSING_WORDS` from the validator) as well as on the text, and it fails on
every arrangement but the first without the change.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun test src/handlers/case-law/` passes; `tsc --noEmit -p apps/api` and `oxlint` on the parser directory are clean.
- [ ] DARK MODE SUPPORT | Not applicable; no UI change.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFajbNiUbN1jFydw7vn6ro)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved European Court of Justice document parsing to preserve text in table cells, including text surrounding inline elements, paragraphs, nested tables and other content.
  * Preserved text separated by line breaks and prevented valid cell content from being omitted or incorrectly split during full-text extraction.
  * Reduced false-positive content validation warnings for documents containing mixed text and formatted elements in table cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->