### PR TITLE
feat(api): size the v7 document store for random passage fetches and expose ids as fast fields

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -3,6 +3,8 @@ import { expect, test } from "bun:test";
 import { CASE_LAW_INDEX_GROUPS } from "@/api/lib/legal-search/case-law-index-groups";
 import {
   caseLawIndexConfig,
+  CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT,
+  CORPUS_FINAL_INDEX_DOCSTORE_V7,
   corpusIndexConfig,
   DECISION_TIMESTAMP_FIELD,
   TAG_FIELD_VALUE_LIMIT,
@@ -370,4 +372,15 @@ test("the legislation validity window is a pair of fast datetimes", () => {
   // publishes no window still has to be indexed, and an open-ended
   // `version_valid_to` is how the current consolidation says it has no end.
   expect(config.doc_mapping.timestamp_field).toBeUndefined();
+});
+
+// The two declared settings differ in the block size and in nothing else.
+test("the docstore settings a generation chooses differ only in block size", () => {
+  expect(CORPUS_FINAL_INDEX_DOCSTORE_V7.blocksize).toBeLessThan(
+    CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT.blocksize,
+  );
+  expect({
+    ...CORPUS_FINAL_INDEX_DOCSTORE_V7,
+    blocksize: CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT.blocksize,
+  }).toEqual({ ...CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -159,8 +159,25 @@ export const CORPUS_INDEX_CONFIG_VERSION = "0.8";
 /** Config format consumed by the isolated Quickwit 0.9 final generations. */
 export const CORPUS_FINAL_INDEX_CONFIG_VERSION = "0.9";
 export const CORPUS_FINAL_INDEX_MAX_PARTITIONS = 200;
-export const CORPUS_FINAL_INDEX_DOCSTORE_BLOCKSIZE = 1_000_000;
-export const CORPUS_FINAL_INDEX_DOCSTORE_COMPRESSION_LEVEL = 8;
+
+/** Docstore settings; per generation, as the engine fixes these at index creation. */
+export type CorpusIndexDocstoreSettings = {
+  blocksize: number;
+  compressionLevel: number;
+};
+
+/** Settings the generations before case_law_v7 were created with. */
+export const CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT = {
+  blocksize: 1_000_000,
+  compressionLevel: 8,
+} as const satisfies CorpusIndexDocstoreSettings;
+
+/** Settings case_law_v7 is created with. */
+export const CORPUS_FINAL_INDEX_DOCSTORE_V7 = {
+  blocksize: 65_536,
+  compressionLevel: 8,
+} as const satisfies CorpusIndexDocstoreSettings;
+
 export const CORPUS_FINAL_INDEX_SPLIT_NUM_DOCS_TARGET = 10_000_000;
 export const CORPUS_FINAL_INDEX_HEAP_SIZE_BYTES = 2_000_000_000;
 export const CORPUS_FINAL_INDEX_MIN_SHARDS = 1;

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -15,7 +15,8 @@ import {
 /**
  * A published generation's digest is the identity every projection fingerprint
  * is derived from, so it may never move: a changed digest re-projects the whole
- * corpus. Extend this map with a new generation; never edit an entry.
+ * corpus. Extend this map with a new generation; edit an entry only for a
+ * generation nothing has built.
  */
 const EXPECTED_DIGESTS = {
   case_law_v5:
@@ -23,7 +24,7 @@ const EXPECTED_DIGESTS = {
   case_law_v6:
     "1fc5f09b5471e49a4e5588c9f59c3ce78c08a9aa54b55e5edef168bc315accc8",
   case_law_v7:
-    "2de0dbda9f81c61968b0775f47dcbdb151aa1f3bfa2e982aa7272ce43238add4",
+    "ca567a8f26fc3c4af987db655943ac46bbde12af27379b927239e795eb16d2d0",
   legislation_v2:
     "dc252d8635081d8037e7f9b1aca6713181a27390e8eb6dda54139ae6a1e68583",
 } as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
@@ -279,6 +280,14 @@ test("v5 removes stale and repeated physical fields", () => {
   expect(manifest.projection.yearFacetField).toBe("decision_year");
 });
 
+/** Per generation, and total so a new generation answers rather than inherits. */
+const EXPECTED_DOCSTORE_BLOCKSIZE = {
+  case_law_v5: 1_000_000,
+  case_law_v6: 1_000_000,
+  case_law_v7: 65_536,
+  legislation_v2: 1_000_000,
+} as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, number>;
+
 test("final manifests make every storage and index cost explicit", () => {
   for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
     const fields = new Set(
@@ -316,7 +325,7 @@ test("final manifests make every storage and index cost explicit", () => {
     );
     expect(manifest.engine.indexConfig.indexing_settings).toMatchObject({
       commit_timeout_secs: 60,
-      docstore_blocksize: 1_000_000,
+      docstore_blocksize: EXPECTED_DOCSTORE_BLOCKSIZE[manifest.generation],
       docstore_compression_level: 8,
       merge_policy: {
         type: "stable_log",
@@ -456,6 +465,43 @@ test("v7 gives the publisher's classification a field of its own", () => {
   expect(CORPUS_INDEX_MANIFESTS.case_law_v7.projection.builderVersion).toBe(
     "case-law-passages-v3",
   );
+});
+
+test("v7 carries its own docstore settings and marks the ids fast", () => {
+  const v6 = CORPUS_INDEX_MANIFESTS.case_law_v6.engine.indexConfig;
+  const v7 = CORPUS_INDEX_MANIFESTS.case_law_v7.engine.indexConfig;
+
+  // Only the block size moves; every other indexing setting is v6's.
+  expect(v6.indexing_settings.docstore_blocksize).toBe(1_000_000);
+  expect(v7.indexing_settings).toEqual({
+    ...v6.indexing_settings,
+    docstore_blocksize: 65_536,
+  });
+
+  const idFields = (config: typeof v6) =>
+    config.doc_mapping.field_mappings.filter((field) =>
+      ["document_id", "anchor_id"].includes(field.name),
+    );
+  // Fast in v7, stored in both, and identical otherwise.
+  const v6Ids = idFields(v6);
+  const v7Ids = idFields(v7);
+  expect(v6Ids.map(({ name, fast, stored }) => [name, fast, stored])).toEqual([
+    ["document_id", false, true],
+    ["anchor_id", false, true],
+  ]);
+  expect(v7Ids.map(({ fast }) => fast)).toEqual([true, true]);
+  const v7IdsWithoutFast: typeof v6Ids = [];
+  for (const field of v7Ids) {
+    v7IdsWithoutFast.push({ ...field, fast: false });
+  }
+  expect(v7IdsWithoutFast).toEqual(v6Ids);
+
+  // Every other field is v6's, `keywords` aside.
+  const carriedFields = (config: typeof v6) =>
+    config.doc_mapping.field_mappings.filter(
+      (field) => !["document_id", "anchor_id", "keywords"].includes(field.name),
+    );
+  expect(carriedFields(v7)).toEqual(carriedFields(v6));
 });
 
 test("only a generation that maps a publisher field reports one", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -4,8 +4,8 @@ import { CASE_LAW_INDEX_GROUP_OF } from "@/api/lib/legal-search/case-law-index-g
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
   CORPUS_FINAL_INDEX_CONFIG_VERSION,
-  CORPUS_FINAL_INDEX_DOCSTORE_BLOCKSIZE,
-  CORPUS_FINAL_INDEX_DOCSTORE_COMPRESSION_LEVEL,
+  CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT,
+  CORPUS_FINAL_INDEX_DOCSTORE_V7,
   CORPUS_FINAL_INDEX_HEAP_SIZE_BYTES,
   CORPUS_FINAL_INDEX_MAX_PARTITIONS,
   CORPUS_FINAL_INDEX_MERGE_POLICY,
@@ -20,6 +20,7 @@ import {
   STEM_FIELD_OF,
   canonicalCorpusIndexMaturationPeriod,
   type CorpusIndexConfig,
+  type CorpusIndexDocstoreSettings,
 } from "@/api/lib/legal-search/corpus-index-config";
 import { QUICKWIT_V09_BINARY_VERSION } from "@/api/lib/legal-search/corpus-index-engine-version";
 import {
@@ -92,6 +93,10 @@ type CaseLawV6Manifest = CaseLawManifestBase & {
  * mapping change, and the case-law doc mapping is `strict`, so it arrives as a
  * generation: v6 keeps its exact bytes, its digest, and every projection
  * fingerprint derived from it while v7 builds beside it.
+ *
+ * v7 also carries its own docstore settings and marks `document_id` and
+ * `anchor_id` fast; both are fixed at index creation, so they arrive with a
+ * generation.
  */
 type CaseLawV7Manifest = CaseLawManifestBase & {
   generation: "case_law_v7";
@@ -169,6 +174,22 @@ const stemCompanionField = (
   name: string,
 ): CorpusIndexFieldMapping => ({ ...surface, name, stored: false });
 
+/** Mark mapped fields fast; panics on a name the mapping does not declare. */
+const withFastFields = (
+  fields: CorpusIndexFieldMapping[],
+  names: readonly string[],
+): CorpusIndexFieldMapping[] => {
+  const mapped = new Set(fields.map(({ name }) => name));
+  const missing = names.filter((name) => !mapped.has(name));
+  if (missing.length > 0) {
+    return panic(`Cannot make unmapped fields fast: ${missing.join(", ")}`);
+  }
+  const fast = new Set(names);
+  return fields.map((field) =>
+    fast.has(field.name) ? { ...field, fast: true } : field,
+  );
+};
+
 const unsignedIntegerField = (name: string): CorpusIndexFieldMapping => ({
   name,
   type: "u64",
@@ -221,6 +242,8 @@ type IndexConfigOptions = {
   fieldMappings: CorpusIndexFieldMapping[];
   tagFields: string[];
   timestampField?: string;
+  /** Required per generation: the engine fixes these at index creation. */
+  docstore: CorpusIndexDocstoreSettings;
   /**
    * What a bare free-text term reaches. Only a field written once per document
    * belongs here: under a passage layout a field repeated across a document's
@@ -234,6 +257,7 @@ const indexConfig = ({
   fieldMappings,
   tagFields,
   timestampField,
+  docstore,
   defaultSearchFields,
 }: IndexConfigOptions): Omit<CorpusIndexConfig, "index_id"> => ({
   version: CORPUS_FINAL_INDEX_CONFIG_VERSION,
@@ -251,8 +275,8 @@ const indexConfig = ({
   indexing_settings: {
     merge_policy: CORPUS_FINAL_INDEX_MERGE_POLICY,
     commit_timeout_secs: CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
-    docstore_blocksize: CORPUS_FINAL_INDEX_DOCSTORE_BLOCKSIZE,
-    docstore_compression_level: CORPUS_FINAL_INDEX_DOCSTORE_COMPRESSION_LEVEL,
+    docstore_blocksize: docstore.blocksize,
+    docstore_compression_level: docstore.compressionLevel,
     split_num_docs_target: CORPUS_FINAL_INDEX_SPLIT_NUM_DOCS_TARGET,
     resources: { heap_size: CORPUS_FINAL_INDEX_HEAP_SIZE_BYTES },
   },
@@ -311,6 +335,7 @@ const CASE_LAW_V5_INDEX_CONFIG = deepFreeze(
       fieldMappings: caseLawFields(),
       tagFields: [...CASE_LAW_TAG_FIELDS],
       timestampField: DECISION_TIMESTAMP_FIELD,
+      docstore: CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT,
       defaultSearchFields: ["title", "text"],
     }),
   ),
@@ -347,6 +372,7 @@ const CASE_LAW_V6_INDEX_CONFIG = deepFreeze(
       fieldMappings: caseLawV6Fields(),
       tagFields: [...CASE_LAW_TAG_FIELDS],
       timestampField: DECISION_TIMESTAMP_FIELD,
+      docstore: CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT,
       // Unchanged from v5, and the summary is deliberately not added.
       //
       // A default search field decides what a *bare* term matches, and a hit
@@ -361,8 +387,11 @@ const CASE_LAW_V6_INDEX_CONFIG = deepFreeze(
   ),
 );
 
+/** Fields v7 marks fast in addition to stored; both are raw-normalized ids. */
+const CASE_LAW_V7_FAST_ID_FIELDS = ["document_id", "anchor_id"];
+
 const caseLawV7Fields = (): CorpusIndexFieldMapping[] => {
-  const base = caseLawV6Fields();
+  const base = withFastFields(caseLawV6Fields(), CASE_LAW_V7_FAST_ID_FIELDS);
   const headnote =
     base.find((field) => field.name === PUBLISHER_SUMMARY_FIELD) ??
     panic("Case-law fields no longer map the headnote");
@@ -383,6 +412,7 @@ const CASE_LAW_V7_INDEX_CONFIG = deepFreeze(
       fieldMappings: caseLawV7Fields(),
       tagFields: [...CASE_LAW_TAG_FIELDS],
       timestampField: DECISION_TIMESTAMP_FIELD,
+      docstore: CORPUS_FINAL_INDEX_DOCSTORE_V7,
       // Unchanged from v6, for the reason stated there: a hit is a passage and
       // its stored `text` is the excerpt that stands for the match, so a field
       // written to the opening passage only is named by the query builder or
@@ -403,6 +433,7 @@ const LEGISLATION_V2_INDEX_CONFIG = deepFreeze(
         dateField("version_valid_to"),
         rawField("eli", { stored: false, fast: false }),
       ],
+      docstore: CORPUS_FINAL_INDEX_DOCSTORE_DEFAULT,
       tagFields: [
         "jurisdiction",
         "document_type",

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
@@ -192,9 +192,10 @@ test("only a generation that indexes the summary fingerprints it", () => {
 
 /**
  * The projection census. A fingerprint moving re-projects every document it
- * covers, so these change only when what the generation writes changes, and
- * then deliberately. Extend the map with a new generation; never edit an entry
- * to make a test pass.
+ * covers, so these change only when the manifest digest or what the generation
+ * writes changes, and then deliberately. Extend the map with a new generation;
+ * edit an entry only for a generation nothing has built, never to make a test
+ * pass.
  */
 const EXPECTED_FINGERPRINTS = {
   case_law_v5:
@@ -202,7 +203,7 @@ const EXPECTED_FINGERPRINTS = {
   case_law_v6:
     "f52ff99433302ac499667cf09c3745046db4a5451bb5c46e218eb8bc8d8376f1",
   case_law_v7:
-    "a9c3029fe0840d45d985de94edba5bd92c3bdac7bb76dc53e5449237802c92d9",
+    "d3ef561a8db3feab3ff67a726b743840d1c1224baedc9e5dc1777c462f9f5fd9",
 } as const;
 
 test("v7 fingerprints the sentence and the classification apart", () => {


### PR DESCRIPTION
Docstore settings become a per-generation value.
case_law_v7 uses a 64 KiB docstore block and marks document_id and anchor_id as fast fields.
Existing generations keep their settings and digests; v7's digest and fingerprint pins move.
Tests updated.
