### PR TITLE
feat(api): the reader-role column map distinguishes required from permitted grants

### DIFF
--- a/apps/api/src/lib/public-law-read-db.test.ts
+++ b/apps/api/src/lib/public-law-read-db.test.ts
@@ -4,7 +4,10 @@ import {
   assertPublicLawDatabaseRolePermissions,
   type PublicLawDatabaseRolePermissions,
 } from "@/api/lib/public-law-read-db";
-import { PUBLIC_LAW_COLUMNS_BY_RELATION } from "@/api/lib/public-law-relations";
+import {
+  PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
+  publicLawColumnPairs,
+} from "@/api/lib/public-law-relations";
 
 const VALID_PERMISSIONS = {
   canAccessOtherDatabase: false,
@@ -22,25 +25,47 @@ const VALID_PERMISSIONS = {
 
 describe("external public-law database boundary", () => {
   test("excludes tenant and operational relations", () => {
-    expect(PUBLIC_LAW_COLUMNS_BY_RELATION).not.toHaveProperty(
+    expect(PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION).not.toHaveProperty(
       "case_law_matter_links",
     );
-    expect(PUBLIC_LAW_COLUMNS_BY_RELATION.case_law_sources).not.toContain(
-      "config",
-    );
-    expect(PUBLIC_LAW_COLUMNS_BY_RELATION.legislation_sources).not.toContain(
-      "config",
-    );
-    expect(PUBLIC_LAW_COLUMNS_BY_RELATION.legislation_documents).toEqual(
+    expect(
+      PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION.case_law_sources,
+    ).not.toHaveProperty("config");
+    expect(
+      PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION.legislation_sources,
+    ).not.toHaveProperty("config");
+    expect(
+      Object.keys(PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION.legislation_documents),
+    ).toEqual(
       expect.arrayContaining([
         "citation_authority",
         "content_hash",
         "indexed_hash",
       ]),
     );
-    expect(PUBLIC_LAW_COLUMNS_BY_RELATION.legislation_documents).not.toContain(
-      "metadata",
-    );
+    expect(
+      PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION.legislation_documents,
+    ).not.toHaveProperty("metadata");
+  });
+
+  test("separates the columns a release reads from the grants it tolerates", () => {
+    const pairs = publicLawColumnPairs({
+      case_law_decisions: { id: "required", ecli: "permitted" },
+      legislation_sources: { id: "required" },
+    });
+
+    expect(
+      pairs
+        .filter(({ grant }) => grant === "required")
+        .map(({ relation, column }) => `${relation}.${column}`),
+    ).toEqual(["case_law_decisions.id", "legislation_sources.id"]);
+    expect(
+      pairs.map(({ relation, column }) => `${relation}.${column}`),
+    ).toEqual([
+      "case_law_decisions.id",
+      "case_law_decisions.ecli",
+      "legislation_sources.id",
+    ]);
   });
 
   test("accepts the exact public-law reader", () => {

--- a/apps/api/src/lib/public-law-read-db.ts
+++ b/apps/api/src/lib/public-law-read-db.ts
@@ -10,7 +10,14 @@ import { rootDb } from "@/api/db/root";
 import type { Transaction } from "@/api/db/root";
 import { envBase } from "@/api/env-base";
 import { queryCountLogger } from "@/api/lib/db-query-counter";
-import { PUBLIC_LAW_COLUMNS_BY_RELATION } from "@/api/lib/public-law-relations";
+import {
+  PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
+  publicLawColumnPairs,
+} from "@/api/lib/public-law-relations";
+import type {
+  PublicLawColumnGrantsByRelation,
+  PublicLawColumnPair,
+} from "@/api/lib/public-law-relations";
 
 const EXTERNAL_PUBLIC_LAW_CONNECTION_TIMEOUT_SECONDS = 10;
 
@@ -95,24 +102,41 @@ type ExternalPublicLawDatabase = {
 let externalPublicLawDatabase: ExternalPublicLawDatabase | null = null;
 
 /**
- * What `current_user` may do, in the terms the validator judges.
- * Exported so the role a migration defines can be held to the same query.
+ * The column tuples of one bound, as a relation a CTE can name. An empty bound
+ * still has to type-check as `(text, text)`, so it degenerates to no rows
+ * rather than to invalid `VALUES ()`.
  */
-export const publicLawDatabaseRolePermissionsSql = (): SqlFragment => {
-  const expectedColumns = Object.entries(
-    PUBLIC_LAW_COLUMNS_BY_RELATION,
-  ).flatMap(([relation, columns]) =>
-    columns.map((column) => ({ relation, column })),
-  );
-  const expectedValues = sql.join(
-    expectedColumns.map(
-      ({ relation, column }) => sql`(${relation}::text, ${column}::text)`,
-    ),
-    sql.raw(","),
+const columnTupleSource = (
+  columns: readonly PublicLawColumnPair[],
+): SqlFragment =>
+  columns.length === 0
+    ? sql`SELECT NULL::text, NULL::text WHERE false`
+    : sql`VALUES ${sql.join(
+        columns.map(
+          ({ relation, column }) => sql`(${relation}::text, ${column}::text)`,
+        ),
+        sql.raw(","),
+      )}`;
+
+/**
+ * What `current_user` may do, in the terms the validator judges.
+ * Exported so the role a migration defines can be held to the same query, and
+ * parameterized so the security suite can judge the same role against a
+ * deliberately staged grant map.
+ */
+export const publicLawDatabaseRolePermissionsSql = (
+  columnGrants: PublicLawColumnGrantsByRelation = PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
+): SqlFragment => {
+  const grantedColumns = publicLawColumnPairs(columnGrants);
+  const requiredColumns = grantedColumns.filter(
+    ({ grant }) => grant === "required",
   );
   return sql`
-      WITH expected(relation, column_name) AS (
-        VALUES ${expectedValues}
+      WITH required(relation, column_name) AS (
+        ${columnTupleSource(requiredColumns)}
+      ),
+      granted(relation, column_name) AS (
+        ${columnTupleSource(grantedColumns)}
       )
       SELECT
         EXISTS (
@@ -145,22 +169,28 @@ export const publicLawDatabaseRolePermissionsSql = (): SqlFragment => {
           'CONNECT'
         ) AS "canConnect",
         (
-          SELECT count(*) = ${expectedColumns.length}
-            AND bool_and(
-              has_column_privilege(
-                current_user,
-                columns.attrelid,
-                columns.attnum,
-                'SELECT'
-              )
+          -- The lower bound: every column this release reads. A grant staged
+          -- ahead of its read is not required here, so the release before it
+          -- still serves.
+          SELECT count(*) = ${requiredColumns.length}
+            AND coalesce(
+              bool_and(
+                has_column_privilege(
+                  current_user,
+                  columns.attrelid,
+                  columns.attnum,
+                  'SELECT'
+                )
+              ),
+              true
             )
-          FROM expected
-          INNER JOIN pg_class AS tables ON tables.relname = expected.relation
+          FROM required
+          INNER JOIN pg_class AS tables ON tables.relname = required.relation
           INNER JOIN pg_namespace AS schemas
             ON schemas.oid = tables.relnamespace
           INNER JOIN pg_attribute AS columns
             ON columns.attrelid = tables.oid
-            AND columns.attname = expected.column_name
+            AND columns.attname = required.column_name
           WHERE schemas.nspname = 'public'
             AND columns.attnum > 0
             AND NOT columns.attisdropped
@@ -200,22 +230,23 @@ export const publicLawDatabaseRolePermissionsSql = (): SqlFragment => {
             )
         ) AS "canUseSequence",
         EXISTS (
-          -- Any readable column outside the exact allowlist is excess.
+          -- The upper bound: required plus permitted. Any readable column
+          -- outside it is excess, including a grant no release has declared.
           SELECT 1
           FROM pg_attribute AS columns
           INNER JOIN pg_class AS tables ON tables.oid = columns.attrelid
           INNER JOIN pg_namespace AS schemas
             ON schemas.oid = tables.relnamespace
-          LEFT JOIN expected
+          LEFT JOIN granted
             ON schemas.nspname = 'public'
-            AND expected.relation = tables.relname
-            AND expected.column_name = columns.attname
+            AND granted.relation = tables.relname
+            AND granted.column_name = columns.attname
           WHERE schemas.nspname <> 'information_schema'
             AND schemas.nspname !~ '^pg_'
             AND tables.relkind IN ('r', 'p', 'v', 'm', 'f')
             AND columns.attnum > 0
             AND NOT columns.attisdropped
-            AND expected.relation IS NULL
+            AND granted.relation IS NULL
             AND has_column_privilege(
               current_user,
               columns.attrelid,

--- a/apps/api/src/lib/public-law-relations.ts
+++ b/apps/api/src/lib/public-law-relations.ts
@@ -26,136 +26,194 @@ export const PUBLIC_CASE_LAW_SCHEMA_IMPORTS = Object.keys(
   PUBLIC_LAW_RELATION_BY_SCHEMA_IMPORT,
 ).filter((schemaImport) => schemaImport.startsWith("caseLaw"));
 
-export const PUBLIC_LAW_COLUMNS_BY_RELATION = {
-  case_law_citations: [
-    "id",
-    "citing_decision_id",
-    "cited_decision_id",
-    "citation_text",
-    "kind",
-    "section_index",
-    "polarity",
-  ],
-  case_law_corpus_index_projections: [
-    "generation",
-    "decision_id",
-    "index_id",
-    "indexed_hash",
-    "pending_action",
-  ],
-  case_law_decision_identifiers: [
-    "decision_id",
-    "type",
-    "value",
-    "normalized_value",
-    "created_at",
-  ],
-  case_law_decisions: [
-    "id",
-    "source_id",
-    "case_number",
-    "slug",
-    "ecli",
-    "citation_key",
-    "court",
-    "country",
-    "language",
-    "language_group_key",
-    "decision_date",
-    "decision_type",
-    "fulltext",
-    "sections",
-    "document_ast",
-    "analysis",
-    "source_url",
-    "document_url",
-    "metadata",
-    "redacted_at",
-    "citation_authority",
-    "citation_count",
-    "text_s3_key",
-    "ast_s3_key",
-    "content_hash",
-    "indexed_hash",
-    "created_at",
-    "updated_at",
-  ],
-  case_law_provision_citations: [
-    "decision_id",
-    "jurisdiction",
-    "work_identifier",
-    "work_number",
-    "work_year",
-    "work_collection",
-    "work_eli",
-    "unit",
-    "section",
-    "section_suffix",
-    "subsection",
-    "letter",
-    "point",
-    "sentence",
-    "open_ended",
-    "anchor",
-    "version_valid_from",
-    "decision_date",
-    "sentence_text",
-    "span_start",
-    "span_end",
-    "work_source",
-    "confidence",
-  ],
-  case_law_sources: ["id", "name", "adapter_key", "descriptor"],
-  corpus_index_generations: [
-    "family",
-    "generation",
-    "cluster",
-    "manifest_digest",
-    "status",
-  ],
+/** How this release relates to a column's grant. */
+export type PublicLawColumnGrant = "required" | "permitted";
+
+export type PublicLawColumnGrantsByRelation = Readonly<
+  Record<string, Readonly<Record<string, PublicLawColumnGrant>>>
+>;
+
+/**
+ * Each column declares how this release relates to its grant:
+ *
+ * - `required`: this release reads the column, so a role that cannot read it
+ *   cannot serve. A missing grant fails the attestation.
+ * - `permitted`: the grant exists but this release does not read it. A missing
+ *   grant still serves, and holding the grant is not over-privilege.
+ *
+ * Anything readable beyond required plus permitted is over-privilege and fails
+ * the attestation either way.
+ *
+ * Staging rule: the release whose migration grants a column lists it
+ * `permitted`, and the release that starts reading it flips it to `required`.
+ * Granting and reading in one release stays a single `required` entry. Give a
+ * grant up in the reverse order: drop the read and the column to `permitted`
+ * first, revoke in a later release. Either way both releases boot while the
+ * migration and the code are one step apart.
+ */
+export const PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION = {
+  case_law_citations: {
+    id: "required",
+    citing_decision_id: "required",
+    cited_decision_id: "required",
+    citation_text: "required",
+    kind: "required",
+    section_index: "required",
+    polarity: "required",
+  },
+  case_law_corpus_index_projections: {
+    generation: "required",
+    decision_id: "required",
+    index_id: "required",
+    indexed_hash: "required",
+    pending_action: "required",
+  },
+  case_law_decision_identifiers: {
+    decision_id: "required",
+    type: "required",
+    value: "required",
+    normalized_value: "required",
+    created_at: "required",
+  },
+  case_law_decisions: {
+    id: "required",
+    source_id: "required",
+    case_number: "required",
+    slug: "required",
+    ecli: "required",
+    citation_key: "required",
+    court: "required",
+    country: "required",
+    language: "required",
+    language_group_key: "required",
+    decision_date: "required",
+    decision_type: "required",
+    fulltext: "required",
+    sections: "required",
+    document_ast: "required",
+    analysis: "required",
+    source_url: "required",
+    document_url: "required",
+    metadata: "required",
+    redacted_at: "required",
+    citation_authority: "required",
+    citation_count: "required",
+    text_s3_key: "required",
+    ast_s3_key: "required",
+    content_hash: "required",
+    indexed_hash: "required",
+    created_at: "required",
+    updated_at: "required",
+  },
+  case_law_provision_citations: {
+    decision_id: "required",
+    jurisdiction: "required",
+    work_identifier: "required",
+    work_number: "required",
+    work_year: "required",
+    work_collection: "required",
+    work_eli: "required",
+    unit: "required",
+    section: "required",
+    section_suffix: "required",
+    subsection: "required",
+    letter: "required",
+    point: "required",
+    sentence: "required",
+    open_ended: "required",
+    anchor: "required",
+    version_valid_from: "required",
+    decision_date: "required",
+    sentence_text: "required",
+    span_start: "required",
+    span_end: "required",
+    work_source: "required",
+    confidence: "required",
+  },
+  case_law_sources: {
+    id: "required",
+    name: "required",
+    adapter_key: "required",
+    descriptor: "required",
+  },
+  corpus_index_generations: {
+    family: "required",
+    generation: "required",
+    cluster: "required",
+    manifest_digest: "required",
+    status: "required",
+  },
   // Exactly what deciding "this generation holds this decision now" reads.
   // The applied revision, the work schedule and the failure detail are
   // operator state and stay on the owning service side.
-  corpus_index_projection_states: [
-    "family",
-    "generation",
-    "entity_id",
-    "desired_action",
-    "desired_epoch",
-    "desired_fingerprint",
-    "desired_index_id",
-    "applied_action",
-    "applied_epoch",
-    "applied_fingerprint",
-    "applied_index_id",
-  ],
-  legislation_documents: [
-    "id",
-    "source_id",
-    "eli",
-    "title",
-    "country",
-    "language",
-    "document_type",
-    "status",
-    "effective_date",
-    "version_valid_from",
-    "version_valid_to",
-    "fulltext",
-    "sections",
-    "document_ast",
-    "source_url",
-    "document_url",
-    "citation_authority",
-    "text_s3_key",
-    "ast_s3_key",
-    "content_hash",
-    "indexed_hash",
-    "created_at",
-    "updated_at",
-  ],
-  legislation_sources: ["id", "descriptor"],
-} as const satisfies Record<PublicLawRelation, readonly string[]>;
+  corpus_index_projection_states: {
+    family: "required",
+    generation: "required",
+    entity_id: "required",
+    desired_action: "required",
+    desired_epoch: "required",
+    desired_fingerprint: "required",
+    desired_index_id: "required",
+    applied_action: "required",
+    applied_epoch: "required",
+    applied_fingerprint: "required",
+    applied_index_id: "required",
+  },
+  legislation_documents: {
+    id: "required",
+    source_id: "required",
+    eli: "required",
+    title: "required",
+    country: "required",
+    language: "required",
+    document_type: "required",
+    status: "required",
+    effective_date: "required",
+    version_valid_from: "required",
+    version_valid_to: "required",
+    fulltext: "required",
+    sections: "required",
+    document_ast: "required",
+    source_url: "required",
+    document_url: "required",
+    citation_authority: "required",
+    text_s3_key: "required",
+    ast_s3_key: "required",
+    content_hash: "required",
+    indexed_hash: "required",
+    created_at: "required",
+    updated_at: "required",
+  },
+  legislation_sources: {
+    id: "required",
+    descriptor: "required",
+  },
+} as const satisfies Record<
+  PublicLawRelation,
+  Readonly<Record<string, PublicLawColumnGrant>>
+>;
+
+export type PublicLawColumnPair = {
+  relation: string;
+  column: string;
+  grant: PublicLawColumnGrant;
+};
+
+/**
+ * Flatten a grant map into one entry per column, tag included. Every column
+ * the reader role may hold is here; migrations grant exactly this set, and the
+ * `required` subset is what a release cannot serve without.
+ */
+export const publicLawColumnPairs = (
+  grants: PublicLawColumnGrantsByRelation,
+): PublicLawColumnPair[] =>
+  Object.entries(grants).flatMap(([relation, columns]) =>
+    Object.entries(columns).map(([column, grant]) => ({
+      relation,
+      column,
+      grant,
+    })),
+  );
 
 /**
  * The v0.7.22 reader contract retained during the bounded rollout window.

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -10,7 +10,7 @@ import * as rlsExports from "@/api/db/rls";
 import * as schema from "@/api/db/schema";
 import type { AnyDrizzle } from "@/api/db/scoped";
 import {
-  PUBLIC_LAW_COLUMNS_BY_RELATION,
+  PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
   ROLLOUT_CASE_LAW_SOURCE_COLUMNS,
   ROLLOUT_CASE_LAW_SOURCE_RELATION,
   ROLLOUT_CASE_LAW_WHOLE_RELATIONS,
@@ -346,9 +346,9 @@ const ROLE_GRANT_STATEMENTS = [
   `
     GRANT USAGE ON SCHEMA public TO stella_public_law_reader
   `,
-  ...Object.entries(PUBLIC_LAW_COLUMNS_BY_RELATION).map(
+  ...Object.entries(PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION).map(
     ([relation, columns]) => `
-      GRANT SELECT (${columns.map(quoteSqlIdentifier).join(", ")})
+      GRANT SELECT (${Object.keys(columns).map(quoteSqlIdentifier).join(", ")})
         ON TABLE ${quoteSqlIdentifier(relation)}
         TO stella_public_law_reader
     `,

--- a/apps/api/src/tests/security/public-law-reader-role.test.ts
+++ b/apps/api/src/tests/security/public-law-reader-role.test.ts
@@ -59,11 +59,16 @@ import {
   type PublicLawDatabaseRolePermissions,
 } from "@/api/lib/public-law-read-db";
 import {
-  PUBLIC_LAW_COLUMNS_BY_RELATION,
+  PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
+  publicLawColumnPairs,
   ROLLOUT_CASE_LAW_RELATIONS,
   ROLLOUT_CASE_LAW_SOURCE_COLUMNS,
   ROLLOUT_CASE_LAW_SOURCE_RELATION,
   ROLLOUT_CASE_LAW_WHOLE_RELATIONS,
+} from "@/api/lib/public-law-relations";
+import type {
+  PublicLawColumnGrant,
+  PublicLawColumnGrantsByRelation,
 } from "@/api/lib/public-law-relations";
 import { PUBLIC_LAW_SHARED_QUERY } from "@/api/lib/public-law-shared-query";
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
@@ -106,10 +111,10 @@ const forbiddenColumnRead = async (
       (error: unknown) => error,
     );
 
-const expectedQualifiedColumns = Object.entries(PUBLIC_LAW_COLUMNS_BY_RELATION)
-  .flatMap(([relation, columns]) =>
-    columns.map((column) => `${relation}.${column}`),
-  )
+const expectedQualifiedColumns = publicLawColumnPairs(
+  PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
+)
+  .map(({ relation, column }) => `${relation}.${column}`)
   .toSorted();
 
 let testDb: TestDatabase;
@@ -133,6 +138,7 @@ const revokeOtherDatabaseConnectFromPublic = async (
 
 const rolePermissionsAfter = async (
   setup: (tx: TestDatabaseTransaction) => Promise<void>,
+  columnGrants: PublicLawColumnGrantsByRelation = PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
 ): Promise<PublicLawDatabaseRolePermissions | undefined> => {
   let permissions: PublicLawDatabaseRolePermissions | undefined;
   try {
@@ -141,7 +147,7 @@ const rolePermissionsAfter = async (
       await setup(tx);
       await tx.execute(sql.raw(`SET LOCAL ROLE ${quoted(READER_ROLE)}`));
       const result = await tx.execute<PublicLawDatabaseRolePermissions>(
-        publicLawDatabaseRolePermissionsSql(),
+        publicLawDatabaseRolePermissionsSql(columnGrants),
       );
       permissions = result.rows.at(0);
       tx.rollback();
@@ -171,6 +177,49 @@ const caseLawReaderDb = (): CaseLawPublicReadDb => {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only branded read handle
   return readDb as unknown as CaseLawPublicReadDb;
 };
+
+// A column the reader role is never granted, used to stage one grant against
+// the map: the same column reads as required, permitted, or undeclared.
+const STAGED_RELATION = "legislation_sources";
+const STAGED_COLUMN = "config";
+
+const grantsStaging = (
+  grant: PublicLawColumnGrant,
+): PublicLawColumnGrantsByRelation => ({
+  ...PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
+  [STAGED_RELATION]: {
+    ...PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION.legislation_sources,
+    [STAGED_COLUMN]: grant,
+  },
+});
+
+const grantStagedColumn = async (
+  tx: TestDatabaseTransaction,
+): Promise<void> => {
+  await tx.execute(
+    sql.raw(
+      `GRANT SELECT (${quoted(STAGED_COLUMN)}) ON TABLE ${quoted(STAGED_RELATION)} TO ${quoted(READER_ROLE)}`,
+    ),
+  );
+};
+
+const withoutExtraGrants = async (): Promise<void> => {};
+
+/** The same grants, every column staged rather than read. */
+const wholeMapPermitted = (): PublicLawColumnGrantsByRelation =>
+  Object.fromEntries(
+    Object.entries(PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION).map(
+      ([relation, columns]) => [
+        relation,
+        Object.fromEntries(
+          Object.keys(columns).map((column): [string, PublicLawColumnGrant] => [
+            column,
+            "permitted",
+          ]),
+        ),
+      ],
+    ),
+  );
 
 beforeAll(
   async () => {
@@ -307,6 +356,40 @@ describe("public-law reader role", () => {
     expect(crossSchemaReader).toMatchObject({ canReadOtherData: true });
   });
 
+  test("startup attestation refuses a required column the role cannot read", async () => {
+    expect(
+      await rolePermissionsAfter(withoutExtraGrants, grantsStaging("required")),
+    ).toMatchObject({ canReadPublicLaw: false, canReadOtherData: false });
+  });
+
+  test("startup attestation serves without a permitted column's grant", async () => {
+    expect(
+      await rolePermissionsAfter(
+        withoutExtraGrants,
+        grantsStaging("permitted"),
+      ),
+    ).toMatchObject({ canReadPublicLaw: true, canReadOtherData: false });
+  });
+
+  test("startup attestation serves a permitted column granted ahead of its read", async () => {
+    expect(
+      await rolePermissionsAfter(grantStagedColumn, grantsStaging("permitted")),
+    ).toMatchObject({ canReadPublicLaw: true, canReadOtherData: false });
+  });
+
+  test("startup attestation refuses a grant the map declares at neither stage", async () => {
+    expect(await rolePermissionsAfter(grantStagedColumn)).toMatchObject({
+      canReadPublicLaw: true,
+      canReadOtherData: true,
+    });
+  });
+
+  test("startup attestation holds when the map requires nothing", async () => {
+    expect(
+      await rolePermissionsAfter(withoutExtraGrants, wholeMapPermitted()),
+    ).toMatchObject({ canReadPublicLaw: true, canReadOtherData: false });
+  });
+
   test("startup attestation rejects database CREATE, sequences, and delegable SELECT", async () => {
     const databaseCreator = await rolePermissionsAfter(async (tx) => {
       const result = await tx.execute<{ name: string }>(
@@ -427,11 +510,11 @@ describe("public-law reader role", () => {
           ),
         );
         for (const [relation, columns] of Object.entries(
-          PUBLIC_LAW_COLUMNS_BY_RELATION,
+          PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
         )) {
           await tx.execute(
             sql.raw(
-              `GRANT SELECT (${columns.map(quoted).join(", ")}) ON TABLE ${quoted(relation)} TO reader_attestation_admin`,
+              `GRANT SELECT (${Object.keys(columns).map(quoted).join(", ")}) ON TABLE ${quoted(relation)} TO reader_attestation_admin`,
             ),
           );
         }
@@ -461,11 +544,11 @@ describe("public-law reader role", () => {
     await testDb.transaction(async (tx) => {
       await tx.execute(sql.raw(`SET LOCAL ROLE ${quoted(READER_ROLE)}`));
       for (const [relation, columns] of Object.entries(
-        PUBLIC_LAW_COLUMNS_BY_RELATION,
+        PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION,
       )) {
         await tx.execute(
           sql.raw(
-            `SELECT ${columns.map(quoted).join(", ")} FROM ${quoted(relation)} LIMIT 0`,
+            `SELECT ${Object.keys(columns).map(quoted).join(", ")} FROM ${quoted(relation)} LIMIT 0`,
           ),
         );
       }
@@ -764,7 +847,7 @@ describe("public-law reader role", () => {
     `);
 
     expect(result.rows.map(({ tablename }) => tablename)).toEqual(
-      Object.keys(PUBLIC_LAW_COLUMNS_BY_RELATION).toSorted(),
+      Object.keys(PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION).toSorted(),
     );
   });
 
@@ -870,7 +953,10 @@ const sortedColumns = (grants: EffectiveSelectGrants) =>
   );
 
 describe("public-law reader migrations", () => {
-  test("effective grants equal the source-of-truth map", () => {
+  // Migrations grant required plus permitted: a column staged ahead of its
+  // read is already granted, and one whose read has gone away is not revoked
+  // until a later release.
+  test("effective grants equal every column the map declares", () => {
     const sources = readdirSync(DRIZZLE_DIR, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) =>
@@ -882,8 +968,8 @@ describe("public-law reader migrations", () => {
 
     const grants = foldReaderSelectGrants(sources, READER_ROLE);
     const expected = Object.fromEntries(
-      Object.entries(PUBLIC_LAW_COLUMNS_BY_RELATION).map(
-        ([relation, columns]) => [relation, [...columns].toSorted()],
+      Object.entries(PUBLIC_LAW_COLUMN_GRANTS_BY_RELATION).map(
+        ([relation, columns]) => [relation, Object.keys(columns).toSorted()],
       ),
     );
 


### PR DESCRIPTION
The reader-role column map distinguishes required from permitted columns; the two attestation bounds derive from that. Tests updated.