### PR TITLE
fix(api): read split opstamps from the pass that stabilized

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -722,6 +722,48 @@ test("delete settlement repeats an offset scan until split identities stabilize"
   expect(firstPageReads).toBe(3);
 });
 
+test("delete settlement reads each split's opstamp from the pass that stabilized", async () => {
+  let firstPageReads = 0;
+  responseBodyForUrl = () => {
+    firstPageReads += 1;
+    return {
+      splits: [
+        {
+          split_id: "split-lagging",
+          split_state: "Published",
+          // The first pass observes this split before its delete task lands.
+          delete_opstamp: firstPageReads === 1 ? 41 : 42,
+        },
+        ...(firstPageReads === 1
+          ? []
+          : [
+              {
+                split_id: "split-added",
+                split_state: "Published",
+                delete_opstamp: 42,
+              },
+            ]),
+      ],
+    };
+  };
+
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
+    "legal_corpus_v1_cze",
+    42,
+  );
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value).toEqual({
+      requiredOpstamp: 42,
+      publishedSplits: 2,
+      laggingSplits: 0,
+      minAppliedOpstamp: 42,
+      settled: true,
+    });
+  }
+});
+
 test("delete settlement accepts exactly the published split ceiling", async () => {
   responseBodyForUrl = settlementResponse(10_000);
 

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -823,9 +823,10 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
           }
           return Math.min(remaining, ADMIN_TIMEOUT_MS);
         };
-        const observedSplitOpstamps = new Map<string, number>();
         let scanPasses = 0;
-        const readSplitPass = async (): Promise<Set<string>> => {
+        // Keyed by split id; the value is the lowest opstamp this pass saw for
+        // it, since a split shifting between offset pages can be read twice.
+        const readSplitPass = async (): Promise<Map<string, number>> => {
           scanPasses += 1;
           if (scanPasses > MAX_SETTLEMENT_SCAN_PASSES) {
             throw new CorpusIndexError({
@@ -835,7 +836,7 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
           }
           let offset = 0;
           let scannedSplits = 0;
-          const currentSplitIds = new Set<string>();
+          const passSplitOpstamps = new Map<string, number>();
           const readSplitPage = async (): Promise<void> => {
             const response = await requestJson({
               baseUrl: mutationBaseUrl(cluster),
@@ -873,16 +874,13 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
                     "corpus index split list returned an invalid response",
                 });
               }
-              const previousOpstamp = observedSplitOpstamps.get(splitId);
-              currentSplitIds.add(splitId);
-              if (previousOpstamp === undefined) {
-                observedSplitOpstamps.set(splitId, opstamp);
-              } else {
-                observedSplitOpstamps.set(
-                  splitId,
-                  Math.min(previousOpstamp, opstamp),
-                );
-              }
+              const previousOpstamp = passSplitOpstamps.get(splitId);
+              passSplitOpstamps.set(
+                splitId,
+                previousOpstamp === undefined
+                  ? opstamp
+                  : Math.min(previousOpstamp, opstamp),
+              );
             }
             if (splits.length < SPLIT_PAGE_SIZE) {
               return;
@@ -891,12 +889,13 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
             await readSplitPage();
           };
           await readSplitPage();
-          return currentSplitIds;
+          return passSplitOpstamps;
         };
         const readStableSplitPass = async (
           previousPassSplitIds: ReadonlySet<string>,
-        ): Promise<Set<string>> => {
-          const currentSplitIds = await readSplitPass();
+        ): Promise<Map<string, number>> => {
+          const currentPass = await readSplitPass();
+          const currentSplitIds = new Set(currentPass.keys());
           // Quickwit lists by numeric offset, not a snapshot cursor. A split
           // published or retired while an earlier page is read can shift a
           // later page. Only clear durable delete state after one complete
@@ -905,19 +904,18 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
             currentSplitIds.size === previousPassSplitIds.size &&
             currentSplitIds.isSubsetOf(previousPassSplitIds);
           if (stable) {
-            return currentSplitIds;
+            return currentPass;
           }
           return await readStableSplitPass(currentSplitIds);
         };
-        const finalPassSplitIds = await readStableSplitPass(new Set());
-        const appliedOpstamps = [...finalPassSplitIds].map((splitId) => {
-          const opstamp = observedSplitOpstamps.get(splitId);
-          if (opstamp === undefined) {
-            panic("settlement scan lost a published split opstamp");
-          }
-          return opstamp;
-        });
-        const publishedSplits = finalPassSplitIds.size;
+        // Opstamps come from the stabilizing pass alone. A split read before
+        // its delete task landed is caught up by the time the pass that
+        // settles the identity set reads it again, and carrying the earlier
+        // value forward would report it as lagging for as long as the index
+        // keeps churning.
+        const finalPass = await readStableSplitPass(new Set());
+        const appliedOpstamps = [...finalPass.values()];
+        const publishedSplits = finalPass.size;
         const laggingSplits = appliedOpstamps.filter(
           (opstamp) => opstamp < requiredOpstamp,
         ).length;


### PR DESCRIPTION
## Proposed change

`readDeleteSettlement` decides whether the corpus index has applied a delete down to a required opstamp by listing every published split and comparing each split's `delete_opstamp` against it.

Quickwit lists splits by numeric offset rather than a snapshot cursor, so a split published or retired mid-scan can shift a later page. The scan already handles that: it repeats the whole listing until two consecutive passes return the same split identities, and takes the identity set from the pass that stabilized.

The opstamps did not follow that rule. They accumulated in a single map spanning every pass, keeping `Math.min` of every value ever seen for a split id. A split read before its delete task landed kept that lower opstamp even after a later pass observed it caught up, so the scan counted it in `laggingSplits` and withheld settlement.

The two conditions compound. The scan only needs a second pass when the index is churning, which is exactly when a split's `delete_opstamp` is likely to advance mid-scan. A caller retrying against a continuously churning index can therefore re-observe a stale value on every call, and the settlement never converges even though no split is behind. Callers treat a pending settlement as "try again later", so the cleanup that depends on it does not progress.

Scope the opstamp map to a single pass and return it, so identities and opstamps both come from the pass that stabilized. The per-split minimum is still taken within a pass, where a split shifting between offset pages can legitimately be read twice. This also makes the missing-opstamp `panic` unrepresentable: keys and values now come from the same map.

Added `delete settlement reads each split's opstamp from the pass that stabilized`, covering a split whose opstamp advances between a discarded first pass and the stabilizing second pass. Without the fix it reports `laggingSplits: 1` / `settled: false`; with it, the split set settles.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-facing surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VtACbCSZHR1Cqk39MoV37B)_