### PR TITLE
fix(desktop): polish clipboard navigation and image paste

### DIFF
--- a/.changeset/inline-color-swatches.md
+++ b/.changeset/inline-color-swatches.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Add inline color swatches with an optional custom-color popover, and preserve Escape dismissal from the custom hex input.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,7 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]] || ! git diff --quiet "origin/$BASE_REF"...HEAD -- \
             .github/actions/setup-playwright/action.yml \
             .github/workflows/ci.yml \
+            apps/desktop \
             apps/web/e2e/playwright.ui-playground.config.ts \
             apps/web/e2e/ui-playground \
             apps/web/package.json \
@@ -1010,6 +1011,10 @@ jobs:
       - name: Test UI browser interactions
         if: steps.ui-browser-tests.outputs.required == 'true'
         run: bun --filter @stll/ui test:browser
+
+      - name: Test desktop browser interactions
+        if: steps.ui-browser-tests.outputs.required == 'true'
+        run: bun --filter @stll/desktop test:browser
 
       - name: Test UI playground visuals
         if: steps.ui-browser-tests.outputs.required == 'true'

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/desktop",
     "rpc:check": "cargo test --manifest-path src-tauri/Cargo.toml --locked types::rpc_codegen_tests::generated_desktop_rpc_bindings_are_current -- --exact",
     "rpc:generate": "cargo test --manifest-path src-tauri/Cargo.toml --locked types::rpc_codegen_tests::generate_desktop_rpc_bindings -- --ignored --exact",
-    "test": "bun test --pass-with-no-tests",
+    "test": "bun test --pass-with-no-tests --path-ignore-patterns '**/*.playwright.spec.ts'",
+    "test:browser": "playwright test --config playwright.config.ts",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
@@ -32,6 +33,7 @@
     "use-intl": "catalog:"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.0",
     "@stll/typescript-config": "workspace:*",
     "@tailwindcss/vite": "catalog:",
     "@tauri-apps/cli": "^2.11.4",

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     browserName: "chromium",
     baseURL: "http://127.0.0.1:4177",
     viewport: { height: 326, width: 1100 },
+    screenshot: "only-on-failure",
   },
   webServer: {
     command: "vite --host 127.0.0.1 --port 4177",

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const PORT = 4177;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
 export default defineConfig({
   testDir: "./tests/browser",
   testMatch: "**/*.playwright.spec.ts",
@@ -9,12 +12,12 @@ export default defineConfig({
   use: {
     ...devices["Desktop Chrome"],
     browserName: "chromium",
-    baseURL: "http://127.0.0.1:4177",
+    baseURL: BASE_URL,
     viewport: { height: 326, width: 1100 },
     screenshot: "only-on-failure",
   },
   webServer: {
-    command: "vite --host 127.0.0.1 --port 4177",
-    port: 4177,
+    command: `vite --host 127.0.0.1 --port ${PORT}`,
+    url: BASE_URL,
   },
 });

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  testMatch: "**/*.playwright.spec.ts",
+  fullyParallel: true,
+  workers: 1,
+  retries: 0,
+  use: {
+    ...devices["Desktop Chrome"],
+    browserName: "chromium",
+    baseURL: "http://127.0.0.1:4177",
+    viewport: { height: 326, width: 1100 },
+  },
+  webServer: {
+    command: "vite --host 127.0.0.1 --port 4177",
+    port: 4177,
+  },
+});

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -114,6 +114,8 @@ const MACOS_PNG_FORMAT: &str = "public.png";
 #[cfg(target_os = "macos")]
 const MACOS_FILE_URL_FORMAT: &str = "public.file-url";
 #[cfg(target_os = "macos")]
+const MAX_CLIPBOARD_FILE_URL_BYTES: usize = 16 * 1024;
+#[cfg(target_os = "macos")]
 const CLIPBOARD_IMAGE_FORMATS: &[&str] = &[MACOS_PNG_FORMAT, "public.tiff"];
 #[cfg(target_os = "windows")]
 const CLIPBOARD_IMAGE_FORMATS: &[&str] = &["PNG"];
@@ -865,6 +867,7 @@ pub enum ClipboardImageCleanupStatus {
 #[serde(rename_all = "camelCase")]
 pub struct ClipboardSnapshot {
   pub capture_status: ClipboardCaptureStatus,
+  pub group_limit: usize,
   pub groups: Vec<ClipboardGroup>,
   pub items: Vec<ClipboardItem>,
   pub persistence: ClipboardPersistenceStatus,
@@ -1322,6 +1325,7 @@ impl ClipboardManager {
     source_app_visuals.sort_by(|left, right| left.key.cmp(&right.key));
     ClipboardSnapshot {
       capture_status: self.capture_status,
+      group_limit: MAX_GROUPS,
       groups: self.groups.clone(),
       items: self
         .items
@@ -3305,21 +3309,21 @@ impl ClipboardHandler for HistoryClipboardHandler {
         return;
       }
     };
-    if formats
-      .iter()
-      .any(|format| format.eq_ignore_ascii_case(INTERNAL_CLIPBOARD_FORMAT))
-    {
-      manager.clear_suppression();
-      return;
-    }
     #[cfg(target_os = "macos")]
-    if let Err(error) = manager.image_exports.clear_if_active() {
+    if let Err(error) = manager.reconcile_image_exports() {
       tracing::warn!(error = %error, "replaced clipboard image export cleanup will be retried");
       self.telemetry.capture(DesktopErrorReport {
         window: DesktopTelemetryWindow::Clipboard,
         operation: DesktopTelemetryOperation::ClipboardWatcherRead,
         code: DesktopTelemetryErrorCode::PersistenceFailed,
       });
+    }
+    if formats
+      .iter()
+      .any(|format| format.eq_ignore_ascii_case(INTERNAL_CLIPBOARD_FORMAT))
+    {
+      manager.clear_suppression();
+      return;
     }
     drop(manager);
     if should_ignore_formats(&formats) {
@@ -3956,6 +3960,7 @@ impl ClipboardManager {
           .map_err(|error| format!("clipboard image is invalid: {error}"))?;
         #[cfg(target_os = "macos")]
         {
+          self.reconcile_image_exports()?;
           let png = encode_png_bounded(&image, MAX_ITEM_IMAGE_BYTES)?;
           return self.image_exports.publish(&png, |url| {
             // Both representations belong to one pasteboard item. Publishing
@@ -3984,16 +3989,48 @@ impl ClipboardManager {
     }
     set_clipboard_contents(&clipboard, contents)?;
     #[cfg(target_os = "macos")]
-    self.clear_image_exports();
+    if let Err(error) = self.reconcile_image_exports() {
+      tracing::warn!(error = %error, "clipboard image export cleanup will be retried");
+    }
     Ok(())
   }
 
   #[cfg(target_os = "macos")]
-  pub fn clear_image_exports(&mut self) {
-    if let Err(error) = self.image_exports.clear() {
-      tracing::warn!(error = %error, "clipboard image export cleanup will be retried");
-    }
+  pub fn reconcile_image_exports(&mut self) -> Result<(), String> {
+    let current_file = current_clipboard_export_file()?;
+    self.image_exports.reconcile(current_file.as_deref())
   }
+}
+
+#[cfg(target_os = "macos")]
+fn current_clipboard_export_file() -> Result<Option<PathBuf>, String> {
+  use objc2_app_kit::NSPasteboard;
+  use objc2_foundation::NSString;
+
+  let pasteboard = NSPasteboard::generalPasteboard();
+  let change_count = pasteboard.changeCount();
+  let file_url_type = NSString::from_str(MACOS_FILE_URL_FORMAT);
+  let has_file_url = pasteboard
+    .types()
+    .is_some_and(|types| types.containsObject(&file_url_type));
+  let path = if has_file_url {
+    let data = pasteboard
+      .dataForType(&file_url_type)
+      .ok_or_else(|| "clipboard file URL could not be read".to_string())?;
+    if data.length() > MAX_CLIPBOARD_FILE_URL_BYTES {
+      return Err("clipboard file URL exceeds the size limit".to_string());
+    }
+    String::from_utf8(data.to_vec())
+      .ok()
+      .and_then(|value| Url::parse(&value).ok())
+      .and_then(|url| url.to_file_path().ok())
+  } else {
+    None
+  };
+  if pasteboard.changeCount() != change_count {
+    return Err("clipboard changed while reading its file URL".to_string());
+  }
+  Ok(path)
 }
 
 fn set_clipboard_contents(
@@ -6358,6 +6395,22 @@ mod tests {
         .create_group("One too many", ClipboardGroupColor::default(), None)
         .is_err()
     );
+
+    let snapshot = manager.snapshot();
+    assert_eq!(snapshot.group_limit, MAX_GROUPS);
+    let snapshot_json = serde_json::to_value(snapshot).unwrap();
+    assert_eq!(snapshot_json["groupLimit"], MAX_GROUPS);
+
+    let persisted = PersistedClipboardState {
+      capture_status: manager.capture_status,
+      groups: manager.groups.clone(),
+      items: manager.items.clone(),
+      pending_image_blob_ids: manager.pending_image_blob_ids.clone(),
+      retention: manager.retention,
+      source_app_visuals: Vec::new(),
+    };
+    let persisted_json = serde_json::to_value(persisted).unwrap();
+    assert!(persisted_json.get("groupLimit").is_none());
 
     let mut manager = ready_manager();
     assert!(

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -110,7 +110,11 @@ const MAX_FAVICON_BYTES: usize = 512 * 1024;
 #[cfg(target_os = "linux")]
 const CLIPBOARD_IMAGE_FORMATS: &[&str] = &["image/png"];
 #[cfg(target_os = "macos")]
-const CLIPBOARD_IMAGE_FORMATS: &[&str] = &["public.png", "public.tiff"];
+const MACOS_PNG_FORMAT: &str = "public.png";
+#[cfg(target_os = "macos")]
+const MACOS_FILE_URL_FORMAT: &str = "public.file-url";
+#[cfg(target_os = "macos")]
+const CLIPBOARD_IMAGE_FORMATS: &[&str] = &[MACOS_PNG_FORMAT, "public.tiff"];
 #[cfg(target_os = "windows")]
 const CLIPBOARD_IMAGE_FORMATS: &[&str] = &["PNG"];
 #[cfg(debug_assertions)]
@@ -896,6 +900,8 @@ pub struct PersistedClipboardState {
 
 pub struct ClipboardManager {
   capture_status: ClipboardCaptureStatus,
+  #[cfg(target_os = "macos")]
+  image_exports: crate::clipboard_image_export::ClipboardImageExports,
   groups: Vec<ClipboardGroup>,
   image_discovery_status: ClipboardImageCleanupStatus,
   items: Vec<ClipboardItem>,
@@ -1244,6 +1250,8 @@ impl ClipboardManager {
   pub fn new() -> Self {
     Self {
       capture_status: ClipboardCaptureStatus::Active,
+      #[cfg(target_os = "macos")]
+      image_exports: crate::clipboard_image_export::ClipboardImageExports::new(),
       groups: Vec::new(),
       image_discovery_status: ClipboardImageCleanupStatus::Idle,
       items: Vec::new(),
@@ -1440,7 +1448,19 @@ impl ClipboardManager {
     &mut self,
     name: &str,
     color: ClipboardGroupColor,
+    item_id: Option<&str>,
   ) -> Result<String, String> {
+    let item_index = if let Some(item_id) = item_id {
+      Some(
+        self
+          .items
+          .iter()
+          .position(|item| item.id() == item_id)
+          .ok_or_else(|| "clipboard item no longer exists".to_string())?,
+      )
+    } else {
+      None
+    };
     if self.groups.len() >= MAX_GROUPS {
       return Err("clipboard group limit reached".to_string());
     }
@@ -1452,6 +1472,9 @@ impl ClipboardManager {
       id: id.clone(),
       name,
     });
+    if let Some(item_index) = item_index {
+      self.items[item_index].set_group_id(Some(id.clone()), Utc::now());
+    }
     self.persist_or_restore(checkpoint)?;
     Ok(id)
   }
@@ -3260,6 +3283,16 @@ fn resolve_clipboard_image_capture(
 
 impl ClipboardHandler for HistoryClipboardHandler {
   fn on_clipboard_change(&mut self) {
+    // Re-read formats while holding the publication lock: a stale watcher
+    // observation must never remove an export just published by a copy.
+    let Ok(mut manager) = self.manager.lock() else {
+      self.telemetry.capture(DesktopErrorReport {
+        window: DesktopTelemetryWindow::Clipboard,
+        operation: DesktopTelemetryOperation::ClipboardWatcherRead,
+        code: DesktopTelemetryErrorCode::LockPoisoned,
+      });
+      return;
+    };
     let formats = match self.clipboard.available_formats() {
       Ok(formats) => formats,
       Err(error) => {
@@ -3276,11 +3309,19 @@ impl ClipboardHandler for HistoryClipboardHandler {
       .iter()
       .any(|format| format.eq_ignore_ascii_case(INTERNAL_CLIPBOARD_FORMAT))
     {
-      if let Ok(mut manager) = self.manager.lock() {
-        manager.clear_suppression();
-      }
+      manager.clear_suppression();
       return;
     }
+    #[cfg(target_os = "macos")]
+    if let Err(error) = manager.image_exports.clear_if_active() {
+      tracing::warn!(error = %error, "replaced clipboard image export cleanup will be retried");
+      self.telemetry.capture(DesktopErrorReport {
+        window: DesktopTelemetryWindow::Clipboard,
+        operation: DesktopTelemetryOperation::ClipboardWatcherRead,
+        code: DesktopTelemetryErrorCode::PersistenceFailed,
+      });
+    }
+    drop(manager);
     if should_ignore_formats(&formats) {
       return;
     }
@@ -3894,37 +3935,71 @@ pub fn initialize_and_watch(
   watcher.start_watch();
 }
 
-pub fn write_item(
-  item: &ClipboardItem,
-  image_bytes: Option<&[u8]>,
-  plain_text_only: bool,
-) -> Result<(), String> {
-  let clipboard = ClipboardContext::new()
-    .map_err(|error| format!("clipboard is unavailable: {error}"))?;
-  let mut contents = match item {
-    ClipboardItem::Text { plain_text, .. }
-    | ClipboardItem::FormattedText { plain_text, .. } => {
-      vec![ClipboardContent::Text(plain_text.clone())]
-    }
-    ClipboardItem::Image { .. } => {
-      if plain_text_only {
-        return Err("clipboard image cannot be copied as plain text".to_string());
+impl ClipboardManager {
+  pub fn write_item(
+    &mut self,
+    item: &ClipboardItem,
+    image_bytes: Option<&[u8]>,
+  ) -> Result<(), String> {
+    let clipboard = ClipboardContext::new()
+      .map_err(|error| format!("clipboard is unavailable: {error}"))?;
+    self.suppress_next(item, false);
+    let mut contents = match item {
+      ClipboardItem::Text { plain_text, .. }
+      | ClipboardItem::FormattedText { plain_text, .. } => {
+        vec![ClipboardContent::Text(plain_text.clone())]
       }
-      let image =
-        image_bytes.ok_or_else(|| "clipboard image is unavailable".to_string())?;
-      let image = RustImageData::from_bytes(image)
-        .map_err(|error| format!("clipboard image is invalid: {error}"))?;
-      vec![ClipboardContent::Image(image)]
-    }
-  };
-  if !plain_text_only {
+      ClipboardItem::Image { .. } => {
+        let image =
+          image_bytes.ok_or_else(|| "clipboard image is unavailable".to_string())?;
+        let image = RustImageData::from_bytes(image)
+          .map_err(|error| format!("clipboard image is invalid: {error}"))?;
+        #[cfg(target_os = "macos")]
+        {
+          let png = encode_png_bounded(&image, MAX_ITEM_IMAGE_BYTES)?;
+          return self.image_exports.publish(&png, |url| {
+            // Both representations belong to one pasteboard item. Publishing
+            // Files separately would make some receivers paste two objects.
+            set_clipboard_contents(
+              &clipboard,
+              vec![
+                ClipboardContent::Other(MACOS_PNG_FORMAT.to_string(), png.clone()),
+                ClipboardContent::Other(
+                  MACOS_FILE_URL_FORMAT.to_string(),
+                  url.as_str().as_bytes().to_vec(),
+                ),
+              ],
+            )
+          });
+        }
+        #[cfg(not(target_os = "macos"))]
+        vec![ClipboardContent::Image(image)]
+      }
+    };
     if let Some(html) = item.html() {
       contents.push(ClipboardContent::Html(html.to_string()));
     }
     if let Some(rtf) = item.rtf() {
       contents.push(ClipboardContent::Rtf(rtf.to_string()));
     }
+    set_clipboard_contents(&clipboard, contents)?;
+    #[cfg(target_os = "macos")]
+    self.clear_image_exports();
+    Ok(())
   }
+
+  #[cfg(target_os = "macos")]
+  pub fn clear_image_exports(&mut self) {
+    if let Err(error) = self.image_exports.clear() {
+      tracing::warn!(error = %error, "clipboard image export cleanup will be retried");
+    }
+  }
+}
+
+fn set_clipboard_contents(
+  clipboard: &ClipboardContext,
+  mut contents: Vec<ClipboardContent>,
+) -> Result<(), String> {
   contents.push(ClipboardContent::Other(
     INTERNAL_CLIPBOARD_FORMAT.to_string(),
     Vec::new(),
@@ -5557,7 +5632,7 @@ mod tests {
     let now = Utc::now();
     let mut manager = ready_manager();
     let group_id = manager
-      .create_group("Templates", ClipboardGroupColor::default())
+      .create_group("Templates", ClipboardGroupColor::default(), None)
       .unwrap();
     let mut ungrouped = text_item(now - Duration::days(400), "ungrouped");
     ungrouped.set_group_id(Some(group_id.clone()), Utc::now());
@@ -6092,10 +6167,89 @@ mod tests {
   }
 
   #[test]
+  fn creating_a_group_without_an_item_leaves_history_unchanged() {
+    let mut manager = ready_manager();
+    manager.items.push(text_item(Utc::now(), "unfiled"));
+    let items_before = manager.items.clone();
+
+    let group_id = manager
+      .create_group("Research", ClipboardGroupColor::default(), None)
+      .unwrap();
+
+    assert_eq!(manager.groups.len(), 1);
+    assert_eq!(manager.groups[0].id, group_id);
+    assert_eq!(manager.groups[0].name, "Research");
+    assert_eq!(manager.items, items_before);
+  }
+
+  #[test]
+  fn creating_a_group_can_file_an_item_atomically() {
+    let mut manager = ready_manager();
+    manager.items.push(text_item(Utc::now(), "clause"));
+    let item_id = manager.items[0].id().to_string();
+
+    let group_id = manager
+      .create_group(
+        "Research",
+        ClipboardGroupColor::parse("#60a5fa").unwrap(),
+        Some(&item_id),
+      )
+      .unwrap();
+
+    assert_eq!(manager.groups.len(), 1);
+    assert_eq!(manager.groups[0].id, group_id);
+    assert_eq!(manager.items[0].group_id(), Some(group_id.as_str()));
+    assert!(manager.items[0].grouped_at().is_some());
+  }
+
+  #[test]
+  fn creating_a_group_for_a_missing_item_changes_nothing() {
+    let mut manager = ready_manager();
+    manager.items.push(text_item(Utc::now(), "clause"));
+    let groups_before = manager.groups.clone();
+    let items_before = manager.items.clone();
+
+    assert_eq!(
+      manager
+        .create_group("Research", ClipboardGroupColor::default(), Some("missing"),),
+      Err("clipboard item no longer exists".to_string())
+    );
+    assert_eq!(manager.groups, groups_before);
+    assert_eq!(manager.items, items_before);
+  }
+
+  #[test]
+  fn failed_group_creation_restores_the_group_and_item() {
+    let store_path = unique_store_path();
+    std::fs::create_dir_all(&store_path).unwrap();
+    let mut manager = ready_manager();
+    manager.items.push(text_item(Utc::now(), "clause"));
+    let item_id = manager.items[0].id().to_string();
+    let groups_before = manager.groups.clone();
+    let items_before = manager.items.clone();
+    manager.persistence =
+      ClipboardPersistence::Encrypted(ClipboardStore::new([7; 32], store_path.clone()));
+
+    assert!(
+      manager
+        .create_group("Research", ClipboardGroupColor::default(), Some(&item_id),)
+        .is_err()
+    );
+    assert_eq!(manager.groups, groups_before);
+    assert_eq!(manager.items, items_before);
+
+    std::fs::remove_dir(store_path).unwrap();
+  }
+
+  #[test]
   fn deleting_a_group_can_preserve_its_clips() {
     let mut manager = ready_manager();
     let group_id = manager
-      .create_group("Research", ClipboardGroupColor::parse("#60a5fa").unwrap())
+      .create_group(
+        "Research",
+        ClipboardGroupColor::parse("#60a5fa").unwrap(),
+        None,
+      )
       .unwrap();
     let mut grouped = text_item(Utc::now() - Duration::days(400), "grouped");
     let grouped_id = grouped.id().to_string();
@@ -6127,7 +6281,11 @@ mod tests {
     assert!(capture(&mut manager, "grouped", None, Utc::now()));
     assert!(capture(&mut manager, "ungrouped", None, Utc::now()));
     let group_id = manager
-      .create_group("Research", ClipboardGroupColor::parse("#60a5fa").unwrap())
+      .create_group(
+        "Research",
+        ClipboardGroupColor::parse("#60a5fa").unwrap(),
+        None,
+      )
       .unwrap();
     let grouped_id = manager.items[1].id().to_string();
     assert!(
@@ -6149,11 +6307,21 @@ mod tests {
   fn updating_a_group_trims_and_rejects_duplicate_names() {
     let mut manager = ready_manager();
     let research_id = manager
-      .create_group("Research", ClipboardGroupColor::parse("#60a5fa").unwrap())
+      .create_group(
+        "Research",
+        ClipboardGroupColor::parse("#60a5fa").unwrap(),
+        None,
+      )
       .unwrap();
     manager
-      .create_group("Templates", ClipboardGroupColor::default())
+      .create_group("Templates", ClipboardGroupColor::default(), None)
       .unwrap();
+    let groups_before_duplicate = manager.groups.clone();
+    assert_eq!(
+      manager.create_group(" templates ", ClipboardGroupColor::default(), None),
+      Err("clipboard group name already exists".to_string())
+    );
+    assert_eq!(manager.groups, groups_before_duplicate);
     let amber = ClipboardGroupColor::parse("#fbbf24").unwrap();
 
     assert!(
@@ -6177,13 +6345,17 @@ mod tests {
     let mut manager = ready_manager();
     for index in 0..MAX_GROUPS {
       manager
-        .create_group(&format!("Group {index}"), ClipboardGroupColor::default())
+        .create_group(
+          &format!("Group {index}"),
+          ClipboardGroupColor::default(),
+          None,
+        )
         .unwrap();
     }
 
     assert!(
       manager
-        .create_group("One too many", ClipboardGroupColor::default())
+        .create_group("One too many", ClipboardGroupColor::default(), None)
         .is_err()
     );
 
@@ -6193,6 +6365,7 @@ mod tests {
         .create_group(
           &"x".repeat(MAX_GROUP_NAME_CHARACTERS + 1),
           ClipboardGroupColor::default(),
+          None,
         )
         .is_err()
     );
@@ -6207,7 +6380,8 @@ mod tests {
       manager
         .create_group(
           &international_name,
-          ClipboardGroupColor::parse("#60a5fa").unwrap()
+          ClipboardGroupColor::parse("#60a5fa").unwrap(),
+          None,
         )
         .is_ok()
     );
@@ -6216,6 +6390,7 @@ mod tests {
         .create_group(
           &format!("{international_name}界"),
           ClipboardGroupColor::parse("#60a5fa").unwrap(),
+          None,
         )
         .is_err()
     );
@@ -6283,7 +6458,11 @@ mod tests {
     let mut manager = ready_manager();
     assert!(capture(&mut manager, "grouped", None, now));
     let group_id = manager
-      .create_group("Research", ClipboardGroupColor::parse("#34d399").unwrap())
+      .create_group(
+        "Research",
+        ClipboardGroupColor::parse("#34d399").unwrap(),
+        None,
+      )
       .unwrap();
     let item_id = manager.items[0].id().to_string();
     manager
@@ -6304,7 +6483,11 @@ mod tests {
     let mut manager = ready_manager();
     assert!(capture(&mut manager, "clause", None, Utc::now()));
     let group_id = manager
-      .create_group("Research", ClipboardGroupColor::parse("#34d399").unwrap())
+      .create_group(
+        "Research",
+        ClipboardGroupColor::parse("#34d399").unwrap(),
+        None,
+      )
       .unwrap();
     let item_id = manager.items[0].id().to_string();
 

--- a/apps/desktop/src-tauri/src/clipboard_commands.rs
+++ b/apps/desktop/src-tauri/src/clipboard_commands.rs
@@ -10,7 +10,7 @@ use crate::{
   clipboard::{
     ClipboardAppState, ClipboardCaptureStatus, ClipboardGroup, ClipboardGroupColor,
     ClipboardGroupDeletionMode, ClipboardItem, ClipboardRetention, ClipboardSnapshot,
-    ClipboardSourceAppVisual, write_item,
+    ClipboardSourceAppVisual,
   },
   clipboard_screen_capture::ClipboardScreenCapture,
   clipboard_window::{self, ClipboardStartupTrace},
@@ -190,13 +190,14 @@ pub fn clipboard_clear_history(
 #[tauri::command]
 pub fn clipboard_create_group(
   color: ClipboardGroupColor,
+  item_id: Option<String>,
   name: String,
   state: State<'_, ClipboardAppState>,
   window: WebviewWindow,
 ) -> Result<ClipboardSnapshot, String> {
   let snapshot = {
     let mut manager = state.lock().map_err(|_| lock_error())?;
-    manager.create_group(&name, color)?;
+    manager.create_group(&name, color, item_id.as_deref())?;
     manager.snapshot()
   };
   let _ = window.emit(HISTORY_EVENT, ());
@@ -413,20 +414,14 @@ fn write_history_item(
     .map(|image| image.load())
     .transpose()
     .map_err(copy_error)?;
-  state
-    .lock()
-    .map_err(|_| copy_error(lock_error()))?
-    .suppress_next(&item, false);
-  if let Err(error) = write_item(&item, image.as_deref(), false) {
-    if let Ok(mut manager) = state.lock() {
-      manager.clear_suppression();
-    }
+  // Serialize clipboard publication and export lifetime with watcher cleanup.
+  let mut manager = state.lock().map_err(|_| copy_error(lock_error()))?;
+  if let Err(error) = manager.write_item(&item, image.as_deref()) {
+    manager.clear_suppression();
     return Err(copy_error(error));
   }
-  state
-    .lock()
-    .map_err(|_| lock_error())
-    .and_then(|mut manager| manager.touch_item(id, chrono::Utc::now()))
+  manager
+    .touch_item(id, chrono::Utc::now())
     .map(|_| ())
     .map_err(|message| ClipboardCopyError::History { message })
 }

--- a/apps/desktop/src-tauri/src/clipboard_image_export.rs
+++ b/apps/desktop/src-tauri/src/clipboard_image_export.rs
@@ -82,24 +82,26 @@ impl ClipboardImageExports {
     Ok(())
   }
 
-  pub(crate) fn clear_if_active(&mut self) -> Result<(), String> {
-    if self.active.is_none() {
-      return Ok(());
-    }
-    self.clear()
-  }
-
-  /// Also called on startup, after single-instance registration, to remove
-  /// files left by an interrupted process. No directory scan is necessary.
-  pub(crate) fn clear(&mut self) -> Result<(), String> {
+  /// The pasteboard outlives this process. Keep only its referenced fixed slot,
+  /// including across restarts; never adopt or remove a path outside our slots.
+  pub(crate) fn reconcile(
+    &mut self,
+    clipboard_file: Option<&Path>,
+  ) -> Result<(), String> {
     let Some(root) = &self.directory else {
       return Ok(());
     };
     if !private_directory_exists(root)? {
       return Ok(());
     }
+    self.active = EXPORT_SLOTS.iter().position(|slot| {
+      clipboard_file == Some(root.join(slot).join(EXPORT_FILENAME).as_path())
+    });
     let mut result = Ok(());
-    for slot in EXPORT_SLOTS {
+    for (index, slot) in EXPORT_SLOTS.iter().enumerate() {
+      if self.active == Some(index) {
+        continue;
+      }
       let directory = root.join(slot);
       let cleanup = private_directory_exists(&directory).and_then(|exists| {
         if exists {
@@ -110,9 +112,6 @@ impl ClipboardImageExports {
       if let Err(error) = cleanup {
         result = Err(error);
       }
-    }
-    if result.is_ok() {
-      self.active = None;
     }
     result
   }
@@ -379,7 +378,7 @@ mod tests {
     }
     let mut exports = exports_at(&root);
 
-    exports.clear().unwrap();
+    exports.reconcile(None).unwrap();
 
     assert!(existing_export_paths(&root).is_empty());
     assert_eq!(exports.active, None);
@@ -403,6 +402,61 @@ mod tests {
       assert_eq!(paths.len(), 1);
       assert_eq!(fs::read(&paths[0]).unwrap(), payload.as_bytes());
     }
+  }
+
+  #[test]
+  fn live_clipboard_file_survives_restarts_until_replacement() {
+    for live_slot in 0..EXPORT_SLOTS.len() {
+      let sandbox = TestDirectory::new();
+      let root = sandbox.export_root();
+      for (index, slot) in EXPORT_SLOTS.iter().enumerate() {
+        create_private_directory(&root.join(slot));
+        create_private_file(&export_path(&root, index), b"live");
+      }
+      let live_path = export_path(&root, live_slot);
+
+      for _ in 0..3 {
+        let mut restarted = exports_at(&root);
+        restarted.reconcile(Some(&live_path)).unwrap();
+        assert_eq!(restarted.active, Some(live_slot));
+        assert_eq!(existing_export_paths(&root), vec![live_path.clone()]);
+        assert_eq!(fs::read(&live_path).unwrap(), b"live");
+      }
+
+      let mut restarted = exports_at(&root);
+      restarted.reconcile(Some(&live_path)).unwrap();
+      assert_eq!(
+        restarted.publish(b"failed replacement", |_| Err("rejected".into())),
+        Err("rejected".to_string())
+      );
+      assert_eq!(fs::read(&live_path).unwrap(), b"live");
+      restarted
+        .publish(b"replacement", |url| {
+          assert_ne!(url.to_file_path().unwrap(), live_path);
+          assert_eq!(fs::read(&live_path).unwrap(), b"live");
+          Ok(())
+        })
+        .unwrap();
+      assert!(!live_path.exists());
+      restarted.reconcile(None).unwrap();
+      assert!(existing_export_paths(&root).is_empty());
+    }
+  }
+
+  #[test]
+  fn reconciliation_never_adopts_or_removes_an_external_clipboard_file() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let external = sandbox.path.join("external.png");
+    create_private_file(&external, b"external");
+    let mut exports = exports_at(&root);
+    exports.publish(b"previous", |_| Ok(())).unwrap();
+
+    exports.reconcile(Some(&external)).unwrap();
+
+    assert_eq!(exports.active, None);
+    assert!(existing_export_paths(&root).is_empty());
+    assert_eq!(fs::read(&external).unwrap(), b"external");
   }
 
   #[test]
@@ -473,12 +527,12 @@ mod tests {
     };
 
     assert_eq!(
-      exports.clear(),
+      exports.reconcile(None),
       Err("clipboard export directory is not private".to_string())
     );
 
     assert!(!active_path.exists());
     assert_eq!(fs::read(sentinel).unwrap(), b"external");
-    assert_eq!(exports.active, Some(1));
+    assert_eq!(exports.active, None);
   }
 }

--- a/apps/desktop/src-tauri/src/clipboard_image_export.rs
+++ b/apps/desktop/src-tauri/src/clipboard_image_export.rs
@@ -1,0 +1,484 @@
+use std::{
+  fs,
+  io::{ErrorKind, Write},
+  os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt},
+  path::{Path, PathBuf},
+};
+
+use reqwest::Url;
+
+use crate::config::APP_DATA_DIR_NAME;
+
+const EXPORT_SLOTS: [&str; 2] = ["0", "1"];
+const EXPORT_FILENAME: &str = "image.png";
+
+/// Only explicit copies materialize an image. Two fixed slots let a failed
+/// replacement preserve the current clipboard file without growing a cache.
+/// This state is never included in encrypted history or its checkpoints.
+pub(crate) struct ClipboardImageExports {
+  directory: Option<PathBuf>,
+  active: Option<usize>,
+}
+
+impl ClipboardImageExports {
+  pub(crate) fn new() -> Self {
+    Self {
+      directory: dirs::cache_dir()
+        .map(|root| root.join(APP_DATA_DIR_NAME).join("clipboard-export")),
+      active: None,
+    }
+  }
+
+  pub(crate) fn publish(
+    &mut self,
+    png: &[u8],
+    publish: impl FnOnce(&Url) -> Result<(), String>,
+  ) -> Result<(), String> {
+    let root = self
+      .directory
+      .as_ref()
+      .ok_or_else(|| "clipboard export directory is unavailable".to_string())?;
+    ensure_private_directory(root)?;
+    let slot = self.active.map_or(0, |active| 1 - active);
+    let directory = root.join(EXPORT_SLOTS[slot]);
+    ensure_private_directory(&directory)?;
+    let path = directory.join(EXPORT_FILENAME);
+    remove_export_file(&path)?;
+    let url = Url::from_file_path(&path)
+      .map_err(|()| "clipboard export path is invalid".to_string())?;
+    let write = (|| {
+      let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .map_err(|error| {
+          format!("clipboard image export could not be created: {error}")
+        })?;
+      file
+        .write_all(png)
+        .map_err(|error| format!("clipboard image export failed: {error}"))?;
+      publish(&url)
+    })();
+    if let Err(error) = write {
+      if let Err(cleanup) = remove_export_file(&path) {
+        tracing::warn!(error = %cleanup, "failed clipboard export cleanup will be retried");
+      }
+      return Err(error);
+    }
+    self.active = Some(slot);
+    // Publishing already succeeded. Cleanup must not report the copy as failed;
+    // a failed removal is retried before that fixed slot can be reused.
+    let previous = root.join(EXPORT_SLOTS[1 - slot]);
+    let cleanup = private_directory_exists(&previous).and_then(|exists| {
+      if exists {
+        remove_export_file(&previous.join(EXPORT_FILENAME))?;
+      }
+      Ok(())
+    });
+    if let Err(error) = cleanup {
+      tracing::warn!(error = %error, "previous clipboard export cleanup will be retried");
+    }
+    Ok(())
+  }
+
+  pub(crate) fn clear_if_active(&mut self) -> Result<(), String> {
+    if self.active.is_none() {
+      return Ok(());
+    }
+    self.clear()
+  }
+
+  /// Also called on startup, after single-instance registration, to remove
+  /// files left by an interrupted process. No directory scan is necessary.
+  pub(crate) fn clear(&mut self) -> Result<(), String> {
+    let Some(root) = &self.directory else {
+      return Ok(());
+    };
+    if !private_directory_exists(root)? {
+      return Ok(());
+    }
+    let mut result = Ok(());
+    for slot in EXPORT_SLOTS {
+      let directory = root.join(slot);
+      let cleanup = private_directory_exists(&directory).and_then(|exists| {
+        if exists {
+          remove_export_file(&directory.join(EXPORT_FILENAME))?;
+        }
+        Ok(())
+      });
+      if let Err(error) = cleanup {
+        result = Err(error);
+      }
+    }
+    if result.is_ok() {
+      self.active = None;
+    }
+    result
+  }
+}
+
+fn private_directory_exists(path: &Path) -> Result<bool, String> {
+  match fs::symlink_metadata(path) {
+    Ok(metadata) => {
+      if !metadata.is_dir() || metadata.permissions().mode() & 0o077 != 0 {
+        return Err("clipboard export directory is not private".to_string());
+      }
+      Ok(true)
+    }
+    Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+    Err(error) => Err(format!(
+      "clipboard export directory is unavailable: {error}"
+    )),
+  }
+}
+
+fn ensure_private_directory(path: &Path) -> Result<(), String> {
+  if private_directory_exists(path)? {
+    return Ok(());
+  }
+  fs::DirBuilder::new()
+    .recursive(true)
+    .mode(0o700)
+    .create(path)
+    .map_err(|error| {
+      format!("clipboard export directory could not be created: {error}")
+    })?;
+  private_directory_exists(path)?;
+  Ok(())
+}
+
+fn remove_export_file(path: &Path) -> Result<(), String> {
+  match fs::symlink_metadata(path) {
+    Ok(metadata) if metadata.file_type().is_file() => fs::remove_file(path)
+      .map_err(|error| format!("clipboard image export could not be removed: {error}")),
+    Ok(_) => Err("clipboard image export is not a regular file".to_string()),
+    Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+    Err(error) => Err(format!(
+      "clipboard image export could not be inspected: {error}"
+    )),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::{os::unix::fs::symlink, process::Command};
+
+  const CONSTRUCTOR_CHILD_ENV: &str = "STELLA_CLIPBOARD_EXPORT_CONSTRUCTOR_CHILD";
+
+  struct TestDirectory {
+    path: PathBuf,
+  }
+
+  impl TestDirectory {
+    fn new() -> Self {
+      let path = std::env::temp_dir().join(format!(
+        "stella-clipboard-export-test-{}",
+        uuid::Uuid::new_v4()
+      ));
+      create_private_directory(&path);
+      Self { path }
+    }
+
+    fn export_root(&self) -> PathBuf {
+      self.path.join("export")
+    }
+  }
+
+  impl Drop for TestDirectory {
+    fn drop(&mut self) {
+      let _ = fs::remove_dir_all(&self.path);
+    }
+  }
+
+  fn create_private_directory(path: &Path) {
+    fs::DirBuilder::new()
+      .recursive(true)
+      .mode(0o700)
+      .create(path)
+      .unwrap();
+  }
+
+  fn create_private_file(path: &Path, bytes: &[u8]) {
+    let mut file = fs::OpenOptions::new()
+      .write(true)
+      .create_new(true)
+      .mode(0o600)
+      .open(path)
+      .unwrap();
+    file.write_all(bytes).unwrap();
+  }
+
+  fn exports_at(root: &Path) -> ClipboardImageExports {
+    ClipboardImageExports {
+      directory: Some(root.to_path_buf()),
+      active: None,
+    }
+  }
+
+  fn export_path(root: &Path, slot: usize) -> PathBuf {
+    root.join(EXPORT_SLOTS[slot]).join(EXPORT_FILENAME)
+  }
+
+  fn existing_export_paths(root: &Path) -> Vec<PathBuf> {
+    EXPORT_SLOTS
+      .iter()
+      .map(|slot| root.join(slot).join(EXPORT_FILENAME))
+      .filter(|path| path.is_file())
+      .collect()
+  }
+
+  #[test]
+  fn constructing_exports_creates_no_files() {
+    if std::env::var_os(CONSTRUCTOR_CHILD_ENV).is_some() {
+      let expected = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap()
+        .join("Library/Caches")
+        .join(APP_DATA_DIR_NAME)
+        .join("clipboard-export");
+
+      let exports = ClipboardImageExports::new();
+
+      assert_eq!(exports.directory.as_deref(), Some(expected.as_path()));
+      assert!(!expected.exists());
+      return;
+    }
+
+    let sandbox = TestDirectory::new();
+    let output = Command::new(std::env::current_exe().unwrap())
+      .args([
+        "--exact",
+        "clipboard_image_export::tests::constructing_exports_creates_no_files",
+      ])
+      .env(CONSTRUCTOR_CHILD_ENV, "1")
+      .env("HOME", &sandbox.path)
+      .output()
+      .unwrap();
+
+    assert!(
+      output.status.success(),
+      "constructor child failed: {}",
+      String::from_utf8_lossy(&output.stderr)
+    );
+  }
+
+  #[test]
+  fn publishing_exposes_the_complete_file_to_the_callback() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let mut exports = exports_at(&root);
+    let png = b"complete png payload";
+    let mut published_url = None;
+
+    exports
+      .publish(png, |url| {
+        let path = url
+          .to_file_path()
+          .map_err(|()| "published URL was not a file".to_string())?;
+        assert_eq!(path, export_path(&root, 0));
+        assert_eq!(fs::read(path).unwrap(), png);
+        published_url = Some(url.clone());
+        Ok(())
+      })
+      .unwrap();
+
+    assert_eq!(exports.active, Some(0));
+    assert_eq!(
+      published_url.unwrap().to_file_path().unwrap(),
+      export_path(&root, 0)
+    );
+  }
+
+  #[test]
+  fn published_directories_and_files_are_private() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let mut exports = exports_at(&root);
+
+    exports.publish(b"png", |_| Ok(())).unwrap();
+
+    assert_eq!(
+      fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+      0o700
+    );
+    assert_eq!(
+      fs::metadata(root.join(EXPORT_SLOTS[0]))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777,
+      0o700
+    );
+    assert_eq!(
+      fs::metadata(export_path(&root, 0))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777,
+      0o600
+    );
+  }
+
+  #[test]
+  fn successful_replacement_keeps_the_previous_file_until_publication() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let mut exports = exports_at(&root);
+    let previous_path = export_path(&root, 0);
+    let replacement_path = export_path(&root, 1);
+    exports.publish(b"previous", |_| Ok(())).unwrap();
+
+    exports
+      .publish(b"replacement", |url| {
+        assert_eq!(fs::read(&previous_path).unwrap(), b"previous");
+        assert_eq!(url.to_file_path().unwrap(), replacement_path);
+        assert_eq!(fs::read(&replacement_path).unwrap(), b"replacement");
+        Ok(())
+      })
+      .unwrap();
+
+    assert!(!previous_path.exists());
+    assert_eq!(fs::read(replacement_path).unwrap(), b"replacement");
+    assert_eq!(exports.active, Some(1));
+  }
+
+  #[test]
+  fn failed_replacement_retains_the_previous_file_and_removes_the_candidate() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let mut exports = exports_at(&root);
+    let previous_path = export_path(&root, 0);
+    let candidate_path = export_path(&root, 1);
+    exports.publish(b"previous", |_| Ok(())).unwrap();
+
+    assert_eq!(
+      exports.publish(b"candidate", |url| {
+        assert_eq!(fs::read(&previous_path).unwrap(), b"previous");
+        assert_eq!(url.to_file_path().unwrap(), candidate_path);
+        assert_eq!(fs::read(&candidate_path).unwrap(), b"candidate");
+        Err("publication rejected".to_string())
+      }),
+      Err("publication rejected".to_string())
+    );
+
+    assert_eq!(fs::read(previous_path).unwrap(), b"previous");
+    assert!(!candidate_path.exists());
+    assert_eq!(exports.active, Some(0));
+  }
+
+  #[test]
+  fn startup_cleanup_removes_both_fixed_slots_without_active_state() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    create_private_directory(&root);
+    for (slot_index, slot) in EXPORT_SLOTS.iter().enumerate() {
+      create_private_directory(&root.join(slot));
+      create_private_file(&export_path(&root, slot_index), b"stale");
+    }
+    let mut exports = exports_at(&root);
+
+    exports.clear().unwrap();
+
+    assert!(existing_export_paths(&root).is_empty());
+    assert_eq!(exports.active, None);
+  }
+
+  #[test]
+  fn repeated_publication_never_exceeds_the_two_fixed_files() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let mut exports = exports_at(&root);
+
+    for index in 0..64 {
+      let payload = format!("png-{index}");
+      exports
+        .publish(payload.as_bytes(), |_| {
+          assert!(existing_export_paths(&root).len() <= EXPORT_SLOTS.len());
+          Ok(())
+        })
+        .unwrap();
+      let paths = existing_export_paths(&root);
+      assert_eq!(paths.len(), 1);
+      assert_eq!(fs::read(&paths[0]).unwrap(), payload.as_bytes());
+    }
+  }
+
+  #[test]
+  fn root_slot_and_file_symlinks_are_rejected_without_touching_their_targets() {
+    for boundary in ["root", "slot", "file"] {
+      let sandbox = TestDirectory::new();
+      let root = sandbox.export_root();
+      let external = sandbox.path.join("external");
+      create_private_directory(&external);
+      let sentinel = external.join("sentinel");
+      create_private_file(&sentinel, b"external");
+
+      match boundary {
+        "root" => symlink(&external, &root).unwrap(),
+        "slot" => {
+          create_private_directory(&root);
+          symlink(&external, root.join(EXPORT_SLOTS[0])).unwrap();
+        }
+        "file" => {
+          create_private_directory(&root.join(EXPORT_SLOTS[0]));
+          symlink(&sentinel, export_path(&root, 0)).unwrap();
+        }
+        _ => unreachable!(),
+      }
+      let mut exports = exports_at(&root);
+
+      assert!(exports.publish(b"replacement", |_| Ok(())).is_err());
+      assert_eq!(fs::read(&sentinel).unwrap(), b"external");
+      assert_eq!(exports.active, None);
+    }
+  }
+
+  #[test]
+  fn an_inactive_slot_symlink_cannot_replace_an_external_file() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let external = sandbox.path.join("external");
+    create_private_directory(&external);
+    let sentinel = external.join("sentinel");
+    create_private_file(&sentinel, b"external");
+    let mut exports = exports_at(&root);
+    exports.publish(b"active", |_| Ok(())).unwrap();
+    symlink(&external, root.join(EXPORT_SLOTS[1])).unwrap();
+
+    assert!(exports.publish(b"replacement", |_| Ok(())).is_err());
+
+    assert_eq!(fs::read(export_path(&root, 0)).unwrap(), b"active");
+    assert_eq!(fs::read(sentinel).unwrap(), b"external");
+    assert_eq!(exports.active, Some(0));
+  }
+
+  #[test]
+  fn cleanup_continues_to_the_active_slot_after_an_invalid_slot() {
+    let sandbox = TestDirectory::new();
+    let root = sandbox.export_root();
+    let external = sandbox.path.join("external");
+    create_private_directory(&root);
+    create_private_directory(&external);
+    let sentinel = external.join("sentinel");
+    create_private_file(&sentinel, b"external");
+    symlink(&external, root.join(EXPORT_SLOTS[0])).unwrap();
+    create_private_directory(&root.join(EXPORT_SLOTS[1]));
+    let active_path = export_path(&root, 1);
+    create_private_file(&active_path, b"active");
+    let mut exports = ClipboardImageExports {
+      directory: Some(root),
+      active: Some(1),
+    };
+
+    assert_eq!(
+      exports.clear(),
+      Err("clipboard export directory is not private".to_string())
+    );
+
+    assert!(!active_path.exists());
+    assert_eq!(fs::read(sentinel).unwrap(), b"external");
+    assert_eq!(exports.active, Some(1));
+  }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ mod autostart;
 mod bridge;
 mod clipboard;
 mod clipboard_commands;
+#[cfg(target_os = "macos")]
+mod clipboard_image_export;
 mod clipboard_screen_capture;
 mod clipboard_store;
 mod clipboard_welcome;
@@ -106,6 +108,10 @@ pub fn run() {
     .manage(clipboard_window::ClipboardWindowPark::default())
     .setup(move |app| {
       let handle = app.handle().clone();
+      #[cfg(target_os = "macos")]
+      if let Ok(mut clipboard) = clipboard_manager.lock() {
+        clipboard.clear_image_exports();
+      }
       let initial_deep_links = app.deep_link().get_current()?;
       let reveal_clipboard_on_launch =
         app_lifecycle::should_reveal_clipboard_on_launch(
@@ -393,7 +399,7 @@ pub fn run() {
     .invoke_handler(with_stella_commands!(generate_stella_handler))
     .build(tauri::generate_context!())
     .expect("error while building stella desktop")
-    .run(|_app, event| match event {
+    .run(|app, event| match event {
       tauri::RunEvent::ExitRequested { api, code, .. } => {
         if app_lifecycle::should_prevent_exit(code) {
           tracing::info!("prevented background desktop process from exiting");
@@ -402,7 +408,17 @@ pub fn run() {
           tracing::info!(?code, "desktop process received an explicit exit request");
         }
       }
-      tauri::RunEvent::Exit => tracing::info!("desktop event loop exited"),
+      tauri::RunEvent::Exit => {
+        #[cfg(target_os = "macos")]
+        if let Some(clipboard) = app.try_state::<ClipboardAppState>()
+          && let Ok(mut clipboard) = clipboard.lock()
+        {
+          clipboard.clear_image_exports();
+        }
+        #[cfg(not(target_os = "macos"))]
+        let _ = app;
+        tracing::info!("desktop event loop exited");
+      }
       _ => {}
     });
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -109,8 +109,10 @@ pub fn run() {
     .setup(move |app| {
       let handle = app.handle().clone();
       #[cfg(target_os = "macos")]
-      if let Ok(mut clipboard) = clipboard_manager.lock() {
-        clipboard.clear_image_exports();
+      if let Ok(mut clipboard) = clipboard_manager.lock()
+        && let Err(error) = clipboard.reconcile_image_exports()
+      {
+        tracing::warn!(error = %error, "clipboard image export cleanup will be retried");
       }
       let initial_deep_links = app.deep_link().get_current()?;
       let reveal_clipboard_on_launch =
@@ -412,8 +414,9 @@ pub fn run() {
         #[cfg(target_os = "macos")]
         if let Some(clipboard) = app.try_state::<ClipboardAppState>()
           && let Ok(mut clipboard) = clipboard.lock()
+          && let Err(error) = clipboard.reconcile_image_exports()
         {
-          clipboard.clear_image_exports();
+          tracing::warn!(error = %error, "clipboard image export cleanup will be retried");
         }
         #[cfg(not(target_os = "macos"))]
         let _ = app;

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -26,9 +26,8 @@ import {
   ClipboardIcon,
   CircleHelpIcon,
   CopyPlusIcon,
-  CheckIcon,
   ClockIcon,
-  EllipsisIcon,
+  EllipsisVerticalIcon,
   FileTextIcon,
   FolderInputIcon,
   FolderPlusIcon,
@@ -52,6 +51,7 @@ import { useFormatter, useLocale, useTranslations } from "use-intl";
 import { getUiLocaleDirection, isUiLocale } from "@stll/locales";
 import { Button } from "@stll/ui/button";
 import { Checkbox } from "@stll/ui/checkbox";
+import { ColorPickerContent } from "@stll/ui/color-picker";
 import { ContextMenu } from "@stll/ui/context-menu";
 import {
   Dialog,
@@ -109,7 +109,7 @@ import {
   clipboardSourceTintIndex,
   clipboardSourceTitle,
   clipboardTimelineKeyAction,
-  clipboardGroupRailKeyAction,
+  clipboardControlsKeyAction,
   filterClipboardItems,
   formatClipboardAge,
   hasClipboardPrimaryModifier,
@@ -119,7 +119,7 @@ import {
   quickCopyIndex,
   shouldCopyFromClipboardInput,
   shouldReturnToTimelineFromInput,
-  shouldLeaveSearchForGroups,
+  shouldLeaveClipboardSearch,
 } from "./clipboard-logic";
 import type { ClipboardPointerPosition } from "./clipboard-logic";
 import {
@@ -155,6 +155,7 @@ import { useRailViewport } from "./use-rail-viewport";
 
 const STELLA_WEB_APP_URL = "https://my.stll.app";
 const MAX_GROUP_NAME_CHARACTERS = 64;
+const MAX_CLIPBOARD_GROUPS = 24;
 const MAX_ITEM_NAME_CHARACTERS = 80;
 const RETENTION_LABEL_KEYS = {
   week: "retentionWeek",
@@ -162,12 +163,6 @@ const RETENTION_LABEL_KEYS = {
   year: "retentionYear",
 } as const satisfies Record<ClipboardRetention, string>;
 const CLIPBOARD_CARD_SELECTOR = "[data-clipboard-id]";
-const CLIPBOARD_SWATCH_CLASS_NAME =
-  "ring-offset-popover grid size-11 place-items-center rounded-full ring-offset-2 transition-transform outline-none hover:scale-105";
-const CLIPBOARD_CUSTOM_COLOR_RING = `conic-gradient(${[
-  ...CLIPBOARD_GROUP_COLOR_PRESETS,
-  DEFAULT_CLIPBOARD_GROUP_COLOR,
-].join(", ")})`;
 // Which step of a copy failed decides what the user is told: only a `copy`
 // failure means the clip never reached the system clipboard.
 const COPY_FAILURE_FEEDBACK = {
@@ -242,35 +237,33 @@ const clipboardInputDirection = (input: HTMLInputElement) =>
   getComputedStyle(input).direction === "rtl" ? "rtl" : "ltr";
 
 const focusCard = (rail: HTMLDivElement | null, id: string) => {
-  requestAnimationFrame(() => {
-    if (!rail) {
-      return;
-    }
-    const card = rail.querySelector<HTMLElement>(
-      `[data-clipboard-id="${CSS.escape(id)}"]`,
-    );
-    if (!card) {
-      return;
-    }
-    card
-      .querySelector<HTMLElement>("[data-clipboard-card-trigger]")
-      ?.focus({ preventScroll: true });
+  if (!rail) {
+    return;
+  }
+  const card = rail.querySelector<HTMLElement>(
+    `[data-clipboard-id="${CSS.escape(id)}"]`,
+  );
+  if (!card) {
+    return;
+  }
+  card
+    .querySelector<HTMLElement>("[data-clipboard-card-trigger]")
+    ?.focus({ preventScroll: true });
 
-    const railBounds = rail.getBoundingClientRect();
-    const cardBounds = card.getBoundingClientRect();
-    const left = clipboardRailScrollDelta({
-      cardEnd: cardBounds.right,
-      cardStart: cardBounds.left,
-      viewportEnd: railBounds.right - CLIPBOARD_RAIL_PADDING,
-      viewportStart: railBounds.left + CLIPBOARD_RAIL_PADDING,
-    });
-    if (left === 0) {
-      return;
-    }
-    rail.scrollBy({
-      behavior: "auto",
-      left,
-    });
+  const railBounds = rail.getBoundingClientRect();
+  const cardBounds = card.getBoundingClientRect();
+  const left = clipboardRailScrollDelta({
+    cardEnd: cardBounds.right,
+    cardStart: cardBounds.left,
+    viewportEnd: railBounds.right - CLIPBOARD_RAIL_PADDING,
+    viewportStart: railBounds.left + CLIPBOARD_RAIL_PADDING,
+  });
+  if (left === 0) {
+    return;
+  }
+  rail.scrollBy({
+    behavior: "auto",
+    left,
   });
 };
 
@@ -607,7 +600,12 @@ const ClipboardCard = ({
 type ClipboardDialogState =
   | { type: "closed" }
   | { type: "clearHistory" }
-  | { color: ClipboardGroupColor; name: string; type: "createGroup" }
+  | {
+      color: ClipboardGroupColor;
+      itemId: string | null;
+      name: string;
+      type: "createGroup";
+    }
   | {
       groupId: string;
       groupName: string;
@@ -705,7 +703,6 @@ const ClipboardGroupFields = ({
   onChange,
 }: ClipboardGroupFieldsProps) => {
   const t = useTranslations("clipboard");
-  const isPreset = CLIPBOARD_GROUP_COLOR_PRESETS.includes(color);
   return (
     <>
       <label className="block">
@@ -729,62 +726,31 @@ const ClipboardGroupFields = ({
         <legend className="text-muted-foreground text-sm">
           {t("groupColor")}
         </legend>
-        <div className="mt-2 flex items-center gap-2">
-          {CLIPBOARD_GROUP_COLOR_PRESETS.map((swatch, index) => (
-            <button
-              aria-label={`${t("groupColor")} ${index + 1}`}
-              aria-pressed={color === swatch}
-              className={cn(
-                CLIPBOARD_SWATCH_CLASS_NAME,
-                "focus-visible:ring-2",
-                color === swatch && "ring-foreground/70 ring-2",
-              )}
-              key={swatch}
-              onClick={() => onChange({ color: swatch, name })}
-              style={{ backgroundColor: swatch }}
-              type="button"
-            >
-              {color === swatch ? <SwatchCheck /> : null}
-            </button>
-          ))}
-          <label
-            className={cn(
-              CLIPBOARD_SWATCH_CLASS_NAME,
-              "cursor-pointer has-focus-visible:ring-2",
-              !isPreset && "ring-foreground/70 ring-2",
-            )}
-            style={
-              isPreset
-                ? { backgroundImage: CLIPBOARD_CUSTOM_COLOR_RING }
-                : { backgroundColor: color }
-            }
-          >
-            {isPreset ? null : <SwatchCheck />}
-            <input
-              aria-label={t("customColor")}
-              className="sr-only"
-              onChange={(event) => {
-                const picked = event.target.value.toLowerCase();
-                if (isClipboardGroupColor(picked)) {
-                  onChange({ color: picked, name });
-                }
-              }}
-              type="color"
-              value={color}
-            />
-          </label>
+        <div className="mt-2 overflow-visible px-0.5">
+          <ColorPickerContent
+            moreLabel={t("customColor")}
+            onSelect={(value) => {
+              const picked = `#${value.toLowerCase()}`;
+              if (!isClipboardGroupColor(picked)) {
+                panic(
+                  "Color picker returned an invalid clipboard group color.",
+                );
+              }
+              onChange({ color: picked, name });
+            }}
+            presets={CLIPBOARD_GROUP_COLOR_PRESETS.map((preset) => ({
+              color: preset,
+              label: preset.toUpperCase(),
+              value: preset.slice(1).toUpperCase(),
+            }))}
+            presentation="inline"
+            value={color.slice(1).toUpperCase()}
+          />
         </div>
       </fieldset>
     </>
   );
 };
-
-const SwatchCheck = () => (
-  <CheckIcon
-    aria-hidden="true"
-    className="bg-background/88 text-foreground size-5 rounded-full p-0.5 shadow-sm"
-  />
-);
 
 type ClipboardDialogProps = {
   dialog: ClipboardDialogState;
@@ -834,6 +800,7 @@ const ClipboardDialog = ({
               "clipboard_create_group",
               {
                 color: dialog.color,
+                itemId: dialog.itemId,
                 name: dialog.name,
               },
               close,
@@ -848,7 +815,12 @@ const ClipboardDialog = ({
             color={dialog.color}
             name={dialog.name}
             onChange={({ color, name }) => {
-              onChange({ color, name, type: "createGroup" });
+              onChange({
+                color,
+                itemId: dialog.itemId,
+                name,
+                type: "createGroup",
+              });
             }}
           />
         </DialogShell>
@@ -985,6 +957,7 @@ type ClipboardContextMenuProps = {
   groups: ClipboardGroup[];
   menu: Exclude<ClipboardContextMenuState, { type: "closed" }>;
   onClose: () => void;
+  onCreateGroup: (itemId: string) => void;
   onDelete: (id: string) => void;
   onDuplicate: (id: string) => void;
   onEdit: (id: string) => void;
@@ -995,6 +968,7 @@ const ClipboardContextMenu = ({
   groups,
   menu,
   onClose,
+  onCreateGroup,
   onDelete,
   onDuplicate,
   onEdit,
@@ -1015,7 +989,7 @@ const ClipboardContextMenu = ({
       open
     >
       <MenuTrigger nativeButton={false} render={<span className="sr-only" />} />
-      <MenuPopup anchor={anchor} className="w-56">
+      <MenuPopup anchor={anchor} className="w-56" finalFocus={false}>
         <MenuItem
           className="min-h-11 rounded-xl"
           onClick={() => {
@@ -1079,6 +1053,18 @@ const ClipboardContextMenu = ({
                 ),
               )}
             </MenuRadioGroup>
+            <MenuSeparator />
+            <MenuItem
+              className="min-h-11 rounded-xl"
+              disabled={groups.length >= MAX_CLIPBOARD_GROUPS}
+              onClick={() => {
+                onClose();
+                onCreateGroup(menu.item.id);
+              }}
+            >
+              <FolderPlusIcon />
+              {t("createGroup")}
+            </MenuItem>
           </MenuSubPopup>
         </MenuSub>
         <MenuSeparator />
@@ -1356,7 +1342,7 @@ const ClipboardApp = () => {
     : "ltr";
   const searchInputRef = useRef<HTMLInputElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
-  const groupsRailRef = useRef<HTMLElement>(null);
+  const controlsRef = useRef<HTMLElement>(null);
   const timelineRailRef = useRef<HTMLDivElement>(null);
   const railPointerRef = useRef<ClipboardPointerPosition | null>(null);
   const contextMenuTriggerRef = useRef<HTMLElement>(null);
@@ -1680,7 +1666,7 @@ const ClipboardApp = () => {
 
   const closeContextMenu = () => {
     setContextMenu({ type: "closed" });
-    requestAnimationFrame(() => contextMenuTriggerRef.current?.focus());
+    contextMenuTriggerRef.current?.focus();
   };
 
   useEffect(() => {
@@ -1803,7 +1789,9 @@ const ClipboardApp = () => {
     dragState.target.groupId === groupId;
 
   const selectIndex = (index: number) => {
-    setSelectedIndex(index);
+    // Mount a virtualized target before focusing it. Deferring focus to a
+    // frame would let this selection steal focus after a later ArrowDown.
+    flushSync(() => setSelectedIndex(index));
     const item = filteredItems.at(index);
     if (item) {
       focusCard(timelineRailRef.current, item.id);
@@ -1839,31 +1827,40 @@ const ClipboardApp = () => {
     selectIndex(nextIndex);
   };
 
-  const handleGroupRailKeyDown = (
-    event: KeyboardEvent,
-    target: HTMLElement,
-  ) => {
-    const groupsRail = groupsRailRef.current;
-    const railAction = clipboardGroupRailKeyAction(event.key);
-    if (!groupsRail || !railAction) {
-      return;
-    }
-    if (railAction === "focusTimeline") {
-      if (activeItem) {
-        event.preventDefault();
-        selectIndex(activeIndex);
-      }
+  const handleControlsKeyDown = (event: KeyboardEvent, target: HTMLElement) => {
+    const footer = controlsRef.current;
+    const railAction = clipboardControlsKeyAction({
+      direction: railDirection,
+      key: event.key,
+    });
+    if (!footer || !railAction) {
       return;
     }
     event.preventDefault();
+    switch (railAction) {
+      case "stay":
+        return;
+      case "focusTimeline":
+        if (activeItem) {
+          selectIndex(activeIndex);
+        }
+        return;
+      case "previous":
+      case "next":
+        break;
+      default:
+        railAction satisfies never;
+        panic("Unknown clipboard control navigation action.");
+    }
     const controls = Array.from(
-      groupsRail.querySelectorAll<HTMLElement>("button:not([disabled])"),
+      footer.querySelectorAll<HTMLElement>(
+        "button:not([disabled]):not([aria-disabled='true']), a[href], input:not([disabled])",
+      ),
     );
-    const control = target.closest("button");
+    const control = target.closest<HTMLElement>("button, a, input");
     const index = control ? controls.indexOf(control) : -1;
     const nextIndex = index + (railAction === "next" ? 1 : -1);
     if (nextIndex < 0) {
-      searchInputRef.current?.focus();
       return;
     }
     controls.at(nextIndex)?.focus();
@@ -1914,7 +1911,7 @@ const ClipboardApp = () => {
         event.preventDefault();
         selectIndex(activeIndex);
       } else if (
-        shouldLeaveSearchForGroups({
+        shouldLeaveClipboardSearch({
           ...inputKey,
           ...modifiers,
           direction: clipboardInputDirection(event.target),
@@ -1925,9 +1922,7 @@ const ClipboardApp = () => {
         })
       ) {
         event.preventDefault();
-        groupsRailRef.current
-          ?.querySelector<HTMLElement>("button[aria-pressed='true']")
-          ?.focus();
+        handleControlsKeyDown(event, event.target);
       }
       return;
     }
@@ -1952,10 +1947,6 @@ const ClipboardApp = () => {
       return;
     }
     const target = event.target instanceof HTMLElement ? event.target : null;
-    if (target && groupsRailRef.current?.contains(target)) {
-      handleGroupRailKeyDown(event, target);
-      return;
-    }
     const cardTrigger = target?.closest("[data-clipboard-card-trigger]");
     const interactiveTarget = target?.closest(
       "button, a, input, textarea, select, [contenteditable='true']",
@@ -2008,6 +1999,20 @@ const ClipboardApp = () => {
   };
 
   const handleKeyDownCapture = (event: KeyboardEvent) => {
+    if (
+      dialog.type === "closed" &&
+      !welcomeOpen &&
+      !event.isComposing &&
+      event.target instanceof HTMLElement &&
+      !(event.target instanceof HTMLInputElement) &&
+      controlsRef.current?.contains(event.target) &&
+      clipboardControlsKeyAction({ direction: railDirection, key: event.key })
+    ) {
+      // Keep arrows in the two-row navigation; Enter/Space open the menu.
+      event.stopPropagation();
+      handleControlsKeyDown(event, event.target);
+      return;
+    }
     if (event.key !== "Escape" || event.isComposing) {
       return;
     }
@@ -2025,12 +2030,6 @@ const ClipboardApp = () => {
     }
     if (dialog.type !== "closed") {
       setDialog({ type: "closed" });
-      return;
-    }
-    if (query) {
-      setQuery("");
-      setSelectedIndex(0);
-      searchInputRef.current?.focus();
       return;
     }
     requestHide();
@@ -2103,6 +2102,14 @@ const ClipboardApp = () => {
           groups={snapshot.groups}
           menu={contextMenu}
           onClose={closeContextMenu}
+          onCreateGroup={(itemId) =>
+            setDialog({
+              color: nextGroupColor,
+              itemId,
+              name: "",
+              type: "createGroup",
+            })
+          }
           onDelete={(id) =>
             applySnapshotCommand("clipboard_delete_item", { id })
           }
@@ -2215,7 +2222,10 @@ const ClipboardApp = () => {
         )}
       </main>
 
-      <footer className="clipboard-controls grid h-14 shrink-0 grid-cols-[auto_minmax(8rem,22rem)_auto_minmax(0,1fr)_auto] items-center gap-2 px-3">
+      <footer
+        className="clipboard-controls grid h-14 shrink-0 grid-cols-[auto_minmax(8rem,22rem)_minmax(0,1fr)_auto_auto] items-center gap-2 px-3"
+        ref={controlsRef}
+      >
         <div className="flex shrink-0 items-center gap-0.5">
           <a
             aria-label="Stella"
@@ -2295,6 +2305,98 @@ const ClipboardApp = () => {
           </InputGroupAddon>
         </InputGroup>
 
+        <nav
+          aria-label={t("groups")}
+          className="clipboard-groups-rail border-border flex min-w-0 scrollbar-none items-center gap-1 overflow-x-auto border-s ps-2"
+        >
+          <Button
+            aria-pressed={activeGroupId === null}
+            className="h-11 shrink-0 rounded-full px-3 text-xs"
+            data-clipboard-group-id={CLIPBOARD_NO_GROUP_DROP_ID}
+            data-drop-target={isDropTarget(null) ? "" : undefined}
+            onClick={() => {
+              setSelectedGroupId(null);
+              setSelectedIndex(0);
+            }}
+            variant={activeGroupId === null ? "secondary" : "ghost"}
+          >
+            {t("allClips")}
+          </Button>
+          <Button
+            aria-label={t("createGroup")}
+            className="bg-background/80 sticky start-0 z-10 size-11 shrink-0 rounded-full backdrop-blur-sm"
+            disabled={snapshot.groups.length >= MAX_CLIPBOARD_GROUPS}
+            onClick={() =>
+              setDialog({
+                color: nextGroupColor,
+                itemId: null,
+                name: "",
+                type: "createGroup",
+              })
+            }
+            size="icon"
+            title={t("createGroup")}
+            variant="ghost"
+          >
+            <FolderPlusIcon aria-hidden="true" className="size-4" />
+          </Button>
+          {snapshot.groups.map((group) => {
+            const groupStyle: ClipboardGroupStyle = {
+              "--clipboard-group-accent": group.color,
+            };
+            return (
+              <ContextMenu
+                actions={[
+                  {
+                    icon: <PencilIcon aria-hidden="true" />,
+                    label: t("editGroup"),
+                    onClick: () =>
+                      setDialog({
+                        color: group.color,
+                        groupId: group.id,
+                        name: group.name,
+                        type: "editGroup",
+                      }),
+                  },
+                  {
+                    icon: <Trash2Icon aria-hidden="true" />,
+                    label: t("deleteGroup"),
+                    onClick: () =>
+                      setDialog({
+                        groupId: group.id,
+                        groupName: group.name,
+                        mode: "keepClips",
+                        type: "deleteGroup",
+                      }),
+                    separatorBefore: true,
+                    variant: "destructive",
+                  },
+                ]}
+                key={group.id}
+              >
+                <Button
+                  aria-pressed={activeGroupId === group.id}
+                  className="clipboard-group-chip h-11 shrink-0 rounded-full px-3 text-xs"
+                  data-clipboard-group-id={group.id}
+                  data-drop-target={isDropTarget(group.id) ? "" : undefined}
+                  data-group-chip=""
+                  onClick={() => {
+                    setSelectedGroupId(group.id);
+                    setSelectedIndex(0);
+                  }}
+                  style={groupStyle}
+                  variant="ghost"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="clipboard-group-chip-dot size-2 shrink-0 rounded-full"
+                  />
+                  {group.name}
+                </Button>
+              </ContextMenu>
+            );
+          })}
+        </nav>
         <div className="flex shrink-0 items-center gap-0.5 justify-self-end">
           <Menu>
             <MenuTrigger
@@ -2308,7 +2410,7 @@ const ClipboardApp = () => {
                 />
               }
             >
-              <EllipsisIcon aria-hidden="true" className="size-4" />
+              <EllipsisVerticalIcon aria-hidden="true" className="size-4" />
             </MenuTrigger>
             <MenuPopup align="end" className="w-60" side="top">
               <MenuItem
@@ -2389,98 +2491,6 @@ const ClipboardApp = () => {
             </MenuPopup>
           </Menu>
         </div>
-        <nav
-          aria-label={t("groups")}
-          ref={groupsRailRef}
-          className="clipboard-groups-rail border-border flex min-w-0 scrollbar-none items-center gap-1 overflow-x-auto border-s ps-2"
-        >
-          <Button
-            aria-pressed={activeGroupId === null}
-            className="h-11 shrink-0 rounded-full px-3 text-xs"
-            data-clipboard-group-id={CLIPBOARD_NO_GROUP_DROP_ID}
-            data-drop-target={isDropTarget(null) ? "" : undefined}
-            onClick={() => {
-              setSelectedGroupId(null);
-              setSelectedIndex(0);
-            }}
-            variant={activeGroupId === null ? "secondary" : "ghost"}
-          >
-            {t("allClips")}
-          </Button>
-          <Button
-            aria-label={t("createGroup")}
-            className="bg-background/80 sticky start-0 z-10 size-11 shrink-0 rounded-full backdrop-blur-sm"
-            disabled={snapshot.groups.length >= 24}
-            onClick={() =>
-              setDialog({
-                color: nextGroupColor,
-                name: "",
-                type: "createGroup",
-              })
-            }
-            size="icon"
-            title={t("createGroup")}
-            variant="ghost"
-          >
-            <FolderPlusIcon aria-hidden="true" className="size-4" />
-          </Button>
-          {snapshot.groups.map((group) => {
-            const groupStyle: ClipboardGroupStyle = {
-              "--clipboard-group-accent": group.color,
-            };
-            return (
-              <ContextMenu
-                actions={[
-                  {
-                    icon: <PencilIcon aria-hidden="true" />,
-                    label: t("editGroup"),
-                    onClick: () =>
-                      setDialog({
-                        color: group.color,
-                        groupId: group.id,
-                        name: group.name,
-                        type: "editGroup",
-                      }),
-                  },
-                  {
-                    icon: <Trash2Icon aria-hidden="true" />,
-                    label: t("deleteGroup"),
-                    onClick: () =>
-                      setDialog({
-                        groupId: group.id,
-                        groupName: group.name,
-                        mode: "keepClips",
-                        type: "deleteGroup",
-                      }),
-                    separatorBefore: true,
-                    variant: "destructive",
-                  },
-                ]}
-                key={group.id}
-              >
-                <Button
-                  aria-pressed={activeGroupId === group.id}
-                  className="clipboard-group-chip h-11 shrink-0 rounded-full px-3 text-xs"
-                  data-clipboard-group-id={group.id}
-                  data-drop-target={isDropTarget(group.id) ? "" : undefined}
-                  data-group-chip=""
-                  onClick={() => {
-                    setSelectedGroupId(group.id);
-                    setSelectedIndex(0);
-                  }}
-                  style={groupStyle}
-                  variant="ghost"
-                >
-                  <span
-                    aria-hidden="true"
-                    className="clipboard-group-chip-dot size-2 shrink-0 rounded-full"
-                  />
-                  {group.name}
-                </Button>
-              </ContextMenu>
-            );
-          })}
-        </nav>
         <Button
           aria-label={t("close")}
           className="size-11 shrink-0 rounded-full"

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -157,7 +157,6 @@ import { useRailViewport } from "./use-rail-viewport";
 
 const STELLA_WEB_APP_URL = "https://my.stll.app";
 const MAX_GROUP_NAME_CHARACTERS = 64;
-const MAX_CLIPBOARD_GROUPS = 24;
 const MAX_ITEM_NAME_CHARACTERS = 80;
 const RETENTION_LABEL_KEYS = {
   week: "retentionWeek",
@@ -211,6 +210,8 @@ const IMAGE_CLIPBOARD_CAPTURE_SUPPORTED =
 
 const EMPTY_SNAPSHOT = {
   captureStatus: "active",
+  // Native owns the limit; fail closed until the first runtime snapshot.
+  groupLimit: 0,
   groups: [],
   items: [],
   persistence: { status: "initializing" },
@@ -956,6 +957,7 @@ type ClipboardDragState =
     };
 
 type ClipboardContextMenuProps = {
+  groupLimit: number;
   groups: ClipboardGroup[];
   menu: Exclude<ClipboardContextMenuState, { type: "closed" }>;
   onClose: () => void;
@@ -967,6 +969,7 @@ type ClipboardContextMenuProps = {
 };
 
 const ClipboardContextMenu = ({
+  groupLimit,
   groups,
   menu,
   onClose,
@@ -1058,7 +1061,7 @@ const ClipboardContextMenu = ({
             <MenuSeparator />
             <MenuItem
               className="min-h-11 rounded-xl"
-              disabled={groups.length >= MAX_CLIPBOARD_GROUPS}
+              disabled={groups.length >= groupLimit}
               onClick={() => {
                 onClose();
                 onCreateGroup(menu.item.id);
@@ -2143,6 +2146,7 @@ const ClipboardApp = () => {
       {welcomeOpen ? <ClipboardWelcomeDialog onClose={closeWelcome} /> : null}
       {contextMenu.type === "closed" ? null : (
         <ClipboardContextMenu
+          groupLimit={snapshot.groupLimit}
           groups={snapshot.groups}
           menu={contextMenu}
           onClose={closeContextMenu}
@@ -2369,7 +2373,7 @@ const ClipboardApp = () => {
           <Button
             aria-label={t("createGroup")}
             className="bg-background/80 sticky start-0 z-10 size-11 shrink-0 rounded-full backdrop-blur-sm"
-            disabled={snapshot.groups.length >= MAX_CLIPBOARD_GROUPS}
+            disabled={snapshot.groups.length >= snapshot.groupLimit}
             onClick={() =>
               setDialog({
                 color: nextGroupColor,

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -21,6 +21,8 @@ import {
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { preserveOffsetOnSource } from "@atlaskit/pragmatic-drag-and-drop/utils/preserve-offset-on-source";
 import { invoke } from "@tauri-apps/api/core";
+import { TauriEvent } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { panic } from "better-result";
 import {
   ClipboardIcon,
@@ -1506,6 +1508,43 @@ const ClipboardApp = () => {
   };
 
   useEffect(() => {
+    const prepareNextOpen = () => {
+      if (welcomeOpen) {
+        return;
+      }
+      // The parked panel is painted before its next focus event. Prepare that
+      // frame now, and prevent WebKit from restoring focus to the old card.
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+      railPointerRef.current = null;
+      flushSync(() => {
+        setQuery("");
+        setSelectedIndex(0);
+      });
+      timelineRailRef.current?.scrollTo({ behavior: "instant", left: 0 });
+    };
+    const stopListening = subscribeDesktopEvent({
+      event: TauriEvent.WINDOW_BLUR,
+      handler: prepareNextOpen,
+      options: { target: { kind: "Window", label: getCurrentWindow().label } },
+      onError: () => {
+        reportDesktopError({
+          code: DESKTOP_TELEMETRY_ERROR_CODES.eventSubscriptionFailed,
+          operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardWindowHide,
+          window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+        });
+        setError({ message: t("errorUpdateHistory"), source: "operation" });
+      },
+    });
+    window.addEventListener("blur", prepareNextOpen);
+    return () => {
+      stopListening();
+      window.removeEventListener("blur", prepareNextOpen);
+    };
+  }, [t, welcomeOpen]);
+
+  useEffect(() => {
     const focusActiveCard = () => {
       if (activeItemId) {
         focusCard(timelineRailRef.current, activeItemId);
@@ -1513,9 +1552,6 @@ const ClipboardApp = () => {
       }
       timelineRef.current?.focus();
     };
-    // The window hides on blur, so a focus event is always an open, and every
-    // open starts on the newest clip. flushSync commits the reset first so the
-    // newest card is in the DOM (the rail is virtualized) before it is focused.
     const handleWindowFocus = () => {
       setAgeReferenceTime(Date.now());
       // The pointer may have moved while the window was hidden; the next

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -655,7 +655,7 @@ const DialogShell = ({
         bottomStickOnMobile={false}
         className="bg-popover/92 max-w-sm rounded-[26px] border-0 shadow-2xl backdrop-blur-3xl"
         showCloseButton={false}
-        viewportClassName="grid-rows-[1fr_auto_1fr] p-5"
+        viewportClassName="grid-rows-[1fr_auto_1fr] px-5 py-3"
       >
         <form
           className="flex min-h-0 flex-col"
@@ -726,7 +726,7 @@ const ClipboardGroupFields = ({
         <legend className="text-muted-foreground text-sm">
           {t("groupColor")}
         </legend>
-        <div className="mt-2 overflow-visible px-0.5">
+        <div className="mt-2 overflow-visible px-0.5 py-1">
           <ColorPickerContent
             moreLabel={t("customColor")}
             onSelect={(value) => {

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -2013,7 +2013,11 @@ const ClipboardApp = () => {
       handleControlsKeyDown(event, event.target);
       return;
     }
-    if (event.key !== "Escape" || event.isComposing) {
+    handleEscape(event);
+  };
+
+  const handleEscape = (event: KeyboardEvent) => {
+    if (event.key !== "Escape" || event.isComposing || event.defaultPrevented) {
       return;
     }
     if (
@@ -2042,11 +2046,15 @@ const ClipboardApp = () => {
     }
     timeline.addEventListener("keydown", handleKeyDown);
     timeline.addEventListener("keydown", handleKeyDownCapture, true);
+    // Bubble after popup handlers, and keep dismissal available when native
+    // focus returns to the document body instead of a timeline control.
+    window.addEventListener("keydown", handleEscape);
     return () => {
       timeline.removeEventListener("keydown", handleKeyDown);
       timeline.removeEventListener("keydown", handleKeyDownCapture, true);
+      window.removeEventListener("keydown", handleEscape);
     };
-  }, [handleKeyDown, handleKeyDownCapture]);
+  }, [handleEscape, handleKeyDown, handleKeyDownCapture]);
 
   const captureActive = snapshot.captureStatus === "active";
   const nextCaptureStatus: ClipboardCaptureStatus = captureActive

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -136,15 +136,11 @@ type ClipboardSearchArrowKey = ClipboardInputKey &
   };
 
 /**
- * ArrowRight with the caret at the search field's visual right edge hands
- * focus to the group rail beside the search field (an empty field qualifies).
- * The field resolves its own direction from the query, so an Arabic or Hebrew
- * query puts that edge at offset 0 and the end of the text on the left. With
- * text still to the right of the caret the arrow keeps moving the caret, and
- * any modifier leaves the platform's own word, line, and selection gestures
- * alone.
+ * Horizontal arrows leave search only at the corresponding visual edge.
+ * Query direction determines the caret edge; the toolbar's direction
+ * determines which control receives focus. Modifiers retain native editing.
  */
-export const shouldLeaveSearchForGroups = ({
+export const shouldLeaveClipboardSearch = ({
   altGraphKey,
   altKey,
   ctrlKey,
@@ -158,34 +154,46 @@ export const shouldLeaveSearchForGroups = ({
   shiftKey,
   valueLength,
 }: ClipboardSearchArrowKey) => {
-  const rightEdge = direction === "rtl" ? 0 : valueLength;
+  if (key !== "ArrowLeft" && key !== "ArrowRight") {
+    return false;
+  }
+  const edge =
+    (key === "ArrowRight") === (direction === "ltr") ? valueLength : 0;
   return (
     !isClipboardNameInput(dataset) &&
-    key === "ArrowRight" &&
     !isComposing &&
     !altGraphKey &&
     !altKey &&
     !ctrlKey &&
     !metaKey &&
     !shiftKey &&
-    selectionStart === rightEdge &&
-    selectionEnd === rightEdge
+    selectionStart === edge &&
+    selectionEnd === edge
   );
 };
 
+type ClipboardDirectionalKey = {
+  direction: TextDirection;
+  key: string;
+};
+
 /**
- * The group rail is the row below the timeline: left and right walk its
- * controls, ArrowUp returns to the selected card. Stepping before the first
- * control lands back in the search field, so the two arrows pair up.
+ * Every footer control follows visual order, including the overflow menu
+ * trigger after its popup closes. ArrowUp returns to the selected card.
  */
-export const clipboardGroupRailKeyAction = (key: string) => {
+export const clipboardControlsKeyAction = ({
+  direction,
+  key,
+}: ClipboardDirectionalKey) => {
   switch (key) {
     case "ArrowLeft":
-      return "previous";
+      return direction === "rtl" ? "next" : "previous";
     case "ArrowRight":
-      return "next";
+      return direction === "rtl" ? "previous" : "next";
     case "ArrowUp":
       return "focusTimeline";
+    case "ArrowDown":
+      return "stay";
     default:
       return null;
   }
@@ -209,11 +217,6 @@ export const isClipboardCopyShortcut = (shortcut: ClipboardCopyShortcut) =>
   !shortcut.shiftKey &&
   shortcut.key.toLocaleLowerCase() === "c";
 
-type ClipboardTimelineKey = {
-  direction: TextDirection;
-  key: string;
-};
-
 /**
  * The horizontal arrows follow the rail's visual order, not a fixed side: an
  * RTL rail runs right-to-left, so ArrowLeft advances and ArrowRight goes back.
@@ -221,7 +224,7 @@ type ClipboardTimelineKey = {
 export const clipboardTimelineKeyAction = ({
   direction,
   key,
-}: ClipboardTimelineKey) => {
+}: ClipboardDirectionalKey) => {
   if (key === "ArrowDown") {
     return "focusSearch";
   }

--- a/apps/desktop/src/clipboard/clipboard-types.ts
+++ b/apps/desktop/src/clipboard/clipboard-types.ts
@@ -102,6 +102,7 @@ const isClipboardRetention = (value: unknown): value is ClipboardRetention =>
 
 export type ClipboardSnapshot = {
   captureStatus: ClipboardCaptureStatus;
+  groupLimit: number;
   groups: ClipboardGroup[];
   items: ClipboardItem[];
   persistence: ClipboardPersistence;
@@ -252,8 +253,12 @@ export const isClipboardSnapshot = (
     return false;
   }
   const captureStatus = value["captureStatus"];
+  const groupLimit = value["groupLimit"];
   return (
     (captureStatus === "active" || captureStatus === "paused") &&
+    typeof groupLimit === "number" &&
+    Number.isSafeInteger(groupLimit) &&
+    groupLimit > 0 &&
     Array.isArray(value["groups"]) &&
     value["groups"].every(isClipboardGroup) &&
     Array.isArray(value["items"]) &&

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -89,6 +89,13 @@ body:has(.clipboard-editor-window) .font-sans {
   backdrop-filter: none;
 }
 
+/* Like search, footer controls keep a focus marker after pointer interaction.
+ * Insetting it prevents the scrolling group rail from clipping the outline. */
+.clipboard-controls :is(button, a):focus {
+  outline: 2px solid var(--option-blue);
+  outline-offset: -2px;
+}
+
 .clipboard-group-chip[data-group-chip] {
   background-color: color-mix(
     in oklab,
@@ -150,19 +157,16 @@ body:has(.clipboard-editor-window) .font-sans {
   transition: opacity 120ms ease-out;
 }
 
-/* While the search field holds focus the selected card stays the Enter
- * target but renders exactly like its siblings: the highlight would read as
- * a competing focus. It returns when ArrowUp hands focus back to the rail.
- * `.clipboard-search-input` lands on the input's wrapper, so the guard reads
- * `:focus-within` rather than `:focus`. */
-.clipboard-window:not(:has(.clipboard-search-input:focus-within))
+/* Keep the selected card for ArrowUp without a competing highlight while
+ * focus moves through the search field and the other footer controls. */
+.clipboard-window:not(:has(.clipboard-controls:focus-within))
   .clipboard-card[aria-current="true"] {
   box-shadow:
     inset 0 0 0 1.5px color-mix(in srgb, var(--foreground) 30%, transparent),
     0 12px 30px rgb(23 28 38 / 0.16);
 }
 
-.clipboard-window:not(:has(.clipboard-search-input:focus-within))
+.clipboard-window:not(:has(.clipboard-controls:focus-within))
   .clipboard-card[aria-current="true"]::after {
   border-color: var(--option-blue);
   box-shadow: inset 0 0 0 1px
@@ -171,7 +175,7 @@ body:has(.clipboard-editor-window) .font-sans {
 }
 
 /* Match the resting opacity of unselected cards (opacity-86, full on hover). */
-.clipboard-window:has(.clipboard-search-input:focus-within)
+.clipboard-window:has(.clipboard-controls:focus-within)
   .clipboard-card[aria-current="true"]:not(:hover) {
   opacity: 0.86;
 }
@@ -204,7 +208,7 @@ body:has(.clipboard-editor-window) .font-sans {
 }
 
 .dark
-  .clipboard-window:not(:has(.clipboard-search-input:focus-within))
+  .clipboard-window:not(:has(.clipboard-controls:focus-within))
   .clipboard-card[aria-current="true"] {
   box-shadow:
     inset 0 0 0 1.5px color-mix(in srgb, var(--color-white) 32%, transparent),

--- a/apps/desktop/src/shared/desktop-events.ts
+++ b/apps/desktop/src/shared/desktop-events.ts
@@ -1,5 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
-import type { EventCallback, EventName } from "@tauri-apps/api/event";
+import type { EventCallback, EventName, Options } from "@tauri-apps/api/event";
 
 /**
  * Tauri types the unlisten function it resolves as `() => void`, although
@@ -11,6 +11,7 @@ type StopListening = () => void | Promise<void>;
 type SubscribeDesktopEventOptions<T> = {
   event: EventName;
   handler: EventCallback<T>;
+  options?: Options;
   /** Runs when the subscription or its teardown fails. */
   onError: () => void;
   /** Runs once the subscription is live, before any event reaches `handler`. */
@@ -31,6 +32,7 @@ type SubscribeDesktopEventOptions<T> = {
 export const subscribeDesktopEvent = <T>({
   event,
   handler,
+  options,
   onError,
   onSubscribed,
 }: SubscribeDesktopEventOptions<T>) => {
@@ -39,7 +41,7 @@ export const subscribeDesktopEvent = <T>({
   const unsubscribe = (stopListening: StopListening) => {
     Promise.resolve(stopListening()).catch(onError);
   };
-  listen<T>(event, handler)
+  listen<T>(event, handler, options)
     .then((stopListening) => {
       if (cancelled) {
         unsubscribe(stopListening);

--- a/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
+++ b/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
@@ -472,6 +472,14 @@ test("Escape closes the active overlay before hiding the clipboard", async ({
   await expect
     .poll(async () => await invocationCount(page, "clipboard_hide"))
     .toBe(3);
+
+  await page.getByRole("searchbox").focus();
+  await page.getByRole("searchbox").evaluate((input) => input.blur());
+  await expect(page.locator("body")).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect
+    .poll(async () => await invocationCount(page, "clipboard_hide"))
+    .toBe(4);
 });
 
 test("creates a group from a clip with inline preset and custom colors", async ({

--- a/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
+++ b/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
@@ -1,0 +1,602 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+import { DEFAULT_CLIPBOARD_GROUP_COLOR } from "../../src/clipboard/clipboard-style";
+import { isClipboardSnapshot } from "../../src/clipboard/clipboard-types";
+import type { ClipboardSnapshot } from "../../src/clipboard/clipboard-types";
+
+const CLIPBOARD_ITEMS = Array.from({ length: 14 }, (_, index) => ({
+  copiedAt: "2026-09-08T05:00:00.000Z",
+  groupId: index === 1 ? "work" : null,
+  groupedAt: index === 1 ? "2026-09-08T05:00:00.000Z" : null,
+  id: `clip-${index + 1}`,
+  name: `Clip ${index + 1}`,
+  plainText: `Clipboard item ${index + 1}`,
+  sourceApp: null,
+  type: "text" as const,
+})) satisfies ClipboardSnapshot["items"];
+
+const SNAPSHOT = {
+  captureStatus: "active",
+  groups: [{ color: DEFAULT_CLIPBOARD_GROUP_COLOR, id: "work", name: "Work" }],
+  items: CLIPBOARD_ITEMS,
+  persistence: { imageCleanup: "idle", status: "encrypted" },
+  retention: "month",
+  screenCapture: "hidden",
+  sourceAppVisuals: [],
+  welcomeStatus: "completed",
+} satisfies ClipboardSnapshot;
+
+const installNativeBoundary = async (page: Page, language: "ar" | "en") => {
+  expect(isClipboardSnapshot(SNAPSHOT)).toBe(true);
+  await page.addInitScript(
+    ({ clipboardSnapshot, nativeLanguage }) => {
+      const callbacks = new Map<number, (data: unknown) => unknown>();
+      const invocations: {
+        args: Record<string, unknown>;
+        command: string;
+      }[] = [];
+      let nextCallbackId = 1;
+
+      Reflect.set(window, "__STELLA_TEST_INVOCATIONS__", invocations);
+      Reflect.set(window, "__TAURI_EVENT_PLUGIN_INTERNALS__", {
+        unregisterListener: () => undefined,
+      });
+      Reflect.set(window, "__TAURI_INTERNALS__", {
+        callbacks,
+        convertFileSrc: (path: string) => path,
+        invoke: async (command: string, args: Record<string, unknown> = {}) => {
+          invocations.push({ args, command });
+          if (command === "clipboard_get_snapshot") {
+            return clipboardSnapshot;
+          }
+          if (command === "clipboard_create_group") {
+            const groupId = "created-group";
+            const itemId = args["itemId"];
+            const name = args["name"];
+            return {
+              ...clipboardSnapshot,
+              groups: [
+                ...clipboardSnapshot.groups,
+                {
+                  color:
+                    typeof args["color"] === "string"
+                      ? args["color"]
+                      : clipboardSnapshot.groups[0]?.color,
+                  id: groupId,
+                  name: typeof name === "string" ? name : "Created group",
+                },
+              ],
+              items: clipboardSnapshot.items.map((item) =>
+                item.id === itemId
+                  ? {
+                      ...item,
+                      groupId,
+                      groupedAt: "2026-09-08T06:00:00.000Z",
+                    }
+                  : item,
+              ),
+            };
+          }
+          if (command === "clipboard_update_group") {
+            return {
+              ...clipboardSnapshot,
+              groups: clipboardSnapshot.groups.map((group) =>
+                group.id === args["id"]
+                  ? {
+                      ...group,
+                      color:
+                        typeof args["color"] === "string"
+                          ? args["color"]
+                          : group.color,
+                      name:
+                        typeof args["name"] === "string"
+                          ? args["name"]
+                          : group.name,
+                    }
+                  : group,
+              ),
+            };
+          }
+          if (command === "clipboard_set_screen_capture") {
+            return {
+              ...clipboardSnapshot,
+              screenCapture:
+                args["capture"] === "visible" ? "visible" : "hidden",
+            };
+          }
+          if (command === "get_desktop_language") {
+            return nativeLanguage;
+          }
+          if (command === "is_autostart_enabled") {
+            return false;
+          }
+          if (command === "plugin:event|listen") {
+            return args["handler"];
+          }
+          return undefined;
+        },
+        metadata: {
+          currentWebview: {
+            label: "clipboard",
+            windowLabel: "clipboard",
+          },
+          currentWindow: { label: "clipboard" },
+        },
+        runCallback: (id: number, data: unknown) => callbacks.get(id)?.(data),
+        transformCallback: (
+          callback: ((data: unknown) => unknown) | undefined,
+          once = false,
+        ) => {
+          const id = nextCallbackId;
+          nextCallbackId += 1;
+          callbacks.set(id, (data) => {
+            if (once) {
+              callbacks.delete(id);
+            }
+            return callback?.(data);
+          });
+          return id;
+        },
+        unregisterCallback: (id: number) => callbacks.delete(id),
+      });
+    },
+    { clipboardSnapshot: SNAPSHOT, nativeLanguage: language },
+  );
+};
+
+const openClipboard = async (page: Page, language: "ar" | "en") => {
+  await installNativeBoundary(page, language);
+  await page.goto("/");
+  const cards = page.locator("[data-clipboard-card-trigger]");
+  await expect(cards.first()).toBeFocused();
+  return cards;
+};
+
+const readCardEmphasis = async (page: Page, id: string) =>
+  page.locator(`[data-clipboard-id="${id}"]`).evaluate((card) => {
+    const cardStyle = getComputedStyle(card);
+    const selectionStyle = getComputedStyle(card, "::after");
+    return {
+      backgroundColor: cardStyle.backgroundColor,
+      boxShadow: cardStyle.boxShadow,
+      selectionOpacity: selectionStyle.opacity,
+    };
+  });
+
+const readFocusIndicator = async (
+  page: Page,
+  selector = '[data-clipboard-group-id][aria-pressed="true"]',
+) =>
+  page.locator(selector).evaluate((control) => {
+    const style = getComputedStyle(control);
+    return {
+      outlineColor: style.outlineColor,
+      outlineStyle: style.outlineStyle,
+      outlineWidth: style.outlineWidth,
+    };
+  });
+
+const invocationCount = async (page: Page, command: string) =>
+  page.evaluate((expectedCommand) => {
+    const invocations: unknown = Reflect.get(
+      window,
+      "__STELLA_TEST_INVOCATIONS__",
+    );
+    if (!Array.isArray(invocations)) {
+      return 0;
+    }
+    return invocations.filter(
+      (invocation) =>
+        typeof invocation === "object" &&
+        invocation !== null &&
+        "command" in invocation &&
+        invocation.command === expectedCommand,
+    ).length;
+  }, command);
+
+const DIRECTIONS = [
+  { groupKey: "ArrowRight", language: "en", nextCardKey: "ArrowRight" },
+  { groupKey: "ArrowLeft", language: "ar", nextCardKey: "ArrowLeft" },
+] as const;
+
+for (const { groupKey, language, nextCardKey } of DIRECTIONS) {
+  test.describe(`${language} clipboard direction`, () => {
+    test.use({ locale: language });
+
+    test("keeps card emphasis hidden while focus traverses the footer", async ({
+      page,
+    }) => {
+      const cards = await openClipboard(page, language);
+      const selectedCard = page.locator('[data-clipboard-id="clip-2"]');
+      const restingCard = page.locator('[data-clipboard-id="clip-1"]');
+      const activeGroup = page.locator(
+        '[data-clipboard-group-id][aria-pressed="true"]',
+      );
+
+      await page.keyboard.press(nextCardKey);
+      await expect(cards.nth(1)).toBeFocused();
+      await page.mouse.move(0, 0);
+      await page.keyboard.press("ArrowDown");
+      await expect(page.getByRole("searchbox")).toBeFocused();
+
+      await page.keyboard.press(groupKey);
+      await expect(activeGroup).toBeFocused();
+      await expect(selectedCard).toHaveAttribute("aria-current", "true");
+      await expect
+        .poll(
+          async () => (await readCardEmphasis(page, "clip-2")).selectionOpacity,
+        )
+        .toBe("0");
+      const selectedEmphasis = await readCardEmphasis(page, "clip-2");
+      const restingEmphasis = await readCardEmphasis(page, "clip-1");
+      expect({
+        backgroundColor: selectedEmphasis.backgroundColor,
+        boxShadow: selectedEmphasis.boxShadow,
+      }).toEqual({
+        backgroundColor: restingEmphasis.backgroundColor,
+        boxShadow: restingEmphasis.boxShadow,
+      });
+      await expect(restingCard).not.toHaveAttribute("aria-current", "true");
+
+      await page.keyboard.press(groupKey);
+      await expect(
+        page.locator(".clipboard-groups-rail button").nth(1),
+      ).toBeFocused();
+      await page.keyboard.press("ArrowUp");
+      await expect(cards.nth(1)).toBeFocused();
+      await expect
+        .poll(
+          async () => (await readCardEmphasis(page, "clip-2")).selectionOpacity,
+        )
+        .toBe("1");
+    });
+
+    test("a queued card navigation cannot steal focus from the footer", async ({
+      page,
+    }) => {
+      const cards = await openClipboard(page, language);
+      const search = page.getByRole("searchbox");
+
+      await cards.first().evaluate(
+        (card, keys) => {
+          for (const key of keys) {
+            card.dispatchEvent(
+              new KeyboardEvent("keydown", {
+                bubbles: true,
+                cancelable: true,
+                key,
+              }),
+            );
+          }
+        },
+        [nextCardKey, "ArrowDown"],
+      );
+      await expect(search).toBeFocused();
+
+      await page.evaluate(
+        async () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                resolve();
+              });
+            });
+          }),
+      );
+      await expect(search).toBeFocused();
+      await expect(
+        page.locator('[data-clipboard-id="clip-2"]'),
+      ).toHaveAttribute("aria-current", "true");
+    });
+  });
+}
+
+test("keyboard navigation mounts and focuses virtualized cards", async ({
+  page,
+}) => {
+  await openClipboard(page, "en");
+  await expect(page.locator('[data-clipboard-id="clip-13"]')).toHaveCount(0);
+
+  for (let index = 1; index < 13; index += 1) {
+    await page.keyboard.press("ArrowRight");
+  }
+
+  const targetCard = page.locator('[data-clipboard-id="clip-13"]');
+  await expect(
+    targetCard.locator("[data-clipboard-card-trigger]"),
+  ).toBeFocused();
+  await expect(targetCard).toHaveAttribute("aria-current", "true");
+});
+
+test("restores footer arrow navigation after changing a menu setting", async ({
+  page,
+}) => {
+  const cards = await openClipboard(page, "en");
+  const search = page.getByRole("searchbox");
+  const activeGroup = page.locator(
+    '[data-clipboard-group-id][aria-pressed="true"]',
+  );
+  const focusActiveGroup = async () => {
+    await page.keyboard.press("ArrowDown");
+    await expect(search).toBeFocused();
+    const searchFocusColor = await page
+      .locator(".clipboard-search")
+      .evaluate(
+        (control) => getComputedStyle(control, "::after").borderTopColor,
+      );
+    await page.keyboard.press("ArrowRight");
+    await expect(activeGroup).toBeFocused();
+    return { indicator: await readFocusIndicator(page), searchFocusColor };
+  };
+
+  const initialFocus = await focusActiveGroup();
+  expect(initialFocus.indicator.outlineColor).toBe(
+    initialFocus.searchFocusColor,
+  );
+  expect(initialFocus.indicator.outlineStyle).toBe("solid");
+  expect(initialFocus.indicator.outlineWidth).toBe("2px");
+  await page.keyboard.press("ArrowUp");
+  await expect(cards.first()).toBeFocused();
+
+  const moreOptions = page.getByRole("button", { name: "More options" });
+  await moreOptions.click();
+  const screenCaptureSetting = page.getByRole("menuitemcheckbox");
+  await screenCaptureSetting.click();
+  await expect(screenCaptureSetting).toBeChecked();
+  await page.keyboard.press("Escape");
+  await expect(screenCaptureSetting).toBeHidden();
+  await expect(moreOptions).toBeFocused();
+
+  await page.keyboard.press("ArrowDown");
+  await expect(moreOptions).toBeFocused();
+  await expect(screenCaptureSetting).toBeHidden();
+  await page.keyboard.press("ArrowLeft");
+  const workGroup = page.locator('[data-clipboard-group-id="work"]');
+  await expect(workGroup).toBeFocused();
+  expect(
+    await readFocusIndicator(page, '[data-clipboard-group-id="work"]'),
+  ).toEqual(initialFocus.indicator);
+  await page.keyboard.press("ArrowRight");
+  await expect(moreOptions).toBeFocused();
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("button", { name: "Close" })).toBeFocused();
+  await page.keyboard.press("ArrowLeft");
+  await expect(moreOptions).toBeFocused();
+  await page.keyboard.press("ArrowUp");
+  await expect(cards.first()).toBeFocused();
+
+  await page.keyboard.press("ArrowDown");
+  const footerControls = page.locator(
+    ".clipboard-controls button:not([disabled]):not([aria-disabled='true']), .clipboard-controls a[href], .clipboard-controls input:not([disabled])",
+  );
+  await expect(footerControls).toHaveCount(7);
+  await expect(footerControls.nth(1)).toBeFocused();
+  await page.keyboard.press("ArrowLeft");
+  await expect(footerControls.first()).toBeFocused();
+  await page.keyboard.press("ArrowRight");
+  await expect(footerControls.nth(1)).toBeFocused();
+  for (let index = 2; index < 7; index += 1) {
+    await page.keyboard.press("ArrowRight");
+    await expect(footerControls.nth(index)).toBeFocused();
+  }
+  for (let index = 5; index >= 0; index -= 1) {
+    await page.keyboard.press("ArrowLeft");
+    await expect(footerControls.nth(index)).toBeFocused();
+  }
+});
+
+test("Escape closes the active overlay before hiding the clipboard", async ({
+  page,
+}) => {
+  const cards = await openClipboard(page, "en");
+
+  await page.getByRole("searchbox").fill("Clipboard");
+  await page.keyboard.press("Escape");
+  await expect
+    .poll(async () => await invocationCount(page, "clipboard_hide"))
+    .toBe(1);
+  await expect(page.getByRole("searchbox")).toHaveValue("Clipboard");
+
+  const moreOptions = page.getByRole("button", { name: "More options" });
+  await moreOptions.click();
+  const menuSetting = page.getByRole("menuitemcheckbox");
+  await expect(menuSetting).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(menuSetting).toBeHidden();
+  expect(await invocationCount(page, "clipboard_hide")).toBe(1);
+  await page.keyboard.press("Escape");
+  await expect
+    .poll(async () => await invocationCount(page, "clipboard_hide"))
+    .toBe(2);
+
+  await cards.first().click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Move to group" }).hover();
+  await page.getByRole("menuitem", { name: "New group" }).click();
+  const dialog = page.getByRole("dialog", { name: "New group" });
+  await expect(dialog).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  expect(await invocationCount(page, "clipboard_hide")).toBe(2);
+  await page.keyboard.press("Escape");
+  await expect
+    .poll(async () => await invocationCount(page, "clipboard_hide"))
+    .toBe(3);
+});
+
+test("creates a group from a clip with inline preset and custom colors", async ({
+  page,
+}) => {
+  const cards = await openClipboard(page, "en");
+
+  await cards.first().click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Move to group" }).hover();
+  await page.getByRole("menuitem", { name: "New group" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New group" });
+  await expect(dialog).toBeVisible();
+  const groupName = dialog.getByRole("textbox");
+  await expect(groupName).toBeFocused();
+  await groupName.fill("Client intake");
+
+  const picker = dialog.locator('[data-slot="color-picker"]');
+  const colorControls = picker.getByRole("button");
+  await expect(colorControls).toHaveCount(7);
+  await expect(page.locator('[data-slot="color-picker-popup"]')).toHaveCount(0);
+  await expect(
+    page.locator('[data-slot="color-picker-custom-popup"]'),
+  ).toHaveCount(0);
+  await expect(dialog).not.toContainText("#60A5FA");
+  const clipping = await picker.evaluate((controls) => {
+    const dialogBounds = controls
+      .closest('[role="dialog"]')
+      ?.getBoundingClientRect();
+    if (!dialogBounds) {
+      return null;
+    }
+    return Array.from(controls.querySelectorAll("button")).map((swatch) => {
+      const bounds = swatch.getBoundingClientRect();
+      return {
+        bottom: bounds.bottom > Math.min(dialogBounds.bottom, innerHeight),
+        height: bounds.height,
+        left: bounds.left < Math.max(dialogBounds.left, 0),
+        right: bounds.right > Math.min(dialogBounds.right, innerWidth),
+        top: bounds.top < Math.max(dialogBounds.top, 0),
+        width: bounds.width,
+      };
+    });
+  });
+  expect(clipping).toEqual(
+    Array.from({ length: 7 }, () => ({
+      bottom: false,
+      height: 44,
+      left: false,
+      right: false,
+      top: false,
+      width: 44,
+    })),
+  );
+  const preset = picker.getByRole("button", { name: "#60A5FA" });
+  await preset.click();
+  await expect(preset).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    page.locator('[data-slot="color-picker-custom-popup"]'),
+  ).toHaveCount(0);
+
+  const customColor = picker.getByRole("button", { name: "Custom color" });
+  await customColor.click();
+  const customPicker = page.locator('[data-slot="color-picker-custom-popup"]');
+  await expect(customPicker).toBeVisible();
+  const customHex = customPicker.getByRole("textbox", {
+    name: "Custom hex color",
+  });
+  await expect(customHex).toBeVisible();
+  await customHex.fill("112233");
+  await expect(customColor).toHaveAttribute("aria-pressed", "true");
+  await expect(customColor).toHaveCSS("background-color", "rgb(17, 34, 51)");
+  await expect(dialog).not.toContainText("#112233");
+  const expandedPickerBounds = await customPicker.evaluate((popup) => {
+    const bounds = popup.getBoundingClientRect();
+    return {
+      bottom: bounds.bottom <= innerHeight,
+      left: bounds.left >= 0,
+      right: bounds.right <= innerWidth,
+      top: bounds.top >= 0,
+    };
+  });
+  expect(expandedPickerBounds).toEqual({
+    bottom: true,
+    left: true,
+    right: true,
+    top: true,
+  });
+  await page.keyboard.press("Escape");
+  await expect(customPicker).toBeHidden();
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Create" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(
+    page.getByRole("button", { name: "Client intake" }),
+  ).toBeVisible();
+  const createGroupArgs = await page.evaluate(() => {
+    const invocations: unknown = Reflect.get(
+      window,
+      "__STELLA_TEST_INVOCATIONS__",
+    );
+    if (!Array.isArray(invocations)) {
+      return null;
+    }
+    for (const invocation of invocations) {
+      if (
+        typeof invocation !== "object" ||
+        invocation === null ||
+        !("command" in invocation) ||
+        invocation.command !== "clipboard_create_group" ||
+        !("args" in invocation) ||
+        typeof invocation.args !== "object" ||
+        invocation.args === null
+      ) {
+        continue;
+      }
+      return {
+        color: "color" in invocation.args ? invocation.args.color : undefined,
+        itemId:
+          "itemId" in invocation.args ? invocation.args.itemId : undefined,
+        name: "name" in invocation.args ? invocation.args.name : undefined,
+      };
+    }
+    return null;
+  });
+  expect(createGroupArgs).toEqual({
+    color: "#112233",
+    itemId: "clip-1",
+    name: "Client intake",
+  });
+
+  const createdGroup = page.getByRole("button", { name: "Client intake" });
+  await createdGroup.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Edit group" }).click();
+  const editDialog = page.getByRole("dialog", { name: "Edit group" });
+  const savedCustomColor = editDialog.getByRole("button", {
+    name: "Custom color",
+  });
+  await expect(savedCustomColor).toHaveAttribute("aria-pressed", "true");
+  await expect(savedCustomColor).toHaveCSS(
+    "background-color",
+    "rgb(17, 34, 51)",
+  );
+  await editDialog.getByRole("textbox").fill("Client intake renamed");
+  await editDialog.getByRole("button", { name: "Edit group" }).click();
+  const updateGroupArgs = await page.evaluate(() => {
+    const invocations: unknown = Reflect.get(
+      window,
+      "__STELLA_TEST_INVOCATIONS__",
+    );
+    if (!Array.isArray(invocations)) {
+      return null;
+    }
+    const invocation = invocations.findLast(
+      (candidate) =>
+        typeof candidate === "object" &&
+        candidate !== null &&
+        "command" in candidate &&
+        candidate.command === "clipboard_update_group",
+    );
+    if (
+      typeof invocation !== "object" ||
+      invocation === null ||
+      !("args" in invocation) ||
+      typeof invocation.args !== "object" ||
+      invocation.args === null
+    ) {
+      return null;
+    }
+    return invocation.args;
+  });
+  expect(updateGroupArgs).toEqual({
+    color: "#112233",
+    id: "created-group",
+    name: "Client intake renamed",
+  });
+});

--- a/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
+++ b/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
@@ -21,6 +21,7 @@ const CLIPBOARD_ITEMS = Array.from({ length: 14 }, (_, index) => ({
 
 const SNAPSHOT = {
   captureStatus: "active",
+  groupLimit: 24,
   groups: [{ color: DEFAULT_CLIPBOARD_GROUP_COLOR, id: "work", name: "Work" }],
   items: CLIPBOARD_ITEMS,
   persistence: { imageCleanup: "idle", status: "encrypted" },

--- a/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
+++ b/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
+import { TauriEvent } from "@tauri-apps/api/event";
 
 import { DEFAULT_CLIPBOARD_GROUP_COLOR } from "../../src/clipboard/clipboard-style";
 import { isClipboardSnapshot } from "../../src/clipboard/clipboard-types";
@@ -32,7 +33,7 @@ const SNAPSHOT = {
 const installNativeBoundary = async (page: Page, language: "ar" | "en") => {
   expect(isClipboardSnapshot(SNAPSHOT)).toBe(true);
   await page.addInitScript(
-    ({ clipboardSnapshot, nativeLanguage }) => {
+    ({ clipboardSnapshot, nativeLanguage, nativeBlurEvent }) => {
       const callbacks = new Map<number, (data: unknown) => unknown>();
       const invocations: {
         args: Record<string, unknown>;
@@ -41,6 +42,19 @@ const installNativeBoundary = async (page: Page, language: "ar" | "en") => {
       let nextCallbackId = 1;
 
       Reflect.set(window, "__STELLA_TEST_INVOCATIONS__", invocations);
+      Reflect.set(window, "__STELLA_TEST_NATIVE_BLUR__", () => {
+        const subscription = invocations.findLast(
+          ({ args, command }) =>
+            command === "plugin:event|listen" &&
+            args["event"] === nativeBlurEvent,
+        );
+        const id = subscription?.args["handler"];
+        if (typeof id !== "number") {
+          throw new TypeError("Native window blur listener is not installed");
+        }
+        callbacks.get(id)?.({ event: nativeBlurEvent, id, payload: null });
+        return subscription?.args["target"];
+      });
       Reflect.set(window, "__TAURI_EVENT_PLUGIN_INTERNALS__", {
         unregisterListener: () => undefined,
       });
@@ -143,7 +157,11 @@ const installNativeBoundary = async (page: Page, language: "ar" | "en") => {
         unregisterCallback: (id: number) => callbacks.delete(id),
       });
     },
-    { clipboardSnapshot: SNAPSHOT, nativeLanguage: language },
+    {
+      clipboardSnapshot: SNAPSHOT,
+      nativeLanguage: language,
+      nativeBlurEvent: TauriEvent.WINDOW_BLUR,
+    },
   );
 };
 
@@ -230,6 +248,63 @@ const DIRECTIONS = [
 for (const { groupKey, language, nextCardKey } of DIRECTIONS) {
   test.describe(`${language} clipboard direction`, () => {
     test.use({ locale: language });
+
+    for (const dismissal of ["dom", "native"] as const) {
+      test(`prepares the first card before reopening after ${dismissal} dismissal`, async ({
+        page,
+      }) => {
+        await openClipboard(page, language);
+        for (let index = 0; index < 10; index += 1) {
+          await page.keyboard.press(nextCardKey);
+        }
+        await expect(
+          page.locator('[data-clipboard-id="clip-11"]'),
+        ).toHaveAttribute("aria-current", "true");
+
+        const parked = await page.evaluate((source) => {
+          let eventTarget: unknown;
+          if (source === "native") {
+            const emit: unknown = Reflect.get(
+              window,
+              "__STELLA_TEST_NATIVE_BLUR__",
+            );
+            if (typeof emit !== "function") {
+              throw new TypeError(
+                "Native window blur boundary is not installed",
+              );
+            }
+            eventTarget = emit();
+          } else {
+            window.dispatchEvent(new FocusEvent("blur"));
+          }
+          const selected = document.querySelector<HTMLElement>(
+            '[data-clipboard-id][aria-current="true"]',
+          );
+          const rail = selected?.closest('[role="list"]');
+          return {
+            selectedId: selected?.dataset["clipboardId"],
+            scrollLeft: rail?.scrollLeft,
+            eventTarget,
+          };
+        }, dismissal);
+        expect(parked).toEqual({
+          selectedId: "clip-1",
+          scrollLeft: 0,
+          eventTarget:
+            dismissal === "native"
+              ? { kind: "Window", label: "clipboard" }
+              : undefined,
+        });
+        await page.evaluate(() =>
+          window.dispatchEvent(new FocusEvent("focus")),
+        );
+        await expect(
+          page.locator(
+            '[data-clipboard-id="clip-1"] [data-clipboard-card-trigger]',
+          ),
+        ).toBeFocused();
+      });
+    }
 
     test("color swatches and selection rings fit without scrollbars", async ({
       page,

--- a/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
+++ b/apps/desktop/tests/browser/clipboard-keyboard.playwright.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "@playwright/test";
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 import { DEFAULT_CLIPBOARD_GROUP_COLOR } from "../../src/clipboard/clipboard-style";
 import { isClipboardSnapshot } from "../../src/clipboard/clipboard-types";
 import type { ClipboardSnapshot } from "../../src/clipboard/clipboard-types";
+import arMessages from "../../src/i18n/langs/ar.json" with { type: "json" };
+import enMessages from "../../src/i18n/langs/en.json" with { type: "json" };
 
 const CLIPBOARD_ITEMS = Array.from({ length: 14 }, (_, index) => ({
   copiedAt: "2026-09-08T05:00:00.000Z",
@@ -153,6 +155,31 @@ const openClipboard = async (page: Page, language: "ar" | "en") => {
   return cards;
 };
 
+const readPickerOverflow = async (picker: Locator) =>
+  picker.evaluate((controls) => {
+    const viewport = controls.closest('[data-slot="scroll-area-viewport"]');
+    if (!viewport) {
+      return null;
+    }
+    const viewportBounds = viewport.getBoundingClientRect();
+    return {
+      horizontal: viewport.scrollWidth > viewport.clientWidth,
+      vertical: viewport.scrollHeight > viewport.clientHeight,
+      clipped: Array.from(controls.querySelectorAll("button")).flatMap(
+        (swatch) => {
+          const bounds = swatch.getBoundingClientRect();
+          const ring = 4;
+          return bounds.top - ring < viewportBounds.top ||
+            bounds.bottom + ring > viewportBounds.bottom ||
+            bounds.left - ring < viewportBounds.left ||
+            bounds.right + ring > viewportBounds.right
+            ? [swatch.getAttribute("aria-label")]
+            : [];
+        },
+      ),
+    };
+  });
+
 const readCardEmphasis = async (page: Page, id: string) =>
   page.locator(`[data-clipboard-id="${id}"]`).evaluate((card) => {
     const cardStyle = getComputedStyle(card);
@@ -203,6 +230,29 @@ const DIRECTIONS = [
 for (const { groupKey, language, nextCardKey } of DIRECTIONS) {
   test.describe(`${language} clipboard direction`, () => {
     test.use({ locale: language });
+
+    test("color swatches and selection rings fit without scrollbars", async ({
+      page,
+    }) => {
+      const messages = language === "ar" ? arMessages : enMessages;
+      await openClipboard(page, language);
+      await page
+        .getByRole("button", {
+          name: messages.clipboard.createGroup,
+          exact: true,
+        })
+        .click();
+      const dialog = page.getByRole("dialog", {
+        name: messages.clipboard.createGroup,
+      });
+      await expect(dialog).toBeVisible();
+      const picker = dialog.locator('[data-slot="color-picker"]');
+      await expect(picker.getByRole("button")).toHaveCount(7);
+      await picker.getByRole("button", { name: "#FB7185" }).click();
+      await expect
+        .poll(async () => readPickerOverflow(picker))
+        .toEqual({ clipped: [], horizontal: false, vertical: false });
+    });
 
     test("keeps card emphasis hidden while focus traverses the footer", async ({
       page,
@@ -479,6 +529,12 @@ test("creates a group from a clip with inline preset and custom colors", async (
   const preset = picker.getByRole("button", { name: "#60A5FA" });
   await preset.click();
   await expect(preset).toHaveAttribute("aria-pressed", "true");
+  const pickerOverflow = await readPickerOverflow(picker);
+  expect(pickerOverflow).toEqual({
+    clipped: [],
+    horizontal: false,
+    vertical: false,
+  });
   await expect(
     page.locator('[data-slot="color-picker-custom-popup"]'),
   ).toHaveCount(0);

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -7,7 +7,7 @@ import {
   clipboardDraggedItemId,
   clipboardItemLink,
   clipboardPointerMoved,
-  clipboardGroupRailKeyAction,
+  clipboardControlsKeyAction,
   clipboardTimelineKeyAction,
   clipboardRailScrollDelta,
   clipboardRailWindow,
@@ -21,7 +21,7 @@ import {
   isClipboardNameInput,
   quickCopyIndex,
   shouldCopyFromClipboardInput,
-  shouldLeaveSearchForGroups,
+  shouldLeaveClipboardSearch,
   shouldReturnToTimelineFromInput,
 } from "../src/clipboard/clipboard-logic";
 import type { ClipboardItem } from "../src/clipboard/clipboard-types";
@@ -343,12 +343,21 @@ describe("keyboard indexes", () => {
     expect(rtl("ArrowUp")).toBeNull();
   });
 
-  test("group rail arrows walk horizontally and Arrow Up returns to the timeline", () => {
-    expect(clipboardGroupRailKeyAction("ArrowLeft")).toBe("previous");
-    expect(clipboardGroupRailKeyAction("ArrowRight")).toBe("next");
-    expect(clipboardGroupRailKeyAction("ArrowUp")).toBe("focusTimeline");
-    expect(clipboardGroupRailKeyAction("ArrowDown")).toBeNull();
-    expect(clipboardGroupRailKeyAction("Enter")).toBeNull();
+  test("footer arrows follow visual order and Arrow Up returns to the timeline", () => {
+    const ltr = (key: string) =>
+      clipboardControlsKeyAction({ direction: "ltr", key });
+    expect(ltr("ArrowLeft")).toBe("previous");
+    expect(ltr("ArrowRight")).toBe("next");
+    expect(ltr("ArrowUp")).toBe("focusTimeline");
+    expect(ltr("ArrowDown")).toBe("stay");
+    expect(ltr("Enter")).toBeNull();
+
+    const rtl = (key: string) =>
+      clipboardControlsKeyAction({ direction: "rtl", key });
+    expect(rtl("ArrowLeft")).toBe("next");
+    expect(rtl("ArrowRight")).toBe("previous");
+    expect(rtl("ArrowUp")).toBe("focusTimeline");
+    expect(rtl("ArrowDown")).toBe("stay");
   });
 
   test("timeline navigation has no target beyond either edge", () => {
@@ -556,33 +565,41 @@ describe("clipboard input keyboard handling", () => {
       shiftKey: false,
       valueLength: 3,
     };
-    expect(shouldLeaveSearchForGroups(atEnd)).toBe(true);
+    expect(shouldLeaveClipboardSearch(atEnd)).toBe(true);
     expect(
-      shouldLeaveSearchForGroups({
+      shouldLeaveClipboardSearch({
         ...atEnd,
         selectionEnd: 0,
         selectionStart: 0,
         valueLength: 0,
       }),
     ).toBe(true);
-    expect(shouldLeaveSearchForGroups({ ...atEnd, selectionStart: 2 })).toBe(
+    expect(shouldLeaveClipboardSearch({ ...atEnd, selectionStart: 2 })).toBe(
       false,
     );
     expect(
-      shouldLeaveSearchForGroups({
+      shouldLeaveClipboardSearch({
         ...atEnd,
         selectionEnd: 1,
         selectionStart: 1,
       }),
     ).toBe(false);
-    expect(shouldLeaveSearchForGroups({ ...atEnd, isComposing: true })).toBe(
+    expect(shouldLeaveClipboardSearch({ ...atEnd, isComposing: true })).toBe(
       false,
     );
-    expect(shouldLeaveSearchForGroups({ ...atEnd, key: "ArrowLeft" })).toBe(
+    expect(shouldLeaveClipboardSearch({ ...atEnd, key: "ArrowLeft" })).toBe(
       false,
     );
     expect(
-      shouldLeaveSearchForGroups({
+      shouldLeaveClipboardSearch({
+        ...atEnd,
+        key: "ArrowLeft",
+        selectionEnd: 0,
+        selectionStart: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldLeaveClipboardSearch({
         ...atEnd,
         dataset: { clipboardNameInput: "" },
       }),
@@ -611,7 +628,7 @@ describe("clipboard input keyboard handling", () => {
       "metaKey",
       "shiftKey",
     ] as const) {
-      expect(shouldLeaveSearchForGroups({ ...atEnd, [modifier]: true })).toBe(
+      expect(shouldLeaveClipboardSearch({ ...atEnd, [modifier]: true })).toBe(
         false,
       );
     }
@@ -632,15 +649,23 @@ describe("clipboard input keyboard handling", () => {
       shiftKey: false,
       valueLength: 3,
     };
-    expect(shouldLeaveSearchForGroups(rtl)).toBe(true);
+    expect(shouldLeaveClipboardSearch(rtl)).toBe(true);
     expect(
-      shouldLeaveSearchForGroups({
+      shouldLeaveClipboardSearch({
         ...rtl,
         selectionEnd: 3,
         selectionStart: 3,
       }),
     ).toBe(false);
-    expect(shouldLeaveSearchForGroups({ ...rtl, selectionEnd: 3 })).toBe(false);
+    expect(shouldLeaveClipboardSearch({ ...rtl, selectionEnd: 3 })).toBe(false);
+    expect(
+      shouldLeaveClipboardSearch({
+        ...rtl,
+        key: "ArrowLeft",
+        selectionEnd: 3,
+        selectionStart: 3,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/desktop/tests/clipboard-types.test.ts
+++ b/apps/desktop/tests/clipboard-types.test.ts
@@ -15,6 +15,7 @@ import {
 
 const snapshotWithWelcomeStatus = (welcomeStatus: unknown) => ({
   captureStatus: "active",
+  groupLimit: 24,
   groups: [],
   items: [],
   persistence: { imageCleanup: "idle", status: "encrypted" },
@@ -41,6 +42,31 @@ describe("clipboard snapshot welcome state", () => {
     expect(isClipboardSnapshot(snapshotWithWelcomeStatus("initializing"))).toBe(
       false,
     );
+  });
+});
+
+describe("clipboard snapshot group limit", () => {
+  test("requires a positive safe integer supplied by native", () => {
+    for (const groupLimit of [
+      undefined,
+      0,
+      -1,
+      1.5,
+      Number.MAX_SAFE_INTEGER + 1,
+    ]) {
+      expect(
+        isClipboardSnapshot({
+          ...snapshotWithWelcomeStatus("completed"),
+          groupLimit,
+        }),
+      ).toBe(false);
+    }
+    expect(
+      isClipboardSnapshot({
+        ...snapshotWithWelcomeStatus("completed"),
+        groupLimit: 24,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "types": ["vite/client"]
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "vite.config.ts", "playwright.config.ts"],
   "exclude": [
     "dist",
     "node_modules",

--- a/apps/desktop/tsconfig.test.json
+++ b/apps/desktop/tsconfig.test.json
@@ -4,6 +4,6 @@
     "types": ["bun-types"],
     "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.test.json"
   },
-  "include": ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+  "include": ["tests/**/*.ts", "tests/**/*.tsx"],
   "exclude": ["dist", "node_modules", "src-tauri"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -199,6 +199,7 @@
         "use-intl": "catalog:",
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.0",
         "@stll/typescript-config": "workspace:*",
         "@tailwindcss/vite": "catalog:",
         "@tauri-apps/cli": "^2.11.4",

--- a/packages/ui/src/components/color-picker.playwright.spec.ts
+++ b/packages/ui/src/components/color-picker.playwright.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+const fixturePath = "/src/components/fixtures/color-picker.fixture.html";
+
+test("popover presentation closes for presets and stays open for custom input", async ({
+  page,
+}) => {
+  await page.goto(fixturePath);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["colorPickerReady"] ?? "",
+        ),
+    )
+    .toBe("true");
+
+  const trigger = page.locator('[data-slot="color-picker-trigger"]');
+  const popup = page.locator('[data-slot="color-picker-popup"]');
+  await trigger.click();
+  await expect(popup).toBeVisible();
+  await popup.getByRole("button", { name: "Blue" }).click();
+  await expect(popup).toBeHidden();
+  await expect(page.getByRole("status", { name: "Selected color" })).toHaveText(
+    "3B82F6",
+  );
+
+  await trigger.click();
+  await popup.getByRole("button", { name: "Custom color" }).click();
+  await expect(popup).toBeVisible();
+  const customHex = popup.getByRole("textbox", { name: "Custom hex color" });
+  await expect(customHex).toBeVisible();
+  await customHex.fill("112233");
+  await expect(page.getByRole("status", { name: "Selected color" })).toHaveText(
+    "112233",
+  );
+  await page.keyboard.press("Escape");
+  await expect(popup).toBeHidden();
+});

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -123,6 +123,11 @@ const isLightHex = (hex: string): boolean => {
   return (r * 299 + g * 587 + b * 114) / 1000 > 220;
 };
 
+const checkIconColorClassNames = {
+  dark: "text-(--color-white)",
+  light: "text-(--color-black)",
+} as const;
+
 /** Check if a value looks like a 6-char hex (no CSS vars, no named colors). */
 const looksLikeHex = (v: string) => /^[0-9A-Fa-f]{6}$/u.test(v);
 
@@ -174,12 +179,9 @@ const ColorSwatch = ({
             presentation === "inline"
               ? "bg-background/88 text-foreground size-5 rounded-full p-0.5 shadow-sm"
               : "size-3 sm:size-2.5",
+            presentation === "popover" &&
+              checkIconColorClassNames[isLight ? "light" : "dark"],
           )}
-          style={
-            presentation === "popover"
-              ? { color: isLight ? "#000" : "#fff" }
-              : undefined
-          }
         />
       )}
     </button>
@@ -371,11 +373,7 @@ const ColorPickerContent = ({
 
   if (presentation === "inline") {
     return (
-      <div
-        className="flex items-center gap-1"
-        data-slot="color-picker"
-        role="group"
-      >
+      <div className="flex items-center gap-1" data-slot="color-picker">
         {presets.map((preset) => (
           <ColorSwatch
             key={preset.value}

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -6,6 +6,7 @@ import type * as React from "react";
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 
+import { OVERLAY_LAYER_CLASS_NAMES } from "../lib/overlay-layer";
 import { cn } from "../lib/utils";
 
 const HexColorPicker = lazy(async () => {
@@ -50,15 +51,30 @@ type ColorPickerProps = {
   className?: string;
 };
 
-type ColorPickerContentProps = {
+type ColorPickerContentBaseProps = {
   value?: string | undefined;
   onSelect?: ((value: string) => void) | undefined;
-  onClear?: (() => void) | undefined;
   presets: ColorPreset[];
-  columns: number;
-  defaultExpanded: boolean;
   moreLabel: string;
 };
+
+type ColorPickerContentProps = ColorPickerContentBaseProps &
+  (
+    | {
+        columns: number;
+        defaultExpanded: boolean;
+        onClear?: (() => void) | undefined;
+        /** Popover content closes on preset selection. */
+        presentation?: "popover";
+      }
+    | {
+        columns?: never;
+        defaultExpanded?: never;
+        onClear?: never;
+        /** Inline content stays mounted and reserves its popup for custom color. */
+        presentation: "inline";
+      }
+  );
 
 // ---------------------------------------------------------------------------
 // Default presets — 18 curated colors using semantic CSS variables
@@ -120,38 +136,191 @@ const ColorSwatch = ({
   label,
   isLight,
   onClick,
+  presentation,
 }: {
   cssColor: string;
   selected: boolean;
   label: string;
   isLight: boolean;
   onClick: () => void;
-}) => (
-  <PopoverPrimitive.Close
-    render={
-      <button
-        aria-label={label}
-        className={cn(
-          "hover:border-foreground relative flex size-6 items-center justify-center rounded-md border transition-[transform,border-color] hover:scale-115 sm:size-5",
-          selected
-            ? "border-foreground ring-ring/24 ring-1"
-            : "border-border/40",
-          isLight && !selected && "border-border",
-        )}
-        onClick={onClick}
-        style={{ backgroundColor: cssColor }}
-        type="button"
+  presentation: "inline" | "popover";
+}) => {
+  let selectionClassName = "border-border/40";
+  if (selected) {
+    selectionClassName =
+      presentation === "inline"
+        ? "border-transparent ring-2 ring-ring"
+        : "border-foreground ring-ring/24 ring-1";
+  }
+  const swatch = (
+    <button
+      aria-label={label}
+      aria-pressed={selected}
+      className={cn(
+        presentation === "inline"
+          ? "ring-offset-popover relative grid size-11 shrink-0 place-items-center rounded-full border ring-offset-2 transition-transform outline-none hover:scale-105 focus-visible:ring-2"
+          : "hover:border-foreground relative flex size-6 items-center justify-center rounded-md border transition-[transform,border-color] hover:scale-115 sm:size-5",
+        selectionClassName,
+        isLight && !selected && "border-border",
+      )}
+      onClick={onClick}
+      style={{ backgroundColor: cssColor }}
+      type="button"
+    >
+      {selected && (
+        <CheckIcon
+          className={cn(
+            "pointer-events-none",
+            presentation === "inline"
+              ? "bg-background/88 text-foreground size-5 rounded-full p-0.5 shadow-sm"
+              : "size-3 sm:size-2.5",
+          )}
+          style={
+            presentation === "popover"
+              ? { color: isLight ? "#000" : "#fff" }
+              : undefined
+          }
+        />
+      )}
+    </button>
+  );
+
+  return presentation === "inline" ? (
+    swatch
+  ) : (
+    <PopoverPrimitive.Close render={swatch} />
+  );
+};
+
+type CustomColorControlsProps = {
+  handleInputChange: (raw: string) => void;
+  handlePickerChange: (hex: string) => void;
+  inputHex: string;
+  pickerHex: string;
+};
+
+const CustomColorControls = ({
+  handleInputChange,
+  handlePickerChange,
+  inputHex,
+  pickerHex,
+}: CustomColorControlsProps) => (
+  <>
+    <Suspense
+      fallback={
+        <div
+          aria-hidden
+          className="ring-border/30 h-[140px] w-full rounded-lg ring-1"
+        />
+      }
+    >
+      <HexColorPicker
+        className="ring-border/30 !h-[140px] !w-full overflow-hidden rounded-lg ring-1"
+        color={pickerHex}
+        onChange={(hex) => handlePickerChange(hex.replace("#", ""))}
       />
-    }
-  >
-    {selected && (
-      <CheckIcon
-        className="pointer-events-none size-3 sm:size-2.5"
-        style={{ color: isLight ? "#000" : "#fff" }}
+    </Suspense>
+    <div className="flex items-center gap-1.5">
+      <span className="text-muted-foreground text-[11px]">#</span>
+      <input
+        aria-label="Custom hex color"
+        className="border-input bg-background text-foreground h-6 flex-1 rounded border px-1.5 font-mono text-[11px] outline-none"
+        dir="ltr"
+        maxLength={6}
+        onChange={(event) => handleInputChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") {
+            event.stopPropagation();
+          }
+        }}
+        onMouseDown={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+        placeholder="FF0000"
+        value={inputHex}
       />
-    )}
-  </PopoverPrimitive.Close>
+      {isValidHex(inputHex) && (
+        <span
+          className="border-border size-6 shrink-0 rounded border"
+          style={{ backgroundColor: `#${inputHex}` }}
+        />
+      )}
+    </div>
+  </>
 );
+
+type InlineCustomColorProps = {
+  customSelected: boolean;
+  handleInputChange: (raw: string) => void;
+  handlePickerChange: (hex: string) => void;
+  inputHex: string;
+  label: string;
+  pickerHex: string;
+  presets: ColorPreset[];
+  value: string | undefined;
+};
+
+const InlineCustomColor = ({
+  customSelected,
+  handleInputChange,
+  handlePickerChange,
+  inputHex,
+  label,
+  pickerHex,
+  presets,
+  value,
+}: InlineCustomColorProps) => {
+  const customColor = customSelected ? `#${value}` : undefined;
+  const customGradient = `conic-gradient(${presets
+    .map((preset) => swatchColor(preset))
+    .join(", ")})`;
+
+  return (
+    <PopoverPrimitive.Root>
+      <PopoverPrimitive.Trigger
+        render={
+          <button
+            aria-label={label}
+            aria-pressed={customSelected}
+            className={cn(
+              "ring-offset-popover relative grid size-11 shrink-0 place-items-center rounded-full border border-transparent ring-offset-2 transition-transform outline-none hover:scale-105 focus-visible:ring-2",
+              customSelected && "ring-ring ring-2",
+            )}
+            style={
+              customColor
+                ? { backgroundColor: customColor }
+                : { backgroundImage: customGradient }
+            }
+            type="button"
+          />
+        }
+      >
+        {customSelected ? (
+          <CheckIcon className="bg-background/88 text-foreground pointer-events-none size-5 rounded-full p-0.5 shadow-sm" />
+        ) : null}
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Positioner
+          align="end"
+          className={OVERLAY_LAYER_CLASS_NAMES.popup}
+          side="bottom"
+          sideOffset={4}
+        >
+          <PopoverPrimitive.Popup
+            className="bg-popover text-popover-foreground flex w-56 flex-col gap-2 rounded-lg border p-2 shadow-lg/5"
+            data-slot="color-picker-custom-popup"
+          >
+            <CustomColorControls
+              handleInputChange={handleInputChange}
+              handlePickerChange={handlePickerChange}
+              inputHex={inputHex}
+              pickerHex={pickerHex}
+            />
+          </PopoverPrimitive.Popup>
+        </PopoverPrimitive.Positioner>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+};
 
 // ---------------------------------------------------------------------------
 // ColorPickerContent (public — for embedding without popover)
@@ -165,6 +334,7 @@ const ColorPickerContent = ({
   columns,
   defaultExpanded,
   moreLabel,
+  presentation = "popover",
 }: ColorPickerContentProps) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   // pickerHex: last valid 6-char hex from the visual picker (drives the picker's color prop)
@@ -173,6 +343,8 @@ const ColorPickerContent = ({
     () => (looksLikeHex(value ?? "") ? value : "000000") ?? "000000",
   );
   const [inputHex, setInputHex] = useState("");
+  const presetSelected = presets.some((preset) => preset.value === value);
+  const customSelected = !presetSelected && looksLikeHex(value ?? "");
 
   /** Called when the visual picker (SB square / hue strip) emits a color. */
   const handlePickerChange = (hex: string) => {
@@ -196,6 +368,38 @@ const ColorPickerContent = ({
       onSelect?.(cleaned);
     }
   };
+
+  if (presentation === "inline") {
+    return (
+      <div
+        className="flex items-center gap-1"
+        data-slot="color-picker"
+        role="group"
+      >
+        {presets.map((preset) => (
+          <ColorSwatch
+            key={preset.value}
+            cssColor={swatchColor(preset)}
+            isLight={looksLikeHex(preset.value) && isLightHex(preset.value)}
+            label={preset.label}
+            onClick={() => onSelect?.(preset.value)}
+            presentation="inline"
+            selected={value === preset.value}
+          />
+        ))}
+        <InlineCustomColor
+          customSelected={customSelected}
+          handleInputChange={handleInputChange}
+          handlePickerChange={handlePickerChange}
+          inputHex={inputHex}
+          label={moreLabel}
+          pickerHex={pickerHex}
+          presets={presets}
+          value={value}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-1.5" data-slot="color-picker">
@@ -233,6 +437,7 @@ const ColorPickerContent = ({
             isLight={looksLikeHex(preset.value) && isLightHex(preset.value)}
             label={preset.label}
             onClick={() => onSelect?.(preset.value)}
+            presentation="popover"
             selected={value === preset.value}
           />
         ))}
@@ -250,41 +455,12 @@ const ColorPickerContent = ({
         </button>
       ) : (
         <div className="border-border flex flex-col gap-2 border-t pt-2">
-          <Suspense
-            fallback={
-              <div
-                aria-hidden
-                className="ring-border/30 h-[140px] w-full rounded-lg ring-1"
-              />
-            }
-          >
-            <HexColorPicker
-              className="ring-border/30 !h-[140px] !w-full overflow-hidden rounded-lg ring-1"
-              color={pickerHex}
-              onChange={(hex) => handlePickerChange(hex.replace("#", ""))}
-            />
-          </Suspense>
-          <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground text-[11px]">#</span>
-            <input
-              aria-label="Custom hex color"
-              className="border-input bg-background text-foreground h-6 flex-1 rounded border px-1.5 font-mono text-[11px] outline-none"
-              dir="ltr"
-              maxLength={6}
-              onChange={(e) => handleInputChange(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              onMouseDown={(e) => e.stopPropagation()}
-              onPointerDown={(e) => e.stopPropagation()}
-              placeholder="FF0000"
-              value={inputHex}
-            />
-            {isValidHex(inputHex) && (
-              <span
-                className="border-border size-6 shrink-0 rounded border"
-                style={{ backgroundColor: `#${inputHex}` }}
-              />
-            )}
-          </div>
+          <CustomColorControls
+            handleInputChange={handleInputChange}
+            handlePickerChange={handlePickerChange}
+            inputHex={inputHex}
+            pickerHex={pickerHex}
+          />
         </div>
       )}
     </div>
@@ -319,7 +495,7 @@ const ColorPicker = ({
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
         align={align}
-        className="z-50"
+        className={OVERLAY_LAYER_CLASS_NAMES.popup}
         side={side}
         sideOffset={4}
       >
@@ -336,6 +512,7 @@ const ColorPicker = ({
             moreLabel={moreLabel}
             onClear={onClear}
             onSelect={onSelect}
+            presentation="popover"
             presets={presets}
             value={value}
           />

--- a/packages/ui/src/components/fixtures/color-picker.fixture.css
+++ b/packages/ui/src/components/fixtures/color-picker.fixture.css
@@ -1,0 +1,6 @@
+@import "tailwindcss";
+@source "../";
+
+body {
+  padding: 2rem;
+}

--- a/packages/ui/src/components/fixtures/color-picker.fixture.html
+++ b/packages/ui/src/components/fixtures/color-picker.fixture.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Color picker fixture</title>
+    <link rel="stylesheet" href="./color-picker.fixture.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./color-picker.fixture.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/src/components/fixtures/color-picker.fixture.tsx
+++ b/packages/ui/src/components/fixtures/color-picker.fixture.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import { panic } from "better-result";
+
+import { ColorPicker } from "../color-picker";
+
+const PRESETS = [
+  { color: "#ef4444", label: "Red", value: "EF4444" },
+  { color: "#3b82f6", label: "Blue", value: "3B82F6" },
+];
+
+const ColorPickerFixture = () => {
+  const [value, setValue] = useState("EF4444");
+
+  useEffect(() => {
+    document.documentElement.dataset["colorPickerReady"] = "true";
+    return () => {
+      delete document.documentElement.dataset["colorPickerReady"];
+    };
+  }, []);
+
+  return (
+    <main>
+      <ColorPicker
+        columns={2}
+        moreLabel="Custom color"
+        onSelect={setValue}
+        presets={PRESETS}
+        value={value}
+      >
+        <button type="button">Choose color</button>
+      </ColorPicker>
+      <output aria-label="Selected color">{value}</output>
+    </main>
+  );
+};
+
+const rootElement = document.querySelector("#root");
+if (!rootElement) {
+  panic("Missing fixture root");
+}
+
+createRoot(rootElement).render(<ColorPickerFixture />);


### PR DESCRIPTION
## Summary

- Prepare clipboard selection, query, focus, and scroll synchronously on DOM blur and targeted native window blur before reopening.
- Extend the desktop event subscription helper with optional Tauri listener options.
- Add Arabic and English browser coverage for both dismissal paths, asserting the first clip and zero scroll before focus.

Mutation check: making the native blur handler a no-op caused both native cases to fail (expected clip-1, received clip-11).
