### PR TITLE
fix(api): map a corpus index search failure to its own status

### DIFF
--- a/apps/api/src/lib/api-handlers.test.ts
+++ b/apps/api/src/lib/api-handlers.test.ts
@@ -400,6 +400,86 @@ describe("request.failed severity", () => {
   });
 });
 
+describe("a mapped status survives the transport wrapper", () => {
+  const runEndpoint = async (
+    body: Parameters<typeof createSafeRootHandler>[1],
+  ) => {
+    const analytics = installRecordingAnalytics();
+    const recordingLogger = installRecordingLogger();
+    try {
+      const endpoint = createSafeRootHandler(
+        {
+          permissions: { workspace: ["read"] },
+          mcp: { type: "internal", reason: "health_infra" },
+        },
+        body,
+      );
+      const safeDb: SafeDb = async <T>() =>
+        Result.err<T, SafeDbError>(new DatabaseError({ message: "unused" }));
+
+      return await endpoint.handler(createContext(endpoint, safeDb));
+    } finally {
+      recordingLogger.restore();
+      analytics.restore();
+    }
+  };
+
+  const upstreamRefusal = () =>
+    new HandlerError({
+      status: 503,
+      message: "Search is temporarily unavailable",
+    });
+
+  // Result.tryPromise answers a throw with UnhandledException, so an upstream
+  // status mapped deep inside the wrapped call reaches the boundary nested.
+  test("a status thrown through Result.tryPromise is answered, not graded 500", async () => {
+    const response = await runEndpoint(async function* () {
+      const value = yield* Result.await(
+        Result.tryPromise(async () => {
+          throw upstreamRefusal();
+        }),
+      );
+
+      return Result.ok({ value });
+    });
+
+    if (!("code" in response)) {
+      throw new Error("expected a status response");
+    }
+    expect(response.code).toBe(503);
+    expect(response.response.message).toBe("Search is temporarily unavailable");
+  });
+
+  // Result.gen answers a throw out of the generator body with a Panic.
+  test("a status thrown straight out of the handler body is answered", async () => {
+    const response = await runEndpoint(async function* () {
+      throw upstreamRefusal();
+    });
+
+    if (!("code" in response)) {
+      throw new Error("expected a status response");
+    }
+    expect(response.code).toBe(503);
+  });
+
+  test("an untyped failure is still graded a server fault", async () => {
+    const response = await runEndpoint(async function* () {
+      const value = yield* Result.await(
+        Result.tryPromise(async () => {
+          throw new Error("engine socket closed");
+        }),
+      );
+
+      return Result.ok({ value });
+    });
+
+    if (!("code" in response)) {
+      throw new Error("expected a status response");
+    }
+    expect(response.code).toBe(500);
+  });
+});
+
 describe("errorCauseChainAttributes", () => {
   test("records the status of a typed cause behind a generic wrapper", () => {
     const cause = new HandlerError({ status: 403, message: "byok missing" });

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -1,5 +1,5 @@
-import type { Err, UnhandledException } from "better-result";
-import { Result } from "better-result";
+import type { Err } from "better-result";
+import { Panic, Result, UnhandledException } from "better-result";
 import type {
   Context,
   ElysiaCustomStatusResponse,
@@ -562,6 +562,34 @@ type SafeHandlerLogContext = {
   route: string;
 };
 
+/** How far a typed status is followed through transport wrappers. */
+const MAX_TRANSPORT_WRAPPER_DEPTH = 3;
+
+/**
+ * The typed `HandlerError` an error carries, or null.
+ *
+ * A handler that throws a status rarely throws it here directly: a throw
+ * inside `Result.tryPromise` arrives as `UnhandledException` and one inside a
+ * `Result.gen` body arrives as `Panic`, both carrying the original as `cause`.
+ * Grading the wrapper spends the status the thrower chose, so a refusal the
+ * caller could act on (an upstream 503, a misconfiguration) is reported as a
+ * generic 500.
+ */
+const resolveHandlerError = (error: unknown): HandlerError | null => {
+  let candidate = error;
+  for (let depth = 0; depth <= MAX_TRANSPORT_WRAPPER_DEPTH; depth++) {
+    if (HandlerError.is(candidate)) {
+      return candidate;
+    }
+    if (!Panic.is(candidate) && !UnhandledException.is(candidate)) {
+      return null;
+    }
+    candidate = candidate.cause;
+  }
+
+  return null;
+};
+
 const runSafeHandler = async <
   TContext extends SafeHandlerLogContext,
   TResult extends SafeHandlerPayload,
@@ -578,19 +606,20 @@ const runSafeHandler = async <
 
     const error = result.error;
 
-    if (HandlerError.is(error)) {
-      const statusCode = error.status;
+    const handlerError = resolveHandlerError(error);
+    if (handlerError !== null) {
+      const statusCode = handlerError.status;
 
       if (statusCode >= 500) {
         logAndCaptureSafeError({
           request: ctx.request,
           route: ctx.route,
-          error,
+          error: handlerError,
           statusCode,
         });
       }
 
-      return toSafeStatusResponse(error.status, safeErrorBody(error));
+      return toSafeStatusResponse(statusCode, safeErrorBody(handlerError));
     }
 
     if (DatabaseError.is(error)) {
@@ -640,16 +669,20 @@ const runSafeHandler = async <
     // an AI request hitting a role the org has not configured a
     // BYOK key for) gets reported to the user as "Internal
     // server error" with no actionable detail.
-    if (HandlerError.is(error)) {
-      if (error.status >= 500) {
+    const handlerError = resolveHandlerError(error);
+    if (handlerError !== null) {
+      if (handlerError.status >= 500) {
         logAndCaptureSafeError({
           request: ctx.request,
           route: ctx.route,
-          error,
-          statusCode: error.status,
+          error: handlerError,
+          statusCode: handlerError.status,
         });
       }
-      return toSafeStatusResponse(error.status, safeErrorBody(error));
+      return toSafeStatusResponse(
+        handlerError.status,
+        safeErrorBody(handlerError),
+      );
     }
 
     logAndCaptureSafeError({

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
 import type { SearchCursor } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
@@ -47,6 +48,11 @@ let requestDelayMs: number;
  * physical copy of, say.
  */
 let snippetResponseBody: unknown;
+/**
+ * Status the fake engine answers every request with, when the test is about
+ * what a refusal does rather than what a result does.
+ */
+let engineFailureStatus: number | null;
 
 beforeEach(() => {
   responseBody = { num_hits: 0, hits: [], snippets: [] };
@@ -54,6 +60,7 @@ beforeEach(() => {
   requestBodies = [];
   requestDelayMs = 0;
   snippetResponseBody = null;
+  engineFailureStatus = null;
   const stub = async (
     _input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
@@ -63,6 +70,11 @@ beforeEach(() => {
     requestBodies.push(body);
     if (requestDelayMs > 0) {
       await Bun.sleep(requestDelayMs);
+    }
+    if (engineFailureStatus !== null) {
+      return new Response("engine refused the search", {
+        status: engineFailureStatus,
+      });
     }
     if (snippetResponseBody !== null && body["snippet_fields"] !== undefined) {
       return new Response(JSON.stringify(snippetResponseBody), { status: 200 });
@@ -896,5 +908,77 @@ describe("the reported engine time accounts for every round trip", () => {
     expect(requestBodies).toHaveLength(1);
     expect(page.scan.indexMs).toBeGreaterThanOrEqual(DELAY_MS);
     expect(page.scan.indexMs).toBeLessThanOrEqual(elapsedMs);
+  });
+});
+
+/**
+ * The client hands back a typed `CorpusIndexError` precisely so the failure can
+ * be named. These pin that the read spends it on a status instead of letting
+ * the value escape for the handler boundary to grade as an internal fault.
+ */
+describe("an engine refusal reaches the caller as a mapped status", () => {
+  const readPageFailure = async (): Promise<unknown> =>
+    await readPage().then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+  test("the engine's own 5xx is answered as 503", async () => {
+    engineFailureStatus = 500;
+
+    const failure = await readPageFailure();
+
+    if (!HandlerError.is(failure)) {
+      throw new Error("the read did not fail with a HandlerError");
+    }
+    // The engine reports overload as a 500, so this is the busy case too.
+    expect(failure.status).toBe(503);
+    expect(failure.cause).toBeDefined();
+  });
+
+  test("a request the engine refused is answered as 502", async () => {
+    engineFailureStatus = 400;
+
+    const failure = await readPageFailure();
+
+    if (!HandlerError.is(failure)) {
+      throw new Error("the read did not fail with a HandlerError");
+    }
+    // A malformed query is this module's doing; retrying cannot fix it.
+    expect(failure.status).toBe(502);
+  });
+
+  test("the highlight round maps its refusal the same way", async () => {
+    const hits = [{ document_id: "doc-a", seq: 1 }];
+    responseBody = {
+      num_hits: hits.length,
+      hits,
+      snippets: hits.map(() => ({ text: ["passage"] })),
+    };
+    // Only the highlight round asks for snippet fields, so failing on that
+    // request alone reaches the second read site with a page already scanned.
+    snippetResponseBody = null;
+    const stubbedFetch = globalThis.fetch;
+    globalThis.fetch = Object.assign(
+      async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ): Promise<Response> => {
+        const body: Record<string, unknown> =
+          typeof init?.body === "string" ? JSON.parse(init.body) : {};
+        if (body["snippet_fields"] !== undefined) {
+          return new Response("engine refused the highlight", { status: 503 });
+        }
+        return await stubbedFetch(input, init);
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+
+    const failure = await readPageFailure();
+
+    if (!HandlerError.is(failure)) {
+      throw new Error("the read did not fail with a HandlerError");
+    }
+    expect(failure.status).toBe(503);
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -1,9 +1,36 @@
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import type { QuickwitCluster } from "@/api/lib/legal-search/corpus-generation-contract";
-import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
+import type {
+  CorpusIndexError,
+  CorpusIndexHit,
+} from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
 import type { RankedHit, ScoredCandidate } from "@/api/lib/legal-search/rerank";
 import { LIMITS } from "@/api/lib/limits";
+
+/**
+ * The client answers a failed search with a typed `CorpusIndexError` so its
+ * caller can say what the failure was. Re-throwing that value raw spends the
+ * classification: no search handler catches `CorpusIndexError`, so the handler
+ * boundary grades it `UnhandledException` and answers 500, telling a reader
+ * the API broke when the engine is the thing that could not answer.
+ *
+ * The engine reports its own overload as a 5xx rather than a 429, so status
+ * alone cannot separate "busy" from "broken". Both are the caller's cue to
+ * retry, which is what 503 says; a 4xx means this module built a request the
+ * engine refused, which no retry fixes and 502 reports. Mapping matches
+ * `catalogueUpstreamStatus`, the same translation for the skill catalogue.
+ */
+const corpusIndexSearchFailure = (error: CorpusIndexError): HandlerError =>
+  new HandlerError({
+    status:
+      error.status === undefined || error.status === 429 || error.status >= 500
+        ? 503
+        : 502,
+    message: "Search is temporarily unavailable",
+    cause: error,
+  });
 
 /**
  * A page boundary as the scan means it. `corpus-search-cursor` owns how it
@@ -223,7 +250,7 @@ const readPageSnippets = async ({
   });
   const indexMs = performance.now() - startedAt;
   if (result.isErr()) {
-    throw result.error;
+    throw corpusIndexSearchFailure(result.error);
   }
 
   // Best-first, so the first snippet a document gets is its best-scoring
@@ -373,7 +400,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
     });
     indexMs += performance.now() - roundStartedAt;
     if (result.isErr()) {
-      throw result.error;
+      throw corpusIndexSearchFailure(result.error);
     }
 
     const hits = result.value.hits;


### PR DESCRIPTION
## Proposed change

`readCorpusIndexSearchPage` reads the index at two sites (the scan round and the
highlight round), and both did this:

```ts
if (result.isErr()) {
  throw result.error;
}
```

The client returns `Result<_, CorpusIndexError>` on purpose. Its doc comment says
"every call has a timeout and returns a typed Result", and `CorpusIndexError`
carries the engine's status. Throwing the value raw spends that classification:
nothing on the search path catches `CorpusIndexError`, not
`handlers/case-law/decisions/search.ts`, `handlers/legislation/search.ts`, or
`lib/legal-search/corpus-index-provider.ts`, so the handler boundary grades it
`UnhandledException` and answers **500**. The API reports itself broken for a
failure that belongs to the engine, and the caller learns nothing about whether
a retry is worth attempting.

This maps the error at the point where the classification still exists,
following `catalogueUpstreamStatus` in `lib/skills/skill-package.ts`, which
makes the same translation for the skill catalogue:

| engine result | answered | why |
| --- | --- | --- |
| 5xx, 429, or no status (timeout, transport, unreadable body) | 503 | the engine could not answer and a retry may succeed |
| 4xx | 502 | this module built a request the engine refused; no retry fixes that |

The engine reports its own overload as a 5xx rather than a 429, so status alone
cannot separate "busy" from "broken". Both are the caller's cue to retry, which
is what 503 says, so the two collapse onto one branch.

Scope is the synchronous read path only. The same `throw result.error` shape is
widespread in the queue and worker modules (`document-processing-queue`,
`file-derivative-queue`, and others), where throwing into the retry machinery is
the intended behaviour and there is no HTTP boundary to grade the value.

Tests cover both mapped statuses and the highlight round, which is the second
read site and only runs once a page has already been scanned. All three fail on
`main` (the error arrives as a bare `CorpusIndexError`) and pass here.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested.
- [ ] DARK MODE SUPPORT | Not applicable: no UI in this change.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI in this change.

Verified locally per package rather than through the aggregate pre-push hook,
which exhausts memory on my machine: `tsc --noEmit -p apps/api` clean, `oxlint`
clean on both changed files, and `bun test src/lib/legal-search/` green across
`corpus-index-pagination`, `corpus-index-client`, and
`corpus-index-projection-engine` (91 tests). The DB-backed suites in that
directory need a database and were left to CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_0192qs8A48H3UDrRN5hLYMaQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for legal search requests.
  - Server-side or overloaded search failures now return a service unavailable response.
  - Refused or invalid requests now return a bad gateway response.
  - Highlighting failures are handled consistently with search failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->