### PR TITLE
fix(api): read a final-projection generation's row currency from its projection state

### DIFF
--- a/apps/api/drizzle/20260908120000_public_law_reader_projection_states/migration.sql
+++ b/apps/api/drizzle/20260908120000_public_law_reader_projection_states/migration.sql
@@ -1,0 +1,23 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The public read path decides from projection state whether a generation
+-- built by the final projection holds a decision. The reader role gets the
+-- columns that decision reads and nothing else: the applied revision, the
+-- work schedule and the failure detail stay on the owning service side.
+GRANT SELECT (
+  family,
+  generation,
+  entity_id,
+  desired_action,
+  desired_epoch,
+  desired_fingerprint,
+  desired_index_id,
+  applied_action,
+  applied_epoch,
+  applied_fingerprint,
+  applied_index_id
+) ON TABLE "corpus_index_projection_states" TO stella_public_law_reader;--> statement-breakpoint
+
+CREATE POLICY "public_law_reader_access" ON "corpus_index_projection_states"
+  AS PERMISSIVE FOR SELECT TO "stella_public_law_reader" USING (true);

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -19,6 +19,7 @@ import {
 import {
   globalCaseLawPolicies,
   p,
+  publicLawReaderPolicies,
   pUuid,
   type SafeId,
   sql,
@@ -537,5 +538,9 @@ export const corpusIndexProjectionStates = p.pgTable(
       END`,
     ),
     ...globalCaseLawPolicies(),
+    // The public read path decides from this row whether a generation holds a
+    // decision, so the reader role sees it under the same column grants as
+    // every other public-law relation.
+    ...publicLawReaderPolicies(),
   ],
 );

--- a/apps/api/src/handlers/case-law/decisions/search-hydration.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/search-hydration.db.test.ts
@@ -2,7 +2,13 @@ import type { PGlite } from "@electric-sql/pglite";
 import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/pglite";
 
-import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import {
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
+} from "@/api/db/schema";
 import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
 import {
   readCaseLawPageDecisionRows,
@@ -13,6 +19,11 @@ import type {
   CaseLawPublicReadDb,
   CaseLawPublicReadTransaction,
 } from "@/api/lib/case-law-public-read-db";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
 import {
   createTestPglite,
@@ -29,11 +40,20 @@ import {
  */
 
 const GENERATION = "case_law_v3";
+/** A generation the final projection builds: its state row is authoritative. */
+const PROJECTED_GENERATION = "case_law_v6";
+const PROJECTED_INDEX_ID = corpusIndexId(PROJECTED_GENERATION, "CZE");
+const APPLIED_FINGERPRINT = "a".repeat(64);
+const DESIRED_FINGERPRINT = "b".repeat(64);
 const sourceId = createSafeId<"caseLawSource">();
 const closedSourceId = createSafeId<"caseLawSource">();
 const czechId = createSafeId<"caseLawDecision">();
 const slovakId = createSafeId<"caseLawDecision">();
 const closedId = createSafeId<"caseLawDecision">();
+const projectedId = createSafeId<"caseLawDecision">();
+const queuedId = createSafeId<"caseLawDecision">();
+const projectedIntentId = createSafeId<"corpusIndexProjectionIntent">();
+const queuedIntentId = createSafeId<"corpusIndexProjectionIntent">();
 
 /** Same budget as the schema push: an embedded Postgres is not fast. */
 const DB_TEST_TIMEOUT_MS = 120_000;
@@ -124,6 +144,96 @@ beforeAll(
         language: "cs",
         contentHash: "hash-closed",
         indexedHash: "hash-closed",
+      },
+    ]);
+
+    // A generation the final projection builds writes no projection row and
+    // never sets the serving marker: what it holds is stated by its
+    // projection state alone.
+    await db.insert(corpusIndexGenerations).values({
+      family: "case_law",
+      generation: PROJECTED_GENERATION,
+      cluster: "q09",
+      manifestDigest: corpusIndexManifestDigest(
+        CORPUS_INDEX_MANIFESTS[PROJECTED_GENERATION],
+      ),
+      status: "building",
+    });
+    await db.insert(caseLawDecisions).values([
+      {
+        id: projectedId,
+        sourceId,
+        caseNumber: "30 Cdo 3/2026",
+        court: "Nejvyšší soud",
+        country: "CZE",
+        language: "cs",
+        languageGroupKey: "projected-group",
+        contentHash: "hash-projected",
+        indexedHash: null,
+      },
+      {
+        id: queuedId,
+        sourceId,
+        caseNumber: "30 Cdo 4/2026",
+        court: "Nejvyšší soud",
+        country: "CZE",
+        language: "cs",
+        languageGroupKey: "queued-group",
+        contentHash: "hash-queued",
+        indexedHash: null,
+      },
+    ]);
+    await db.insert(corpusIndexProjectionIntents).values(
+      [
+        { id: projectedIntentId, entityId: projectedId },
+        { id: queuedIntentId, entityId: queuedId },
+      ].map(({ id, entityId }) => ({
+        id,
+        family: "case_law" as const,
+        generation: PROJECTED_GENERATION,
+        entityId,
+        epoch: 1n,
+        fingerprint: APPLIED_FINGERPRINT,
+        indexId: PROJECTED_INDEX_ID,
+        status: "applied" as const,
+        appendStartedAt: new Date(),
+        appendCommittedAt: new Date(),
+        expectedDocumentCount: 1,
+        appliedAt: new Date(),
+      })),
+    );
+    await db.insert(corpusIndexProjectionStates).values([
+      {
+        family: "case_law",
+        generation: PROJECTED_GENERATION,
+        entityId: projectedId,
+        desiredAction: "upsert",
+        desiredEpoch: 1n,
+        desiredFingerprint: APPLIED_FINGERPRINT,
+        desiredIndexId: PROJECTED_INDEX_ID,
+        appliedAction: "upsert",
+        appliedEpoch: 1n,
+        appliedRevision: projectedIntentId,
+        appliedFingerprint: APPLIED_FINGERPRINT,
+        appliedIndexId: PROJECTED_INDEX_ID,
+        appliedAt: new Date(),
+      },
+      // The applied revision is behind a queued content change, so what the
+      // engine holds for this decision is not what the generation wants.
+      {
+        family: "case_law",
+        generation: PROJECTED_GENERATION,
+        entityId: queuedId,
+        desiredAction: "upsert",
+        desiredEpoch: 2n,
+        desiredFingerprint: DESIRED_FINGERPRINT,
+        desiredIndexId: PROJECTED_INDEX_ID,
+        appliedAction: "upsert",
+        appliedEpoch: 1n,
+        appliedRevision: queuedIntentId,
+        appliedFingerprint: APPLIED_FINGERPRINT,
+        appliedIndexId: PROJECTED_INDEX_ID,
+        appliedAt: new Date(),
       },
     ]);
   },
@@ -230,6 +340,45 @@ test("an empty page reads nothing", async () => {
 
   expect(rows.size).toBe(0);
   expect(reads).toBe(0);
+});
+
+test("a final-projection generation admits exactly what its projection state holds", async () => {
+  const scoped = {
+    body: { query: "promlčení" },
+    caseLawDb,
+    courtWeights,
+    generation: PROJECTED_GENERATION,
+  };
+
+  const ranking = await rehydrateCaseLawCandidates({
+    ...scoped,
+    candidates: candidatesOf(projectedId, queuedId, czechId),
+  });
+  // Applied equals desired for the first decision, though it carries no
+  // serving marker at all. The second still owes the index a mutation, and
+  // the third has no state row in this generation, which is not something a
+  // marker on the decision may answer for.
+  expect(ranking.ranked.map((hit) => hit.id)).toEqual([projectedId]);
+
+  const rows = await readCaseLawPageDecisionRows({
+    body: scoped.body,
+    caseLawDb,
+    generation: PROJECTED_GENERATION,
+    ids: [projectedId, queuedId, czechId],
+  });
+  expect([...rows.keys()]).toEqual([projectedId]);
+});
+
+test("a legacy generation still reads the projection row and the serving marker", async () => {
+  const ranking = await rehydrateCaseLawCandidates({
+    body: { query: "promlčení" },
+    candidates: candidatesOf(projectedId, czechId),
+    caseLawDb,
+    courtWeights,
+    generation: GENERATION,
+  });
+
+  expect(ranking.ranked.map((hit) => hit.id)).toEqual([czechId]);
 });
 
 test("both reads reapply the request filters and the redistribution boundary", async () => {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -67,7 +67,10 @@ import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
-import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
+import {
+  corpusIndexClusterForGeneration,
+  corpusIndexProjectionStore,
+} from "@/api/lib/legal-search/corpus-generation-contract";
 import type { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import { corpusIndexReadContract } from "@/api/lib/legal-search/corpus-index-read-contract";
@@ -826,8 +829,19 @@ export const clearIndexMarks = async ({
   generation,
   indexId,
   limit,
-}: ClearIndexMarksOptions): Promise<number> =>
-  await scopedDb(async (tx) => {
+}: ClearIndexMarksOptions): Promise<number> => {
+  // The repair is the legacy projection trigger: clearing the mark is what
+  // re-enqueues the decision. A generation whose work comes from projection
+  // state has no such trigger, so the same write would leave every row in the
+  // slice current and the next run would clear it again.
+  if (
+    corpusIndexProjectionStore("case_law", generation) === "projection_state"
+  ) {
+    panic(
+      `${generation} is projected from its projection state; clearing index marks cannot re-enqueue it`,
+    );
+  }
+  return await scopedDb(async (tx) => {
     // audit: skip — search index maintenance; rebuilds derived state
     const cleared = await tx.execute(sql`
       UPDATE ${caseLawDecisions}
@@ -845,3 +859,4 @@ export const clearIndexMarks = async ({
     `);
     return countReturnedRows(cleared);
   });
+};

--- a/apps/api/src/lib/legal-search/case-law-corpus-projection.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-projection.ts
@@ -1,27 +1,94 @@
-import { sql } from "drizzle-orm";
+import { panic } from "better-result";
+import { type SQL, sql } from "drizzle-orm";
 
 import {
   caseLawCorpusIndexProjections,
   caseLawDecisions,
+  corpusIndexProjectionStates,
 } from "@/api/db/schema";
 import { caseLawIndexIdSql } from "@/api/lib/legal-search/case-law-index-groups";
+import {
+  type CorpusFamily,
+  corpusIndexProjectionStore,
+} from "@/api/lib/legal-search/corpus-generation-contract";
 
-/** Join one decision to its durable state for the selected generation. */
-export const caseLawCorpusProjectionJoin = (generation: string) =>
-  sql`${caseLawCorpusIndexProjections.decisionId} = ${caseLawDecisions.id}
+const CASE_LAW_FAMILY = "case_law" satisfies CorpusFamily;
+
+/** Where this case-law generation records that it holds a decision. */
+const caseLawProjectionStore = (generation: string) =>
+  corpusIndexProjectionStore(CASE_LAW_FAMILY, generation);
+
+/**
+ * Join one decision to its durable state for the selected generation.
+ *
+ * Only a generation the per-decision projection queue builds has such a row.
+ * A final-projection generation records desired and applied state in
+ * `corpus_index_projection_states`, which the predicate below reads on its
+ * own key, so the legacy relation is joined to nothing rather than probed for
+ * an answer it never holds.
+ */
+export const caseLawCorpusProjectionJoin = (generation: string): SQL => {
+  const store = caseLawProjectionStore(generation);
+  switch (store) {
+    case "legacy_projection_row":
+      return sql`${caseLawCorpusIndexProjections.decisionId} = ${caseLawDecisions.id}
     AND ${caseLawCorpusIndexProjections.generation} = ${generation}`;
+    case "projection_state":
+      return sql`false`;
+    default:
+      store satisfies never;
+      return panic(`Unhandled case-law projection store: ${String(store)}`);
+  }
+};
 
 /** The physical index this generation projects a decision's current country into. */
 export const caseLawDecisionCorpusIndexIdSql = (generation: string) =>
   caseLawIndexIdSql(sql`${generation}`, caseLawDecisions.country);
 
 /**
- * Accept a physical hit only when this generation recorded the current
- * decision in its current jurisdiction and has no queued mutation. Older
- * serving generations without a rebuild checkpoint retain the legacy marker.
+ * The state row a final-projection generation keeps for the decision, in the
+ * one shape that means "the engine holds this content now".
+ *
+ * Applied equals desired on every field that can change what is served, and
+ * the applied revision sits in the index this generation routes the decision's
+ * current country to. A queued mutation moves desired ahead of applied, and a
+ * queued erasure leaves `desired_fingerprint` null, so neither is accepted. No
+ * row at all means the generation does not hold the decision: unlike the
+ * legacy shape, there is no marker on the decision to fall back to, and one
+ * would answer for a pipeline that never wrote it.
+ *
+ * The lookup is the states table's primary key, `(family, generation,
+ * entity_id)`, once per candidate row.
  */
-export const currentCaseLawCorpusProjection = (generation: string) =>
-  sql`(
+const currentCaseLawProjectionState = (generation: string): SQL =>
+  sql`EXISTS (
+      SELECT 1
+      FROM ${corpusIndexProjectionStates}
+      WHERE ${corpusIndexProjectionStates.family} = ${CASE_LAW_FAMILY}
+        AND ${corpusIndexProjectionStates.generation} = ${generation}
+        AND ${corpusIndexProjectionStates.entityId} = ${caseLawDecisions.id}
+        AND ${corpusIndexProjectionStates.desiredAction} = 'upsert'
+        AND ${corpusIndexProjectionStates.appliedAction} = 'upsert'
+        AND ${corpusIndexProjectionStates.appliedEpoch} = ${corpusIndexProjectionStates.desiredEpoch}
+        AND ${corpusIndexProjectionStates.appliedFingerprint} = ${corpusIndexProjectionStates.desiredFingerprint}
+        AND ${corpusIndexProjectionStates.appliedIndexId} = ${corpusIndexProjectionStates.desiredIndexId}
+        AND ${corpusIndexProjectionStates.appliedIndexId} = (${caseLawDecisionCorpusIndexIdSql(generation)})
+    )`;
+
+/**
+ * Accept a physical hit only when this generation recorded the current
+ * decision in its current jurisdiction and has no queued mutation.
+ *
+ * Which state that is read from follows the generation's store: a
+ * final-projection generation answers from `corpus_index_projection_states`,
+ * a legacy generation from its projection row, with the serving marker on the
+ * decision for the generations that predate the projection table.
+ */
+export const currentCaseLawCorpusProjection = (generation: string): SQL => {
+  const store = caseLawProjectionStore(generation);
+  switch (store) {
+    case "legacy_projection_row":
+      return sql`(
     (
       ${caseLawCorpusIndexProjections.indexedHash} = ${caseLawDecisions.contentHash}
       AND ${caseLawCorpusIndexProjections.indexId} = (${caseLawDecisionCorpusIndexIdSql(generation)})
@@ -32,3 +99,10 @@ export const currentCaseLawCorpusProjection = (generation: string) =>
       AND ${caseLawDecisions.indexedHash} = ${caseLawDecisions.contentHash}
     )
   )`;
+    case "projection_state":
+      return currentCaseLawProjectionState(generation);
+    default:
+      store satisfies never;
+      return panic(`Unhandled case-law projection store: ${String(store)}`);
+  }
+};

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
@@ -5,6 +5,7 @@ import {
   CORPUS_INDEX_GENERATION_MAX_LENGTH,
   CORPUS_INDEX_GENERATION_STATUSES,
   corpusIndexClusterForGeneration,
+  corpusIndexProjectionStore,
   isCorpusGeneration,
   parseCorpusFamily,
   parseCorpusIndexGenerationStatus,
@@ -71,6 +72,26 @@ test("every deployable generation selects one explicit Quickwit cluster", () => 
   expect(() =>
     corpusIndexClusterForGeneration("case_law", "case_law_v8"),
   ).toThrow("Unknown case_law corpus index generation");
+});
+
+test("a generation reads its row currency from one declared store", () => {
+  expect(corpusIndexProjectionStore("case_law", "case_law_v4")).toBe(
+    "legacy_projection_row",
+  );
+  expect(corpusIndexProjectionStore("case_law", "case_law_v6")).toBe(
+    "projection_state",
+  );
+  expect(corpusIndexProjectionStore("legislation", "legislation_v1")).toBe(
+    "legacy_projection_row",
+  );
+  expect(corpusIndexProjectionStore("legislation", "legislation_v2")).toBe(
+    "projection_state",
+  );
+  // An undeclared generation is nothing the final projection builds, so it
+  // keeps the store every rebuild rehearsal and fixture writes.
+  expect(corpusIndexProjectionStore("case_law", "case_law_v40")).toBe(
+    "legacy_projection_row",
+  );
 });
 
 test("every final manifest generation selects its declared cluster", () => {

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -97,6 +97,45 @@ export const requireQuickwitCluster = (value: unknown): QuickwitCluster =>
   parseQuickwitCluster(value) ??
   panic(`Unknown Quickwit cluster reference: ${String(value)}`);
 
+/**
+ * Which relation answers "this generation holds the entity now, with no queued
+ * mutation".
+ *
+ * A generation built by the per-entity projection queue keeps that answer in
+ * its own projection row. A generation built by the final projection keeps
+ * desired and applied state in `corpus_index_projection_states` and never
+ * writes a projection row, so reading one for it returns nothing at all.
+ * Both sets are the generation declarations above, read once here, so a
+ * generation cannot be routed to one store in a query and to the other in the
+ * pipeline that builds it.
+ */
+const CORPUS_INDEX_PROJECTION_STORES = [
+  "legacy_projection_row",
+  "projection_state",
+] as const;
+export type CorpusIndexProjectionStore =
+  (typeof CORPUS_INDEX_PROJECTION_STORES)[number];
+
+const PROJECTION_STORE_BY_CLUSTER = {
+  q08: "legacy_projection_row",
+  q09: "projection_state",
+} as const satisfies Record<QuickwitCluster, CorpusIndexProjectionStore>;
+
+/**
+ * An undeclared generation keeps the legacy store: only a declared final
+ * generation is built by the final projection, and rebuild rehearsals and
+ * fixtures drive the legacy queue.
+ */
+export const corpusIndexProjectionStore = (
+  family: CorpusFamily,
+  generation: string,
+): CorpusIndexProjectionStore => {
+  const cluster = parseCorpusIndexClusterForGeneration(family, generation);
+  return cluster === null
+    ? "legacy_projection_row"
+    : PROJECTION_STORE_BY_CLUSTER[cluster];
+};
+
 export const parseCorpusIndexGenerationStatus = (
   value: unknown,
 ): CorpusIndexGenerationStatus | null =>

--- a/apps/api/src/lib/public-law-relations.ts
+++ b/apps/api/src/lib/public-law-relations.ts
@@ -14,6 +14,7 @@ export const PUBLIC_LAW_RELATION_BY_SCHEMA_IMPORT = {
   caseLawProvisionCitations: "case_law_provision_citations",
   caseLawSources: "case_law_sources",
   corpusIndexGenerations: "corpus_index_generations",
+  corpusIndexProjectionStates: "corpus_index_projection_states",
   legislationDocuments: "legislation_documents",
   legislationSources: "legislation_sources",
 } as const;
@@ -111,6 +112,22 @@ export const PUBLIC_LAW_COLUMNS_BY_RELATION = {
     "cluster",
     "manifest_digest",
     "status",
+  ],
+  // Exactly what deciding "this generation holds this decision now" reads.
+  // The applied revision, the work schedule and the failure detail are
+  // operator state and stay on the owning service side.
+  corpus_index_projection_states: [
+    "family",
+    "generation",
+    "entity_id",
+    "desired_action",
+    "desired_epoch",
+    "desired_fingerprint",
+    "desired_index_id",
+    "applied_action",
+    "applied_epoch",
+    "applied_fingerprint",
+    "applied_index_id",
   ],
   legislation_documents: [
     "id",

--- a/apps/api/src/tests/security/public-law-reader-role.test.ts
+++ b/apps/api/src/tests/security/public-law-reader-role.test.ts
@@ -587,6 +587,17 @@ describe("public-law reader role", () => {
     });
     expect(search.ranked).toEqual([]);
 
+    // A generation the final projection builds reads its projection state
+    // instead of the projection row, so the census covers both predicates.
+    const projectedSearch = await rehydrateCaseLawCandidates({
+      body: { query: "reader role census" },
+      candidates: [{ id: createSafeId<"caseLawDecision">(), score: 1 }],
+      caseLawDb,
+      courtWeights: new Map(),
+      generation: "case_law_v6",
+    });
+    expect(projectedSearch.ranked).toEqual([]);
+
     // Search reads twice: narrow rows for every candidate it blends, wide
     // rows for the ids the page emits. Both have to clear the reader role.
     const pageRows = await readCaseLawPageDecisionRows({
@@ -596,6 +607,14 @@ describe("public-law reader role", () => {
       ids: [createSafeId<"caseLawDecision">()],
     });
     expect(pageRows.size).toBe(0);
+
+    const projectedPageRows = await readCaseLawPageDecisionRows({
+      body: { query: "reader role census" },
+      caseLawDb,
+      generation: "case_law_v6",
+      ids: [createSafeId<"caseLawDecision">()],
+    });
+    expect(projectedPageRows.size).toBe(0);
 
     const byDocket = await findDecisionIdsByIdentity({
       caseLawDb,


### PR DESCRIPTION
A generation built by the final projection reads a row's currency from its projection state; legacy generations keep the legacy predicate. Reader-role grant for the state columns. Tests updated.