### PR TITLE
fix: pin release workflow to published revision

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: read
       checks: read
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/changeset-release-pr.yml@92db66a41a2f9f9930bde9e835823af4e24436a9
+    uses: stella/.github/.github/workflows/changeset-release-pr.yml@fb1e83fbc3fae39902da763ca7b2613090571717
     with:
       bun-version-file: package.json
       auto-merge-command: bun scripts/merge-bar.ts "$RELEASE_PR_NUMBER"


### PR DESCRIPTION
Release maintenance failed before starting any jobs because GitHub could not resolve the reusable workflow at its pre-squash PR revision. Pin the caller to the published main revision from https://github.com/stella/.github/pull/106, whose lifecycle action also points to a published revision.

The release behavior is unchanged. Validated with actionlint and repository verification.

A branch dispatch resolved the published workflow successfully and skipped the mutation job under its main-only guard: https://github.com/stella/stella/actions/runs/34211437084.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow reference to a newer verified revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->