### PR TITLE
fix(api): a page the origin never answered does not move the cursor

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
@@ -392,8 +392,16 @@ const mockFailingEndpoint = (
  */
 describe("a page the origin never answered does not move the cursor", () => {
   let restore: (() => void) | undefined;
+  const realSleep = Bun.sleep;
+
+  beforeEach(() => {
+    // Every refused page exhausts its retry budget, and the backoff between
+    // attempts is randomized wall-clock time. Nothing here is about waiting.
+    Bun.sleep = () => Promise.resolve();
+  });
 
   afterEach(() => {
+    Bun.sleep = realSleep;
     restore?.();
     restore = undefined;
   });
@@ -417,35 +425,46 @@ describe("a page the origin never answered does not move the cursor", () => {
     return cursor;
   };
 
-  test("a gateway outage holds the cursor instead of consuming the collection", async () => {
-    // Every page answers alike while the publisher's gateway is down, so a
-    // skip that advanced would walk the whole collection one page per refusal
-    // and end far past the tip. The cursor stays, and the same page is asked
-    // for again.
+  test("a bad-gateway outage holds the cursor instead of consuming the collection", async () => {
+    // The gateway got nothing from the origin, so this page's items are
+    // unknown. Every page answers alike while it is down, so a skip that
+    // advanced would walk the whole collection one page per refusal and end
+    // far past the tip.
     const endpoint = mockFailingEndpoint(502);
     restore = endpoint.restore;
 
-    const fetchPage = createTestFetch({ firstPage: 0 });
-    const cursor = await walk(fetchPage, "offset:30", 2);
+    const cursor = await walk(
+      createTestFetch({ firstPage: 0 }),
+      "offset:30",
+      3,
+    );
 
     expect(cursor).toBe("offset:30");
     expect(new Set(endpoint.requestedPages)).toEqual(new Set([10]));
-    // Each refused page exhausts its retry budget before answering, so the
-    // walk costs real backoff.
-  }, 30_000);
+  });
 
-  test("a server error the origin produced still skips its own page", async () => {
-    // The origin ran this request and failed on it, which is a fact about the
-    // page. Skipping it is what keeps one poison page from stalling a source.
-    const endpoint = mockFailingEndpoint(500);
-    restore = endpoint.restore;
+  /**
+   * The origin answered, so the refusal is about this page and skipping it is
+   * what keeps one page from stalling a source. A 504 is the publisher proxy's
+   * own read timeout, which the origin earns by being slow on this page — the
+   * same event `page_skipped_timeout` skips when our timeout fires first.
+   */
+  test.each([500, 503, 504])(
+    "a %i still skips its own page",
+    async (status) => {
+      const endpoint = mockFailingEndpoint(status);
+      restore = endpoint.restore;
 
-    const fetchPage = createTestFetch({ firstPage: 0 });
-    const cursor = await walk(fetchPage, "offset:30", 2);
+      const cursor = await walk(
+        createTestFetch({ firstPage: 0 }),
+        "offset:30",
+        2,
+      );
 
-    expect(cursor).toBe("offset:36");
-    expect(endpoint.requestedPages).toContain(11);
-  }, 30_000);
+      expect(cursor).toBe("offset:36");
+      expect(endpoint.requestedPages).toContain(11);
+    },
+  );
 });
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -360,6 +360,94 @@ const requestUrl = (input: string | URL | Request): string => {
   return input instanceof URL ? input.href : input.url;
 };
 
+const mockFailingEndpoint = (
+  status: number,
+): { restore: () => void; requestedPages: number[] } => {
+  const originalFetch = globalThis.fetch;
+  const requestedPages: number[] = [];
+
+  globalThis.fetch = Object.assign(
+    async (input: string | URL | Request): Promise<Response> => {
+      const url = new URL(requestUrl(input));
+      requestedPages.push(
+        Number.parseInt(url.searchParams.get("page") ?? "", 10),
+      );
+      return await Promise.resolve(new Response("", { status }));
+    },
+    { preconnect: originalFetch.preconnect.bind(originalFetch) },
+  );
+
+  return {
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+    requestedPages,
+  };
+};
+
+/**
+ * Cursor movement is what a refused page costs, and it is only affordable when
+ * the refusal is about that page. These pin which refusals are which, because
+ * the two look identical in a single call and differ only over a run of them.
+ */
+describe("a page the origin never answered does not move the cursor", () => {
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  /**
+   * Drive the walk the way the pipeline does: a failed page leaves the cursor
+   * where it was, so only a successful page supplies the next one.
+   */
+  const walk = async (
+    fetchPage: ReturnType<typeof createTestFetch>,
+    from: string,
+    cycles: number,
+  ): Promise<string | null> => {
+    let cursor: string | null = from;
+    for (let cycle = 0; cycle < cycles; cycle++) {
+      const result = await fetchPage(cursor, {});
+      if (result.isOk()) {
+        cursor = result.unwrap().nextCursor;
+      }
+    }
+    return cursor;
+  };
+
+  test("a gateway outage holds the cursor instead of consuming the collection", async () => {
+    // Every page answers alike while the publisher's gateway is down, so a
+    // skip that advanced would walk the whole collection one page per refusal
+    // and end far past the tip. The cursor stays, and the same page is asked
+    // for again.
+    const endpoint = mockFailingEndpoint(502);
+    restore = endpoint.restore;
+
+    const fetchPage = createTestFetch({ firstPage: 0 });
+    const cursor = await walk(fetchPage, "offset:30", 2);
+
+    expect(cursor).toBe("offset:30");
+    expect(new Set(endpoint.requestedPages)).toEqual(new Set([10]));
+    // Each refused page exhausts its retry budget before answering, so the
+    // walk costs real backoff.
+  }, 30_000);
+
+  test("a server error the origin produced still skips its own page", async () => {
+    // The origin ran this request and failed on it, which is a fact about the
+    // page. Skipping it is what keeps one poison page from stalling a source.
+    const endpoint = mockFailingEndpoint(500);
+    restore = endpoint.restore;
+
+    const fetchPage = createTestFetch({ firstPage: 0 });
+    const cursor = await walk(fetchPage, "offset:30", 2);
+
+    expect(cursor).toBe("offset:36");
+    expect(endpoint.requestedPages).toContain(11);
+  }, 30_000);
+});
+
 /**
  * A publisher that numbers pages from one usually clamps below it — asking for
  * page zero answers page one rather than an error — so a walk configured with

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -397,7 +397,9 @@ describe("a page the origin never answered does not move the cursor", () => {
   beforeEach(() => {
     // Every refused page exhausts its retry budget, and the backoff between
     // attempts is randomized wall-clock time. Nothing here is about waiting.
-    Bun.sleep = () => Promise.resolve();
+    Bun.sleep = async () => {
+      // no-op
+    };
   });
 
   afterEach(() => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -170,6 +170,27 @@ type PagePaginationOptions<TResponse> = {
  */
 /** Max retries for transient 5xx / timeout errors before skipping. */
 const SERVER_ERROR_RETRIES = 2;
+
+/**
+ * Statuses a gateway answers when it never reached the origin.
+ *
+ * The page-skip below rests on a 5xx being a fact about the page: the
+ * publisher ran the request and failed on it, so losing that one page is
+ * better than letting it stall the source. A gateway status carries no such
+ * fact. The origin was never asked, so the page's items are unknown rather
+ * than terminal, and advancing over them checkpoints past pages nobody read.
+ *
+ * The difference only shows at scale. A publisher-wide outage answers every
+ * page this way, so a skip that advances one page per failure walks the whole
+ * collection at the speed of the failures and leaves the cursor far past the
+ * tip, where it sees nothing new again. Holding is also what the crawl already
+ * does when the same outage arrives as a 429 or as an unparseable maintenance
+ * page: the cursor stays, and the next cycle asks again.
+ */
+const ORIGIN_UNREACHABLE_STATUSES = [502, 503, 504] as const;
+
+const isOriginUnreachableStatus = (status: number): boolean =>
+  ORIGIN_UNREACHABLE_STATUSES.some((candidate) => candidate === status);
 const OFFSET_CURSOR_PREFIX = "offset:";
 const CANONICAL_NON_NEGATIVE_INTEGER_PATTERN = /^(?:0|[1-9]\d*)$/u;
 
@@ -432,11 +453,17 @@ export const createPagePaginatedFetch = <TResponse>(
         }
 
         if (!response.ok) {
-          // 5xx after all retries: skip this page and advance.
+          // A 5xx the origin itself produced, after all retries: skip this
+          // page and advance.
           // 429 is NOT skipped — it's transient throttling, not
           // a page error. The cursor stays put so the page is
-          // retried in the next cycle.
-          if (response.status >= 500) {
+          // retried in the next cycle. A gateway status is the same case for
+          // the same reason (see ORIGIN_UNREACHABLE_STATUSES): nothing was
+          // read, so there is nothing to advance past.
+          if (
+            response.status >= 500 &&
+            !isOriginUnreachableStatus(response.status)
+          ) {
             // Same rule as the timeout skip above: a publisher-side 5xx
             // is operational, logged per page, and aggregated by the
             // coverage ledger rather than captured per attempt.

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -172,25 +172,31 @@ type PagePaginationOptions<TResponse> = {
 const SERVER_ERROR_RETRIES = 2;
 
 /**
- * Statuses a gateway answers when it never reached the origin.
+ * The gateway got no usable answer from the origin: the upstream refused the
+ * connection, dropped it, or replied unintelligibly.
  *
- * The page-skip below rests on a 5xx being a fact about the page: the
- * publisher ran the request and failed on it, so losing that one page is
- * better than letting it stall the source. A gateway status carries no such
- * fact. The origin was never asked, so the page's items are unknown rather
- * than terminal, and advancing over them checkpoints past pages nobody read.
+ * The page-skip below rests on a 5xx being a fact about the page — the
+ * publisher ran the request and failed on it, so losing that one page beats
+ * stalling the source. 502 carries no such fact. Nothing was read, so the
+ * page's items are unknown rather than terminal, and advancing over them
+ * checkpoints past pages nobody looked at.
  *
- * The difference only shows at scale. A publisher-wide outage answers every
- * page this way, so a skip that advances one page per failure walks the whole
- * collection at the speed of the failures and leaves the cursor far past the
- * tip, where it sees nothing new again. Holding is also what the crawl already
- * does when the same outage arrives as a 429 or as an unparseable maintenance
- * page: the cursor stays, and the next cycle asks again.
+ * The cost only shows at scale: a publisher whose gateway is down answers
+ * every page this way, so a skip that advances one page per refusal walks the
+ * entire collection at the speed of the failures and leaves the cursor far
+ * past the tip, where nothing new is ever listed again.
+ *
+ * Deliberately only 502. A 504 is the proxy's own read timeout, which the
+ * origin earns by being slow on this page — the same event the client-side
+ * timeout below skips, so holding it would decide identical situations
+ * opposite ways on whose stopwatch was shorter. A 503 can come from the
+ * origin itself. Both stay skippable.
+ *
+ * This puts 502 in the bucket 429 already occupies: hold, and ask again next
+ * cycle. It inherits that bucket's open question too — neither is bounded, so
+ * a page that answers this way forever holds its cursor forever.
  */
-const ORIGIN_UNREACHABLE_STATUSES = [502, 503, 504] as const;
-
-const isOriginUnreachableStatus = (status: number): boolean =>
-  ORIGIN_UNREACHABLE_STATUSES.some((candidate) => candidate === status);
+const BAD_GATEWAY_STATUS = 502;
 const OFFSET_CURSOR_PREFIX = "offset:";
 const CANONICAL_NON_NEGATIVE_INTEGER_PATTERN = /^(?:0|[1-9]\d*)$/u;
 
@@ -457,12 +463,12 @@ export const createPagePaginatedFetch = <TResponse>(
           // page and advance.
           // 429 is NOT skipped — it's transient throttling, not
           // a page error. The cursor stays put so the page is
-          // retried in the next cycle. A gateway status is the same case for
-          // the same reason (see ORIGIN_UNREACHABLE_STATUSES): nothing was
-          // read, so there is nothing to advance past.
+          // retried in the next cycle. 502 joins it for the same reason
+          // (see BAD_GATEWAY_STATUS): nothing was read, so there is nothing
+          // to advance past.
           if (
             response.status >= 500 &&
-            !isOriginUnreachableStatus(response.status)
+            response.status !== BAD_GATEWAY_STATUS
           ) {
             // Same rule as the timeout skip above: a publisher-side 5xx
             // is operational, logged per page, and aggregated by the


### PR DESCRIPTION
## The defect

`createPagePaginatedFetch` skips a page and advances past it on any 5xx that survives the retry budget, so one page a publisher cannot serve does not stall a source. That is rule 13, and it rests on the status being a fact about the page: the origin ran the request and failed on it.

A **502** is not that fact. The gateway got no usable answer from upstream — the connection was refused, dropped, or the reply was unintelligible — so the page's items are unknown rather than terminal, and advancing over them checkpoints past pages nobody read. That is what rule 4 (`conventions-ingestion`) forbids: *"On an ambiguous failure, hold the old checkpoint and replay."*

The cost only appears over a run of them, which is why a single call cannot tell the two apart. While a publisher's gateway is down **every** page answers alike, so a skip that advances one page per refusal walks the entire collection at the speed of the failures. A source whose cursor sat near the tip ends far past the end of the collection, and once there it is in exactly the state the bounded walks in this file exist to prevent: parked where nothing new is ever listed, reached from the other end. Recovering costs one backward step per page (`resolveNextCursor`'s overshoot branch), so the walk pays for the outage twice.

The adjacent paths already hold. A 429 holds the cursor, and an unparseable maintenance page thrown as `AdapterFetchError` holds it too.

## The change

`BAD_GATEWAY_STATUS` is excluded from the existing `>= 500` branch, so it falls through to the `AdapterFetchError` the 4xx path already throws, which fails the page and holds its cursor for the next cycle. Every other 5xx keeps the skip unchanged.

**502 only, and the boundary is the point.** An earlier revision held 503 and 504 as well; Codex was right that this was wrong, and the 504 case is decisive. A gateway read timeout fires *because* the origin received the request and is slow on that page, so the refusal is a fact about the page after all — and the client-side timeout branch a few lines below skips exactly that event when our own timeout fires first. Holding one and skipping the other would decide identical situations opposite ways on whose stopwatch was shorter, and would pin the cursor forever on a page that is merely expensive. A 503 can come from the origin directly. Both stay skippable.

## Validation

Tests drive the walk the way the pipeline does — a failed page leaves the cursor where it was, so only a successful page supplies the next one:

- **the class regression**: a run of 502s leaves both the cursor and the requested page where they started. Verified to **fail on `origin/main` and to be the only failure there**.
- **the discriminators**: 500, 503 and 504 each still skip their own page and advance. All three pass on `origin/main` too, which is what shows only 502 behaviour changed.

They stub `Bun.sleep` for the retry backoff, the idiom `cursor-conformance.test.ts` already uses, so the retry ladder still runs in full while the randomized wall-clock waiting is gone: the file runs in ~0.3s instead of ~17s.

`pagination.test.ts` 26 pass, `oxlint-guardrails.test.ts` 25 pass, typecheck clean, type-aware oxlint clean on both files, format clean, `ratchet --check` OK at 69 metrics.

## Notes for review

- **Deliberately out of scope**: a bounded, durable failure policy that eventually isolates a persistently failing page. That is the general answer to "when may a refused page be abandoned", and it needs state surviving across calls — `fetchPage` runs once per page with the cursor as its only durable channel, so a consecutive-failure count means changing the cursor grammar. Worth noting 429 already carries the same unbounded-hold property; the code comment now says so rather than implying the hold is free.
- Also out of scope: the `page_skipped_timeout` branch has the same unbounded-advance shape. A slow page is plausibly a property of that page, where a 502 cannot be, so the two are not the same call.
