### PR TITLE
fix: make docs MCP retrieval readable and bounded

### DIFF
--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -85,8 +85,10 @@ check. Run the bar as soon as the PR is ready; it is idempotent. Raw
 ## Documentation Access
 
 The `stella-docs` MCP server provides on-demand access to library documentation via
-`llms.txt`. When implementing features, fetch the relevant docs first using
-`list_doc_sources` and `fetch_docs` tools.
+`llms.txt`. When implementing features, call `search_docs` for the relevant topic,
+then pass a selected URL to `fetch_doc_chunks`. Use `list_doc_sources` to select or
+narrow libraries; reserve `fetch_docs` for a small, known Markdown or plain-text
+index or page.
 
 **Not covered (no `llms.txt`):** Tailwind CSS, oxfmt. For these, use `WebFetch` or
 `WebSearch` directly.

--- a/.claude/mcp/doc-content.test.ts
+++ b/.claude/mcp/doc-content.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatFetchDocsOutput,
+  MAX_FETCH_DOC_CHARS,
+  readableDocText,
+  resolveMarkdownDocUrl,
+} from "./doc-content";
+
+describe("documentation content", () => {
+  test("rewrites only known provider page paths while preserving URL state", () => {
+    expect(
+      resolveMarkdownDocUrl(
+        "https://tanstack.com/query/latest/docs/framework/react/guides/query-options?version=5#example",
+      ),
+    ).toBe(
+      "https://tanstack.com/query/latest/docs/framework/react/guides/query-options.md?version=5#example",
+    );
+    expect(
+      resolveMarkdownDocUrl(
+        "https://oxc.rs/docs/guide/usage/linter/js-plugins.html?lang=en#setup",
+      ),
+    ).toBe(
+      "https://oxc.rs/docs/guide/usage/linter/js-plugins.md?lang=en#setup",
+    );
+
+    const stableUrls = [
+      "https://tanstack.com/llms.txt",
+      "https://tanstack.com/query/latest/llms.txt?scope=react#guides",
+      "https://tanstack.com/query/latest/docs/framework/react/index",
+      "https://tanstack.com/query/latest/docs/framework/react/overview.md",
+      "https://oxc.rs/docs/index.html",
+      "https://oxc.rs/docs/guide/usage/linter/js-plugins.md",
+      "https://oxc.rs/api/data",
+    ];
+
+    for (const url of stableUrls) {
+      expect(resolveMarkdownDocUrl(url)).toBe(url);
+    }
+  });
+
+  test("rejects HTML identified by its media type or document marker", () => {
+    expect(() =>
+      readableDocText({
+        contentType: "text/html; charset=utf-8",
+        text: "<main>Documentation</main>",
+        url: "https://docs.example/page",
+      }),
+    ).toThrow("returned HTML, which is not sent to the model");
+    expect(() =>
+      readableDocText({
+        contentType: "text/plain",
+        text: `\uFEFF<?xml version="1.0"?><!-- ${"generated".repeat(400)} -->\n<!doctype html><html><body>Documentation</body></html>`,
+        url: "https://docs.example/page",
+      }),
+    ).toThrow("Use search_docs");
+  });
+
+  test("returns Markdown unchanged", () => {
+    const markdown = "# Query options\n\nUse `queryOptions`.";
+    expect(
+      readableDocText({
+        contentType: "text/markdown; charset=utf-8",
+        text: markdown,
+        url: "https://docs.example/page.md",
+      }),
+    ).toBe(markdown);
+  });
+
+  test("bounds full fetch output and provides the accepted next call", () => {
+    const url = "https://docs.example/page.md";
+    const output = formatFetchDocsOutput({
+      text: "a".repeat(MAX_FETCH_DOC_CHARS + 1),
+      url,
+    });
+
+    expect(output.length).toBeLessThanOrEqual(MAX_FETCH_DOC_CHARS);
+    expect(output).toContain(
+      `[Response truncated at ${MAX_FETCH_DOC_CHARS} characters.`,
+    );
+    expect(output).toContain(
+      `fetch_doc_chunks with {"url":"${url}","query":"the specific API or behavior you need","maxChunks":3}`,
+    );
+
+    const longUrl = `https://docs.example/${"segment".repeat(MAX_FETCH_DOC_CHARS)}`;
+    const longUrlOutput = formatFetchDocsOutput({
+      text: "a".repeat(MAX_FETCH_DOC_CHARS + 1),
+      url: longUrl,
+    });
+    expect(longUrlOutput.length).toBeLessThanOrEqual(MAX_FETCH_DOC_CHARS);
+    expect(longUrlOutput).toEndWith(
+      "Call fetch_doc_chunks with the same URL and a specific query.]",
+    );
+  });
+});

--- a/.claude/mcp/doc-content.ts
+++ b/.claude/mcp/doc-content.ts
@@ -61,7 +61,7 @@ const normalizedContentType = (contentType: string | null): string | null =>
 const looksLikeHtmlDocument = (text: string): boolean => {
   let prefix = text.replace(/^\uFEFF/u, "").trimStart();
   while (true) {
-    const preamble = prefix.match(/^(?:<\?xml[\s\S]*?\?>|<!--[\s\S]*?-->)/iu);
+    const preamble = /^(?:<\?xml[\s\S]*?\?>|<!--[\s\S]*?-->)/iu.exec(prefix);
     if (!preamble) {
       break;
     }

--- a/.claude/mcp/doc-content.ts
+++ b/.claude/mcp/doc-content.ts
@@ -1,0 +1,116 @@
+import { DOC_SOURCES } from "./doc-sources";
+import type { FetchedAllowedUrl } from "./fetch-allowed-url";
+
+export const MAX_FETCH_DOC_CHARS = 12_000;
+
+const markdownPageRules = Object.values(DOC_SOURCES).flatMap((source) =>
+  "markdownPages" in source
+    ? [
+        {
+          hostname: new URL(source.url).hostname,
+          ...source.markdownPages,
+        },
+      ]
+    : [],
+);
+
+const hasStableTextPath = (pathname: string): boolean => {
+  const basename = pathname.split("/").at(-1)?.toLowerCase() ?? "";
+  return (
+    basename.length === 0 ||
+    basename === "index" ||
+    basename.startsWith("index.") ||
+    basename.endsWith(".md") ||
+    basename.endsWith(".txt")
+  );
+};
+
+export const resolveMarkdownDocUrl = (rawUrl: string): string => {
+  const url = new URL(rawUrl);
+  if (hasStableTextPath(url.pathname)) {
+    return rawUrl;
+  }
+
+  const rule = markdownPageRules.find(
+    ({ hostname, pathIncludes }) =>
+      hostname === url.hostname && url.pathname.includes(pathIncludes),
+  );
+  if (!rule) {
+    return rawUrl;
+  }
+
+  if (rule.rewrite === "append-md") {
+    const basename = url.pathname.split("/").at(-1) ?? "";
+    if (basename.includes(".")) {
+      return rawUrl;
+    }
+    url.pathname = `${url.pathname}.md`;
+    return url.toString();
+  }
+
+  if (!url.pathname.toLowerCase().endsWith(".html")) {
+    return rawUrl;
+  }
+  url.pathname = `${url.pathname.slice(0, -".html".length)}.md`;
+  return url.toString();
+};
+
+const normalizedContentType = (contentType: string | null): string | null =>
+  contentType?.split(";").at(0)?.trim().toLowerCase() ?? null;
+
+const looksLikeHtmlDocument = (text: string): boolean => {
+  let prefix = text.replace(/^\uFEFF/u, "").trimStart();
+  while (true) {
+    const preamble = prefix.match(/^(?:<\?xml[\s\S]*?\?>|<!--[\s\S]*?-->)/iu);
+    if (!preamble) {
+      break;
+    }
+    prefix = prefix.slice(preamble[0].length).trimStart();
+  }
+  return /^(?:<!doctype\s+html\b|<html\b)/iu.test(prefix.slice(0, 256));
+};
+
+export const readableDocText = ({
+  contentType,
+  text,
+  url,
+}: FetchedAllowedUrl): string => {
+  const type = normalizedContentType(contentType);
+  if (
+    type === "text/html" ||
+    type === "application/xhtml+xml" ||
+    looksLikeHtmlDocument(text)
+  ) {
+    throw new Error(
+      `Documentation source ${url} returned HTML, which is not sent to the model. Use search_docs to select a Markdown or plain-text URL from the source index, then call fetch_doc_chunks with that URL.`,
+    );
+  }
+  return text;
+};
+
+export const formatFetchDocsOutput = ({
+  text,
+  url,
+}: {
+  text: string;
+  url: string;
+}): string => {
+  if (text.length <= MAX_FETCH_DOC_CHARS) {
+    return text;
+  }
+
+  const nextCall = JSON.stringify({
+    url,
+    query: "the specific API or behavior you need",
+    maxChunks: 3,
+  });
+  const detailedNotice =
+    `\n\n[Response truncated at ${MAX_FETCH_DOC_CHARS} characters. ` +
+    `Call fetch_doc_chunks with ${nextCall}.]`;
+  const notice =
+    detailedNotice.length < MAX_FETCH_DOC_CHARS
+      ? detailedNotice
+      : `\n\n[Response truncated at ${MAX_FETCH_DOC_CHARS} characters. Call fetch_doc_chunks with the same URL and a specific query.]`;
+  const bodyLimit = Math.max(0, MAX_FETCH_DOC_CHARS - notice.length);
+  return `${text.slice(0, bodyLimit).trimEnd()}${notice}`;
+};

--- a/.claude/mcp/doc-sources.ts
+++ b/.claude/mcp/doc-sources.ts
@@ -1,5 +1,9 @@
 export type DocSource = {
   dependencies: readonly [string, ...string[]];
+  markdownPages?: {
+    pathIncludes: string;
+    rewrite: "append-md" | "replace-html-with-md";
+  };
   url: string;
 };
 
@@ -37,26 +41,43 @@ export const DOC_SOURCES = {
       "@tanstack/ai-react",
       "@tanstack/ai-sandbox",
       "@tanstack/devtools-vite",
-      "@tanstack/eslint-plugin-query",
       "@tanstack/eslint-plugin-router",
       "@tanstack/react-devtools",
       "@tanstack/react-form",
       "@tanstack/react-hotkeys",
-      "@tanstack/react-query",
-      "@tanstack/react-query-devtools",
       "@tanstack/react-router",
       "@tanstack/react-router-devtools",
-      "@tanstack/react-router-ssr-query",
       "@tanstack/react-store",
       "@tanstack/react-table",
       "@tanstack/react-table-devtools",
       "@tanstack/react-virtual",
       "@tanstack/table-core",
     ],
+    markdownPages: {
+      pathIncludes: "/docs/",
+      rewrite: "append-md",
+    },
     url: "https://tanstack.com/llms.txt",
+  },
+  TanStackQuery: {
+    dependencies: [
+      "@tanstack/eslint-plugin-query",
+      "@tanstack/react-query",
+      "@tanstack/react-query-devtools",
+      "@tanstack/react-router-ssr-query",
+    ],
+    markdownPages: {
+      pathIncludes: "/docs/",
+      rewrite: "append-md",
+    },
+    url: "https://tanstack.com/query/latest/llms.txt",
   },
   TanStackStart: {
     dependencies: ["@tanstack/react-start"],
+    markdownPages: {
+      pathIncludes: "/docs/",
+      rewrite: "append-md",
+    },
     url: "https://tanstack.com/start/latest/llms.txt",
   },
   React: {
@@ -190,6 +211,10 @@ export const DOC_SOURCES = {
       "oxfmt",
       "oxlint-tsgolint",
     ],
+    markdownPages: {
+      pathIncludes: "/docs/",
+      rewrite: "replace-html-with-md",
+    },
     url: "https://oxc.rs/llms.txt",
   },
   Streamdown: {

--- a/.claude/mcp/docs-retrieval.eval.ts
+++ b/.claude/mcp/docs-retrieval.eval.ts
@@ -1,0 +1,189 @@
+/**
+ * Live stella-docs retrieval eval. It talks to the server through MCP stdio,
+ * lists the production tool schemas and descriptions, then exercises the
+ * documented search-to-chunks workflow and two formerly HTML-heavy page URLs.
+ * This deterministic check measures the retrieval contract, not model success.
+ *
+ * Run against this checkout:
+ *   bun run eval:retrieval -- --label after
+ *
+ * Compare another checkout without copying its schemas or handlers:
+ *   bun run eval:retrieval -- --label before --server /path/to/.claude/mcp/stella-docs.ts
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import path from "node:path";
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const args = process.argv.slice(2);
+
+const argumentValue = (name: string): string | undefined => {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args.at(index + 1);
+};
+
+const label = argumentValue("--label") ?? "current";
+const serverEntry = path.resolve(
+  argumentValue("--server") ?? path.join(import.meta.dirname, "stella-docs.ts"),
+);
+const transport = new StdioClientTransport({
+  args: ["run", serverEntry],
+  command: "bun",
+  cwd: path.dirname(serverEntry),
+  stderr: "inherit",
+});
+const client = new Client({ name: "stella-docs-eval", version: "1.0.0" });
+
+const resultText = ({ content }: CallToolResult): string =>
+  content
+    .flatMap((item) =>
+      item.type === "text" && typeof item.text === "string" ? [item.text] : [],
+    )
+    .join("\n");
+
+const isCallToolResult = (result: unknown): result is CallToolResult =>
+  isRecord(result) && Array.isArray(result["content"]);
+
+const callTool = async (
+  name: string,
+  toolArguments: Record<string, unknown>,
+): Promise<CallToolResult> => {
+  const result = await client.callTool(
+    { name, arguments: toolArguments },
+    undefined,
+    {
+      timeout: REQUEST_TIMEOUT_MS,
+    },
+  );
+  if (!isCallToolResult(result)) {
+    throw new Error(`Tool ${name} returned a task instead of content`);
+  }
+  return result;
+};
+
+const looksLikeHtml = (text: string): boolean =>
+  /<!doctype\s+html\b|<html\b/iu.test(text.slice(0, 2048));
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+try {
+  await client.connect(transport, { timeout: REQUEST_TIMEOUT_MS });
+  const listed = await client.listTools(undefined, {
+    timeout: REQUEST_TIMEOUT_MS,
+  });
+  const descriptions = Object.fromEntries(
+    listed.tools.map(({ description, name }) => [name, description ?? ""]),
+  );
+  const sourceList = await callTool("list_doc_sources", {});
+  const sourceListText = resultText(sourceList);
+  const selectedSource = sourceListText.includes("TanStackQuery:")
+    ? "TanStackQuery"
+    : "TanStack";
+
+  const rejectedInput = { url: "not-a-url" };
+  let rejectionMessage = "";
+  let schemaRejected = false;
+  try {
+    const rejected = await callTool("fetch_docs", rejectedInput);
+    rejectionMessage = resultText(rejected);
+    schemaRejected = rejected.isError === true;
+  } catch (error) {
+    rejectionMessage =
+      error instanceof Error ? error.message : "Unknown schema rejection";
+    schemaRejected = true;
+  }
+
+  const pageUrls = [
+    "https://tanstack.com/query/latest/docs/framework/react/guides/query-options",
+    "https://oxc.rs/docs/guide/usage/linter/js-plugins.html",
+  ];
+  const pageResults = [];
+  for (const url of pageUrls) {
+    const input = { url };
+    const result = await callTool("fetch_docs", input);
+    const text = resultText(result);
+    pageResults.push({
+      chars: text.length,
+      input,
+      isError: result.isError === true,
+      rawHtml: looksLikeHtml(text),
+      readableAndBounded:
+        result.isError !== true &&
+        !looksLikeHtml(text) &&
+        text.length <= 12_000,
+    });
+  }
+
+  const searchInput = {
+    maxResults: 1,
+    query: "react query options",
+    sources: [selectedSource],
+  };
+  const search = await callTool("search_docs", searchInput);
+  const searchText = resultText(search);
+  const selected: unknown = JSON.parse(searchText);
+  if (!Array.isArray(selected)) {
+    throw new TypeError("search_docs did not return a result array");
+  }
+  const first = selected.at(0);
+  const selectedUrl = isRecord(first) ? first["url"] : undefined;
+  if (typeof selectedUrl !== "string") {
+    throw new TypeError("search_docs did not return a page URL");
+  }
+  const chunksInput = {
+    maxChunks: 3,
+    query: "query options type inference",
+    url: selectedUrl,
+  };
+  const chunks = await callTool("fetch_doc_chunks", chunksInput);
+  const chunksText = resultText(chunks);
+  const containsGuidance =
+    chunksText.includes("One of the best ways to share") &&
+    chunksText.includes("queryOptions(") &&
+    chunksText.includes("queryClient.setQueryData(");
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        label,
+        pages: pageResults,
+        schemaRejection: {
+          input: rejectedInput,
+          rejected: schemaRejected,
+          rejectionMessage,
+        },
+        workflow: {
+          chunks: {
+            chars: chunksText.length,
+            input: chunksInput,
+            isError: chunks.isError === true,
+            rawHtml: looksLikeHtml(chunksText),
+            containsGuidance,
+            succeeded:
+              chunks.isError !== true &&
+              !looksLikeHtml(chunksText) &&
+              containsGuidance,
+          },
+          search: {
+            chars: searchText.length,
+            input: searchInput,
+            isError: search.isError === true,
+            succeeded: search.isError !== true,
+          },
+          selectedSource,
+          selectedUrl,
+          startsAtSearch:
+            descriptions["search_docs"]?.includes(
+              "Start documentation retrieval",
+            ) ?? false,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} finally {
+  await client.close();
+}

--- a/.claude/mcp/docs-retrieval.eval.ts
+++ b/.claude/mcp/docs-retrieval.eval.ts
@@ -25,7 +25,8 @@ const argumentValue = (name: string): string | undefined => {
 
 const label = argumentValue("--label") ?? "current";
 const serverEntry = path.resolve(
-  argumentValue("--server") ?? path.join(import.meta.dirname, "stella-docs.ts"),
+  argumentValue("--server") ??
+    path.join(import.meta.dirname, "..", "stella-docs.ts"),
 );
 const transport = new StdioClientTransport({
   args: ["run", serverEntry],

--- a/.claude/mcp/docs-retrieval.eval.ts
+++ b/.claude/mcp/docs-retrieval.eval.ts
@@ -68,6 +68,9 @@ const looksLikeHtml = (text: string): boolean =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+const isUnknownArray = (value: unknown): value is unknown[] =>
+  Array.isArray(value);
+
 try {
   await client.connect(transport, { timeout: REQUEST_TIMEOUT_MS });
   const listed = await client.listTools(undefined, {
@@ -124,7 +127,7 @@ try {
   const search = await callTool("search_docs", searchInput);
   const searchText = resultText(search);
   const selected: unknown = JSON.parse(searchText);
-  if (!Array.isArray(selected)) {
+  if (!isUnknownArray(selected)) {
     throw new TypeError("search_docs did not return a result array");
   }
   const first = selected.at(0);

--- a/.claude/mcp/fetch-allowed-url.test.ts
+++ b/.claude/mcp/fetch-allowed-url.test.ts
@@ -6,9 +6,11 @@ const allowedHosts = new Set(["docs.example"]);
 
 describe("fetchAllowedUrl", () => {
   test("follows redirects that stay on allowlisted HTTPS hosts", async () => {
+    const acceptHeaders: (string | null)[] = [];
     const result = await fetchAllowedUrl({
       allowedHosts,
-      fetchImpl: async (input) => {
+      fetchImpl: async (input, init) => {
+        acceptHeaders.push(new Headers(init?.headers).get("accept"));
         const url = new URL(input.toString());
         if (url.pathname === "/start") {
           return new Response(null, {
@@ -16,12 +18,22 @@ describe("fetchAllowedUrl", () => {
             status: 302,
           });
         }
-        return new Response("docs");
+        return new Response("docs", {
+          headers: { "content-type": "text/plain;charset=utf-8" },
+        });
       },
       url: "https://docs.example/start",
     });
 
-    expect(result).toBe("docs");
+    expect(result).toEqual({
+      contentType: "text/plain;charset=utf-8",
+      text: "docs",
+      url: "https://docs.example/target",
+    });
+    expect(acceptHeaders).toEqual([
+      "text/markdown, text/plain;q=0.9, text/html;q=0.5, */*;q=0.1",
+      "text/markdown, text/plain;q=0.9, text/html;q=0.5, */*;q=0.1",
+    ]);
   });
 
   test("blocks redirects to non-allowlisted hosts before fetching them", async () => {

--- a/.claude/mcp/fetch-allowed-url.test.ts
+++ b/.claude/mcp/fetch-allowed-url.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import assert from "node:assert/strict";
 
 import { fetchAllowedUrl } from "./fetch-allowed-url";
 
 const allowedHosts = new Set(["docs.example"]);
+
+const fetchInputUrl = (input: string | URL | Request): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof Request ? input.url : input.href;
+};
 
 describe("fetchAllowedUrl", () => {
   test("follows redirects that stay on allowlisted HTTPS hosts", async () => {
@@ -11,7 +19,7 @@ describe("fetchAllowedUrl", () => {
       allowedHosts,
       fetchImpl: async (input, init) => {
         acceptHeaders.push(new Headers(init?.headers).get("accept"));
-        const url = new URL(input.toString());
+        const url = new URL(fetchInputUrl(input));
         if (url.pathname === "/start") {
           return new Response(null, {
             headers: { location: "/target" },
@@ -39,11 +47,11 @@ describe("fetchAllowedUrl", () => {
   test("blocks redirects to non-allowlisted hosts before fetching them", async () => {
     const fetchedUrls: string[] = [];
 
-    await expect(
+    await assert.rejects(
       fetchAllowedUrl({
         allowedHosts,
         fetchImpl: async (input) => {
-          fetchedUrls.push(input.toString());
+          fetchedUrls.push(fetchInputUrl(input));
           return new Response(null, {
             headers: { location: "https://127.0.0.1/secret" },
             status: 302,
@@ -51,7 +59,10 @@ describe("fetchAllowedUrl", () => {
         },
         url: "https://docs.example/start",
       }),
-    ).rejects.toThrow("Blocked: 127.0.0.1 is not a configured doc source");
+      {
+        message: "Blocked: 127.0.0.1 is not a configured doc source",
+      },
+    );
 
     expect(fetchedUrls).toEqual(["https://docs.example/start"]);
   });
@@ -83,7 +94,7 @@ describe("fetchAllowedUrl", () => {
   });
 
   test("rejects responses with oversized content-length", async () => {
-    await expect(
+    await assert.rejects(
       fetchAllowedUrl({
         allowedHosts,
         fetchImpl: async () =>
@@ -93,17 +104,19 @@ describe("fetchAllowedUrl", () => {
         maxResponseBytes: 4,
         url: "https://docs.example/start",
       }),
-    ).rejects.toThrow("Documentation response exceeds size limit");
+      { message: "Documentation response exceeds size limit" },
+    );
   });
 
   test("rejects streamed responses that exceed the byte limit", async () => {
-    await expect(
+    await assert.rejects(
       fetchAllowedUrl({
         allowedHosts,
         fetchImpl: async () => new Response("toolong"),
         maxResponseBytes: 4,
         url: "https://docs.example/start",
       }),
-    ).rejects.toThrow("Documentation response exceeds size limit");
+      { message: "Documentation response exceeds size limit" },
+    );
   });
 });

--- a/.claude/mcp/fetch-allowed-url.ts
+++ b/.claude/mcp/fetch-allowed-url.ts
@@ -1,6 +1,14 @@
 const DOC_FETCH_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
+const DOC_ACCEPT_HEADER =
+  "text/markdown, text/plain;q=0.9, text/html;q=0.5, */*;q=0.1";
+
+export type FetchedAllowedUrl = {
+  contentType: string | null;
+  text: string;
+  url: string;
+};
 
 type FetchAllowedUrlProps = {
   allowedHosts: ReadonlySet<string>;
@@ -29,7 +37,7 @@ export const fetchAllowedUrl = async ({
   maxResponseBytes = MAX_RESPONSE_BYTES,
   timeoutMs = DOC_FETCH_TIMEOUT_MS,
   url,
-}: FetchAllowedUrlProps): Promise<string> => {
+}: FetchAllowedUrlProps): Promise<FetchedAllowedUrl> => {
   let currentUrl = new URL(url);
   const signal = AbortSignal.timeout(timeoutMs);
 
@@ -37,6 +45,7 @@ export const fetchAllowedUrl = async ({
     validateAllowedUrl(currentUrl, allowedHosts);
 
     const response = await fetchImpl(currentUrl, {
+      headers: { Accept: DOC_ACCEPT_HEADER },
       redirect: "manual",
       signal,
     });
@@ -45,10 +54,14 @@ export const fetchAllowedUrl = async ({
       if (!response.ok) {
         throw new Error(`${response.status} ${response.statusText}`);
       }
-      return await readLimitedText({
-        maxBytes: maxResponseBytes,
-        response,
-      });
+      return {
+        contentType: response.headers.get("content-type"),
+        text: await readLimitedText({
+          maxBytes: maxResponseBytes,
+          response,
+        }),
+        url: currentUrl.toString(),
+      };
     }
 
     const location = response.headers.get("location");

--- a/.claude/mcp/fetch-allowed-url.ts
+++ b/.claude/mcp/fetch-allowed-url.ts
@@ -116,9 +116,15 @@ const readLimitedText = async ({
   let totalBytes = 0;
 
   while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
+    const result = await reader.read();
+    if (result.done) {
       break;
+    }
+    const value: unknown = result.value;
+    if (!(value instanceof Uint8Array)) {
+      throw new TypeError(
+        "Documentation response returned an invalid byte chunk",
+      );
     }
 
     totalBytes += value.byteLength;

--- a/.claude/mcp/package.json
+++ b/.claude/mcp/package.json
@@ -2,6 +2,9 @@
   "name": "stella-docs-mcp",
   "private": true,
   "type": "module",
+  "scripts": {
+    "eval:retrieval": "node docs-retrieval.eval.ts"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^4.4.3"

--- a/.claude/mcp/package.json
+++ b/.claude/mcp/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "eval:retrieval": "node docs-retrieval.eval.ts"
+    "eval:retrieval": "bun build docs-retrieval.eval.ts --target=node --packages=external --outfile=.cache/docs-retrieval.eval.mjs 1>&2 && node .cache/docs-retrieval.eval.mjs",
+    "test": "bun test *.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/.claude/mcp/server.ts
+++ b/.claude/mcp/server.ts
@@ -2,6 +2,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod/v3";
 
+import {
+  formatFetchDocsOutput,
+  MAX_FETCH_DOC_CHARS,
+  readableDocText,
+  resolveMarkdownDocUrl,
+} from "./doc-content";
 import { DOC_SOURCES } from "./doc-sources";
 import {
   fetchAllowedUrl,
@@ -66,7 +72,7 @@ type RegisterInputTool = <InputSchema extends z.ZodTypeAny>(
   callback: (input: z.infer<InputSchema>) => ToolResult | Promise<ToolResult>,
 ) => unknown;
 
-// The SDK's Zod 3/4 compatibility overload exceeds TypeScript's instantiation
+// SAFETY: The SDK's Zod 3/4 compatibility overload exceeds TypeScript's instantiation
 // depth in a clean install. Keep schema inference and handlers checked on this
 // side of a narrow boundary while preserving registerTool's runtime behavior.
 const registerInputTool = server.registerTool.bind(
@@ -75,7 +81,10 @@ const registerInputTool = server.registerTool.bind(
 
 server.registerTool(
   "list_doc_sources",
-  { description: "List available library documentation sources" },
+  {
+    description:
+      "List source names available to search_docs when you need to select or narrow documentation libraries",
+  },
   () => ({
     content: Object.entries(DOC_SOURCES).map(([name, { url }]) => ({
       type: "text" as const,
@@ -399,7 +408,12 @@ const validateSources = (sourceNames?: string[]) => {
 };
 
 const fetchConfiguredDocUrl = async (url: string) =>
-  await fetchAllowedUrl({ allowedHosts: ALLOWED_HOSTS, url });
+  readableDocText(
+    await fetchAllowedUrl({
+      allowedHosts: ALLOWED_HOSTS,
+      url: resolveMarkdownDocUrl(url),
+    }),
+  );
 
 const isAllowedDocUrl = (url: string) =>
   isAllowedDocUrlForHosts(url, ALLOWED_HOSTS);
@@ -559,14 +573,20 @@ const splitIntoChunks = (pageText: string) => {
 registerInputTool(
   "fetch_docs",
   {
-    description: "Fetch a llms.txt index or a specific doc page URL",
+    description:
+      `Fetch one small, known Markdown or plain-text documentation URL; successful content is capped at ${MAX_FETCH_DOC_CHARS} characters. ` +
+      "For normal retrieval, call search_docs first and fetch_doc_chunks with its selected URL.",
     inputSchema: z.object({ url: z.string().url() }),
   },
   async ({ url }) => {
     try {
+      const text = await fetchConfiguredDocUrl(url);
       return {
         content: [
-          { type: "text" as const, text: await fetchConfiguredDocUrl(url) },
+          {
+            type: "text" as const,
+            text: formatFetchDocsOutput({ text, url }),
+          },
         ],
       };
     } catch (error) {
@@ -588,7 +608,7 @@ registerInputTool(
   "search_docs",
   {
     description:
-      "Search configured doc indexes and return only the top matching pages",
+      "Start documentation retrieval here: search configured indexes and return only the top matching page URLs. Pass a selected URL to fetch_doc_chunks, which normalizes known providers to Markdown.",
     inputSchema: z.object({
       query: z.string().min(2),
       sources: z.array(z.string()).optional(),
@@ -715,7 +735,7 @@ registerInputTool(
   "fetch_doc_chunks",
   {
     description:
-      "Fetch only the most relevant chunks from a doc page for a given query",
+      "After search_docs, fetch only the most relevant bounded chunks from its selected Markdown or plain-text page URL.",
     inputSchema: z.object({
       url: z.string().url(),
       query: z.string().min(2),

--- a/.claude/mcp/server.ts
+++ b/.claude/mcp/server.ts
@@ -61,24 +61,6 @@ type DocChunk = {
   score: number;
 };
 
-type ToolResult = {
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-};
-
-type RegisterInputTool = <InputSchema extends z.ZodTypeAny>(
-  name: string,
-  config: { description: string; inputSchema: InputSchema },
-  callback: (input: z.infer<InputSchema>) => ToolResult | Promise<ToolResult>,
-) => unknown;
-
-// SAFETY: The SDK's Zod 3/4 compatibility overload exceeds TypeScript's instantiation
-// depth in a clean install. Keep schema inference and handlers checked on this
-// side of a narrow boundary while preserving registerTool's runtime behavior.
-const registerInputTool = server.registerTool.bind(
-  server,
-) as unknown as RegisterInputTool;
-
 server.registerTool(
   "list_doc_sources",
   {
@@ -570,13 +552,13 @@ const splitIntoChunks = (pageText: string) => {
   return [{ heading: DEFAULT_HEADING, text: fallbackText }];
 };
 
-registerInputTool(
+server.registerTool(
   "fetch_docs",
   {
     description:
       `Fetch one small, known Markdown or plain-text documentation URL; successful content is capped at ${MAX_FETCH_DOC_CHARS} characters. ` +
       "For normal retrieval, call search_docs first and fetch_doc_chunks with its selected URL.",
-    inputSchema: z.object({ url: z.string().url() }),
+    inputSchema: { url: z.string().url() },
   },
   async ({ url }) => {
     try {
@@ -604,16 +586,16 @@ registerInputTool(
   },
 );
 
-registerInputTool(
+server.registerTool(
   "search_docs",
   {
     description:
       "Start documentation retrieval here: search configured indexes and return only the top matching page URLs. Pass a selected URL to fetch_doc_chunks, which normalizes known providers to Markdown.",
-    inputSchema: z.object({
+    inputSchema: {
       query: z.string().min(2),
       sources: z.array(z.string()).optional(),
       maxResults: z.number().int().min(1).max(MAX_RESULTS_LIMIT).optional(),
-    }),
+    },
   },
   async ({ query, sources, maxResults }) => {
     try {
@@ -731,16 +713,16 @@ registerInputTool(
   },
 );
 
-registerInputTool(
+server.registerTool(
   "fetch_doc_chunks",
   {
     description:
       "After search_docs, fetch only the most relevant bounded chunks from its selected Markdown or plain-text page URL.",
-    inputSchema: z.object({
+    inputSchema: {
       url: z.string().url(),
       query: z.string().min(2),
       maxChunks: z.number().int().min(1).max(MAX_CHUNKS_LIMIT).optional(),
-    }),
+    },
   },
   async ({ url, query, maxChunks }) => {
     try {

--- a/.claude/mcp/tsconfig.json
+++ b/.claude/mcp/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  // Oxlint's type-aware pass resolves compiler options from the nearest
+  // tsconfig.json. Keep MCP tooling on the same project as typecheck:repo.
+  "extends": "../../tsconfig.tooling.json"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -996,6 +996,7 @@ jobs:
         env:
           AFFECTED_FLAG: ${{ steps.affected.outputs.flag }}
         run: |
+          bun --cwd .claude/mcp test
           args=()
           [[ -z "$AFFECTED_FLAG" ]] || args+=("$AFFECTED_FLAG")
           bun run test -- --concurrency=2 "${args[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,8 +315,10 @@ check. Run the bar as soon as the PR is ready; it is idempotent. Raw
 ## Documentation Access
 
 The `stella-docs` MCP server provides on-demand access to library documentation via
-`llms.txt`. When implementing features, fetch the relevant docs first using
-`list_doc_sources` and `fetch_docs` tools.
+`llms.txt`. When implementing features, call `search_docs` for the relevant topic,
+then pass a selected URL to `fetch_doc_chunks`. Use `list_doc_sources` to select or
+narrow libraries; reserve `fetch_docs` for a small, known Markdown or plain-text
+index or page.
 
 **Not covered (no `llms.txt`):** Tailwind CSS, oxfmt. For these, use `WebFetch` or
 `WebSearch` directly.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "check:railway-template-source-runtime": "bun scripts/sync-railway-template-source.ts --check-rendered-credentials",
     "sync:railway-template-source": "bun scripts/sync-railway-template-source.ts",
     "generate:snowball-stemmers": "bun scripts/generate-snowball-stemmers.ts",
-    "test": "turbo run test",
+    "test": "bun --cwd .claude/mcp test && turbo run test",
     "test:property": "turbo run test:property",
     "verify": "bash scripts/verify.sh",
     "db:push": "bun --filter @stll/api db:push",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typegen": "turbo run typegen",
     "typecheck": "turbo run typecheck",
     "typecheck:repo": "bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.scripts.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.tooling.json && bun packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.oxlint-plugins.json",
-    "code-check": "bun run env:check && bun run assets:check && bun scripts/check-oxlint-plugin-registry.ts && bash scripts/lint-oxlint-fixtures.sh && bash scripts/lint-root-scripts.sh && bun --cwd apps/landing typecheck && bun apps/landing/scripts/check-logical-properties.ts && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware --type-check apps packages && bun run typecheck:repo",
+    "code-check": "bun run env:check && bun run assets:check && bun scripts/check-oxlint-plugin-registry.ts && bash scripts/lint-oxlint-fixtures.sh && bash scripts/lint-root-scripts.sh && bun --cwd apps/landing typecheck && bun apps/landing/scripts/check-logical-properties.ts && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware --type-check .claude/mcp apps packages && bun run typecheck:repo",
     "code-check:affected": "bun scripts/code-check-affected.ts",
     "secrets:check:staged": "bash scripts/check-staged-secrets.sh",
     "dependencies:dedupe": "bun --no-env-file dedupe",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "check:railway-template-source-runtime": "bun scripts/sync-railway-template-source.ts --check-rendered-credentials",
     "sync:railway-template-source": "bun scripts/sync-railway-template-source.ts",
     "generate:snowball-stemmers": "bun scripts/generate-snowball-stemmers.ts",
-    "test": "bun --cwd .claude/mcp test && turbo run test",
+    "test": "turbo run test",
     "test:property": "turbo run test:property",
     "verify": "bash scripts/verify.sh",
     "db:push": "bun --filter @stll/api db:push",

--- a/scripts/typecheck-coverage.ts
+++ b/scripts/typecheck-coverage.ts
@@ -57,6 +57,10 @@ type ProjectBuildInfo = {
 // covers. Root-only projects have no source subtree suitable for a proxy.
 const OXC_PROJECT_PROXIES = [
   {
+    config: ".claude/mcp/tsconfig.json",
+    target: "tsconfig.tooling.json",
+  },
+  {
     config: "apps/api/contracts/tsconfig.json",
     target: "apps/api/tsconfig.contracts.json",
   },

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -313,6 +313,7 @@ run_step "Capability catalog drift" run_capability_catalog
 run_step "Capability description ledger" run_capability_description_ledger
 run_step "Knip production deps" run_knip
 run_step "Knip dead-export budget" run_knip_exports
+run_step "Documentation MCP tests" bun --cwd .claude/mcp test
 run_step "Test" run_test
 run_step "Bridge-version guard self-test" bash scripts/check-bridge-version.test.sh
 run_step "Release-channel self-test" bash scripts/release-channel.test.sh


### PR DESCRIPTION
## Proposed change

Documentation page fetches could return large HTML documents, including scripts and navigation. Prefer Markdown through content negotiation and known TanStack/Oxc page mappings, reject remaining HTML, and cap successful `fetch_docs` output at 12,000 characters with guidance to fetch relevant chunks.

Tool descriptions and generated agent guidance now lead with `search_docs` → `fetch_doc_chunks`. A dedicated `TanStackQuery` source makes Query searches return guides instead of a parent index. Search and chunk ranking retain the full readable document. Existing host, redirect, timeout, and response-size restrictions remain in place; dependencies are unchanged.

Typed lint now uses the tooling TypeScript project for the MCP subtree in both repository verification and push checks. Tool registration uses SDK schemas directly, removing the previous assertion-based adapter.

The live MCP retrieval evaluation uses the production tools and schemas. These are deterministic retrieval measurements, not model authoring success rates.

Before:

| Step | Result | Output characters |
| --- | --- | ---: |
| TanStack query-options page | Raw HTML | 455,680 |
| Oxc JS-plugins page | Raw HTML | 80,168 |
| Search through `TanStack` | Parent index | 172 |
| Selected-page chunks | Link lists, no API guidance | 5,054 |

After:

| Step | Result | Output characters |
| --- | --- | ---: |
| TanStack query-options page | Markdown | 1,567 |
| Oxc JS-plugins page | Markdown | 6,618 |
| Search through discovered `TanStackQuery` | Query-options guide | 217 |
| Selected-page chunks | API guidance and cache-update example | 1,670 |

The evaluation discovers available sources and records the intentionally rejected invalid-URL input. The server runs under Bun; the evaluation client uses Node to avoid an SDK/Zod compatibility failure under Bun.

Validation: `bun run verify` passed; subsequent boundary fixes pass the affected code check, tooling typecheck, and full MCP typed lint. Nine content/fetch tests and the before/after live MCP evaluation also pass.
