### PR TITLE
fix(api): prove delete settlement against the splits that could hold the deleted revisions

### DIFF
--- a/apps/api/drizzle/20260908140000_corpus_projection_delete_task_instant/migration.sql
+++ b/apps/api/drizzle/20260908140000_corpus_projection_delete_task_instant/migration.sql
@@ -1,0 +1,19 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Settlement proves a delete against the splits that could hold the revisions
+-- it targeted, which is decided by the metastore's own creation instant for
+-- the delete task. The opstamp alone is no longer a complete receipt.
+ALTER TABLE "corpus_index_projection_intents"
+  ADD COLUMN "delete_task_created_at" timestamptz;--> statement-breakpoint
+
+-- The status shape already decides per status whether a delete receipt is on
+-- the row; pairing the two receipt columns keeps that one decision total.
+-- NOT VALID because receipts recorded before this column existed carry an
+-- opstamp and no instant: the online repair
+-- `corpus-projection-delete-receipt` fills those in and validates this
+-- constraint when none is left.
+ALTER TABLE "corpus_index_projection_intents"
+  ADD CONSTRAINT "corpus_index_projection_intents_delete_receipt_paired"
+    CHECK (("delete_opstamp" IS NULL) = ("delete_task_created_at" IS NULL))
+    NOT VALID;--> statement-breakpoint

--- a/apps/api/src/db/corpus-projection-delete-receipt-repair.ts
+++ b/apps/api/src/db/corpus-projection-delete-receipt-repair.ts
@@ -1,0 +1,208 @@
+/**
+ * Online repair behind migration
+ * 20260908140000_corpus_projection_delete_task_instant.
+ *
+ * The migration adds `delete_task_created_at` and pairs it with
+ * `delete_opstamp` by a NOT VALID check, because settlement now proves a
+ * delete against the splits published no later than the task that issued it.
+ * Receipts recorded before the column existed carry an opstamp and no
+ * instant, and settlement skips them, so the data work runs here: every such
+ * receipt takes the instant its own row was last written at, and once none is
+ * left the constraint is validated.
+ *
+ * `updated_at` is a local instant, not the metastore's. It is at or after the
+ * moment the task was recorded, so it excludes no split the metastore
+ * published before the task, which is the direction that keeps the proof
+ * honest; the exact revision count in the settlement proof is what makes that
+ * proof exact either way.
+ *
+ * Self-checkpointing in two senses: a repaired row leaves the selection
+ * predicate, so a completed run changes nothing and an interrupted run
+ * resumes by running again, and every row written after the migration
+ * satisfies the constraint already. Completion is a catalog fact,
+ * `pg_constraint.convalidated`, which is also what the API's startup gate
+ * reads.
+ */
+
+import { panic } from "better-result";
+
+import { isRecord } from "../lib/type-guards";
+import type {
+  OnlineMigrationConnection,
+  OnlineRepair,
+} from "./online-migration-connection";
+
+const REPAIR_NAME = "corpus-projection-delete-receipt";
+const TABLE_NAME = "corpus_index_projection_intents";
+const CONSTRAINT_NAME = "corpus_index_projection_intents_delete_receipt_paired";
+
+/**
+ * Rows per transaction, walked in primary-key order. The batch is a bounded
+ * index range rather than a scan for the rows that still need the instant:
+ * those have no index of their own, and the table keeps one row per append
+ * attempt of the whole corpus.
+ */
+const BATCH = 1000;
+const BATCH_LOCK_TIMEOUT = "30s";
+const BATCH_STATEMENT_TIMEOUT = "1min";
+/**
+ * VALIDATE takes SHARE UPDATE EXCLUSIVE, which queues behind an autovacuum of
+ * the table until that vacuum notices the waiter and yields. Longer than the
+ * online phase's default, which is sized for index builds; the phase restores
+ * its own setting afterwards.
+ */
+const VALIDATE_LOCK_TIMEOUT = "1min";
+
+/** Primary-key floor: every UUID sorts after it, so the walk starts here. */
+const ID_FLOOR = "00000000-0000-0000-0000-000000000000";
+
+const READ_BATCH_BOUNDARY_SQL = `
+  SELECT id
+  FROM public."${TABLE_NAME}"
+  WHERE id > $1
+  ORDER BY id
+  OFFSET ${BATCH - 1}
+  LIMIT 1
+`;
+
+const REPAIR_RANGE_SQL = `
+  UPDATE public."${TABLE_NAME}"
+  SET "delete_task_created_at" = "updated_at"
+  WHERE id > $1
+    AND id <= $2
+    AND "delete_opstamp" IS NOT NULL
+    AND "delete_task_created_at" IS NULL
+`;
+
+const REPAIR_TAIL_SQL = `
+  UPDATE public."${TABLE_NAME}"
+  SET "delete_task_created_at" = "updated_at"
+  WHERE id > $1
+    AND "delete_opstamp" IS NOT NULL
+    AND "delete_task_created_at" IS NULL
+`;
+
+const READ_CONSTRAINT_STATE_SQL = `
+  SELECT constraint_state.convalidated AS "isValidated"
+  FROM pg_catalog.pg_constraint constraint_state
+  JOIN pg_catalog.pg_class table_relation
+    ON table_relation.oid = constraint_state.conrelid
+  JOIN pg_catalog.pg_namespace table_namespace
+    ON table_namespace.oid = table_relation.relnamespace
+  WHERE table_namespace.nspname = $1
+    AND table_relation.relname = $2
+    AND constraint_state.conname = $3
+`;
+
+const readBatchBoundary = async (
+  connection: OnlineMigrationConnection,
+  cursor: string,
+): Promise<string | null> => {
+  const row = (await connection.query(READ_BATCH_BOUNDARY_SQL, [cursor])).at(0);
+  if (row === undefined) {
+    return null;
+  }
+  if (!isRecord(row) || typeof row["id"] !== "string") {
+    return panic(
+      `Online repair ${REPAIR_NAME}: batch boundary has an invalid shape`,
+    );
+  }
+  return row["id"];
+};
+
+/**
+ * One batch in its own transaction; the primary key the next batch starts
+ * after, or null once the walk has repaired the tail of the table.
+ */
+const repairOneBatch = async (
+  connection: OnlineMigrationConnection,
+  cursor: string,
+): Promise<string | null> => {
+  await connection.execute("BEGIN");
+  // Transaction boundary on a raw connection: a failed batch is rolled back so
+  // the session stays usable for the lock release, then rethrown to fail the
+  // migrate task, whose retry resumes from the rows still selected.
+  try {
+    await connection.execute(
+      `SET LOCAL lock_timeout = '${BATCH_LOCK_TIMEOUT}'`,
+    );
+    await connection.execute(
+      `SET LOCAL statement_timeout = '${BATCH_STATEMENT_TIMEOUT}'`,
+    );
+    const boundary = await readBatchBoundary(connection, cursor);
+    if (boundary === null) {
+      await connection.execute(REPAIR_TAIL_SQL, [cursor]);
+      await connection.execute("COMMIT");
+      return null;
+    }
+    await connection.execute(REPAIR_RANGE_SQL, [cursor, boundary]);
+    await connection.execute("COMMIT");
+    return boundary;
+  } catch (error: unknown) {
+    await connection.execute("ROLLBACK");
+    throw error;
+  }
+};
+
+/**
+ * Walk the table in batches. Recursive rather than a loop with an awaited
+ * body: each batch depends on the previous one having committed, so the
+ * sequencing is structural.
+ */
+const repairFrom = async (
+  connection: OnlineMigrationConnection,
+  cursor: string,
+): Promise<void> => {
+  const next = await repairOneBatch(connection, cursor);
+  if (next === null) {
+    return;
+  }
+  await repairFrom(connection, next);
+};
+
+const validateConstraint = async (
+  connection: OnlineMigrationConnection,
+): Promise<void> => {
+  await connection.execute(`SET lock_timeout = '${VALIDATE_LOCK_TIMEOUT}'`);
+  // A no-op on an already validated constraint, which is what makes the
+  // repair a fixed point.
+  await connection.execute(
+    `ALTER TABLE public."${TABLE_NAME}" VALIDATE CONSTRAINT "${CONSTRAINT_NAME}"`,
+  );
+};
+
+const assertConstraintValidated = async (
+  connection: OnlineMigrationConnection,
+): Promise<void> => {
+  const row = (
+    await connection.query(READ_CONSTRAINT_STATE_SQL, [
+      "public",
+      TABLE_NAME,
+      CONSTRAINT_NAME,
+    ])
+  ).at(0);
+  if (row === undefined) {
+    panic(
+      `Online repair ${REPAIR_NAME}: constraint ${CONSTRAINT_NAME} is missing`,
+    );
+  }
+  if (!isRecord(row) || typeof row["isValidated"] !== "boolean") {
+    panic(
+      `Online repair ${REPAIR_NAME}: constraint state has an invalid shape`,
+    );
+  }
+  if (!row["isValidated"]) {
+    panic(
+      `Online repair ${REPAIR_NAME} is not complete: constraint ${CONSTRAINT_NAME} is not validated`,
+    );
+  }
+};
+
+export const CORPUS_PROJECTION_DELETE_RECEIPT_REPAIR: OnlineRepair = {
+  name: REPAIR_NAME,
+  repair: async (connection) => {
+    await repairFrom(connection, ID_FLOOR);
+    await validateConstraint(connection);
+  },
+  assertComplete: assertConstraintValidated,
+};

--- a/apps/api/src/db/online-migrations.test.ts
+++ b/apps/api/src/db/online-migrations.test.ts
@@ -23,6 +23,9 @@ const FILTER_INDEX = FILTER_INDEX_CUTOVER.final.name;
 const FILTER_INDEX_REPLACEMENT = FILTER_INDEX_CUTOVER.staged.name;
 const DECISION_DATE_CONSTRAINT = "case_law_decisions_decision_date_bounds";
 const VALIDATE_CONSTRAINT_FRAGMENT = `VALIDATE CONSTRAINT "${DECISION_DATE_CONSTRAINT}"`;
+const DELETE_RECEIPT_CONSTRAINT =
+  "corpus_index_projection_intents_delete_receipt_paired";
+const VALIDATE_DELETE_RECEIPT_FRAGMENT = `VALIDATE CONSTRAINT "${DELETE_RECEIPT_CONSTRAINT}"`;
 
 describe("online migrations", () => {
   test("accepts an already valid index without rebuilding it", async () => {
@@ -311,6 +314,43 @@ describe("online migrations", () => {
     expect(harness.released()).toBe(true);
   });
 
+  test("validates the delete-receipt constraint after walking the intents", async () => {
+    const harness = createHarness();
+
+    await runOnlineMigrations(harness.pool);
+
+    const validateOffset = indexOfStatement(
+      harness.statements,
+      VALIDATE_DELETE_RECEIPT_FRAGMENT,
+    );
+    expect(validateOffset).toBeGreaterThan(
+      indexOfStatement(
+        harness.statements,
+        'UPDATE public."corpus_index_projection_intents"',
+      ),
+    );
+    expect(harness.released()).toBe(true);
+  });
+
+  test("startup validation rejects an unvalidated delete-receipt constraint without repairing", async () => {
+    const harness = createHarness({ constraintValidated: false });
+
+    const rejection: unknown = await assertOnlineMigrationsApplied(
+      harness.pool,
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
+      message: expect.stringContaining("is not complete: constraint"),
+    });
+    expect(
+      indexOfStatement(harness.statements, VALIDATE_DELETE_RECEIPT_FRAGMENT),
+    ).toBe(-1);
+    expect(harness.released()).toBe(true);
+  });
+
   test("startup validation rejects an unvalidated decision-date constraint without repairing", async () => {
     const harness = createHarness({ constraintValidated: false });
 
@@ -395,6 +435,11 @@ const createHarness = ({
           }
           // The decision-date repair's selection: nothing left to repair.
           if (query.includes("corrupt AS MATERIALIZED")) {
+            return [];
+          }
+          // The delete-receipt repair's walk: no batch boundary left, so the
+          // walk is on its last range.
+          if (query.includes("corpus_index_projection_intents")) {
             return [];
           }
           if (query.includes("starts_with")) {

--- a/apps/api/src/db/online-migrations.ts
+++ b/apps/api/src/db/online-migrations.ts
@@ -4,6 +4,7 @@ import {
   REWRITTEN_MIGRATION_INDEXES,
   type RequiredMigrationIndex,
 } from "../lib/db/migration-history";
+import { CORPUS_PROJECTION_DELETE_RECEIPT_REPAIR } from "./corpus-projection-delete-receipt-repair";
 import { DECISION_DATE_CEILING_REPAIR } from "./decision-date-ceiling-repair";
 import type {
   OnlineMigrationConnection,
@@ -220,6 +221,7 @@ const ONLINE_INDEX_REPLACEMENTS: readonly OnlineIndexReplacement[] = [
  */
 export const ONLINE_MIGRATION_REPAIRS: readonly OnlineRepair[] = [
   DECISION_DATE_CEILING_REPAIR,
+  CORPUS_PROJECTION_DELETE_RECEIPT_REPAIR,
 ];
 
 type PresentIndexState = {

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -61,6 +61,13 @@ export const corpusIndexProjectionIntents = p.pgTable(
     cleanupNotBefore: timestamptz("cleanup_not_before"),
     cleanupStartedAt: timestamptz("cleanup_started_at"),
     deleteOpstamp: p.bigint("delete_opstamp", { mode: "bigint" }),
+    /**
+     * The metastore's creation instant for the delete task the opstamp
+     * identifies. Settlement proves the delete against the splits that were
+     * published no later than this, so it is engine-issued state, not a local
+     * transition timestamp, and it is paired with the opstamp by a check.
+     */
+    deleteTaskCreatedAt: timestamptz("delete_task_created_at"),
     settledAt: timestamptz("settled_at"),
     cancelledAt: timestamptz("cancelled_at"),
     cleanupAttempts: p.integer("cleanup_attempts").default(0).notNull(),
@@ -192,6 +199,13 @@ export const corpusIndexProjectionIntents = p.pgTable(
     p.check(
       "corpus_index_projection_intents_delete_opstamp_nonnegative",
       sql`${t.deleteOpstamp} IS NULL OR ${t.deleteOpstamp} >= 0`,
+    ),
+    // The status shape decides per status whether a delete receipt is on the
+    // row; pairing the two receipt columns here keeps that one decision total
+    // instead of restating it for the second column.
+    p.check(
+      "corpus_index_projection_intents_delete_receipt_paired",
+      sql`(${t.deleteOpstamp} IS NULL) = (${t.deleteTaskCreatedAt} IS NULL)`,
     ),
     p.check(
       "corpus_index_projection_intents_expected_document_count_shape",

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -434,12 +434,19 @@ export const reconcileNextLegislationCorpusIndexDelete = async (
           "legislation",
           corpusIndexGeneration(next.indexId),
         ),
-      ).readDeleteSettlement(next.indexId, next.opstamp);
+      ).readDeleteSettlement({
+        indexId: next.indexId,
+        requiredOpstamp: next.opstamp,
+        // The watermark keeps an opstamp, not the metastore instant that
+        // issued it, so no split can be ruled out of the proof and the
+        // pruning below stays behind every split the engine still holds.
+        deleteCreatedAt: null,
+      });
       if (settlement.isErr()) {
         throw settlement.error;
       }
       const appliedOpstamp =
-        settlement.value.publishedSplits === 0
+        settlement.value.provingSplits === 0
           ? next.opstamp
           : settlement.value.minAppliedOpstamp;
       const pending = await scopedDb(async (tx) => {

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -329,7 +329,8 @@ describe("index census", () => {
     );
     expect(census.isOk() && census.value.deleteSettlement).toEqual({
       requiredOpstamp: 42,
-      publishedSplits: 3,
+      provingSplits: 3,
+      excludedSplits: 0,
       laggingSplits: 1,
       minAppliedOpstamp: 41,
       pendingDocuments: 40_000,
@@ -509,7 +510,8 @@ describe("census reporting", () => {
         disposition: CENSUS_DISPOSITION.pendingDelete,
         deleteSettlement: {
           requiredOpstamp: 42,
-          publishedSplits: 3,
+          provingSplits: 3,
+          excludedSplits: 0,
           laggingSplits: 1,
           minAppliedOpstamp: 41,
           pendingDocuments: 2000,
@@ -535,7 +537,8 @@ describe("census reporting", () => {
         disposition: CENSUS_DISPOSITION.pendingDelete,
         deleteSettlement: {
           requiredOpstamp: 42,
-          publishedSplits: 3,
+          provingSplits: 3,
+          excludedSplits: 0,
           laggingSplits: 1,
           minAppliedOpstamp: 41,
           pendingDocuments: 2000,

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -333,7 +333,8 @@ export type IndexCensus = {
   disposition: CensusDisposition;
   deleteSettlement: {
     requiredOpstamp: number;
-    publishedSplits: number;
+    provingSplits: number;
+    excludedSplits: number;
     laggingSplits: number;
     minAppliedOpstamp: number | null;
     pendingDocuments: number;
@@ -379,12 +380,19 @@ const readDeleteSettlement = async (
   }
   const settlement = await getCorpusIndexClient(
     corpusIndexClusterForGeneration("case_law", generation),
-  ).readDeleteSettlement(indexId, watermark.opstamp);
+  ).readDeleteSettlement({
+    indexId,
+    requiredOpstamp: watermark.opstamp,
+    // The watermark keeps an opstamp, not the metastore instant that issued
+    // it, so no split can be ruled out of the proof and the pruning below
+    // stays behind every split the engine still holds.
+    deleteCreatedAt: null,
+  });
   if (Result.isError(settlement)) {
     return Result.err(settlement.error);
   }
   const appliedOpstamp =
-    settlement.value.publishedSplits === 0
+    settlement.value.provingSplits === 0
       ? watermark.opstamp
       : settlement.value.minAppliedOpstamp;
   const pending = await scopedDb(async (tx) => {

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -30,6 +30,9 @@ import { isRecord } from "@/api/lib/type-guards";
  * boundary it must never cut across.
  */
 
+/** The metastore stamps a delete task's creation in whole seconds. */
+const DELETE_TASK_SECONDS = 1_787_000_000;
+
 const utf8Bytes = (value: string): number => Buffer.byteLength(value, "utf-8");
 
 const builtRow = (id: string, passages: number, filler: string) => ({
@@ -342,9 +345,15 @@ describe("idempotent corpus removals", () => {
     globalThis.fetch = Object.assign(
       async () => {
         nextDeleteOpstamp += 1;
-        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-          status: 200,
-        });
+        return new Response(
+          JSON.stringify({
+            opstamp: nextDeleteOpstamp,
+            create_timestamp: DELETE_TASK_SECONDS,
+          }),
+          {
+            status: 200,
+          },
+        );
       },
       { preconnect: originalFetch.preconnect },
     );
@@ -388,7 +397,10 @@ describe("idempotent corpus removals", () => {
       async (input: Parameters<typeof fetch>[0]) => {
         const url = requestUrl(input);
         requestHost = new URL(url).host;
-        return new Response(JSON.stringify({ opstamp: 7 }), { status: 200 });
+        return new Response(
+          JSON.stringify({ opstamp: 7, create_timestamp: DELETE_TASK_SECONDS }),
+          { status: 200 },
+        );
       },
       { preconnect: originalFetch.preconnect },
     );
@@ -458,9 +470,15 @@ describe("idempotent corpus removals", () => {
     globalThis.fetch = Object.assign(
       async () => {
         nextDeleteOpstamp += 1;
-        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-          status: 200,
-        });
+        return new Response(
+          JSON.stringify({
+            opstamp: nextDeleteOpstamp,
+            create_timestamp: DELETE_TASK_SECONDS,
+          }),
+          {
+            status: 200,
+          },
+        );
       },
       { preconnect: originalFetch.preconnect },
     );
@@ -644,9 +662,15 @@ describe("fenced serving-generation appends", () => {
         events.push(url.includes("/ingest") ? "ingest" : "remote");
         if (url.includes("/delete-tasks")) {
           nextDeleteOpstamp += 1;
-          return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-            status: 200,
-          });
+          return new Response(
+            JSON.stringify({
+              opstamp: nextDeleteOpstamp,
+              create_timestamp: DELETE_TASK_SECONDS,
+            }),
+            {
+              status: 200,
+            },
+          );
         }
         return new Response(
           url.includes("/ingest")
@@ -787,9 +811,15 @@ describe("failed index jobs always reach the audit trail", () => {
       }
       if (url.includes("/delete-tasks")) {
         nextDeleteOpstamp += 1;
-        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-          status: 200,
-        });
+        return new Response(
+          JSON.stringify({
+            opstamp: nextDeleteOpstamp,
+            create_timestamp: DELETE_TASK_SECONDS,
+          }),
+          {
+            status: 200,
+          },
+        );
       }
       return new Response(JSON.stringify({}), { status: 200 });
     };
@@ -869,7 +899,10 @@ describe("failed index jobs always reach the audit trail", () => {
         });
       }
       if (lastUrl.includes("/delete-tasks")) {
-        return new Response(JSON.stringify({ opstamp: 1 }), { status: 200 });
+        return new Response(
+          JSON.stringify({ opstamp: 1, create_timestamp: DELETE_TASK_SECONDS }),
+          { status: 200 },
+        );
       }
       return new Response(JSON.stringify({}), { status: 200 });
     };
@@ -975,9 +1008,15 @@ describe("failed index jobs always reach the audit trail", () => {
       }
       if (url.includes("/delete-tasks")) {
         nextDeleteOpstamp += 1;
-        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-          status: 200,
-        });
+        return new Response(
+          JSON.stringify({
+            opstamp: nextDeleteOpstamp,
+            create_timestamp: DELETE_TASK_SECONDS,
+          }),
+          {
+            status: 200,
+          },
+        );
       }
       return new Response(JSON.stringify({}), { status: 200 });
     };
@@ -1401,7 +1440,10 @@ describe("first-ever fenced appends", () => {
   ) => {
     const url = requestUrl(input);
     if (url.includes("/delete-tasks")) {
-      return new Response(JSON.stringify({ opstamp: 1 }), { status: 200 });
+      return new Response(
+        JSON.stringify({ opstamp: 1, create_timestamp: DELETE_TASK_SECONDS }),
+        { status: 200 },
+      );
     }
     if (!url.includes("/ingest")) {
       return new Response(JSON.stringify({}), { status: 200 });
@@ -1682,9 +1724,15 @@ describe("delete-task amplification", () => {
             : "";
         deletes.push({ url, query });
         nextDeleteOpstamp += 1;
-        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-          status: 200,
-        });
+        return new Response(
+          JSON.stringify({
+            opstamp: nextDeleteOpstamp,
+            create_timestamp: DELETE_TASK_SECONDS,
+          }),
+          {
+            status: 200,
+          },
+        );
       }
       if (url.includes("/ingest")) {
         const sent = body.split("\n").filter((line) => line.length > 0).length;

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 
+import { Temporal } from "@stll/time";
+
 import { envBase } from "@/api/env-base";
 import {
   CORPUS_INDEX_CLUSTER_CONFIG,
@@ -20,6 +22,12 @@ import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-p
 // missing or misnamed sort parameter silently degrades search to
 // id-order results. These tests stub global fetch and assert on the
 // outgoing request, not on engine behaviour.
+
+/** The metastore stamps a delete task and a split publish in whole seconds. */
+const DELETE_TASK_SECONDS = 1_787_000_000;
+const DELETE_TASK_CREATED_AT = Temporal.Instant.fromEpochMilliseconds(
+  DELETE_TASK_SECONDS * 1000,
+);
 
 type RecordedRequest = {
   host: string;
@@ -570,7 +578,7 @@ test("ingest fails when the engine reports rejected documents", async () => {
 });
 
 test("delete-by-query posts one document-scoped delete task", async () => {
-  responseBody = { opstamp: 42 };
+  responseBody = { opstamp: 42, create_timestamp: DELETE_TASK_SECONDS };
 
   const result = await getCorpusIndexClient("q08").deleteByQuery(
     "legal_corpus_v1_cze",
@@ -579,7 +587,10 @@ test("delete-by-query posts one document-scoped delete task", async () => {
 
   expect(result.isOk()).toBe(true);
   if (result.isOk()) {
-    expect(result.value).toEqual({ opstamp: 42 });
+    expect(result.value).toEqual({
+      opstamp: 42,
+      createdAt: DELETE_TASK_CREATED_AT,
+    });
   }
   // One task per document, whatever the index layout: a passage-split
   // document is removed by the same single query as a whole one, so the
@@ -593,7 +604,7 @@ test("delete-by-query posts one document-scoped delete task", async () => {
 });
 
 test("delete-by-query rejects a response without a usable opstamp", async () => {
-  responseBody = {};
+  responseBody = { create_timestamp: DELETE_TASK_SECONDS };
 
   const result = await getCorpusIndexClient("q08").deleteByQuery(
     "legal_corpus_v1_cze",
@@ -606,39 +617,47 @@ test("delete-by-query rejects a response without a usable opstamp", async () => 
   }
 });
 
-test("delete settlement compares every published split with the retained task", async () => {
+const publishedSplit = ({
+  id,
+  deleteOpstamp,
+  publishedAtSeconds = DELETE_TASK_SECONDS - 60,
+}: {
+  id: string;
+  deleteOpstamp: number;
+  publishedAtSeconds?: number;
+}) => ({
+  split_id: id,
+  split_state: "Published",
+  delete_opstamp: deleteOpstamp,
+  publish_timestamp: publishedAtSeconds,
+});
+
+const readSettlement = async (requiredOpstamp: number) =>
+  await getCorpusIndexClient("q08").readDeleteSettlement({
+    indexId: "legal_corpus_v1_cze",
+    requiredOpstamp,
+    deleteCreatedAt: DELETE_TASK_CREATED_AT,
+  });
+
+test("delete settlement compares every proving split with the retained task", async () => {
   responseBody = {
     offset: 0,
     size: 3,
     splits: [
-      {
-        split_id: "split-42",
-        split_state: "Published",
-        delete_opstamp: 42,
-      },
-      {
-        split_id: "split-41",
-        split_state: "Published",
-        delete_opstamp: 41,
-      },
-      {
-        split_id: "split-45",
-        split_state: "Published",
-        delete_opstamp: 45,
-      },
+      publishedSplit({ id: "split-42", deleteOpstamp: 42 }),
+      publishedSplit({ id: "split-41", deleteOpstamp: 41 }),
+      publishedSplit({ id: "split-45", deleteOpstamp: 45 }),
     ],
   };
 
-  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
-    "legal_corpus_v1_cze",
-    42,
-  );
+  const result = await readSettlement(42);
 
   expect(result.isOk()).toBe(true);
   if (result.isOk()) {
     expect(result.value).toEqual({
       requiredOpstamp: 42,
-      publishedSplits: 3,
+      provingSplits: 3,
+      excludedSplits: 0,
       laggingSplits: 1,
       minAppliedOpstamp: 41,
       settled: false,
@@ -648,15 +667,128 @@ test("delete settlement compares every published split with the retained task", 
     "/api/v1/indexes/legal_corpus_v1_cze/splits",
   );
   expect(requests.at(0)?.search).toBe(
-    "?offset=0&limit=1000&split_states=Published",
+    "?offset=0&limit=1000&split_states=Published,Staged",
   );
 });
 
+test("delete settlement excludes a split published after the delete task", async () => {
+  responseBody = {
+    splits: [
+      publishedSplit({ id: "split-caught-up", deleteOpstamp: 42 }),
+      // A steady append stream keeps producing these; the delete task cannot
+      // have targeted a revision they alone hold.
+      publishedSplit({
+        id: "split-later",
+        deleteOpstamp: 41,
+        publishedAtSeconds: DELETE_TASK_SECONDS + 1,
+      }),
+    ],
+  };
+
+  const result = await readSettlement(42);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value).toEqual({
+      requiredOpstamp: 42,
+      provingSplits: 1,
+      excludedSplits: 1,
+      laggingSplits: 0,
+      minAppliedOpstamp: 42,
+      settled: true,
+    });
+  }
+});
+
+test("delete settlement keeps a split published inside the task's own second", async () => {
+  responseBody = {
+    splits: [
+      publishedSplit({
+        id: "split-same-second",
+        deleteOpstamp: 41,
+        publishedAtSeconds: DELETE_TASK_SECONDS,
+      }),
+    ],
+  };
+
+  const result = await readSettlement(42);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.excludedSplits).toBe(0);
+    expect(result.value.laggingSplits).toBe(1);
+    expect(result.value.settled).toBe(false);
+  }
+});
+
+test("delete settlement holds a staged split inside the proof", async () => {
+  responseBody = {
+    splits: [
+      publishedSplit({ id: "split-caught-up", deleteOpstamp: 42 }),
+      {
+        split_id: "split-staged",
+        split_state: "Staged",
+        delete_opstamp: 41,
+        publish_timestamp: null,
+      },
+    ],
+  };
+
+  const result = await readSettlement(42);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.provingSplits).toBe(2);
+    expect(result.value.excludedSplits).toBe(0);
+    expect(result.value.laggingSplits).toBe(1);
+    expect(result.value.settled).toBe(false);
+  }
+});
+
+test("delete settlement settles once every proving split crossed the opstamp", async () => {
+  responseBody = {
+    splits: [
+      publishedSplit({ id: "split-42", deleteOpstamp: 42 }),
+      publishedSplit({ id: "split-45", deleteOpstamp: 45 }),
+    ],
+  };
+
+  const result = await readSettlement(42);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.settled).toBe(true);
+    expect(result.value.minAppliedOpstamp).toBe(42);
+  }
+});
+
+test("delete settlement without a delete instant keeps every split", async () => {
+  responseBody = {
+    splits: [
+      publishedSplit({
+        id: "split-later",
+        deleteOpstamp: 41,
+        publishedAtSeconds: DELETE_TASK_SECONDS + 1,
+      }),
+    ],
+  };
+
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement({
+    indexId: "legal_corpus_v1_cze",
+    requiredOpstamp: 42,
+    deleteCreatedAt: null,
+  });
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.provingSplits).toBe(1);
+    expect(result.value.excludedSplits).toBe(0);
+    expect(result.value.settled).toBe(false);
+  }
+});
+
 test("delete settlement rejects an invalid required opstamp", async () => {
-  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
-    "legal_corpus_v1_cze",
-    -1,
-  );
+  const result = await readSettlement(-1);
 
   expect(result.isErr()).toBe(true);
   if (result.isErr()) {
@@ -669,10 +801,27 @@ test("delete settlement rejects a split without a usable delete opstamp", async 
     splits: [{ split_id: "split-1", split_state: "Published" }],
   };
 
-  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
-    "legal_corpus_v1_cze",
-    42,
-  );
+  const result = await readSettlement(42);
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("invalid response");
+  }
+});
+
+test("delete settlement rejects a split with an unusable publish timestamp", async () => {
+  responseBody = {
+    splits: [
+      {
+        split_id: "split-1",
+        split_state: "Published",
+        delete_opstamp: 42,
+        publish_timestamp: "2026-08-25T12:00:00Z",
+      },
+    ],
+  };
+
+  const result = await readSettlement(42);
 
   expect(result.isErr()).toBe(true);
   if (result.isErr()) {
@@ -684,11 +833,9 @@ const settlementResponse = (splitCount: number) => (url: URL) => {
   const offset = Number(url.searchParams.get("offset") ?? "0");
   const pageSize = Math.min(1000, Math.max(splitCount - offset, 0));
   return {
-    splits: Array.from({ length: pageSize }, (_, index) => ({
-      split_id: `split-${offset + index}`,
-      split_state: "Published",
-      delete_opstamp: 42,
-    })),
+    splits: Array.from({ length: pageSize }, (_, index) =>
+      publishedSplit({ id: `split-${offset + index}`, deleteOpstamp: 42 }),
+    ),
   };
 };
 
@@ -699,27 +846,58 @@ test("delete settlement repeats an offset scan until split identities stabilize"
     if (offset === 0) {
       firstPageReads += 1;
       return {
-        splits: Array.from({ length: 1000 }, (_, index) => ({
-          split_id:
-            firstPageReads === 1 || index > 0 ? `split-${index}` : "split-new",
-          split_state: "Published",
-          delete_opstamp: 42,
-        })),
+        splits: Array.from({ length: 1000 }, (_, index) =>
+          publishedSplit({
+            id:
+              firstPageReads === 1 || index > 0
+                ? `split-${index}`
+                : "split-new",
+            deleteOpstamp: 42,
+          }),
+        ),
       };
     }
     return { splits: [] };
   };
 
-  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
-    "legal_corpus_v1_cze",
-    42,
-  );
+  const result = await readSettlement(42);
 
   expect(result.isOk()).toBe(true);
   if (result.isOk()) {
-    expect(result.value.publishedSplits).toBe(1000);
+    expect(result.value.provingSplits).toBe(1000);
   }
   expect(firstPageReads).toBe(3);
+});
+
+test("delete settlement ignores churn among the splits it excluded", async () => {
+  let pageReads = 0;
+  responseBodyForUrl = () => {
+    pageReads += 1;
+    return {
+      splits: [
+        publishedSplit({ id: "split-proving", deleteOpstamp: 42 }),
+        // One more append lands between the passes: the proof does not
+        // depend on it, so the scan does not have to wait for it to stop.
+        ...Array.from({ length: pageReads }, (_, index) =>
+          publishedSplit({
+            id: `split-appended-${index}`,
+            deleteOpstamp: 41,
+            publishedAtSeconds: DELETE_TASK_SECONDS + 1,
+          }),
+        ),
+      ],
+    };
+  };
+
+  const result = await readSettlement(42);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.provingSplits).toBe(1);
+    expect(result.value.excludedSplits).toBe(2);
+    expect(result.value.settled).toBe(true);
+  }
+  expect(pageReads).toBe(2);
 });
 
 test("delete settlement reads each split's opstamp from the pass that stabilized", async () => {
@@ -728,35 +906,26 @@ test("delete settlement reads each split's opstamp from the pass that stabilized
     firstPageReads += 1;
     return {
       splits: [
-        {
-          split_id: "split-lagging",
-          split_state: "Published",
+        publishedSplit({
+          id: "split-lagging",
           // The first pass observes this split before its delete task lands.
-          delete_opstamp: firstPageReads === 1 ? 41 : 42,
-        },
+          deleteOpstamp: firstPageReads === 1 ? 41 : 42,
+        }),
         ...(firstPageReads === 1
           ? []
-          : [
-              {
-                split_id: "split-added",
-                split_state: "Published",
-                delete_opstamp: 42,
-              },
-            ]),
+          : [publishedSplit({ id: "split-added", deleteOpstamp: 42 })]),
       ],
     };
   };
 
-  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
-    "legal_corpus_v1_cze",
-    42,
-  );
+  const result = await readSettlement(42);
 
   expect(result.isOk()).toBe(true);
   if (result.isOk()) {
     expect(result.value).toEqual({
       requiredOpstamp: 42,
-      publishedSplits: 2,
+      provingSplits: 2,
+      excludedSplits: 0,
       laggingSplits: 0,
       minAppliedOpstamp: 42,
       settled: true,
@@ -764,17 +933,14 @@ test("delete settlement reads each split's opstamp from the pass that stabilized
   }
 });
 
-test("delete settlement accepts exactly the published split ceiling", async () => {
+test("delete settlement accepts exactly the split ceiling", async () => {
   responseBodyForUrl = settlementResponse(10_000);
 
-  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
-    "legal_corpus_v1_cze",
-    42,
-  );
+  const result = await readSettlement(42);
 
   expect(result.isOk()).toBe(true);
   if (result.isOk()) {
-    expect(result.value.publishedSplits).toBe(10_000);
+    expect(result.value.provingSplits).toBe(10_000);
     expect(result.value.settled).toBe(true);
   }
 });
@@ -782,10 +948,7 @@ test("delete settlement accepts exactly the published split ceiling", async () =
 test("delete settlement rejects the first split beyond its ceiling", async () => {
   responseBodyForUrl = settlementResponse(10_001);
 
-  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
-    "legal_corpus_v1_cze",
-    42,
-  );
+  const result = await readSettlement(42);
 
   expect(result.isErr()).toBe(true);
   if (result.isErr()) {

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -57,6 +57,15 @@ const SPLIT_PAGE_SIZE = 1000;
 const MAX_SETTLEMENT_SPLITS = 10_000;
 const MAX_SETTLEMENT_SCAN_PASSES = 3;
 const SETTLEMENT_SCAN_TIMEOUT_MS = 60_000;
+/**
+ * Both split states a targeted revision can be in. A staged split is either
+ * an indexer split the engine has not published yet or a merge output waiting
+ * to replace its inputs; leaving it out would prove a delete against a
+ * snapshot the index is about to replace.
+ */
+const SETTLEMENT_SPLIT_STATES = "Published,Staged";
+/** Quickwit stamps split and delete-task instants in whole seconds. */
+const METASTORE_TIMESTAMP_UNIT_MS = 1000;
 
 /**
  * What "the engine accepted this batch" is allowed to mean.
@@ -131,11 +140,39 @@ export type CorpusIndexSearchResponse = {
  */
 export type CorpusIndexDeleteTask = {
   opstamp: number;
+  /**
+   * The metastore's own creation instant for the task, at its second
+   * precision. Read from the engine rather than from this process's clock:
+   * it is compared against split publish timestamps issued by the same
+   * metastore, and a local instant would put clock skew inside that
+   * comparison.
+   */
+  createdAt: Temporal.Instant;
+};
+
+type CorpusIndexDeleteSettlementInput = {
+  indexId: string;
+  requiredOpstamp: number;
+  /**
+   * The delete task's metastore creation instant, for a caller that retained
+   * it. A split first published after that instant is excluded from the
+   * proof; `null` keeps every observed split in it.
+   */
+  deleteCreatedAt: Temporal.Instant | null;
 };
 
 export type CorpusIndexDeleteSettlement = {
   requiredOpstamp: number;
-  publishedSplits: number;
+  /**
+   * Splits the proof stands on: published no later than the delete task, or
+   * not published yet.
+   */
+  provingSplits: number;
+  /**
+   * Splits first published after the delete task. They are outside the proof,
+   * and counting them keeps a stalled-settlement diagnostic readable.
+   */
+  excludedSplits: number;
   laggingSplits: number;
   minAppliedOpstamp: number | null;
   settled: boolean;
@@ -195,8 +232,7 @@ export type CorpusIndexClient = {
     query: string,
   ) => Promise<Result<CorpusIndexDeleteTask, CorpusIndexError>>;
   readDeleteSettlement: (
-    indexId: string,
-    requiredOpstamp: number,
+    input: CorpusIndexDeleteSettlementInput,
   ) => Promise<Result<CorpusIndexDeleteSettlement, CorpusIndexError>>;
 };
 
@@ -323,6 +359,57 @@ const requestJson = async (request: CorpusIndexRequest): Promise<unknown> => {
       unaborted: "returned an unreadable body",
     });
   });
+};
+
+type SettlementSplit = {
+  splitId: string;
+  appliedOpstamp: number;
+  /** Null while the split has never been published. */
+  publishedAtSeconds: number | null;
+};
+
+type SettlementPass = {
+  /** Lowest applied opstamp this pass read for each split inside the proof. */
+  provingSplits: Map<string, number>;
+  excludedSplits: number;
+};
+
+const invalidSplitList = () =>
+  new CorpusIndexError({
+    message: "corpus index split list returned an invalid response",
+  });
+
+/** Null while the split has never been published. */
+const parseSplitPublishedAtSeconds = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw invalidSplitList();
+  }
+  return value;
+};
+
+const parseSettlementSplit = (
+  split: Record<string, unknown>,
+): SettlementSplit => {
+  const publishedAtSeconds = parseSplitPublishedAtSeconds(
+    split["publish_timestamp"],
+  );
+  const splitId = split["split_id"];
+  const appliedOpstamp = split["delete_opstamp"];
+  const splitState = split["split_state"];
+  if (
+    (splitState !== "Published" && splitState !== "Staged") ||
+    typeof splitId !== "string" ||
+    splitId.length === 0 ||
+    typeof appliedOpstamp !== "number" ||
+    !Number.isSafeInteger(appliedOpstamp) ||
+    appliedOpstamp < 0
+  ) {
+    throw invalidSplitList();
+  }
+  return { splitId, appliedOpstamp, publishedAtSeconds };
 };
 
 const parseRecordArray = (value: unknown): Record<string, unknown>[] | null => {
@@ -791,22 +878,33 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
           },
           timeoutMs: ADMIN_TIMEOUT_MS,
         });
+        const createdAtSeconds = isRecord(response)
+          ? response["create_timestamp"]
+          : null;
         if (
           !isRecord(response) ||
           typeof response["opstamp"] !== "number" ||
           !Number.isSafeInteger(response["opstamp"]) ||
-          response["opstamp"] < 0
+          response["opstamp"] < 0 ||
+          typeof createdAtSeconds !== "number" ||
+          !Number.isSafeInteger(createdAtSeconds) ||
+          createdAtSeconds < 0
         ) {
           throw new CorpusIndexError({
             message: "corpus index delete task returned an invalid response",
           });
         }
-        return { opstamp: response["opstamp"] };
+        return {
+          opstamp: response["opstamp"],
+          createdAt: Temporal.Instant.fromEpochMilliseconds(
+            createdAtSeconds * METASTORE_TIMESTAMP_UNIT_MS,
+          ),
+        };
       },
       catch: toCorpusIndexError,
     }),
 
-  readDeleteSettlement: async (indexId, requiredOpstamp) =>
+  readDeleteSettlement: async ({ indexId, requiredOpstamp, deleteCreatedAt }) =>
     await Result.tryPromise({
       try: async () => {
         if (!Number.isSafeInteger(requiredOpstamp) || requiredOpstamp < 0) {
@@ -815,6 +913,15 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
               "corpus index delete settlement received an invalid opstamp",
           });
         }
+        // The metastore stamps both instants in whole seconds, so the delete
+        // task's own instant is compared at that precision. A split published
+        // inside the task's second stays in the proof.
+        const deleteCreatedAtSeconds =
+          deleteCreatedAt === null
+            ? null
+            : Math.floor(
+                deleteCreatedAt.epochMilliseconds / METASTORE_TIMESTAMP_UNIT_MS,
+              );
         const deadline =
           Temporal.Now.instant().epochMilliseconds + SETTLEMENT_SCAN_TIMEOUT_MS;
         const remainingBudget = (): number => {
@@ -827,23 +934,25 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
           return Math.min(remaining, ADMIN_TIMEOUT_MS);
         };
         let scanPasses = 0;
-        // Keyed by split id; the value is the lowest opstamp this pass saw for
-        // it, since a split shifting between offset pages can be read twice.
-        const readSplitPass = async (): Promise<Map<string, number>> => {
+        const readSplitPass = async (): Promise<SettlementPass> => {
           scanPasses += 1;
           if (scanPasses > MAX_SETTLEMENT_SCAN_PASSES) {
             throw new CorpusIndexError({
               message:
-                "corpus index split list did not reach a stable published-split set",
+                "corpus index split list did not reach a stable proving-split set",
             });
           }
           let offset = 0;
           let scannedSplits = 0;
-          const passSplitOpstamps = new Map<string, number>();
+          let excludedSplits = 0;
+          // Keyed by split id; the value is the lowest opstamp this pass saw
+          // for it, since a split shifting between offset pages can be read
+          // twice.
+          const provingSplits = new Map<string, number>();
           const readSplitPage = async (): Promise<void> => {
             const response = await requestJson({
               baseUrl: mutationBaseUrl(cluster),
-              path: `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
+              path: `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=${SETTLEMENT_SPLIT_STATES}`,
               init: { method: "GET" },
               timeoutMs: remainingBudget(),
             });
@@ -851,38 +960,34 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
               ? parseRecordArray(response["splits"])
               : null;
             if (splits === null) {
-              throw new CorpusIndexError({
-                message: "corpus index split list returned an invalid response",
-              });
+              throw invalidSplitList();
             }
             scannedSplits += splits.length;
             if (scannedSplits > MAX_SETTLEMENT_SPLITS) {
               throw new CorpusIndexError({
-                message: `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
+                message: `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} splits`,
               });
             }
             for (const split of splits) {
-              const splitId = split["split_id"];
-              const opstamp = split["delete_opstamp"];
+              const parsed = parseSettlementSplit(split);
+              // A split published after the delete task was created is outside
+              // the proof; see the settlement call site in the projection
+              // cleanup store for why that is exact. A split with no publish
+              // timestamp has not been published yet and stays in the proof.
               if (
-                split["split_state"] !== "Published" ||
-                typeof splitId !== "string" ||
-                splitId.length === 0 ||
-                typeof opstamp !== "number" ||
-                !Number.isSafeInteger(opstamp) ||
-                opstamp < 0
+                deleteCreatedAtSeconds !== null &&
+                parsed.publishedAtSeconds !== null &&
+                parsed.publishedAtSeconds > deleteCreatedAtSeconds
               ) {
-                throw new CorpusIndexError({
-                  message:
-                    "corpus index split list returned an invalid response",
-                });
+                excludedSplits += 1;
+                continue;
               }
-              const previousOpstamp = passSplitOpstamps.get(splitId);
-              passSplitOpstamps.set(
-                splitId,
+              const previousOpstamp = provingSplits.get(parsed.splitId);
+              provingSplits.set(
+                parsed.splitId,
                 previousOpstamp === undefined
-                  ? opstamp
-                  : Math.min(previousOpstamp, opstamp),
+                  ? parsed.appliedOpstamp
+                  : Math.min(previousOpstamp, parsed.appliedOpstamp),
               );
             }
             if (splits.length < SPLIT_PAGE_SIZE) {
@@ -892,17 +997,19 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
             await readSplitPage();
           };
           await readSplitPage();
-          return passSplitOpstamps;
+          return { provingSplits, excludedSplits };
         };
         const readStableSplitPass = async (
           previousPassSplitIds: ReadonlySet<string>,
-        ): Promise<Map<string, number>> => {
+        ): Promise<SettlementPass> => {
           const currentPass = await readSplitPass();
-          const currentSplitIds = new Set(currentPass.keys());
+          const currentSplitIds = new Set(currentPass.provingSplits.keys());
           // Quickwit lists by numeric offset, not a snapshot cursor. A split
           // published or retired while an earlier page is read can shift a
           // later page. Only clear durable delete state after one complete
           // pass has exactly the same identity set; ongoing churn fails closed.
+          // Only the proving set has to settle: an index taking continuous
+          // appends never stops adding splits the proof already excludes.
           const stable =
             currentSplitIds.size === previousPassSplitIds.size &&
             currentSplitIds.isSubsetOf(previousPassSplitIds);
@@ -917,8 +1024,7 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
         // value forward would report it as lagging for as long as the index
         // keeps churning.
         const finalPass = await readStableSplitPass(new Set());
-        const appliedOpstamps = [...finalPass.values()];
-        const publishedSplits = finalPass.size;
+        const appliedOpstamps = [...finalPass.provingSplits.values()];
         const laggingSplits = appliedOpstamps.filter(
           (opstamp) => opstamp < requiredOpstamp,
         ).length;
@@ -926,7 +1032,8 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
           appliedOpstamps.length === 0 ? null : Math.min(...appliedOpstamps);
         return {
           requiredOpstamp,
-          publishedSplits,
+          provingSplits: finalPass.provingSplits.size,
+          excludedSplits: finalPass.excludedSplits,
           laggingSplits,
           minAppliedOpstamp,
           settled: laggingSplits === 0,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -1,5 +1,18 @@
 import { panic, Result } from "better-result";
-import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  min,
+  or,
+  sql,
+} from "drizzle-orm";
+
+import { Temporal } from "@stll/time";
 
 import type { Transaction } from "@/api/db/root";
 import {
@@ -22,7 +35,6 @@ import {
   CORPUS_PROJECTION_DELETE_MAX_REVISIONS,
   corpusIndexUnknownAppendBarrierAt,
   countCorpusProjectionRevisions,
-  readCorpusProjectionDeleteSettlement,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
 import { lockCorpusIndexProjectionIntentMutationsTx } from "@/api/lib/legal-search/corpus-index-projection-revision";
 import {
@@ -206,6 +218,8 @@ type RecordCorpusProjectionDeleteOptions = {
   indexId: string;
   leaseToken: string;
   deleteOpstamp: number;
+  /** The metastore's creation instant for the delete task, from its receipt. */
+  deleteTaskCreatedAt: Temporal.Instant;
   testNow?: Date;
 };
 
@@ -216,6 +230,7 @@ export const recordCorpusProjectionDeleteTx = async (
     indexId,
     leaseToken,
     deleteOpstamp,
+    deleteTaskCreatedAt,
     testNow,
   }: RecordCorpusProjectionDeleteOptions,
 ): Promise<number> => {
@@ -237,6 +252,7 @@ export const recordCorpusProjectionDeleteTx = async (
       leaseToken: null,
       leaseExpiresAt: null,
       deleteOpstamp: BigInt(deleteOpstamp),
+      deleteTaskCreatedAt: new Date(deleteTaskCreatedAt.epochMilliseconds),
       lastError: null,
       updatedAt: transitionAt,
     })
@@ -311,7 +327,37 @@ export type CorpusProjectionCleanupSettlementLease = {
   indexId: string;
   intentIds: readonly ProjectionIntentId[];
   deleteOpstamp: number;
+  /** The metastore's creation instant for that delete task. */
+  deleteTaskCreatedAt: Temporal.Instant;
   leaseToken: string;
+};
+
+/**
+ * Delete tasks one settlement turn may lease.
+ *
+ * Cleanup issues one delete task per turn per index, so a turn that could
+ * prove only one of them can never drain a backlog: settlement throughput has
+ * to exceed the issue rate, not match it.
+ */
+const CORPUS_PROJECTION_SETTLEMENT_MAX_TASKS = 32;
+
+type SettlementTaskGroup = {
+  deleteOpstamp: number;
+  deleteTaskCreatedAt: Temporal.Instant;
+  intentIds: ProjectionIntentId[];
+};
+
+const validateSettlementTaskLimit = (taskLimit: number): number => {
+  if (
+    !Number.isSafeInteger(taskLimit) ||
+    taskLimit < 1 ||
+    taskLimit > CORPUS_PROJECTION_SETTLEMENT_MAX_TASKS
+  ) {
+    return panic(
+      `Corpus projection settlement must lease 1 to ${CORPUS_PROJECTION_SETTLEMENT_MAX_TASKS} delete tasks per turn`,
+    );
+  }
+  return taskLimit;
 };
 
 type ClaimCorpusProjectionCleanupSettlementOptions<
@@ -319,7 +365,10 @@ type ClaimCorpusProjectionCleanupSettlementOptions<
 > = CorpusProjectionScopedWorkOptions<Family> & {
   generation: string;
   indexId: string;
+  /** Revisions leased from one delete task. */
   limit: number;
+  /** Delete tasks leased in this turn. */
+  taskLimit: number;
   leaseMs: number;
   /** Deterministic database-test clock; production expiry uses PostgreSQL. */
   testNow?: Date;
@@ -335,13 +384,15 @@ export const claimCorpusProjectionCleanupSettlementTx = async <
     generation,
     indexId,
     limit: requestedLimit,
+    taskLimit: requestedTaskLimit,
     leaseMs: requestedLeaseMs,
     scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
     newLeaseToken = () => Bun.randomUUIDv7(),
   }: ClaimCorpusProjectionCleanupSettlementOptions<Family>,
-): Promise<CorpusProjectionCleanupSettlementLease | null> => {
+): Promise<CorpusProjectionCleanupSettlementLease[]> => {
   const limit = validateCleanupBatchSize(requestedLimit);
+  const taskLimit = validateSettlementTaskLimit(requestedTaskLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
   await lockRegisteredCorpusProjectionManifestForMutation(
@@ -349,61 +400,103 @@ export const claimCorpusProjectionCleanupSettlementTx = async <
     family,
     generation,
   );
-  const first = await tx
-    .select({ deleteOpstamp: corpusIndexProjectionIntents.deleteOpstamp })
+  const settleable = and(
+    eq(corpusIndexProjectionIntents.family, family),
+    eq(corpusIndexProjectionIntents.generation, generation),
+    eq(corpusIndexProjectionIntents.indexId, indexId),
+    scopedEntityIds === null
+      ? undefined
+      : inArray(corpusIndexProjectionIntents.entityId, scopedEntityIds),
+    eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
+    // A receipt written before the delete instant was persisted cannot be
+    // proved against the splits that could hold its revisions. The online
+    // repair behind the paired-receipt constraint fills those rows in, and
+    // they become settleable again with no further transition.
+    isNotNull(corpusIndexProjectionIntents.deleteTaskCreatedAt),
+    or(
+      isNull(corpusIndexProjectionIntents.leaseExpiresAt),
+      sql`${corpusIndexProjectionIntents.leaseExpiresAt} <= clock_timestamp()`,
+    ),
+  );
+  // Grouping cannot take row locks, so these identities are only a plan: the
+  // rows behind them are re-read under lock below, and a task another turn
+  // claimed in between simply yields no lease.
+  const tasks = await tx
+    .select({
+      deleteOpstamp: corpusIndexProjectionIntents.deleteOpstamp,
+      // One instant per task: the opstamp identifies the task inside this
+      // index, and its receipt wrote both columns in one transition.
+      deleteTaskCreatedAt: min(
+        corpusIndexProjectionIntents.deleteTaskCreatedAt,
+      ),
+    })
     .from(corpusIndexProjectionIntents)
-    .where(
+    .where(settleable)
+    .groupBy(corpusIndexProjectionIntents.deleteOpstamp)
+    .orderBy(
+      asc(min(corpusIndexProjectionIntents.cleanupStartedAt)),
+      asc(corpusIndexProjectionIntents.deleteOpstamp),
+    )
+    .limit(taskLimit);
+  const taskInstants = new Map<string, Temporal.Instant>();
+  const leasedOpstamps = tasks.map(({ deleteOpstamp, deleteTaskCreatedAt }) => {
+    if (deleteOpstamp === null || deleteTaskCreatedAt === null) {
+      return panic("Committed corpus projection cleanup has no delete receipt");
+    }
+    taskInstants.set(
+      deleteOpstamp.toString(),
+      Temporal.Instant.fromEpochMilliseconds(deleteTaskCreatedAt.getTime()),
+    );
+    return deleteOpstamp;
+  });
+  if (leasedOpstamps.length === 0) {
+    return [];
+  }
+  const leasedTasks = inArray(
+    corpusIndexProjectionIntents.deleteOpstamp,
+    leasedOpstamps,
+  );
+  // Rank inside each delete task so one long task cannot spend the whole
+  // turn's row budget. The ranking cannot lock (a window function and a
+  // locking clause are exclusive), so the outer statement locks the intent
+  // rows the ranking picked.
+  const rankedRevisions = tx.$with("ranked_revisions").as(
+    tx
+      .select({
+        id: corpusIndexProjectionIntents.id,
+        taskRank: sql<number>`row_number() OVER (
+          PARTITION BY ${corpusIndexProjectionIntents.deleteOpstamp}
+          ORDER BY ${corpusIndexProjectionIntents.createdAt}, ${corpusIndexProjectionIntents.id}
+        )`.as("task_rank"),
+      })
+      .from(corpusIndexProjectionIntents)
+      .where(and(settleable, leasedTasks)),
+  );
+  const candidates = await tx
+    .with(rankedRevisions)
+    .select({
+      id: corpusIndexProjectionIntents.id,
+      deleteOpstamp: corpusIndexProjectionIntents.deleteOpstamp,
+    })
+    .from(corpusIndexProjectionIntents)
+    .innerJoin(
+      rankedRevisions,
       and(
-        eq(corpusIndexProjectionIntents.family, family),
-        eq(corpusIndexProjectionIntents.generation, generation),
-        eq(corpusIndexProjectionIntents.indexId, indexId),
-        scopedEntityIds === null
-          ? undefined
-          : inArray(corpusIndexProjectionIntents.entityId, scopedEntityIds),
-        eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
-        or(
-          isNull(corpusIndexProjectionIntents.leaseExpiresAt),
-          sql`${corpusIndexProjectionIntents.leaseExpiresAt} <= clock_timestamp()`,
-        ),
+        eq(rankedRevisions.id, corpusIndexProjectionIntents.id),
+        lte(rankedRevisions.taskRank, limit),
       ),
     )
     .orderBy(
       asc(corpusIndexProjectionIntents.cleanupStartedAt),
       asc(corpusIndexProjectionIntents.createdAt),
     )
-    .limit(1)
-    .for("update", { skipLocked: true });
-  const deleteOpstamp = first.at(0)?.deleteOpstamp;
-  if (deleteOpstamp === undefined) {
-    return null;
-  }
-  if (deleteOpstamp === null) {
-    return panic("Committed corpus projection cleanup has no delete opstamp");
-  }
-  const candidates = await tx
-    .select({ id: corpusIndexProjectionIntents.id })
-    .from(corpusIndexProjectionIntents)
-    .where(
-      and(
-        eq(corpusIndexProjectionIntents.family, family),
-        eq(corpusIndexProjectionIntents.generation, generation),
-        eq(corpusIndexProjectionIntents.indexId, indexId),
-        scopedEntityIds === null
-          ? undefined
-          : inArray(corpusIndexProjectionIntents.entityId, scopedEntityIds),
-        eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
-        eq(corpusIndexProjectionIntents.deleteOpstamp, deleteOpstamp),
-        or(
-          isNull(corpusIndexProjectionIntents.leaseExpiresAt),
-          sql`${corpusIndexProjectionIntents.leaseExpiresAt} <= clock_timestamp()`,
-        ),
-      ),
-    )
-    .orderBy(asc(corpusIndexProjectionIntents.createdAt))
-    .limit(limit)
-    .for("update", { skipLocked: true });
+    .limit(limit * leasedOpstamps.length)
+    .for("update", {
+      of: corpusIndexProjectionIntents,
+      skipLocked: true,
+    });
   if (candidates.length === 0) {
-    return null;
+    return [];
   }
   const leaseToken = newLeaseToken();
   const claimAt = testNow ?? sql<Date>`clock_timestamp()`;
@@ -411,15 +504,14 @@ export const claimCorpusProjectionCleanupSettlementTx = async <
     testNow === undefined
       ? sql<Date>`clock_timestamp() + ${leaseMs} * INTERVAL '1 millisecond'`
       : new Date(testNow.getTime() + leaseMs);
-  const intentIds = candidates.map(({ id }) => id);
+  const candidateIds = candidates.map(({ id }) => id);
   const claimed = await tx
     .update(corpusIndexProjectionIntents)
     .set({ leaseToken, leaseExpiresAt, updatedAt: claimAt })
     .where(
       and(
-        inArray(corpusIndexProjectionIntents.id, intentIds),
+        inArray(corpusIndexProjectionIntents.id, candidateIds),
         eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
-        eq(corpusIndexProjectionIntents.deleteOpstamp, deleteOpstamp),
       ),
     )
     .returning({ id: corpusIndexProjectionIntents.id });
@@ -428,18 +520,45 @@ export const claimCorpusProjectionCleanupSettlementTx = async <
       `Corpus projection settlement claimed ${claimed.length} of ${candidates.length} revisions`,
     );
   }
-  const numericOpstamp = Number(deleteOpstamp);
-  if (!Number.isSafeInteger(numericOpstamp) || numericOpstamp < 0) {
-    return panic("Corpus projection delete opstamp exceeds safe integer range");
+  // One token for the turn: each lease settles or releases its own revisions,
+  // and the identity sets behind two delete tasks are disjoint.
+  const grouped = new Map<string, SettlementTaskGroup>();
+  for (const { id, deleteOpstamp } of candidates) {
+    if (deleteOpstamp === null) {
+      return panic("Committed corpus projection cleanup has no delete receipt");
+    }
+    const numericOpstamp = Number(deleteOpstamp);
+    if (!Number.isSafeInteger(numericOpstamp) || numericOpstamp < 0) {
+      return panic(
+        "Corpus projection delete opstamp exceeds safe integer range",
+      );
+    }
+    const group = grouped.get(numericOpstamp.toString());
+    if (group === undefined) {
+      const deleteTaskCreatedAt = taskInstants.get(deleteOpstamp.toString());
+      if (deleteTaskCreatedAt === undefined) {
+        return panic("Leased corpus projection delete task lost its instant");
+      }
+      grouped.set(numericOpstamp.toString(), {
+        deleteOpstamp: numericOpstamp,
+        deleteTaskCreatedAt,
+        intentIds: [id],
+      });
+      continue;
+    }
+    group.intentIds.push(id);
   }
-  return {
-    family,
-    generation,
-    indexId,
-    intentIds,
-    deleteOpstamp: numericOpstamp,
-    leaseToken,
-  };
+  return [...grouped.values()].map(
+    ({ deleteOpstamp, deleteTaskCreatedAt, intentIds }) => ({
+      family,
+      generation,
+      indexId,
+      intentIds,
+      deleteOpstamp,
+      deleteTaskCreatedAt,
+      leaseToken,
+    }),
+  );
 };
 
 export type CorpusProjectionCleanupSettlementResult =
@@ -454,8 +573,9 @@ export type CorpusProjectionCleanupSettlementResult =
     };
 
 /**
- * Opaque evidence that Quickwit's published splits crossed the delete opstamp
- * and an exact revision query observed zero remaining documents.
+ * Opaque evidence that every split that could hold the deleted revisions
+ * crossed the delete opstamp and that an exact revision query observed zero
+ * remaining documents.
  */
 export class CorpusProjectionCleanupSettlementProof {
   readonly indexId: string;
@@ -481,7 +601,13 @@ export class CorpusProjectionCleanupSettlementProof {
   }: VerifyCorpusProjectionCleanupSettlementOptions): Promise<
     Result<CorpusProjectionCleanupSettlementResult, CorpusIndexError>
   > {
-    const { indexId, intentIds, deleteOpstamp, leaseToken } = lease;
+    const {
+      indexId,
+      intentIds,
+      deleteOpstamp,
+      deleteTaskCreatedAt,
+      leaseToken,
+    } = lease;
     if (
       intentIds.length === 0 ||
       intentIds.length > CORPUS_PROJECTION_DELETE_MAX_REVISIONS ||
@@ -490,10 +616,22 @@ export class CorpusProjectionCleanupSettlementProof {
     ) {
       return panic("Corpus projection settlement request is invalid");
     }
-    const settlement = await readCorpusProjectionDeleteSettlement({
-      client,
+    // Which splits the delete has to have reached, and why the rest are not
+    // evidence of anything. The cleanup fence issues a delete only after the
+    // append publish barrier, so every revision this task targets was already
+    // published when the metastore created the task; a document lives in
+    // exactly one split. A split first published after that instant therefore
+    // holds no targeted revision of its own, and the appends that keep
+    // arriving cannot hold the proof open. A split with no publish timestamp
+    // stays in the proof: the barrier schedules publication, it does not
+    // prove it. What the split scan cannot see is a merge output published
+    // after the task that inherited documents from an input published before
+    // it; the exact revision count below is what refuses to settle then, and
+    // it is the step that makes the proof exact rather than merely bounded.
+    const settlement = await client.readDeleteSettlement({
       indexId,
       requiredOpstamp: deleteOpstamp,
+      deleteCreatedAt: deleteTaskCreatedAt,
     });
     if (settlement.isErr()) {
       return Result.err(settlement.error);
@@ -719,6 +857,7 @@ export const reopenCorpusProjectionCleanupTx = async (
       cleanupNotBefore: transitionAt,
       cleanupStartedAt: null,
       deleteOpstamp: null,
+      deleteTaskCreatedAt: null,
       settledAt: null,
       lastError: errorMessage.slice(0, 2048),
       updatedAt: transitionAt,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
@@ -8,7 +8,6 @@ import {
   CORPUS_INDEX_INGEST_TIMEOUT_MS,
   CorpusIndexError,
   type CorpusIndexClient,
-  type CorpusIndexDeleteSettlement,
   type CorpusIndexDeleteTask,
 } from "@/api/lib/legal-search/corpus-index-client";
 import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
@@ -399,20 +398,6 @@ export const deleteCorpusProjectionRevisions = async ({
     indexId,
     corpusProjectionRevisionsQuery(revisions),
   );
-
-type ReadCorpusProjectionDeleteSettlementOptions = {
-  client: Pick<CorpusIndexClient, "readDeleteSettlement">;
-  indexId: string;
-  requiredOpstamp: number;
-};
-
-export const readCorpusProjectionDeleteSettlement = async ({
-  client,
-  indexId,
-  requiredOpstamp,
-}: ReadCorpusProjectionDeleteSettlementOptions): Promise<
-  Result<CorpusIndexDeleteSettlement, CorpusIndexError>
-> => await client.readDeleteSettlement(indexId, requiredOpstamp);
 
 type CountCorpusProjectionRevisionsOptions = {
   client: Pick<CorpusIndexClient, "search">;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-reservation-plan.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-reservation-plan.db.test.ts
@@ -56,7 +56,8 @@ const appendSettledHistory = async (depth: number): Promise<void> => {
         (id, family, generation, entity_id, epoch, fingerprint, index_id, status,
          expected_document_count, append_started_at, append_committed_at,
          append_publish_barrier_at, cleanup_not_before, cleanup_started_at,
-         delete_opstamp, settled_at, created_at, updated_at)
+         delete_opstamp, delete_task_created_at, settled_at, created_at,
+         updated_at)
       SELECT
         ${settledRevision("i", String(depth))},
         'case_law', '${GENERATION}', ${entity("i")}, ${depth},
@@ -64,7 +65,8 @@ const appendSettledHistory = async (depth: number): Promise<void> => {
         '2026-07-01'::timestamptz, '2026-07-01'::timestamptz,
         '2026-07-01'::timestamptz, '2026-07-01'::timestamptz,
         '2026-07-01'::timestamptz, 1, '2026-07-01'::timestamptz,
-        '2026-07-01'::timestamptz, '2026-07-01'::timestamptz
+        '2026-07-01'::timestamptz, '2026-07-01'::timestamptz,
+        '2026-07-01'::timestamptz
       FROM generate_series(1, ${CONVERGED + IN_FLIGHT + RESERVABLE}) AS i
     `),
   );

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
+import { Temporal } from "@stll/time";
+
 import type { Transaction } from "@/api/db/root";
 import {
   caseLawDecisions,
@@ -56,6 +58,11 @@ import {
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
+/** The metastore instant a delete task receipt carries in these tests. */
+const DELETE_TASK_CREATED_AT = Temporal.Instant.from("2026-08-25T12:00:00Z");
+const LATER_DELETE_TASK_CREATED_AT = Temporal.Instant.from(
+  "2026-08-25T12:05:00Z",
+);
 const SOURCE_ID = toSafeId<"caseLawSource">(
   "0198e331-e578-7000-8000-000000000201",
 );
@@ -157,10 +164,11 @@ const withDatabaseClock = async <T>(
   });
 
 const settledProjectionClient = {
-  readDeleteSettlement: async (_indexId, requiredOpstamp) =>
+  readDeleteSettlement: async ({ requiredOpstamp }) =>
     Result.ok({
       requiredOpstamp,
-      publishedSplits: 1,
+      provingSplits: 1,
+      excludedSplits: 0,
       laggingSplits: 0,
       minAppliedOpstamp: requiredOpstamp,
       settled: true,
@@ -175,20 +183,23 @@ const verifySettlement = async ({
   intentIds: readonly SafeId<"corpusIndexProjectionIntent">[];
   deleteOpstamp: number;
 }) => {
-  const lease = await db.transaction(
-    async (tx) =>
-      await claimCorpusProjectionCleanupSettlementTx(
-        asTestRaw<Transaction>(tx),
-        {
-          family: "case_law",
-          generation: "case_law_v5",
-          indexId: INDEX_ID,
-          limit: 10,
-          leaseMs: 60_000,
-        },
-      ),
-  );
-  if (lease === null) {
+  const lease = (
+    await db.transaction(
+      async (tx) =>
+        await claimCorpusProjectionCleanupSettlementTx(
+          asTestRaw<Transaction>(tx),
+          {
+            family: "case_law",
+            generation: "case_law_v5",
+            indexId: INDEX_ID,
+            limit: 10,
+            taskLimit: 1,
+            leaseMs: 60_000,
+          },
+        ),
+    )
+  ).at(0);
+  if (lease === undefined) {
     return panic("Expected a projection settlement lease");
   }
   expect(lease.intentIds).toEqual(intentIds);
@@ -599,6 +610,7 @@ test("subject-scoped cleanup and settlement cannot claim another revision", asyn
         indexId: INDEX_ID,
         leaseToken: CLEANUP_LEASE_TOKEN,
         deleteOpstamp: 42,
+        deleteTaskCreatedAt: DELETE_TASK_CREATED_AT,
       }),
   );
 
@@ -612,12 +624,13 @@ test("subject-scoped cleanup and settlement cannot claim another revision", asyn
           indexId: INDEX_ID,
           scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
           limit: 10,
+          taskLimit: 1,
           leaseMs: 60_000,
           newLeaseToken: () => ERASE_CLEANUP_TOKEN,
         },
       ),
   );
-  expect(settlement?.intentIds).toEqual([SECOND_INTENT_ID]);
+  expect(settlement.at(0)?.intentIds).toEqual([SECOND_INTENT_ID]);
   expect(
     await db
       .select({
@@ -1637,6 +1650,7 @@ test("replacement deletes and settles the old revision before reserving the new 
           indexId: INDEX_ID,
           leaseToken: CLEANUP_LEASE_TOKEN,
           deleteOpstamp: 42,
+          deleteTaskCreatedAt: DELETE_TASK_CREATED_AT,
         }),
     ),
   ).toBe(1);
@@ -1649,11 +1663,13 @@ test("replacement deletes and settles the old revision before reserving the new 
           generation: "case_law_v5",
           indexId: INDEX_ID,
           limit: 10,
+          taskLimit: 1,
           leaseMs: 60_000,
         },
       ),
   );
-  if (releasedSettlementLease === null) {
+  const releasedLease = releasedSettlementLease.at(0);
+  if (releasedLease === undefined) {
     panic("Expected a releasable projection settlement lease");
   }
   expect(
@@ -1661,7 +1677,7 @@ test("replacement deletes and settles the old revision before reserving the new 
       async (tx) =>
         await releaseCorpusProjectionCleanupSettlementTx(
           asTestRaw<Transaction>(tx),
-          { lease: releasedSettlementLease },
+          { lease: releasedLease },
         ),
     ),
   ).toBe(1);
@@ -1751,6 +1767,7 @@ test("replacement deletes and settles the old revision before reserving the new 
           indexId: INDEX_ID,
           leaseToken: REOPEN_CLEANUP_LEASE_TOKEN,
           deleteOpstamp: 43,
+          deleteTaskCreatedAt: DELETE_TASK_CREATED_AT,
         }),
     ),
   ).toBe(1);
@@ -2036,6 +2053,7 @@ test("production transitions preserve PostgreSQL clock ordering under process sk
           indexId: INDEX_ID,
           leaseToken: CLEANUP_LEASE_TOKEN,
           deleteOpstamp: 60,
+          deleteTaskCreatedAt: DELETE_TASK_CREATED_AT,
         }),
     ),
   ).toBe(1);
@@ -2046,18 +2064,20 @@ test("production transitions preserve PostgreSQL clock ordering under process sk
         generation: "case_law_v5",
         indexId: INDEX_ID,
         limit: 1,
+        taskLimit: 1,
         leaseMs: 60_000,
         newLeaseToken: () => SECOND_LEASE_TOKEN,
       }),
   );
-  if (firstSettlement === null) {
+  const firstSettlementLease = firstSettlement.at(0);
+  if (firstSettlementLease === undefined) {
     panic("Expected first settlement lease");
   }
   expect(
     await withDatabaseClock(
       async (tx) =>
         await releaseCorpusProjectionCleanupSettlementTx(tx, {
-          lease: firstSettlement,
+          lease: firstSettlementLease,
         }),
     ),
   ).toBe(1);
@@ -2068,16 +2088,18 @@ test("production transitions preserve PostgreSQL clock ordering under process sk
         generation: "case_law_v5",
         indexId: INDEX_ID,
         limit: 1,
+        taskLimit: 1,
         leaseMs: 60_000,
         newLeaseToken: () => REOPEN_CLEANUP_LEASE_TOKEN,
       }),
   );
-  if (settlement === null) {
+  const settlementLease = settlement.at(0);
+  if (settlementLease === undefined) {
     panic("Expected settlement lease");
   }
   const verified = await CorpusProjectionCleanupSettlementProof.verify({
     client: settledProjectionClient,
-    lease: settlement,
+    lease: settlementLease,
   });
   if (verified.isErr()) {
     panic("Expected successful settlement verification");
@@ -2223,6 +2245,7 @@ test("a settled same-epoch attempt reopens after its retry is applied", async ()
         indexId: INDEX_ID,
         leaseToken: CLEANUP_LEASE_TOKEN,
         deleteOpstamp: 50,
+        deleteTaskCreatedAt: DELETE_TASK_CREATED_AT,
       }),
   );
   const firstProof = await verifySettlement({
@@ -2417,6 +2440,7 @@ test("erasure fences an unknown append and applies only after cleanup settlement
           indexId: INDEX_ID,
           leaseToken: ERASE_CLEANUP_TOKEN,
           deleteOpstamp: 43,
+          deleteTaskCreatedAt: DELETE_TASK_CREATED_AT,
         }),
     ),
   ).toBe(1);
@@ -2660,4 +2684,232 @@ test("cleanup claim and settlement phases have bounded partial access paths", as
     expect(definition).toContain("WHERE (status = 'cleanup_committed'::text)");
   }
   expect(definitions.size).toBe(3);
+});
+
+const seedCommittedCleanupPair = async (): Promise<void> => {
+  const cleanupAt = new Date("2026-08-25T00:00:00.000Z");
+  await db.insert(caseLawDecisions).values({
+    id: ERASE_DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "2 A 2/2026",
+    court: "Test court",
+    country: "CZE",
+    language: "cs",
+    contentHash: "d".repeat(64),
+    projectionEpoch: 1n,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: ERASE_DECISION_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: SECOND_FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+    updatedAt: INITIAL_RUNNABLE_AT,
+  });
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents DISABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
+  await db.insert(corpusIndexProjectionIntents).values([
+    {
+      id: FIRST_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: DECISION_ID,
+      epoch: 1n,
+      fingerprint: FIRST_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "cleanup_pending",
+      appendStartedAt: cleanupAt,
+      appendPublishBarrierAt: cleanupAt,
+      cleanupNotBefore: cleanupAt,
+    },
+    {
+      id: SECOND_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: ERASE_DECISION_ID,
+      epoch: 1n,
+      fingerprint: SECOND_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "cleanup_pending",
+      appendStartedAt: cleanupAt,
+      appendPublishBarrierAt: cleanupAt,
+      cleanupNotBefore: cleanupAt,
+    },
+  ]);
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents ENABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
+  await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        indexId: INDEX_ID,
+        limit: 10,
+        leaseMs: 60_000,
+        newLeaseToken: () => CLEANUP_LEASE_TOKEN,
+      }),
+  );
+  // Two delete tasks, one per revision, as cleanup issues them: one task per
+  // turn per index.
+  await db.transaction(
+    async (tx) =>
+      await recordCorpusProjectionDeleteTx(asTestRaw<Transaction>(tx), {
+        intentIds: [FIRST_INTENT_ID],
+        indexId: INDEX_ID,
+        leaseToken: CLEANUP_LEASE_TOKEN,
+        deleteOpstamp: 42,
+        deleteTaskCreatedAt: DELETE_TASK_CREATED_AT,
+      }),
+  );
+  await db.transaction(
+    async (tx) =>
+      await recordCorpusProjectionDeleteTx(asTestRaw<Transaction>(tx), {
+        intentIds: [SECOND_INTENT_ID],
+        indexId: INDEX_ID,
+        leaseToken: CLEANUP_LEASE_TOKEN,
+        deleteOpstamp: 43,
+        deleteTaskCreatedAt: LATER_DELETE_TASK_CREATED_AT,
+      }),
+  );
+};
+
+test("one settlement turn leases every delete task it is asked for", async () => {
+  await seedCommittedCleanupPair();
+
+  const leases = await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupSettlementTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          limit: 10,
+          taskLimit: 2,
+          leaseMs: 60_000,
+          newLeaseToken: () => ERASE_CLEANUP_TOKEN,
+        },
+      ),
+  );
+
+  expect(
+    leases.map(({ deleteOpstamp, deleteTaskCreatedAt, intentIds }) => ({
+      deleteOpstamp,
+      deleteTaskCreatedAt: deleteTaskCreatedAt.toString(),
+      intentIds,
+    })),
+  ).toEqual([
+    {
+      deleteOpstamp: 42,
+      deleteTaskCreatedAt: DELETE_TASK_CREATED_AT.toString(),
+      intentIds: [FIRST_INTENT_ID],
+    },
+    {
+      deleteOpstamp: 43,
+      deleteTaskCreatedAt: LATER_DELETE_TASK_CREATED_AT.toString(),
+      intentIds: [SECOND_INTENT_ID],
+    },
+  ]);
+});
+
+test("a settlement turn asked for one delete task leases one", async () => {
+  await seedCommittedCleanupPair();
+
+  const leases = await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupSettlementTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          limit: 10,
+          taskLimit: 1,
+          leaseMs: 60_000,
+          newLeaseToken: () => ERASE_CLEANUP_TOKEN,
+        },
+      ),
+  );
+
+  expect(leases.map(({ deleteOpstamp }) => deleteOpstamp)).toEqual([42]);
+});
+
+test("settlement proves the lease against the instant its delete task carries", async () => {
+  await seedCommittedCleanupPair();
+  const leases = await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupSettlementTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          limit: 10,
+          taskLimit: 1,
+          leaseMs: 60_000,
+          newLeaseToken: () => ERASE_CLEANUP_TOKEN,
+        },
+      ),
+  );
+  const lease = leases.at(0);
+  if (lease === undefined) {
+    panic("Expected a projection settlement lease");
+  }
+  // Stands in for an index taking continuous appends: the one split still
+  // below the opstamp was published after the delete task, so it holds none
+  // of its revisions. Which splits that rule keeps is pinned in
+  // `corpus-index-client.test.ts`; what this asserts is that the instant the
+  // receipt carries reaches the engine at all, and that a lease can settle.
+  const excludingClient = {
+    readDeleteSettlement: async ({
+      requiredOpstamp,
+      deleteCreatedAt,
+    }: {
+      requiredOpstamp: number;
+      deleteCreatedAt: Temporal.Instant | null;
+    }) => {
+      const excluded =
+        deleteCreatedAt !== null &&
+        Temporal.Instant.compare(deleteCreatedAt, DELETE_TASK_CREATED_AT) === 0;
+      return Result.ok({
+        requiredOpstamp,
+        provingSplits: excluded ? 1 : 2,
+        excludedSplits: excluded ? 1 : 0,
+        laggingSplits: excluded ? 0 : 1,
+        minAppliedOpstamp: excluded ? requiredOpstamp : requiredOpstamp - 1,
+        settled: excluded,
+      });
+    },
+    search: async () => Result.ok({ numHits: 0, hits: [], snippets: [] }),
+  } satisfies Pick<CorpusIndexClient, "readDeleteSettlement" | "search">;
+
+  const verified = await CorpusProjectionCleanupSettlementProof.verify({
+    client: excludingClient,
+    lease,
+  });
+  if (verified.isErr()) {
+    panic("Projection settlement verification failed", verified.error);
+  }
+  if (verified.value.status !== "verified") {
+    panic("Projection settlement unexpectedly remained pending");
+  }
+  const proof = verified.value.proof;
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await settleCorpusProjectionCleanupTx(asTestRaw<Transaction>(tx), {
+          proof,
+        }),
+    ),
+  ).toBe(1);
+  expect(
+    await db
+      .select({ status: corpusIndexProjectionIntents.status })
+      .from(corpusIndexProjectionIntents)
+      .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID)),
+  ).toEqual([{ status: "settled" }]);
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projections.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projections.db.test.ts
@@ -427,7 +427,8 @@ test("an erasure epoch fences an in-flight append until exact cleanup settles", 
   `);
   await db.execute(sql`
     UPDATE corpus_index_projection_intents
-    SET status = 'cleanup_committed', delete_opstamp = 42
+    SET status = 'cleanup_committed', delete_opstamp = 42,
+        delete_task_created_at = clock_timestamp()
     WHERE id = ${RACED_REVISION}
   `);
   await db.execute(sql`


### PR DESCRIPTION
Delete settlement records the delete task's creation instant and proves against the splits published before it; a settlement turn leases several delete tasks. Migration with an online repair. Tests updated.