### PR TITLE
fix(api): read a legislation generation's row currency from its projection state

### DIFF
--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -40,6 +40,7 @@ import {
 } from "@/api/lib/legal-search/corpus-index-client";
 import { readCorpusText } from "@/api/lib/legal-search/corpus-storage";
 import { corpusIndexGeneration } from "@/api/lib/legal-search/index-naming";
+import { legislationDocumentCorpusIndexIdSql } from "@/api/lib/legal-search/legislation-corpus-projection";
 import { logger } from "@/api/lib/observability/logger";
 
 /**
@@ -200,7 +201,7 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
             hasContent,
             redistributableLegislationSource,
             isNotNull(legislationDocuments.indexedHash),
-            sql`${legislationDocuments.indexedGeneration} <> (${generation} || '_' || lower(${legislationDocuments.country}))`,
+            sql`${legislationDocuments.indexedGeneration} <> (${legislationDocumentCorpusIndexIdSql(generation)})`,
           ),
         )
         .limit(limit - fresh.length),
@@ -226,7 +227,7 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
             hasContent,
             redistributableLegislationSource,
             isNotNull(legislationDocuments.indexedHash),
-            sql`${legislationDocuments.indexedGeneration} = (${generation} || '_' || lower(${legislationDocuments.country}))`,
+            sql`${legislationDocuments.indexedGeneration} = (${legislationDocumentCorpusIndexIdSql(generation)})`,
             sql`${legislationDocuments.indexedHash} IS DISTINCT FROM ${legislationDocuments.contentHash}`,
           ),
         )

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -40,7 +40,6 @@ import {
 } from "@/api/lib/legal-search/corpus-index-client";
 import { readCorpusText } from "@/api/lib/legal-search/corpus-storage";
 import { corpusIndexGeneration } from "@/api/lib/legal-search/index-naming";
-import { legislationDocumentCorpusIndexIdSql } from "@/api/lib/legal-search/legislation-corpus-projection";
 import { logger } from "@/api/lib/observability/logger";
 
 /**
@@ -201,7 +200,7 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
             hasContent,
             redistributableLegislationSource,
             isNotNull(legislationDocuments.indexedHash),
-            sql`${legislationDocuments.indexedGeneration} <> (${legislationDocumentCorpusIndexIdSql(generation)})`,
+            sql`${legislationDocuments.indexedGeneration} <> (${generation} || '_' || lower(${legislationDocuments.country}))`,
           ),
         )
         .limit(limit - fresh.length),
@@ -227,7 +226,7 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
             hasContent,
             redistributableLegislationSource,
             isNotNull(legislationDocuments.indexedHash),
-            sql`${legislationDocuments.indexedGeneration} = (${legislationDocumentCorpusIndexIdSql(generation)})`,
+            sql`${legislationDocuments.indexedGeneration} = (${generation} || '_' || lower(${legislationDocuments.country}))`,
             sql`${legislationDocuments.indexedHash} IS DISTINCT FROM ${legislationDocuments.contentHash}`,
           ),
         )

--- a/apps/api/src/handlers/legislation/search-hydration.db.test.ts
+++ b/apps/api/src/handlers/legislation/search-hydration.db.test.ts
@@ -1,0 +1,240 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import { rehydrateLegislationCandidates } from "@/api/handlers/legislation/search";
+import { createSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import type {
+  LegislationReadDb,
+  LegislationReadTransaction,
+} from "@/api/lib/legislation-public-read-db";
+import {
+  createTestPglite,
+  withPublicLawReaderRole,
+} from "@/api/tests/pglite-test-db";
+
+/**
+ * Rehydration decides which corpus hits a legislation page may serve. What
+ * "current" means depends on the generation the hits came from: a legacy
+ * generation marks the document it indexed, a final-projection generation
+ * states desired and applied per row and never writes that marker. These
+ * tests hold both readings against the same fixture.
+ */
+
+const GENERATION = "legislation_v1";
+/** A generation the final projection builds: its state row is authoritative. */
+const PROJECTED_GENERATION = "legislation_v2";
+const PROJECTED_INDEX_ID = corpusIndexId(PROJECTED_GENERATION, "CZE");
+const OTHER_INDEX_ID = corpusIndexId(PROJECTED_GENERATION, "SVK");
+const APPLIED_FINGERPRINT = "a".repeat(64);
+const DESIRED_FINGERPRINT = "b".repeat(64);
+
+const sourceId = createSafeId<"legislationSource">();
+const markedId = createSafeId<"legislationDocument">();
+const projectedId = createSafeId<"legislationDocument">();
+const queuedId = createSafeId<"legislationDocument">();
+const movedId = createSafeId<"legislationDocument">();
+const projectedIntentId = createSafeId<"corpusIndexProjectionIntent">();
+const queuedIntentId = createSafeId<"corpusIndexProjectionIntent">();
+const movedIntentId = createSafeId<"corpusIndexProjectionIntent">();
+
+/** Same budget as the schema push: an embedded Postgres is not fast. */
+const DB_TEST_TIMEOUT_MS = 120_000;
+
+let client: PGlite;
+let legislationDb: LegislationReadDb;
+
+const candidatesOf = (...ids: string[]) => ids.map((id) => ({ id, score: 1 }));
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    const db = drizzle({ client });
+    legislationDb = async <T>(
+      fn: (tx: LegislationReadTransaction) => Promise<T>,
+    ) =>
+      await withPublicLawReaderRole(db, async (roleTx) => {
+        // SAFETY: the role transaction supplies the select surface the reads use.
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test handle stands in for a transaction
+        const tx = roleTx as unknown as LegislationReadTransaction;
+        return await fn(tx);
+      });
+
+    await db
+      .insert(legislationSources)
+      .values([
+        { id: sourceId, adapterKey: "statutes-open", name: "Open statutes" },
+      ]);
+
+    await db.insert(legislationDocuments).values([
+      // `indexed_hash = content_hash` is the serving marker a legacy
+      // generation's queue writes.
+      {
+        id: markedId,
+        sourceId,
+        eli: "CZ/2012/89",
+        title: "Civil Code",
+        country: "CZE",
+        language: "cs",
+        contentHash: "hash-marked",
+        indexedHash: "hash-marked",
+      },
+      // The final projection writes no marker at all; what each of these
+      // documents holds is stated by its projection state alone.
+      ...[projectedId, queuedId, movedId].map((id, index) => ({
+        id,
+        sourceId,
+        eli: `CZ/2020/${index + 1}`,
+        title: `Projected act ${index + 1}`,
+        country: "CZE",
+        language: "cs",
+        contentHash: `hash-${index}`,
+        indexedHash: null,
+      })),
+    ]);
+
+    await db.insert(corpusIndexGenerations).values({
+      family: "legislation",
+      generation: PROJECTED_GENERATION,
+      cluster: "q09",
+      manifestDigest: corpusIndexManifestDigest(
+        CORPUS_INDEX_MANIFESTS[PROJECTED_GENERATION],
+      ),
+      status: "building",
+    });
+
+    await db.insert(corpusIndexProjectionIntents).values(
+      [
+        {
+          id: projectedIntentId,
+          entityId: projectedId,
+          indexId: PROJECTED_INDEX_ID,
+        },
+        { id: queuedIntentId, entityId: queuedId, indexId: PROJECTED_INDEX_ID },
+        { id: movedIntentId, entityId: movedId, indexId: OTHER_INDEX_ID },
+      ].map(({ id, entityId, indexId }) => ({
+        id,
+        family: "legislation" as const,
+        generation: PROJECTED_GENERATION,
+        entityId,
+        epoch: 1n,
+        fingerprint: APPLIED_FINGERPRINT,
+        indexId,
+        status: "applied" as const,
+        appendStartedAt: new Date(),
+        appendCommittedAt: new Date(),
+        expectedDocumentCount: 1,
+        appliedAt: new Date(),
+      })),
+    );
+
+    await db.insert(corpusIndexProjectionStates).values([
+      {
+        family: "legislation",
+        generation: PROJECTED_GENERATION,
+        entityId: projectedId,
+        desiredAction: "upsert",
+        desiredEpoch: 1n,
+        desiredFingerprint: APPLIED_FINGERPRINT,
+        desiredIndexId: PROJECTED_INDEX_ID,
+        appliedAction: "upsert",
+        appliedEpoch: 1n,
+        appliedRevision: projectedIntentId,
+        appliedFingerprint: APPLIED_FINGERPRINT,
+        appliedIndexId: PROJECTED_INDEX_ID,
+        appliedAt: new Date(),
+      },
+      // The applied revision is behind a queued content change, so what the
+      // engine holds for this document is not what the generation wants.
+      {
+        family: "legislation",
+        generation: PROJECTED_GENERATION,
+        entityId: queuedId,
+        desiredAction: "upsert",
+        desiredEpoch: 2n,
+        desiredFingerprint: DESIRED_FINGERPRINT,
+        desiredIndexId: PROJECTED_INDEX_ID,
+        appliedAction: "upsert",
+        appliedEpoch: 1n,
+        appliedRevision: queuedIntentId,
+        appliedFingerprint: APPLIED_FINGERPRINT,
+        appliedIndexId: PROJECTED_INDEX_ID,
+        appliedAt: new Date(),
+      },
+      // Converged, but on the index of a jurisdiction the document no longer
+      // carries: the copy that would answer sits in another index entirely.
+      {
+        family: "legislation",
+        generation: PROJECTED_GENERATION,
+        entityId: movedId,
+        desiredAction: "upsert",
+        desiredEpoch: 1n,
+        desiredFingerprint: APPLIED_FINGERPRINT,
+        desiredIndexId: OTHER_INDEX_ID,
+        appliedAction: "upsert",
+        appliedEpoch: 1n,
+        appliedRevision: movedIntentId,
+        appliedFingerprint: APPLIED_FINGERPRINT,
+        appliedIndexId: OTHER_INDEX_ID,
+        appliedAt: new Date(),
+      },
+    ]);
+  },
+  { timeout: DB_TEST_TIMEOUT_MS },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("a final-projection generation admits exactly what its projection state holds", async () => {
+  const result = await rehydrateLegislationCandidates({
+    body: { query: "smlouva" },
+    candidates: candidatesOf(projectedId, queuedId, movedId, markedId),
+    generation: PROJECTED_GENERATION,
+    legislationDb,
+  });
+
+  // Applied equals desired for the first document, in the index this
+  // generation routes its jurisdiction to, though it carries no serving
+  // marker at all. The second still owes the index a mutation, the third is
+  // converged on another jurisdiction's index, and the fourth has no state
+  // row in this generation, which is not something a marker on the document
+  // may answer for.
+  expect(result.ranked.map((hit) => hit.id)).toEqual([projectedId]);
+  expect([...result.context.byId.keys()]).toEqual([projectedId]);
+});
+
+test("a legacy generation still reads the serving marker", async () => {
+  const result = await rehydrateLegislationCandidates({
+    body: { query: "smlouva" },
+    candidates: candidatesOf(projectedId, queuedId, movedId, markedId),
+    generation: GENERATION,
+    legislationDb,
+  });
+
+  expect(result.ranked.map((hit) => hit.id)).toEqual([markedId]);
+});
+
+test("the request filters still bind on a final-projection generation", async () => {
+  const result = await rehydrateLegislationCandidates({
+    body: { jurisdiction: "SVK", query: "smlouva" },
+    candidates: candidatesOf(projectedId),
+    generation: PROJECTED_GENERATION,
+    legislationDb,
+  });
+
+  expect(result.ranked).toEqual([]);
+});

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -39,6 +39,7 @@ import {
   corpusIndexPattern,
   isCorpusIndexJurisdiction,
 } from "@/api/lib/legal-search/index-naming";
+import { currentLegislationCorpusProjection } from "@/api/lib/legal-search/legislation-corpus-projection";
 import { NO_EXPANSION_DICTIONARY_IDENTITY } from "@/api/lib/legal-search/morphology/dictionary";
 import { buildPgFtsSearchSql } from "@/api/lib/legal-search/pg-fts-query";
 import {
@@ -268,6 +269,8 @@ const extractCorpusSnippet = (
 type RehydrateLegislationCandidatesOptions = {
   body: SearchLegislationBody;
   candidates: readonly ScoredCandidate[];
+  /** The generation the hits were read from; it decides row currency. */
+  generation: string;
   legislationDb: LegislationReadDb;
 };
 
@@ -278,6 +281,7 @@ type RehydrateLegislationCandidatesOptions = {
 export const rehydrateLegislationCandidates = async ({
   body,
   candidates,
+  generation,
   legislationDb,
 }: RehydrateLegislationCandidatesOptions) => {
   const ids = candidates.map((candidate) =>
@@ -288,11 +292,9 @@ export const rehydrateLegislationCandidates = async ({
   // it no longer matches.
   const rehydrationFilters: SQL[] = [
     redistributableLegislationSource,
-    // Accept only hits whose index state is current. The equality fails for
-    // rows cleared for a write retry (null contentHash) and for rows whose
-    // payload changed but are not re-indexed yet (indexedHash cleared by
-    // ingestion), so stale index copies cannot serve outdated snippets.
-    eq(legislationDocuments.indexedHash, legislationDocuments.contentHash),
+    // Accept only hits this generation currently holds, read from whichever
+    // relation the generation records that in.
+    currentLegislationCorpusProjection(generation),
   ];
   if (body.jurisdiction) {
     rehydrationFilters.push(
@@ -403,6 +405,7 @@ const corpusIndexSearch = async (
       await rehydrateLegislationCandidates({
         body,
         candidates,
+        generation,
         legislationDb,
       }),
   });

--- a/apps/api/src/lib/legal-search/corpus-index-route-sql.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-route-sql.db.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { type SQL, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { executedRows } from "@/api/lib/db/executed-rows";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexIdFromManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { corpusIndexIdSqlFromManifest } from "@/api/lib/legal-search/corpus-index-route-sql";
+import { isRecord } from "@/api/lib/type-guards";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+/**
+ * A manifest's route is rendered twice: `corpusIndexIdFromManifest` in
+ * TypeScript, which the projection writer derives `desired_index_id` from,
+ * and `corpusIndexIdSqlFromManifest` in the queries that decide whether a
+ * generation holds a row. Both are proved equal here against a real
+ * PostgreSQL, for every declared manifest and every jurisdiction its route
+ * mentions, in both letter cases. A route rule changed on one side alone
+ * fails this test rather than silently dropping every hit of that
+ * generation.
+ */
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const DB_TEST_TIMEOUT_MS = 120_000;
+
+/** Jurisdictions the manifest's route decides an index for. */
+const routedJurisdictions = (
+  manifest: (typeof CORPUS_INDEX_MANIFESTS)[keyof typeof CORPUS_INDEX_MANIFESTS],
+): readonly string[] => {
+  const declared =
+    manifest.route.type === "case_law_group"
+      ? Object.keys(manifest.route.byJurisdiction)
+      : // The legislation route is open by design: a jurisdiction needs no
+        // manifest entry, so the ones a corpus exists for stand for all.
+        ["CZE", "SVK", "POL", "EU"];
+  return [...declared, ...declared.map((value) => value.toLowerCase())];
+};
+
+const readIndexId = async (expression: SQL) => {
+  const row = executedRows(
+    await db.execute(sql`SELECT (${expression}) AS "index_id"`),
+  ).at(0);
+  return isRecord(row) ? row["index_id"] : undefined;
+};
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+  },
+  { timeout: DB_TEST_TIMEOUT_MS },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test(
+  "both renderings of a manifest route derive the same physical index id",
+  async () => {
+    for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
+      for (const jurisdiction of routedJurisdictions(manifest)) {
+        expect(
+          await readIndexId(
+            corpusIndexIdSqlFromManifest(manifest, sql`${jurisdiction}`),
+          ),
+        ).toBe(corpusIndexIdFromManifest(manifest, jurisdiction));
+      }
+    }
+  },
+  { timeout: DB_TEST_TIMEOUT_MS },
+);

--- a/apps/api/src/lib/legal-search/corpus-index-route-sql.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-route-sql.ts
@@ -1,0 +1,48 @@
+import { panic } from "better-result";
+import { type SQL, type SQLWrapper, sql } from "drizzle-orm";
+
+import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+
+/**
+ * The physical index a manifest routes a jurisdiction to, as a SQL expression
+ * over the row's jurisdiction column: the SQL twin of
+ * `corpusIndexIdFromManifest`.
+ *
+ * The projection writer derives `desired_index_id` from the manifest route,
+ * and a read path deciding whether a generation holds a row compares against
+ * that column, so the comparison has to move with the manifest instead of
+ * restating a routing rule of its own. Both renderings switch on the same
+ * `route` value and are exhaustive over it, so a new route type stops
+ * compiling in both, and `corpus-index-route-sql.db.test.ts` proves the two
+ * agree executably for every declared manifest.
+ *
+ * Constants are inlined with `sql.raw`: they come from the manifest, never
+ * from input.
+ */
+export const corpusIndexIdSqlFromManifest = (
+  manifest: CorpusIndexManifest,
+  jurisdiction: SQLWrapper,
+): SQL => {
+  const generation = sql.raw(`'${manifest.generation}'`);
+  switch (manifest.route.type) {
+    case "case_law_group": {
+      const groupArms = sql.join(
+        Object.entries(manifest.route.byJurisdiction).map(
+          ([country, group]) =>
+            sql`WHEN ${sql.raw(`'${country}'`)} THEN ${sql.raw(`'${group}'`)}`,
+        ),
+        sql`
+    `,
+      );
+      return sql`${generation} || '_' || CASE upper(${jurisdiction})
+    ${groupArms}
+    ELSE lower(${jurisdiction})
+  END`;
+    }
+    case "jurisdiction":
+      return sql`${generation} || '_' || lower(${jurisdiction})`;
+    default:
+      manifest.route satisfies never;
+      return panic(`Unhandled route: ${String(manifest.route)}`);
+  }
+};

--- a/apps/api/src/lib/legal-search/legislation-corpus-projection.ts
+++ b/apps/api/src/lib/legal-search/legislation-corpus-projection.ts
@@ -9,18 +9,10 @@ import {
   type CorpusFamily,
   corpusIndexProjectionStore,
 } from "@/api/lib/legal-search/corpus-generation-contract";
+import { requireCorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+import { corpusIndexIdSqlFromManifest } from "@/api/lib/legal-search/corpus-index-route-sql";
 
 const LEGISLATION_FAMILY = "legislation" satisfies CorpusFamily;
-
-/**
- * The physical index this generation projects a document's current
- * jurisdiction into, as SQL: `corpusIndexId` renders no group for the
- * legislation route, so the id is the generation and the lowercased country.
- * Declared once here because the read predicate and the queue scans both
- * compare against it.
- */
-export const legislationDocumentCorpusIndexIdSql = (generation: string): SQL =>
-  sql`${generation} || '_' || lower(${legislationDocuments.country})`;
 
 /**
  * The state row a final-projection generation keeps for the document, in the
@@ -34,11 +26,20 @@ export const legislationDocumentCorpusIndexIdSql = (generation: string): SQL =>
  * document: there is no marker on the document to fall back to, and one would
  * answer for a pipeline that never wrote it.
  *
+ * The index the applied revision has to sit in is the manifest's own route
+ * rendered as SQL, the expression the projection writer derives
+ * `desired_index_id` from. Only a declared final generation reaches here, so
+ * the manifest is always there to read.
+ *
  * The lookup is the states table's primary key, `(family, generation,
  * entity_id)`, once per candidate row.
  */
-const currentLegislationProjectionState = (generation: string): SQL =>
-  sql`EXISTS (
+const currentLegislationProjectionState = (generation: string): SQL => {
+  const routedIndexId = corpusIndexIdSqlFromManifest(
+    requireCorpusIndexManifest(LEGISLATION_FAMILY, generation),
+    legislationDocuments.country,
+  );
+  return sql`EXISTS (
       SELECT 1
       FROM ${corpusIndexProjectionStates}
       WHERE ${corpusIndexProjectionStates.family} = ${LEGISLATION_FAMILY}
@@ -49,8 +50,9 @@ const currentLegislationProjectionState = (generation: string): SQL =>
         AND ${corpusIndexProjectionStates.appliedEpoch} = ${corpusIndexProjectionStates.desiredEpoch}
         AND ${corpusIndexProjectionStates.appliedFingerprint} = ${corpusIndexProjectionStates.desiredFingerprint}
         AND ${corpusIndexProjectionStates.appliedIndexId} = ${corpusIndexProjectionStates.desiredIndexId}
-        AND ${corpusIndexProjectionStates.appliedIndexId} = (${legislationDocumentCorpusIndexIdSql(generation)})
+        AND ${corpusIndexProjectionStates.appliedIndexId} = (${routedIndexId})
     )`;
+};
 
 /**
  * Accept a physical hit only when this generation holds the current document

--- a/apps/api/src/lib/legal-search/legislation-corpus-projection.ts
+++ b/apps/api/src/lib/legal-search/legislation-corpus-projection.ts
@@ -1,0 +1,79 @@
+import { panic } from "better-result";
+import { type SQL, sql } from "drizzle-orm";
+
+import {
+  corpusIndexProjectionStates,
+  legislationDocuments,
+} from "@/api/db/schema";
+import {
+  type CorpusFamily,
+  corpusIndexProjectionStore,
+} from "@/api/lib/legal-search/corpus-generation-contract";
+
+const LEGISLATION_FAMILY = "legislation" satisfies CorpusFamily;
+
+/**
+ * The physical index this generation projects a document's current
+ * jurisdiction into, as SQL: `corpusIndexId` renders no group for the
+ * legislation route, so the id is the generation and the lowercased country.
+ * Declared once here because the read predicate and the queue scans both
+ * compare against it.
+ */
+export const legislationDocumentCorpusIndexIdSql = (generation: string): SQL =>
+  sql`${generation} || '_' || lower(${legislationDocuments.country})`;
+
+/**
+ * The state row a final-projection generation keeps for the document, in the
+ * one shape that means "the engine holds this content now".
+ *
+ * Applied equals desired on every field that can change what is served, and
+ * the applied revision sits in the index this generation routes the
+ * document's current jurisdiction to. A queued mutation moves desired ahead
+ * of applied, and a queued erasure leaves `desired_fingerprint` null, so
+ * neither is accepted. No row at all means the generation does not hold the
+ * document: there is no marker on the document to fall back to, and one would
+ * answer for a pipeline that never wrote it.
+ *
+ * The lookup is the states table's primary key, `(family, generation,
+ * entity_id)`, once per candidate row.
+ */
+const currentLegislationProjectionState = (generation: string): SQL =>
+  sql`EXISTS (
+      SELECT 1
+      FROM ${corpusIndexProjectionStates}
+      WHERE ${corpusIndexProjectionStates.family} = ${LEGISLATION_FAMILY}
+        AND ${corpusIndexProjectionStates.generation} = ${generation}
+        AND ${corpusIndexProjectionStates.entityId} = ${legislationDocuments.id}
+        AND ${corpusIndexProjectionStates.desiredAction} = 'upsert'
+        AND ${corpusIndexProjectionStates.appliedAction} = 'upsert'
+        AND ${corpusIndexProjectionStates.appliedEpoch} = ${corpusIndexProjectionStates.desiredEpoch}
+        AND ${corpusIndexProjectionStates.appliedFingerprint} = ${corpusIndexProjectionStates.desiredFingerprint}
+        AND ${corpusIndexProjectionStates.appliedIndexId} = ${corpusIndexProjectionStates.desiredIndexId}
+        AND ${corpusIndexProjectionStates.appliedIndexId} = (${legislationDocumentCorpusIndexIdSql(generation)})
+    )`;
+
+/**
+ * Accept a physical hit only when this generation holds the current document
+ * and has no queued mutation.
+ *
+ * Which state that is read from follows the generation's store, the same
+ * split case law makes: a final-projection generation answers from
+ * `corpus_index_projection_states`, a legacy generation from the serving
+ * marker on the document, which its queue is what writes.
+ */
+export const currentLegislationCorpusProjection = (generation: string): SQL => {
+  const store = corpusIndexProjectionStore(LEGISLATION_FAMILY, generation);
+  switch (store) {
+    case "legacy_projection_row":
+      // The equality fails for rows cleared for a write retry (null
+      // contentHash) and for rows whose payload changed but are not
+      // re-indexed yet (indexedHash cleared by ingestion), so stale index
+      // copies cannot serve outdated snippets.
+      return sql`${legislationDocuments.indexedHash} = ${legislationDocuments.contentHash}`;
+    case "projection_state":
+      return currentLegislationProjectionState(generation);
+    default:
+      store satisfies never;
+      return panic(`Unhandled legislation projection store: ${String(store)}`);
+  }
+};

--- a/apps/api/src/tests/security/public-law-reader-role.test.ts
+++ b/apps/api/src/tests/security/public-law-reader-role.test.ts
@@ -546,10 +546,22 @@ describe("public-law reader role", () => {
     const result = await rehydrateLegislationCandidates({
       body: { query: "reader role census" },
       candidates: [{ id: createSafeId<"legislationDocument">(), score: 1 }],
+      generation: "legislation_v1",
       legislationDb,
     });
 
     expect(result.ranked).toEqual([]);
+
+    // A generation the final projection builds reads its projection state
+    // instead of the serving marker, so the census covers both predicates.
+    const projected = await rehydrateLegislationCandidates({
+      body: { query: "reader role census" },
+      candidates: [{ id: createSafeId<"legislationDocument">(), score: 1 }],
+      generation: "legislation_v2",
+      legislationDb,
+    });
+
+    expect(projected.ranked).toEqual([]);
   });
 
   test("executes list, sitemap, and search projections as the reader role", async () => {


### PR DESCRIPTION
Legislation search reads a generation's row currency from its projection state, with the legacy marker kept for legacy generations. Tests updated.