### PR TITLE
fix(desktop): grant the language commands the window shell invokes

### DIFF
--- a/apps/desktop/src-tauri/capabilities/clipboard-editor.json
+++ b/apps/desktop/src-tauri/capabilities/clipboard-editor.json
@@ -5,6 +5,8 @@
   "permissions": [
     "core:event:allow-listen",
     "core:event:allow-unlisten",
+    "allow-get-desktop-language",
+    "allow-set-desktop-language",
     "allow-clipboard-get-editor-context",
     "allow-clipboard-get-image-preview",
     "allow-clipboard-set-item-group",

--- a/apps/desktop/src-tauri/capabilities/clipboard.json
+++ b/apps/desktop/src-tauri/capabilities/clipboard.json
@@ -5,6 +5,8 @@
   "permissions": [
     "core:event:allow-listen",
     "core:event:allow-unlisten",
+    "allow-get-desktop-language",
+    "allow-set-desktop-language",
     "allow-is-autostart-enabled",
     "allow-set-autostart",
     "allow-clipboard-get-snapshot",

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -4,6 +4,8 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "allow-get-desktop-language",
+    "allow-set-desktop-language",
     "allow-get-state",
     "allow-open-stella-account",
     "allow-desktop-report-error",

--- a/apps/desktop/tests/window-capabilities.test.ts
+++ b/apps/desktop/tests/window-capabilities.test.ts
@@ -7,7 +7,28 @@ const INVOKE_COMMAND_PATTERN = /\binvoke(?:<[^>]+>)?\(\s*"([a-z_]+)"/gu;
 const SNAPSHOT_COMMAND_PATTERN =
   /\b(?:applySnapshotCommand|onCommand)\(\s*"(clipboard_[a-z_]+)"/gu;
 
-const invokedClipboardCommands = async (sourcePath: string) => {
+/**
+ * Modules every window reaches. `main.tsx` mounts one shell whatever the
+ * window label is, and the shell settles the language before it renders a
+ * branch, so a command the shell invokes has to be granted by every window
+ * capability below and not only by the one the branch belongs to.
+ */
+const SHELL_MODULES = ["src/i18n/index.tsx"] as const;
+
+/** The branch `main.tsx` renders for a window, keyed by that window's capability. */
+const WINDOW_MODULES = {
+  "src-tauri/capabilities/clipboard-editor.json": [
+    "src/clipboard/ClipboardEditor.tsx",
+    "src/clipboard/ClipboardImagePreview.tsx",
+  ],
+  "src-tauri/capabilities/clipboard.json": [
+    "src/clipboard/ClipboardApp.tsx",
+    "src/clipboard/ClipboardImagePreview.tsx",
+  ],
+  "src-tauri/capabilities/default.json": ["src/mainview/App.tsx"],
+} as const satisfies Record<string, readonly string[]>;
+
+const invokedCommands = async (sourcePath: string) => {
   const source = await readFile(path.join(DESKTOP_ROOT, sourcePath), "utf-8");
   return [INVOKE_COMMAND_PATTERN, SNAPSHOT_COMMAND_PATTERN].flatMap((pattern) =>
     [...source.matchAll(pattern)].flatMap((match) => {
@@ -34,25 +55,18 @@ const grantedCommands = async (capabilityPath: string) => {
   return new Set(capability.permissions);
 };
 
-describe("clipboard Tauri capabilities", () => {
-  test.each([
-    ["src/clipboard/ClipboardApp.tsx", "src-tauri/capabilities/clipboard.json"],
-    [
-      "src/clipboard/ClipboardEditor.tsx",
-      "src-tauri/capabilities/clipboard-editor.json",
-    ],
-    [
-      "src/clipboard/ClipboardImagePreview.tsx",
-      "src-tauri/capabilities/clipboard.json",
-    ],
-    [
-      "src/clipboard/ClipboardImagePreview.tsx",
-      "src-tauri/capabilities/clipboard-editor.json",
-    ],
-  ])(
-    "grants every command invoked by %s",
+describe("window Tauri capabilities", () => {
+  test.each(
+    Object.entries(WINDOW_MODULES).flatMap(([capabilityPath, modules]) =>
+      [...SHELL_MODULES, ...modules].map((sourcePath) => [
+        sourcePath,
+        capabilityPath,
+      ]),
+    ),
+  )(
+    "grants every command %s invokes in %s",
     async (sourcePath, capabilityPath) => {
-      const commands = await invokedClipboardCommands(sourcePath);
+      const commands = await invokedCommands(sourcePath);
       const permissions = await grantedCommands(capabilityPath);
 
       expect(commands.length).toBeGreaterThan(0);

--- a/apps/desktop/tests/window-capabilities.test.ts
+++ b/apps/desktop/tests/window-capabilities.test.ts
@@ -3,17 +3,27 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 const DESKTOP_ROOT = path.join(import.meta.dir, "..");
+const ENTRY_MODULE = "src/mainview/main.tsx";
 const INVOKE_COMMAND_PATTERN = /\binvoke(?:<[^>]+>)?\(\s*"([a-z_]+)"/gu;
 const SNAPSHOT_COMMAND_PATTERN =
   /\b(?:applySnapshotCommand|onCommand)\(\s*"(clipboard_[a-z_]+)"/gu;
 
 /**
- * Modules every window reaches. `main.tsx` mounts one shell whatever the
- * window label is, and the shell settles the language before it renders a
- * branch, so a command the shell invokes has to be granted by every window
- * capability below and not only by the one the branch belongs to.
+ * Command owners called by the shell before or outside its window branch.
+ * The telemetry module is narrowed to the imported error reporter because its
+ * timing reporter is reached only by the clipboard branch.
  */
-const SHELL_MODULES = ["src/i18n/index.tsx"] as const;
+const SHELL_INVOKE_SOURCES = [
+  {
+    entryImport: "../i18n",
+    sourcePath: "src/i18n/index.tsx",
+  },
+  {
+    entryImport: "../telemetry/desktop-telemetry",
+    exportedBinding: "reportDesktopError",
+    sourcePath: "src/telemetry/desktop-telemetry.ts",
+  },
+] as const;
 
 /** The branch `main.tsx` renders for a window, keyed by that window's capability. */
 const WINDOW_MODULES = {
@@ -28,21 +38,44 @@ const WINDOW_MODULES = {
   "src-tauri/capabilities/default.json": ["src/mainview/App.tsx"],
 } as const satisfies Record<string, readonly string[]>;
 
-const invokedCommands = async (sourcePath: string) => {
-  const source = await readFile(path.join(DESKTOP_ROOT, sourcePath), "utf-8");
-  return [INVOKE_COMMAND_PATTERN, SNAPSHOT_COMMAND_PATTERN].flatMap((pattern) =>
+const readSource = async (sourcePath: string) =>
+  readFile(path.join(DESKTOP_ROOT, sourcePath), "utf-8");
+
+const invokedCommandsInSource = (source: string) =>
+  [INVOKE_COMMAND_PATTERN, SNAPSHOT_COMMAND_PATTERN].flatMap((pattern) =>
     [...source.matchAll(pattern)].flatMap((match) => {
       const command = match.at(1);
       return command ? [command] : [];
     }),
   );
+
+const exportedBindingSource = (source: string, binding: string) => {
+  const marker = `export const ${binding}`;
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new TypeError(`Missing ${marker}`);
+  }
+  const end = source.indexOf("\nexport const ", start + marker.length);
+  return source.slice(start, end === -1 ? undefined : end);
+};
+
+const invokedCommands = async (
+  invocationSource: (typeof SHELL_INVOKE_SOURCES)[number] | string,
+) => {
+  if (typeof invocationSource === "string") {
+    return invokedCommandsInSource(await readSource(invocationSource));
+  }
+  const source = await readSource(invocationSource.sourcePath);
+  if (!("exportedBinding" in invocationSource)) {
+    return invokedCommandsInSource(source);
+  }
+  return invokedCommandsInSource(
+    exportedBindingSource(source, invocationSource.exportedBinding),
+  );
 };
 
 const grantedCommands = async (capabilityPath: string) => {
-  const source = await readFile(
-    path.join(DESKTOP_ROOT, capabilityPath),
-    "utf-8",
-  );
+  const source = await readSource(capabilityPath);
   const capability: unknown = JSON.parse(source);
   if (
     typeof capability !== "object" ||
@@ -56,17 +89,21 @@ const grantedCommands = async (capabilityPath: string) => {
 };
 
 describe("window Tauri capabilities", () => {
-  test.each(
-    Object.entries(WINDOW_MODULES).flatMap(([capabilityPath, modules]) =>
-      [...SHELL_MODULES, ...modules].map((sourcePath) => [
-        sourcePath,
-        capabilityPath,
-      ]),
-    ),
-  )(
-    "grants every command %s invokes in %s",
-    async (sourcePath, capabilityPath) => {
-      const commands = await invokedCommands(sourcePath);
+  test.each(Object.entries(WINDOW_MODULES))(
+    "%s grants every command its shell and branch invoke",
+    async (capabilityPath, modules) => {
+      const entrySource = await readSource(ENTRY_MODULE);
+      for (const shellSource of SHELL_INVOKE_SOURCES) {
+        expect(entrySource).toContain(`from "${shellSource.entryImport}"`);
+        if ("exportedBinding" in shellSource) {
+          expect(entrySource).toContain(shellSource.exportedBinding);
+        }
+      }
+      const commands = (
+        await Promise.all(
+          [...SHELL_INVOKE_SOURCES, ...modules].map(invokedCommands),
+        )
+      ).flat();
       const permissions = await grantedCommands(capabilityPath);
 
       expect(commands.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Proposed change

`main.tsx` mounts one shell for the `main`, `clipboard` and `clipboard-editor`
windows, and the shell settles the language on mount: `synchronizeDesktopLanguage`
invokes `set_desktop_language` when a choice is stored and `get_desktop_language`
otherwise. `setPreferredLanguage`, behind the language picker, invokes
`set_desktop_language` too.

No capability lists either command, so the ACL refuses both in every window. The
shell's reconciliation never reaches the backend, and the picker cannot persist a
choice at all: it writes to `localStorage` only after the invoke resolves, so a
refused invoke leaves nothing stored and the next window starts where it did.

This grants `allow-get-desktop-language` and `allow-set-desktop-language` in the
three window capabilities that mount the shell. The two HTML dialogs keep their
single-command capabilities; they have their own entry points and never mount it.

`clipboard-capabilities.test.ts` checked a hand-listed set of clipboard sources
against the clipboard capabilities, so nothing covered the shell. It becomes
`window-capabilities.test.ts`, keyed by window capability, and checks the shell's
modules against every one of them. Dropping either grant fails it.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI changes.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no visual changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading and updating the desktop language across supported desktop windows.
  * Language settings are now available in clipboard-related desktop contexts and the default desktop configuration.

* **Tests**
  * Expanded capability validation across desktop windows to ensure required language and application commands remain consistently available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->