### PR TITLE
feat(api): passage highlighter, passage reader and a snippet report script

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -47,6 +47,13 @@ export const FOLDED_TOKENIZER = {
   filters: ["lower_caser", "ascii_folding", "remove_long"],
 } as const satisfies CorpusIndexTokenizer;
 
+/**
+ * Byte length at which `remove_long` drops a token: the filter keeps a token
+ * shorter than this and discards the rest, so a term of this many UTF-8 bytes
+ * or more is in no index and matches no query.
+ */
+export const CORPUS_TOKEN_LENGTH_LIMIT_BYTES = 255;
+
 const CUSTOM_TOKENIZERS = [FOLDED_TOKENIZER] as const;
 
 type CorpusIndexFieldMapping = {

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CORPUS_SNIPPET_MAX_CHARS,
+  highlightCorpusPassage,
+} from "@/api/lib/legal-search/corpus-passage-highlight";
+import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
+import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
+import { searchHighlightMarks } from "@/api/lib/search/highlight";
+
+/**
+ * Window selection, the forms a passage word is matched by, the mark format,
+ * and the cuts: whole words only, budget respected, empty passage empty.
+ */
+
+const highlight = (
+  passage: string,
+  query: string,
+  options: { language?: "cs" | null; maxChars?: number } = {},
+) =>
+  highlightCorpusPassage({
+    passage,
+    tokens: tokenizeCorpusFreeText(query),
+    language: options.language === undefined ? "cs" : options.language,
+    maxChars: options.maxChars,
+  });
+
+describe("window selection", () => {
+  test("prefers the window holding more distinct query terms", () => {
+    const filler = "text ".repeat(30);
+    const passage = `alpha alpha alpha ${filler} alpha beta ${filler} end`;
+
+    const { text } = highlight(passage, "alpha beta", { maxChars: 40 });
+
+    expect(text).toContain("alpha beta");
+  });
+
+  test("prefers more matches when the distinct-term count ties", () => {
+    const filler = "slovo ".repeat(30);
+    const passage = `alpha ${filler} alpha alpha alpha ${filler} konec`;
+
+    const { text } = highlight(passage, "alpha", { maxChars: 40 });
+
+    expect(corpusTokens(text).filter((word) => word === "alpha")).toHaveLength(
+      3,
+    );
+  });
+
+  test("takes the earliest window when nothing else separates them", () => {
+    const filler = "slovo ".repeat(30);
+    const passage = `alpha ${filler} alpha`;
+
+    const { text } = highlight(passage, "alpha", { maxChars: 40 });
+
+    expect(passage.indexOf(text)).toBe(0);
+  });
+
+  test("a passage with no match yields its leading fragment", () => {
+    const passage = "první věta rozhodnutí. ".repeat(20);
+
+    const { html, text } = highlight(passage, "nesouvisející");
+
+    expect(passage.startsWith(text)).toBe(true);
+    expect(html).not.toContain("<mark>");
+    expect(text.length).toBeLessThanOrEqual(CORPUS_SNIPPET_MAX_CHARS);
+  });
+
+  test("an empty passage yields an empty fragment", () => {
+    expect(highlight("", "cokoliv")).toEqual({ html: "", text: "" });
+    expect(highlight("   \n\n  ", "cokoliv")).toEqual({ html: "", text: "" });
+  });
+});
+
+describe("matching", () => {
+  test("matches a Czech inflection through the stem the index holds", () => {
+    const passage =
+      "Soud posoudil ukončení nájemního vztahu k bytu podle občanského zákoníku.";
+
+    const { html } = highlight(passage, "nájemní");
+
+    expect(searchHighlightMarks(html)).toEqual(["nájemního"]);
+  });
+
+  test("matches text written with diacritics from a query written without", () => {
+    const passage = "Nárok na náhradu škody soud zamítl.";
+
+    const { html } = highlight(passage, "skody");
+
+    expect(searchHighlightMarks(html)).toEqual(["škody"]);
+  });
+
+  test("marks a phrase only where its words are adjacent", () => {
+    const passage =
+      "Jednání proti dobrým mravům je neplatné; dobrým úmyslem to nebylo, mravům navzdory.";
+
+    const { html } = highlight(passage, '"dobrým mravům"');
+
+    expect(searchHighlightMarks(html)).toEqual(["dobrým mravům"]);
+  });
+
+  test("a language without stemming still matches surface forms", () => {
+    const passage = "The court dismissed the claim for damages.";
+
+    const { html } = highlight(passage, "damages", { language: null });
+
+    expect(searchHighlightMarks(html)).toEqual(["damages"]);
+  });
+
+  test("overlapping matches merge into one mark", () => {
+    const passage = "Soud posoudil dobré mravy a dobré úmysly stran.";
+
+    const { html } = highlight(passage, '"dobré mravy" mravy');
+
+    expect(searchHighlightMarks(html)).toEqual(["dobré mravy"]);
+  });
+});
+
+describe("format", () => {
+  test("escapes the passage and marks in the form the browser renders", () => {
+    const passage = 'Smlouva & "podmínky" <b>alpha</b> uzavřená stranami.';
+
+    const { html } = highlight(passage, "alpha");
+
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&quot;podmínky&quot;");
+    expect(html).toContain("&lt;b&gt;<mark>alpha</mark>&lt;/b&gt;");
+  });
+
+  test("cuts on word boundaries, never inside a word", () => {
+    const passage =
+      "Nejvyšší soud posoudil neplatnost výpovědi z nájmu bytu podle ustanovení občanského zákoníku a rozhodnutí odvolacího soudu zrušil.";
+
+    const { text } = highlight(passage, "výpovědi", { maxChars: 60 });
+
+    const start = passage.indexOf(text);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const before = passage.slice(0, start);
+    const after = passage.slice(start + text.length);
+    expect(before === "" || /\W$/u.test(before)).toBe(true);
+    expect(after === "" || /^\W/u.test(after)).toBe(true);
+  });
+
+  test("keeps the fragment inside the character budget", () => {
+    const passage = "slovo ".repeat(200);
+
+    const { text } = highlight(passage, "slovo", { maxChars: 50 });
+
+    expect(text.length).toBeLessThanOrEqual(50);
+  });
+
+  test("a single word longer than the budget is still a fragment", () => {
+    const oversized = "a".repeat(200);
+
+    const { text } = highlight(oversized, "cokoliv", { maxChars: 50 });
+
+    expect(text).toBe(oversized);
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
@@ -106,6 +106,25 @@ describe("matching", () => {
     expect(searchHighlightMarks(html)).toEqual(["damages"]);
   });
 
+  test("marks a phrase that outruns the fragment budget", () => {
+    const phrase = "dobré mravy a poctivý obchodní styk podle ustanovení";
+    const passage = `Soud uvedl, že ${phrase} jsou zachovány.`;
+
+    const { html } = highlight(passage, `"${phrase}"`, { maxChars: 20 });
+
+    expect(searchHighlightMarks(html)).toEqual([phrase]);
+  });
+
+  test("ignores a token the index drops for length", () => {
+    const oversized = "a".repeat(300);
+    const passage = `${oversized} náhrada škody ${oversized}`;
+
+    const { html, text } = highlight(passage, `${oversized} škody`);
+
+    expect(searchHighlightMarks(html)).toEqual(["škody"]);
+    expect(text).toContain("náhrada škody");
+  });
+
   test("overlapping matches merge into one mark", () => {
     const passage = "Soud posoudil dobré mravy a dobré úmysly stran.";
 

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
@@ -11,8 +11,11 @@
  * `morphology/stem`. Pure.
  */
 
+import { Buffer } from "node:buffer";
+
 import { foldToAscii } from "@stll/text-normalize";
 
+import { CORPUS_TOKEN_LENGTH_LIMIT_BYTES } from "@/api/lib/legal-search/corpus-index-config";
 import type { CorpusQueryToken } from "@/api/lib/legal-search/corpus-query";
 import type { CorpusTokenSpan } from "@/api/lib/legal-search/corpus-tokens";
 import {
@@ -34,6 +37,13 @@ export const CORPUS_SNIPPET_MAX_CHARS = 100;
 export const foldCorpusTerm = (value: string): string =>
   foldToAscii(value.toLowerCase());
 
+/**
+ * Whether the index holds this folded token at all: `remove_long` drops the
+ * rest, so an over-long token (an OCR run) matches nothing on either side.
+ */
+const isIndexedTerm = (folded: string): boolean =>
+  Buffer.byteLength(folded, "utf-8") < CORPUS_TOKEN_LENGTH_LIMIT_BYTES;
+
 /** A word of the query, as the two forms a passage word is compared against. */
 type QueryWord = {
   folded: string;
@@ -45,7 +55,12 @@ type QueryWord = {
 type QueryTermWords = readonly QueryWord[];
 
 /** A passage word, folded and stemmed once so the scan below can be a scan. */
-type PassageWord = CorpusTokenSpan & { folded: string; stem: string };
+type PassageWord = CorpusTokenSpan & {
+  folded: string;
+  stem: string;
+  /** False for a token `remove_long` drops; such a word matches nothing. */
+  indexed: boolean;
+};
 
 const stemFolded = (
   value: string,
@@ -62,24 +77,34 @@ const queryTermWords = (
       folded: foldCorpusTerm(word),
       stem: stemFolded(word, language),
     }));
-    return words.length === 0 ? [] : [words];
+    // One dropped word makes the whole term unmatchable: a term is its word,
+    // and a phrase needs every one of its words to match adjacently.
+    return words.length === 0 ||
+      !words.every(({ folded }) => isIndexedTerm(folded))
+      ? []
+      : [words];
   });
 
 const passageWords = (
   text: string,
   language: MorphologyLanguage | null,
 ): PassageWord[] =>
-  corpusTokenSpans(text).map((span) => ({
-    value: span.value,
-    start: span.start,
-    end: span.end,
-    folded: foldCorpusTerm(span.value),
-    stem: stemFolded(span.value, language),
-  }));
+  corpusTokenSpans(text).map((span) => {
+    const folded = foldCorpusTerm(span.value);
+    return {
+      value: span.value,
+      start: span.start,
+      end: span.end,
+      folded,
+      stem: stemFolded(span.value, language),
+      indexed: isIndexedTerm(folded),
+    };
+  });
 
 const wordMatches = (word: PassageWord, queryWord: QueryWord): boolean =>
-  word.folded === queryWord.folded ||
-  (queryWord.stem !== "" && word.stem === queryWord.stem);
+  word.indexed &&
+  (word.folded === queryWord.folded ||
+    (queryWord.stem !== "" && word.stem === queryWord.stem));
 
 /** One term matching a run of passage words; `end` is exclusive. */
 type TermMatch = { termIndex: number; start: number; end: number };
@@ -114,8 +139,10 @@ type Window = { start: number; end: number; terms: number; matches: number };
  * matches, then earliest. A passage with no match therefore yields its opening
  * window.
  *
- * Each window is grown to the character budget before it is scored, so `end`
- * never moves backwards as `start` advances and the scan is linear.
+ * Each window is grown to the character budget before it is scored. The budget
+ * edge never moves backwards as `start` advances, so the scan is linear; a
+ * match that begins at `start` and outruns the budget extends that one window
+ * past it, the way an over-long single word forms a window of its own.
  */
 const bestWindow = (
   words: readonly PassageWord[],
@@ -134,7 +161,7 @@ const bestWindow = (
   };
 
   let best: Window | null = null;
-  let end = 0;
+  let budgetEnd = 0;
   // Matches are produced in start order, so a cursor over them is enough to
   // reach the ones a window can hold without rescanning the passage per window.
   let cursor = 0;
@@ -146,9 +173,21 @@ const bestWindow = (
       cursor += 1;
     }
     // A word longer than the whole budget still forms a window of its own.
-    end = Math.max(end, start + 1);
-    while (end < words.length && spanChars(start, end + 1) <= maxChars) {
-      end += 1;
+    budgetEnd = Math.max(budgetEnd, start + 1);
+    while (
+      budgetEnd < words.length &&
+      spanChars(start, budgetEnd + 1) <= maxChars
+    ) {
+      budgetEnd += 1;
+    }
+    // Kept out of `budgetEnd` so the widening applies to this window only.
+    let end = budgetEnd;
+    for (let index = cursor; index < matches.length; index += 1) {
+      const match = matches.at(index);
+      if (match === undefined || match.start > start) {
+        break;
+      }
+      end = Math.max(end, match.end);
     }
 
     const seen = new Set<number>();

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
@@ -1,0 +1,269 @@
+/**
+ * Cut a fragment out of a corpus passage and mark the query's matches in it.
+ *
+ * Takes the passage text, the query's tokens (`tokenizeCorpusFreeText`) and the
+ * language both sides are stemmed in. Returns the fragment twice: as
+ * HTML-escaped text with `<mark>` around each matched run, and as plain text.
+ *
+ * A passage word matches a query word when their folded surfaces are equal or
+ * their stems are; a phrase token matches consecutive passage words. Splitting,
+ * folding and stemming come from `corpus-tokens`, `@stll/text-normalize` and
+ * `morphology/stem`. Pure.
+ */
+
+import { foldToAscii } from "@stll/text-normalize";
+
+import type { CorpusQueryToken } from "@/api/lib/legal-search/corpus-query";
+import type { CorpusTokenSpan } from "@/api/lib/legal-search/corpus-tokens";
+import {
+  corpusTokens,
+  corpusTokenSpans,
+  normalizeCorpusText,
+} from "@/api/lib/legal-search/corpus-tokens";
+import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
+import { stemLegalTerm } from "@/api/lib/legal-search/morphology/stem";
+import { escapeSearchHtml } from "@/api/lib/search/highlight";
+
+/** Characters one fragment may span, unless a caller passes `maxChars`. */
+export const CORPUS_SNIPPET_MAX_CHARS = 100;
+
+/**
+ * The form terms are compared in: lower-cased, then ASCII-folded, matching the
+ * filter order of the index's `folded` tokenizer.
+ */
+export const foldCorpusTerm = (value: string): string =>
+  foldToAscii(value.toLowerCase());
+
+/** A word of the query, as the two forms a passage word is compared against. */
+type QueryWord = {
+  folded: string;
+  /** Empty when the language has no stemmer. */
+  stem: string;
+};
+
+/** One query token's words, in order; a phrase carries more than one. */
+type QueryTermWords = readonly QueryWord[];
+
+/** A passage word, folded and stemmed once so the scan below can be a scan. */
+type PassageWord = CorpusTokenSpan & { folded: string; stem: string };
+
+const stemFolded = (
+  value: string,
+  language: MorphologyLanguage | null,
+): string =>
+  language === null ? "" : foldCorpusTerm(stemLegalTerm(value, language));
+
+const queryTermWords = (
+  tokens: readonly CorpusQueryToken[],
+  language: MorphologyLanguage | null,
+): QueryTermWords[] =>
+  tokens.flatMap((token) => {
+    const words = corpusTokens(token.value).map((word) => ({
+      folded: foldCorpusTerm(word),
+      stem: stemFolded(word, language),
+    }));
+    return words.length === 0 ? [] : [words];
+  });
+
+const passageWords = (
+  text: string,
+  language: MorphologyLanguage | null,
+): PassageWord[] =>
+  corpusTokenSpans(text).map((span) => ({
+    value: span.value,
+    start: span.start,
+    end: span.end,
+    folded: foldCorpusTerm(span.value),
+    stem: stemFolded(span.value, language),
+  }));
+
+const wordMatches = (word: PassageWord, queryWord: QueryWord): boolean =>
+  word.folded === queryWord.folded ||
+  (queryWord.stem !== "" && word.stem === queryWord.stem);
+
+/** One term matching a run of passage words; `end` is exclusive. */
+type TermMatch = { termIndex: number; start: number; end: number };
+
+const termMatches = (
+  words: readonly PassageWord[],
+  terms: readonly QueryTermWords[],
+): TermMatch[] => {
+  const matches: TermMatch[] = [];
+  for (let start = 0; start < words.length; start += 1) {
+    for (const [termIndex, term] of terms.entries()) {
+      if (term.length > words.length - start) {
+        continue;
+      }
+      const matched = term.every((queryWord, offset) => {
+        const word = words.at(start + offset);
+        return word !== undefined && wordMatches(word, queryWord);
+      });
+      if (matched) {
+        matches.push({ termIndex, start, end: start + term.length });
+      }
+    }
+  }
+  return matches;
+};
+
+/** A candidate fragment, as a half-open range of passage words. */
+type Window = { start: number; end: number; terms: number; matches: number };
+
+/**
+ * The window a fragment is cut from: most distinct matched terms, then most
+ * matches, then earliest. A passage with no match therefore yields its opening
+ * window.
+ *
+ * Each window is grown to the character budget before it is scored, so `end`
+ * never moves backwards as `start` advances and the scan is linear.
+ */
+const bestWindow = (
+  words: readonly PassageWord[],
+  matches: readonly TermMatch[],
+  maxChars: number,
+): Window | null => {
+  if (words.length === 0) {
+    return null;
+  }
+  const spanChars = (start: number, end: number): number => {
+    const startWord = words.at(start);
+    const endWord = words.at(end - 1);
+    return startWord === undefined || endWord === undefined
+      ? 0
+      : endWord.end - startWord.start;
+  };
+
+  let best: Window | null = null;
+  let end = 0;
+  // Matches are produced in start order, so a cursor over them is enough to
+  // reach the ones a window can hold without rescanning the passage per window.
+  let cursor = 0;
+  for (let start = 0; start < words.length; start += 1) {
+    while (
+      cursor < matches.length &&
+      (matches.at(cursor)?.start ?? 0) < start
+    ) {
+      cursor += 1;
+    }
+    // A word longer than the whole budget still forms a window of its own.
+    end = Math.max(end, start + 1);
+    while (end < words.length && spanChars(start, end + 1) <= maxChars) {
+      end += 1;
+    }
+
+    const seen = new Set<number>();
+    let held = 0;
+    for (let index = cursor; index < matches.length; index += 1) {
+      const match = matches.at(index);
+      if (match === undefined || match.start >= end) {
+        break;
+      }
+      if (match.end > end) {
+        continue;
+      }
+      seen.add(match.termIndex);
+      held += 1;
+    }
+    if (
+      best === null ||
+      seen.size > best.terms ||
+      (seen.size === best.terms && held > best.matches)
+    ) {
+      best = { start, end, terms: seen.size, matches: held };
+    }
+  }
+  return best;
+};
+
+/** A character range of the passage that a `<mark>` covers. */
+type MarkRange = { start: number; end: number };
+
+const markRanges = (
+  words: readonly PassageWord[],
+  matches: readonly TermMatch[],
+  window: Window,
+): MarkRange[] => {
+  const ranges: MarkRange[] = [];
+  for (const match of matches) {
+    if (match.start < window.start || match.end > window.end) {
+      continue;
+    }
+    const startWord = words.at(match.start);
+    const endWord = words.at(match.end - 1);
+    if (startWord === undefined || endWord === undefined) {
+      continue;
+    }
+    // Matches arrive in start order, so an overlap can only be with the last
+    // range; overlapping ranges merge, because marks never nest.
+    const previous = ranges.at(-1);
+    if (previous !== undefined && startWord.start <= previous.end) {
+      previous.end = Math.max(previous.end, endWord.end);
+      continue;
+    }
+    ranges.push({ start: startWord.start, end: endWord.end });
+  }
+  return ranges;
+};
+
+const markFragment = (
+  text: string,
+  from: number,
+  to: number,
+  ranges: readonly MarkRange[],
+): string => {
+  let html = "";
+  let cursor = from;
+  for (const range of ranges) {
+    html += escapeSearchHtml(text.slice(cursor, range.start));
+    html += `<mark>${escapeSearchHtml(text.slice(range.start, range.end))}</mark>`;
+    cursor = range.end;
+  }
+  return html + escapeSearchHtml(text.slice(cursor, to));
+};
+
+type CorpusPassageFragment = {
+  /** HTML-escaped, with `<mark>` around each matched run. */
+  html: string;
+  /** The same fragment as plain text. */
+  text: string;
+};
+
+type HighlightCorpusPassageOptions = {
+  /** The passage as the index holds it. */
+  passage: string;
+  /** The query's tokens, from `tokenizeCorpusFreeText`. */
+  tokens: readonly CorpusQueryToken[];
+  /** The language both sides are stemmed in; null stems neither. */
+  language: MorphologyLanguage | null;
+  maxChars?: number | undefined;
+};
+
+/**
+ * The fragment of `passage` with the best match coverage for `tokens`.
+ *
+ * Cuts on word boundaries, so no fragment ends inside a word; an empty passage
+ * yields an empty fragment.
+ */
+export const highlightCorpusPassage = ({
+  passage,
+  tokens,
+  language,
+  maxChars = CORPUS_SNIPPET_MAX_CHARS,
+}: HighlightCorpusPassageOptions): CorpusPassageFragment => {
+  // The offsets below index the NFC form, so the fragment is cut from it too.
+  const text = normalizeCorpusText(passage);
+  const words = passageWords(text, language);
+  const matches = termMatches(words, queryTermWords(tokens, language));
+  const window = bestWindow(words, matches, maxChars);
+  if (window === null) {
+    return { html: "", text: "" };
+  }
+
+  const from = words.at(window.start)?.start ?? 0;
+  const to = words.at(window.end - 1)?.end ?? 0;
+  const ranges = markRanges(words, matches, window);
+  return {
+    html: markFragment(text, from, to, ranges),
+    text: text.slice(from, to),
+  };
+};

--- a/apps/api/src/lib/legal-search/corpus-passage-reader.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-reader.test.ts
@@ -146,6 +146,48 @@ describe("readCorpusPassages", () => {
     expect(astReads).toBe(1);
   });
 
+  test("reads the payloads concurrently, up to the limit", async () => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let inFlight = 0;
+    let peak = 0;
+    const pending: CorpusPayloadSource = {
+      readText: async (key) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await gate;
+        inFlight -= 1;
+        return await source.readText(key);
+      },
+      readAst: async (key) => await source.readAst(key),
+    };
+    const documentIds = ["d1", "d2", "d3"];
+
+    const results = readCorpusPassages({
+      requests: documentIds.map((documentId) => ({
+        documentId,
+        anchorId: chunks.at(0)?.anchorId ?? "",
+      })),
+      pointers: documentIds.map((documentId) => ({
+        documentId,
+        textS3Key: TEXT_KEY,
+        astS3Key: AST_KEY,
+      })),
+      source: pending,
+      concurrency: 2,
+    });
+    // A macrotask turn, so every read the pool starts has reached the gate.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    release();
+    await results;
+
+    expect(peak).toBe(2);
+  });
+
   test("reports a hit that carries no anchor", async () => {
     const results = await readCorpusPassages({
       requests: [{ documentId: DECISION_ID, anchorId: null }],

--- a/apps/api/src/lib/legal-search/corpus-passage-reader.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-reader.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+
+import { chunkDocument } from "@/api/lib/corpus-index/chunking";
+import {
+  readCorpusPassages,
+  selectCorpusPassage,
+  type CorpusPayloadSource,
+} from "@/api/lib/legal-search/corpus-passage-reader";
+
+/**
+ * The fixture is asserted against `chunkDocument` rather than a hand-copied
+ * string, so a returned passage is the chunker's passage by construction.
+ */
+
+const paragraph = (index: number, plainText: string): Block => ({
+  id: `p${index}`,
+  anchorId: `p${index}-anchor`,
+  type: "paragraph",
+  inlines: [],
+  plainText,
+});
+
+const astOf = (blocks: Block[]): DocumentAst => ({
+  version: 1,
+  source: { system: "test", documentId: "d", webUrl: "", printUrl: "" },
+  metadata: {
+    caseNumber: null,
+    ecli: null,
+    court: null,
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks,
+});
+
+const DECISION_ID = "decision-1";
+const TEXT_KEY = "corpus/decision-1/text";
+const AST_KEY = "corpus/decision-1/ast";
+
+// Long enough that the chunker closes a passage between them, so the fixture
+// has more than one anchor to address.
+const ast = astOf([
+  paragraph(0, `Úvodní odstavec rozhodnutí. ${"text ".repeat(120)}`),
+  paragraph(1, `Odůvodnění soudu. ${"slovo ".repeat(120)}`),
+  paragraph(2, `Závěrečný výrok. ${"konec ".repeat(120)}`),
+]);
+const fallbackText = "Nestrukturovaný text bez AST.";
+
+const chunks = chunkDocument({ ast, fallbackText });
+
+const source: CorpusPayloadSource = {
+  readText: async (key) =>
+    key === TEXT_KEY
+      ? fallbackText
+      : Promise.reject(new Error(`unexpected text key: ${key}`)),
+  readAst: async (key) =>
+    key === AST_KEY
+      ? ast
+      : Promise.reject(new Error(`unexpected ast key: ${key}`)),
+};
+
+const pointers = [
+  { documentId: DECISION_ID, textS3Key: TEXT_KEY, astS3Key: AST_KEY },
+];
+
+describe("selectCorpusPassage", () => {
+  test("returns the passage the anchor opens, as the chunker cut it", () => {
+    const second = chunks.at(1);
+    expect(second?.anchorId).toBeString();
+
+    expect(
+      selectCorpusPassage({
+        ast,
+        text: fallbackText,
+        anchorId: second?.anchorId ?? "",
+      }),
+    ).toEqual({
+      status: "found",
+      seq: second?.seq ?? -1,
+      text: second?.text ?? "",
+    });
+  });
+
+  test("reports an anchor no passage opens", () => {
+    expect(
+      selectCorpusPassage({ ast, text: fallbackText, anchorId: "p9-anchor" }),
+    ).toEqual({ status: "anchor_not_found" });
+  });
+
+  test("falls back to the plain text when the AST is unusable", () => {
+    expect(
+      selectCorpusPassage({
+        ast: {},
+        text: fallbackText,
+        anchorId: "p0-anchor",
+      }),
+    ).toEqual({ status: "anchor_not_found" });
+  });
+});
+
+describe("readCorpusPassages", () => {
+  test("answers in request order and reads a document's payload once", async () => {
+    let textReads = 0;
+    let astReads = 0;
+    const counting: CorpusPayloadSource = {
+      readText: async (key) => {
+        textReads += 1;
+        return await source.readText(key);
+      },
+      readAst: async (key) => {
+        astReads += 1;
+        return await source.readAst(key);
+      },
+    };
+    const first = chunks.at(0);
+    const second = chunks.at(1);
+
+    const results = await readCorpusPassages({
+      requests: [
+        { documentId: DECISION_ID, anchorId: second?.anchorId ?? "" },
+        { documentId: DECISION_ID, anchorId: first?.anchorId ?? "" },
+      ],
+      pointers,
+      source: counting,
+    });
+
+    expect(results).toEqual([
+      {
+        status: "found",
+        documentId: DECISION_ID,
+        seq: second?.seq ?? -1,
+        text: second?.text ?? "",
+      },
+      {
+        status: "found",
+        documentId: DECISION_ID,
+        seq: first?.seq ?? -1,
+        text: first?.text ?? "",
+      },
+    ]);
+    expect(textReads).toBe(1);
+    expect(astReads).toBe(1);
+  });
+
+  test("reports a hit that carries no anchor", async () => {
+    const results = await readCorpusPassages({
+      requests: [{ documentId: DECISION_ID, anchorId: null }],
+      pointers,
+      source,
+    });
+
+    expect(results).toEqual([
+      { status: "unanchored", documentId: DECISION_ID },
+    ]);
+  });
+
+  test("reports a document with no payload pointer", async () => {
+    const results = await readCorpusPassages({
+      requests: [{ documentId: "missing", anchorId: "p0-anchor" }],
+      pointers,
+      source,
+    });
+
+    expect(results).toEqual([{ status: "no_payload", documentId: "missing" }]);
+  });
+
+  test("reports an anchor the document does not hold", async () => {
+    const results = await readCorpusPassages({
+      requests: [{ documentId: DECISION_ID, anchorId: "p9-anchor" }],
+      pointers,
+      source,
+    });
+
+    expect(results).toEqual([
+      {
+        status: "anchor_not_found",
+        documentId: DECISION_ID,
+        anchorId: "p9-anchor",
+      },
+    ]);
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-passage-reader.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-reader.ts
@@ -12,6 +12,7 @@
 
 import { inArray } from "drizzle-orm";
 
+import { mapWithConcurrency } from "@stll/concurrency";
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
 import type { Transaction } from "@/api/db/root";
@@ -109,10 +110,14 @@ const corpusPayloadStorage: CorpusPayloadSource = {
   readAst: async (storedKey) => await readCorpusAst(storedKey),
 };
 
+/** Payload reads in flight at once, over the whole request list. */
+const PAYLOAD_READ_CONCURRENCY = 8;
+
 type ReadCorpusPassagesOptions = {
   requests: readonly CorpusPassageRequest[];
   pointers: readonly CorpusPassagePointer[];
   source?: CorpusPayloadSource;
+  concurrency?: number;
 };
 
 /** A decision's payload, as the chunker takes it. */
@@ -127,64 +132,66 @@ const loadPayload = async ({
   source: CorpusPayloadSource;
   textKey: string;
   astKey: string | null;
-}): Promise<LoadedPayload> => ({
-  text: await source.readText(textKey),
-  ast: astKey === null ? null : await source.readAst(astKey),
-});
+}): Promise<LoadedPayload> => {
+  const [text, ast] = await Promise.all([
+    source.readText(textKey),
+    astKey === null ? null : source.readAst(astKey),
+  ]);
+  return { text, ast };
+};
 
 /**
- * One result per request, in request order. A document's payload is read once
- * however many of the requests name it.
+ * One result per request, in request order. Each document's payload is read
+ * once however many requests name it, and the reads run `concurrency` at a
+ * time rather than one after another.
  */
 export const readCorpusPassages = async ({
   requests,
   pointers,
   source = corpusPayloadStorage,
+  concurrency = PAYLOAD_READ_CONCURRENCY,
 }: ReadCorpusPassagesOptions): Promise<CorpusPassageResult[]> => {
   const pointerById = new Map(
     pointers.map((pointer) => [pointer.documentId, pointer]),
   );
-  const payloads = new Map<string, Promise<LoadedPayload | null>>();
-  const payloadOf = async (
-    documentId: string,
-  ): Promise<LoadedPayload | null> => {
-    const started = payloads.get(documentId);
-    if (started !== undefined) {
-      return await started;
-    }
-    const pointer = pointerById.get(documentId);
-    const textKey = pointer?.textS3Key ?? null;
-    const astKey = pointer?.astS3Key ?? null;
-    const load: Promise<LoadedPayload | null> =
-      textKey === null
-        ? Promise.resolve(null)
-        : loadPayload({ source, textKey, astKey });
-    payloads.set(documentId, load);
-    return await load;
-  };
+  const wanted = [
+    ...new Set(
+      requests
+        .filter(({ anchorId }) => anchorId !== null)
+        .map(({ documentId }) => documentId),
+    ),
+  ];
+  const loaded = await mapWithConcurrency({
+    items: wanted,
+    limit: concurrency,
+    operation: async (documentId): Promise<LoadedPayload | null> => {
+      const pointer = pointerById.get(documentId);
+      const textKey = pointer?.textS3Key ?? null;
+      return textKey === null
+        ? null
+        : await loadPayload({
+            source,
+            textKey,
+            astKey: pointer?.astS3Key ?? null,
+          });
+    },
+  });
+  // `mapWithConcurrency` answers in input order, so index maps back to id.
+  const payloads = new Map(
+    wanted.map((documentId, index) => [documentId, loaded.at(index) ?? null]),
+  );
 
-  const results: CorpusPassageResult[] = [];
-  for (const { documentId, anchorId } of requests) {
+  return requests.map(({ documentId, anchorId }): CorpusPassageResult => {
     if (anchorId === null) {
-      results.push({ status: "unanchored", documentId });
-      continue;
+      return { status: "unanchored", documentId };
     }
-    const payload = await payloadOf(documentId);
+    const payload = payloads.get(documentId) ?? null;
     if (payload === null) {
-      results.push({ status: "no_payload", documentId });
-      continue;
+      return { status: "no_payload", documentId };
     }
     const selected = selectCorpusPassage({ ...payload, anchorId });
-    results.push(
-      selected.status === "found"
-        ? {
-            status: "found",
-            documentId,
-            seq: selected.seq,
-            text: selected.text,
-          }
-        : { status: "anchor_not_found", documentId, anchorId },
-    );
-  }
-  return results;
+    return selected.status === "found"
+      ? { status: "found", documentId, seq: selected.seq, text: selected.text }
+      : { status: "anchor_not_found", documentId, anchorId };
+  });
 };

--- a/apps/api/src/lib/legal-search/corpus-passage-reader.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-reader.ts
@@ -1,0 +1,190 @@
+/**
+ * Read a decision's passages back out of storage and address one by anchor id.
+ *
+ * Takes `{ documentId, anchorId }` per hit plus the decisions' payload pointers
+ * and returns one result per request, in request order. The payload is chunked
+ * with `chunkDocument`, so a returned passage is the passage that was indexed;
+ * the anchor is a chunk's first block, so it names exactly one chunk.
+ *
+ * A passage from the plain-text fallback carries no anchor and is reported as
+ * `unanchored` rather than located by position.
+ */
+
+import { inArray } from "drizzle-orm";
+
+import type { DocumentAst } from "@stll/legal-ast/document-ast";
+
+import type { Transaction } from "@/api/db/root";
+import { caseLawDecisions } from "@/api/db/schema";
+import { hasUsableAst } from "@/api/lib/case-law/document-ast";
+import { chunkDocument } from "@/api/lib/corpus-index/chunking";
+import {
+  readCorpusAst,
+  readCorpusText,
+} from "@/api/lib/legal-search/corpus-storage";
+import type { EmptyAst } from "@/api/lib/legal-search/document-types";
+import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
+
+/** Where one decision's payload lives, as the row stores it. */
+type CorpusPassagePointer = {
+  documentId: string;
+  textS3Key: string | null;
+  astS3Key: string | null;
+};
+
+/** One hit, as the two fields the passage is addressed by. */
+type CorpusPassageRequest = {
+  documentId: string;
+  /** The hit's `anchor_id`; null for a passage cut from unstructured text. */
+  anchorId: string | null;
+};
+
+/** The passage, or why there is none. Every miss is a value, not a throw. */
+export type CorpusPassageResult =
+  | { status: "found"; documentId: string; seq: number; text: string }
+  /** The hit carries no anchor, so no single passage is named. */
+  | { status: "unanchored"; documentId: string }
+  /** The decision is gone, or its payload pointer was never written. */
+  | { status: "no_payload"; documentId: string }
+  /** The document was read, but no passage of it starts at this anchor. */
+  | { status: "anchor_not_found"; documentId: string; anchorId: string };
+
+type PassageSelection =
+  | { status: "found"; seq: number; text: string }
+  | { status: "anchor_not_found" };
+
+/** The passage of this payload that starts at `anchorId`. Pure. */
+export const selectCorpusPassage = ({
+  ast,
+  text,
+  anchorId,
+}: {
+  ast: DocumentAst | EmptyAst | null;
+  text: string;
+  anchorId: string;
+}): PassageSelection => {
+  const chunks = chunkDocument({
+    ast: hasUsableAst(ast) ? ast : null,
+    fallbackText: text,
+  });
+  const chunk = chunks.find((candidate) => candidate.anchorId === anchorId);
+  return chunk === undefined
+    ? { status: "anchor_not_found" }
+    : { status: "found", seq: chunk.seq, text: chunk.text };
+};
+
+/** Payload pointers for the named decisions, in one statement. */
+export const readCaseLawPassagePointersTx = async (
+  tx: Transaction,
+  documentIds: readonly string[],
+): Promise<CorpusPassagePointer[]> => {
+  if (documentIds.length === 0) {
+    return [];
+  }
+  const ids = documentIds.map((id) => brandPersistedCaseLawDecisionId(id));
+  const rows = await tx
+    .select({
+      documentId: caseLawDecisions.id,
+      textS3Key: caseLawDecisions.textS3Key,
+      astS3Key: caseLawDecisions.astS3Key,
+    })
+    .from(caseLawDecisions)
+    .where(inArray(caseLawDecisions.id, ids))
+    .limit(ids.length);
+  return rows.map((row) => ({
+    documentId: String(row.documentId),
+    textS3Key: row.textS3Key,
+    astS3Key: row.astS3Key,
+  }));
+};
+
+/** The two payload reads, as a seam a test can fill with a fixture. */
+export type CorpusPayloadSource = {
+  readText: (storedKey: string) => Promise<string>;
+  readAst: (storedKey: string) => Promise<DocumentAst | EmptyAst | null>;
+};
+
+const corpusPayloadStorage: CorpusPayloadSource = {
+  readText: async (storedKey) => await readCorpusText(storedKey),
+  readAst: async (storedKey) => await readCorpusAst(storedKey),
+};
+
+type ReadCorpusPassagesOptions = {
+  requests: readonly CorpusPassageRequest[];
+  pointers: readonly CorpusPassagePointer[];
+  source?: CorpusPayloadSource;
+};
+
+/** A decision's payload, as the chunker takes it. */
+type LoadedPayload = { ast: DocumentAst | EmptyAst | null; text: string };
+
+/** Both halves of one decision's payload; no AST pointer means no AST. */
+const loadPayload = async ({
+  source,
+  textKey,
+  astKey,
+}: {
+  source: CorpusPayloadSource;
+  textKey: string;
+  astKey: string | null;
+}): Promise<LoadedPayload> => ({
+  text: await source.readText(textKey),
+  ast: astKey === null ? null : await source.readAst(astKey),
+});
+
+/**
+ * One result per request, in request order. A document's payload is read once
+ * however many of the requests name it.
+ */
+export const readCorpusPassages = async ({
+  requests,
+  pointers,
+  source = corpusPayloadStorage,
+}: ReadCorpusPassagesOptions): Promise<CorpusPassageResult[]> => {
+  const pointerById = new Map(
+    pointers.map((pointer) => [pointer.documentId, pointer]),
+  );
+  const payloads = new Map<string, Promise<LoadedPayload | null>>();
+  const payloadOf = async (
+    documentId: string,
+  ): Promise<LoadedPayload | null> => {
+    const started = payloads.get(documentId);
+    if (started !== undefined) {
+      return await started;
+    }
+    const pointer = pointerById.get(documentId);
+    const textKey = pointer?.textS3Key ?? null;
+    const astKey = pointer?.astS3Key ?? null;
+    const load: Promise<LoadedPayload | null> =
+      textKey === null
+        ? Promise.resolve(null)
+        : loadPayload({ source, textKey, astKey });
+    payloads.set(documentId, load);
+    return await load;
+  };
+
+  const results: CorpusPassageResult[] = [];
+  for (const { documentId, anchorId } of requests) {
+    if (anchorId === null) {
+      results.push({ status: "unanchored", documentId });
+      continue;
+    }
+    const payload = await payloadOf(documentId);
+    if (payload === null) {
+      results.push({ status: "no_payload", documentId });
+      continue;
+    }
+    const selected = selectCorpusPassage({ ...payload, anchorId });
+    results.push(
+      selected.status === "found"
+        ? {
+            status: "found",
+            documentId,
+            seq: selected.seq,
+            text: selected.text,
+          }
+        : { status: "anchor_not_found", documentId, anchorId },
+    );
+  }
+  return results;
+};

--- a/apps/api/src/lib/legal-search/corpus-tokens.ts
+++ b/apps/api/src/lib/legal-search/corpus-tokens.ts
@@ -22,14 +22,45 @@
  */
 const CORPUS_TOKEN_PATTERN = /[\p{L}\p{N}]+/gu;
 
-export const corpusTokens = (text: string): string[] => {
-  const tokens: string[] = [];
+/**
+ * The form the offsets below are measured in. A caller that slices text by
+ * those offsets normalises it with this first.
+ */
+export const normalizeCorpusText = (text: string): string =>
+  text.normalize("NFC");
+
+/** One token and where it sits in {@link normalizeCorpusText} of the input. */
+export type CorpusTokenSpan = {
+  value: string;
+  /** Inclusive start offset. */
+  start: number;
+  /** Exclusive end offset. */
+  end: number;
+};
+
+/**
+ * Tokens with their offsets. The offsets are into the NFC form, not into the
+ * caller's string: normalisation can change length, so an offset taken here
+ * only addresses text that was normalised the same way.
+ */
+export const corpusTokenSpans = (text: string): CorpusTokenSpan[] => {
+  const spans: CorpusTokenSpan[] = [];
   // `matchAll` over `match`: text with no token is an empty iteration rather
   // than a null needing a fallback, so there is one code path and no second
   // spelling of "no tokens". It also iterates its own regex clone, which is
   // what makes a shared pattern object safe to reuse here.
-  for (const [token] of text.normalize("NFC").matchAll(CORPUS_TOKEN_PATTERN)) {
-    tokens.push(token);
+  for (const match of normalizeCorpusText(text).matchAll(
+    CORPUS_TOKEN_PATTERN,
+  )) {
+    spans.push({
+      value: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+    });
   }
-  return tokens;
+  return spans;
 };
+
+/** Derived from the spans, so there is one scan of the rule, not two. */
+export const corpusTokens = (text: string): string[] =>
+  corpusTokenSpans(text).map(({ value }) => value);

--- a/apps/api/src/lib/search/highlight.ts
+++ b/apps/api/src/lib/search/highlight.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import {
   applyArabicFolds,
   applyArabicFoldsWithOffsets,
@@ -814,15 +816,54 @@ export const restoreOriginalSearchPreview = ({
   return truncateHighlightAware(content, maxLength);
 };
 
-/** HTML-escape text, then replace highlight markers with `<mark>` tags. */
-export const escapeAndHighlight = (text: string): string => {
-  const escaped = text
+/** HTML-escape text for a search snippet: `&`, `<`, `>`, `"`, `'`. */
+export const escapeSearchHtml = (text: string): string =>
+  text
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#x27;");
-  return escaped
+
+/** HTML-escape text, then replace highlight markers with `<mark>` tags. */
+export const escapeAndHighlight = (text: string): string =>
+  escapeSearchHtml(text)
     .replaceAll(HIGHLIGHT_START, "<mark>")
     .replaceAll(HIGHLIGHT_STOP, "</mark>");
+
+const HTML_ENTITY_TEXT = new Map<string, string>([
+  ["&amp;", "&"],
+  ["&lt;", "<"],
+  ["&gt;", ">"],
+  ["&quot;", '"'],
+  ["&#x27;", "'"],
+  ["&#39;", "'"],
+]);
+const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#x27|#39);/gu;
+const HIGHLIGHT_TAG_PATTERN = /<\/?mark>/gu;
+
+/**
+ * A snippet as plain text. Tags are dropped before entities are decoded, so an
+ * escaped literal `&lt;mark&gt;` survives as text; entities are decoded in one
+ * pass so `&amp;lt;` decodes to `&lt;`, not `<`.
+ */
+export const stripSearchHighlightMarkup = (snippet: string): string =>
+  snippet
+    .replaceAll(HIGHLIGHT_TAG_PATTERN, "")
+    .replaceAll(
+      HTML_ENTITY_PATTERN,
+      (entity) =>
+        HTML_ENTITY_TEXT.get(entity) ??
+        panic(`Unmapped HTML entity: ${entity}`),
+    );
+
+const MARKED_RUN_PATTERN = /<mark>(?<marked>[^<]*)<\/mark>/gu;
+
+/** The `<mark>`-wrapped runs of a snippet, as text, in order. */
+export const searchHighlightMarks = (snippet: string): string[] => {
+  const marks: string[] = [];
+  for (const match of snippet.matchAll(MARKED_RUN_PATTERN)) {
+    marks.push(stripSearchHighlightMarkup(match[1] ?? ""));
+  }
+  return marks;
 };

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -16,6 +16,7 @@ import {
   decodePaginationCursor,
   encodePaginationCursor,
 } from "@/api/lib/pagination";
+import { stripSearchHighlightMarkup } from "@/api/lib/search/highlight";
 import { isRecord, isUnknownArray } from "@/api/lib/type-guards";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { getAccessibleWorkspaceId } from "@/api/mcp/context";
@@ -1185,39 +1186,15 @@ export const invokeAiTool = async <TArgs extends Record<string, unknown>>({
   }
 };
 
-const HTML_ENTITY_TEXT = new Map([
-  ["&amp;", "&"],
-  ["&lt;", "<"],
-  ["&gt;", ">"],
-  ["&quot;", '"'],
-  ["&#x27;", "'"],
-  ["&#39;", "'"],
-]);
-const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#x27|#39);/gu;
-const HIGHLIGHT_TAG_PATTERN = /<\/?mark>/gu;
-
 /**
- * Plain text for a search snippet built for the web UI. `escapeAndHighlight`
- * (see `lib/search/highlight.ts`) HTML-escapes the snippet and wraps matches in
- * `<mark>`; an MCP client is an agent or a terminal, never a browser, so the
- * markup is noise there. Tags are dropped before entities are decoded, so an
- * escaped literal `&lt;mark&gt;` in the source text survives as text. Entities
- * are decoded in one pass so `&amp;lt;` decodes to `&lt;`, not `<`.
+ * Plain text for a search snippet built for the web UI. A snippet is
+ * HTML-escaped and wraps its matches in `<mark>`; an MCP client is an agent or
+ * a terminal, never a browser, so the markup is noise there. The format's
+ * owner (`lib/search/highlight.ts`) reads it back; what this adds is the
+ * absent-snippet contract every tool here wants.
  */
-export const toPlainTextSnippet = (snippet: string | null): string | null => {
-  if (snippet === null) {
-    return null;
-  }
-
-  return snippet
-    .replaceAll(HIGHLIGHT_TAG_PATTERN, "")
-    .replaceAll(
-      HTML_ENTITY_PATTERN,
-      (entity) =>
-        HTML_ENTITY_TEXT.get(entity) ??
-        panic(`Unmapped HTML entity: ${entity}`),
-    );
-};
+export const toPlainTextSnippet = (snippet: string | null): string | null =>
+  snippet === null ? null : stripSearchHighlightMarkup(snippet);
 
 export const normalizeTextField = ({
   allowEmptyFallback = true,

--- a/apps/api/src/scripts/corpus-snippet-compare-report.test.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare-report.test.ts
@@ -1,0 +1,315 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
+import {
+  compareSnippetFragments,
+  DEFAULT_SNIPPET_COMPARE_LIMIT,
+  parseSnippetCompareArgs,
+  parseSnippetCompareQueryFile,
+  passageSkipReason,
+  renderSnippetCompareMarkdown,
+  SnippetCompareFileError,
+  snippetCompareReport,
+  summarizeSnippetComparison,
+  type SnippetCompareQueryRow,
+} from "@/api/scripts/corpus-snippet-compare-report";
+
+/** Argument and query-file parsing, the fragment comparison, the renderings. */
+
+describe("parseSnippetCompareArgs", () => {
+  test("parses the required flags and defaults the page size", () => {
+    expect(
+      parseSnippetCompareArgs([
+        "--queries",
+        "queries.json",
+        "--out-dir",
+        ".cache/snippets",
+      ]),
+    ).toEqual({
+      type: "parsed",
+      args: {
+        queriesPath: "queries.json",
+        outDir: ".cache/snippets",
+        limit: DEFAULT_SNIPPET_COMPARE_LIMIT,
+      },
+    });
+  });
+
+  test("takes an explicit page size", () => {
+    expect(
+      parseSnippetCompareArgs([
+        "--queries",
+        "q.json",
+        "--out-dir",
+        "out",
+        "--limit",
+        "3",
+      ]),
+    ).toEqual({
+      type: "parsed",
+      args: { queriesPath: "q.json", outDir: "out", limit: 3 },
+    });
+  });
+
+  test.each([
+    [[]],
+    [["--queries", "q.json"]],
+    [["--out-dir", "out"]],
+    [["--queries", "q.json", "--out-dir", "out", "--depth", "3"]],
+    [["--queries", "q.json", "--queries", "r.json", "--out-dir", "out"]],
+    [["queries.json", "--out-dir", "out"]],
+    [["--queries", "--out-dir", "out"]],
+    [["--queries", "q.json", "--out-dir", "out", "--limit", "0"]],
+    [["--queries", "q.json", "--out-dir", "out", "--limit", "many"]],
+  ])("rejects %j", (argv) => {
+    expect(parseSnippetCompareArgs(argv).type).toBe("invalid");
+  });
+});
+
+describe("parseSnippetCompareQueryFile", () => {
+  test("parses a query set", () => {
+    const parsed = parseSnippetCompareQueryFile(
+      JSON.stringify([{ id: "a", text: "náhrada škody", country: "cze" }]),
+    );
+
+    expect(Result.isOk(parsed) && parsed.value).toEqual([
+      { id: "a", text: "náhrada škody", country: "cze" },
+    ]);
+  });
+
+  test.each([
+    ["not json", "{"],
+    ["an empty set", "[]"],
+    [
+      "duplicate ids",
+      JSON.stringify([
+        { id: "a", text: "x", country: "cze" },
+        { id: "a", text: "y", country: "cze" },
+      ]),
+    ],
+    ["a missing country", JSON.stringify([{ id: "a", text: "x" }])],
+    [
+      "a country that is not a code",
+      JSON.stringify([{ id: "a", text: "x", country: "Czech Republic" }]),
+    ],
+    [
+      "an unknown field",
+      JSON.stringify([
+        { id: "a", text: "x", country: "cze", jurisdiction: "cze" },
+      ]),
+    ],
+  ])("rejects %s", (_case, content) => {
+    const parsed = parseSnippetCompareQueryFile(content);
+    expect(Result.isError(parsed)).toBe(true);
+    expect(Result.isError(parsed) && parsed.error).toBeInstanceOf(
+      SnippetCompareFileError,
+    );
+  });
+
+  test("the committed sample covers the query shapes the run is for", async () => {
+    const parsed = parseSnippetCompareQueryFile(
+      await Bun.file(
+        `${import.meta.dir}/corpus-snippet-compare.sample.json`,
+      ).text(),
+    );
+    if (!Result.isOk(parsed)) {
+      throw new Error(
+        `sample query file does not parse: ${parsed.error.message}`,
+      );
+    }
+    const queries = parsed.value;
+
+    expect(new Set(queries.map(({ country }) => country)).size).toBeGreaterThan(
+      1,
+    );
+    // A phrase, so the comparison covers a fragment that has to hold adjacent
+    // words; a single term, where a window has only one thing to centre on.
+    expect(
+      queries.some(({ text }) =>
+        tokenizeCorpusFreeText(text).some(({ type }) => type === "phrase"),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some(({ text }) => tokenizeCorpusFreeText(text).length === 1),
+    ).toBe(true);
+    // Diacritics on one side only: the fold is what has to reach the corpus.
+    expect(queries.some(({ text }) => /[ěščřžýáíéůńśźżôäü]/u.test(text))).toBe(
+      true,
+    );
+    expect(queries.some(({ text }) => /^[\w\s"]+$/u.test(text))).toBe(true);
+  });
+});
+
+describe("compareSnippetFragments", () => {
+  test("scores an identical fragment as agreement", () => {
+    const snippet = "náhrada <mark>škody</mark> z prodlení";
+
+    expect(
+      compareSnippetFragments({
+        engineSnippet: snippet,
+        apiSnippet: snippet,
+      }),
+    ).toEqual({
+      overlap: 1,
+      engineMarks: ["skody"],
+      apiMarks: ["skody"],
+      marks: "identical",
+    });
+  });
+
+  test("reports the API side marking more than the engine", () => {
+    const comparison = compareSnippetFragments({
+      engineSnippet: "náhrada <mark>škody</mark> z prodlení",
+      apiSnippet: "náhrada <mark>škody</mark> z <mark>prodlení</mark>",
+    });
+
+    expect(comparison.overlap).toBe(1);
+    expect(comparison.marks).toBe("api_superset");
+    expect(comparison.apiMarks).toEqual(["prodleni", "skody"]);
+  });
+
+  test("reports marks neither side covers", () => {
+    expect(
+      compareSnippetFragments({
+        engineSnippet: "<mark>škody</mark> a prodlení",
+        apiSnippet: "škody a <mark>prodlení</mark>",
+      }).marks,
+    ).toBe("divergent");
+  });
+
+  test("scores fragments cut from different places of the passage", () => {
+    const comparison = compareSnippetFragments({
+      engineSnippet: "alpha beta gamma delta",
+      apiSnippet: "gamma delta epsilon zeta",
+    });
+
+    // Two words shared of six distinct.
+    expect(comparison.overlap).toBeCloseTo(2 / 6, 10);
+  });
+
+  test("scores disjoint fragments as no overlap", () => {
+    expect(
+      compareSnippetFragments({
+        engineSnippet: "alpha beta",
+        apiSnippet: "gamma delta",
+      }).overlap,
+    ).toBe(0);
+  });
+
+  test("compares the escaped text, not the entities", () => {
+    expect(
+      compareSnippetFragments({
+        engineSnippet: "smlouva &amp; podmínky",
+        apiSnippet: "smlouva &amp; podmínky",
+      }).overlap,
+    ).toBe(1);
+  });
+});
+
+test("passageSkipReason names every miss the reader can report", () => {
+  expect(passageSkipReason("unanchored")).toBe("unanchored");
+  expect(passageSkipReason("no_payload")).toBe("no_payload");
+  expect(passageSkipReason("anchor_not_found")).toBe("anchor_not_found");
+});
+
+const row = (): SnippetCompareQueryRow => ({
+  query: { id: "cze-a", text: "náhrada škody", country: "cze" },
+  searchMs: 40,
+  passageReadMs: 10,
+  hits: [
+    {
+      decisionId: "d1",
+      anchorId: "p1",
+      outcome: {
+        status: "compared",
+        engineFragment: "náhrada <mark>škody</mark> z prodlení",
+        apiFragment: "náhrada <mark>škody</mark> z prodlení",
+        comparison: compareSnippetFragments({
+          engineSnippet: "náhrada <mark>škody</mark> z prodlení",
+          apiSnippet: "náhrada <mark>škody</mark> z prodlení",
+        }),
+        highlightMs: 2,
+      },
+    },
+    {
+      decisionId: "d2",
+      anchorId: "p2",
+      outcome: {
+        status: "compared",
+        engineFragment: "<mark>škody</mark> alpha beta",
+        apiFragment: "gamma delta epsilon",
+        comparison: compareSnippetFragments({
+          engineSnippet: "<mark>škody</mark> alpha beta",
+          apiSnippet: "gamma delta epsilon",
+        }),
+        highlightMs: 4,
+      },
+    },
+    {
+      decisionId: "d3",
+      anchorId: null,
+      outcome: { status: "skipped", reason: "unanchored" },
+    },
+  ],
+});
+
+describe("summarizeSnippetComparison", () => {
+  test("counts hits, agreement and timings", () => {
+    const summary = summarizeSnippetComparison([row()]);
+
+    expect(summary.queries).toBe(1);
+    expect(summary.hits).toBe(3);
+    expect(summary.compared).toBe(2);
+    expect(summary.skipped.unanchored).toBe(1);
+    expect(summary.skipped.no_engine_snippet).toBe(0);
+    expect(summary.marks.identical).toBe(1);
+    // The second hit's API fragment marks nothing the engine marked.
+    expect(summary.marks.engine_superset).toBe(1);
+    expect(summary.overlapAtLeastHalfShare).toBe(0.5);
+    expect(summary.apiMarksCoverEngineShare).toBe(0.5);
+    expect(summary.timings.highlightMsTotal).toBe(6);
+    expect(summary.timings.highlightMsMedian).toBe(3);
+    expect(summary.timings.searchMsTotal).toBe(40);
+    expect(summary.timings.passageReadMsMedian).toBe(10);
+  });
+
+  test("an empty run reports zeroes rather than NaN", () => {
+    const summary = summarizeSnippetComparison([]);
+
+    expect(summary.overlapAtLeastHalfShare).toBe(0);
+    expect(summary.medianOverlap).toBe(0);
+    expect(summary.timings.searchMsMedian).toBe(0);
+  });
+});
+
+describe("renderSnippetCompareMarkdown", () => {
+  test("renders the summary, both fragments and the skips", () => {
+    const markdown = renderSnippetCompareMarkdown(
+      snippetCompareReport([row()]),
+    );
+
+    expect(markdown).toContain("- queries: 1");
+    expect(markdown).toContain("- overlap >= 0.5: 50.0%");
+    expect(markdown).toContain("## cze-a — cze: náhrada škody");
+    expect(markdown).toContain("| 1 | engine |");
+    expect(markdown).toContain("| 1 | api |");
+    expect(markdown).toContain("not compared: unanchored");
+  });
+
+  test("keeps a fragment inside its table cell", () => {
+    const withPipes = row();
+    const [first] = withPipes.hits;
+    if (first?.outcome.status !== "compared") {
+      throw new Error("fixture must hold a compared hit");
+    }
+    first.outcome.engineFragment = "alpha | beta\ngamma";
+
+    const markdown = renderSnippetCompareMarkdown(
+      snippetCompareReport([withPipes]),
+    );
+
+    expect(markdown).toContain("alpha \\| beta gamma");
+    expect(markdown.split("\n").some((line) => line === "")).toBe(true);
+  });
+});

--- a/apps/api/src/scripts/corpus-snippet-compare-report.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare-report.ts
@@ -1,0 +1,470 @@
+import { panic, Result, TaggedError } from "better-result";
+import * as v from "valibot";
+
+import { foldCorpusTerm } from "@/api/lib/legal-search/corpus-passage-highlight";
+import type { CorpusPassageResult } from "@/api/lib/legal-search/corpus-passage-reader";
+import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
+import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
+import {
+  searchHighlightMarks,
+  stripSearchHighlightMarkup,
+} from "@/api/lib/search/highlight";
+
+/**
+ * Pure half of `corpus-snippet-compare.ts`: argument and query-file parsing,
+ * the per-hit fragment comparison, the aggregate, and the report renderings.
+ * The runner owns the search, the storage reads and the clock.
+ */
+
+export class SnippetCompareFileError extends TaggedError(
+  "SnippetCompareFileError",
+)<{ message: string }> {}
+
+const snippetCompareQuerySchema = v.strictObject({
+  id: v.pipe(v.string(), v.nonEmpty()),
+  text: v.pipe(v.string(), v.nonEmpty()),
+  country: v.pipe(
+    v.string(),
+    v.check(isCorpusIndexJurisdiction, "must be a 2-8 letter country code"),
+  ),
+});
+
+const snippetCompareQueryFileSchema = v.pipe(
+  v.array(snippetCompareQuerySchema),
+  v.minLength(1, "query file must hold at least one query"),
+  v.check(
+    (queries) =>
+      new Set(queries.map((query) => query.id)).size === queries.length,
+    "query ids must be unique",
+  ),
+);
+
+export type SnippetCompareQuery = v.InferOutput<
+  typeof snippetCompareQuerySchema
+>;
+
+export const parseSnippetCompareQueryFile = (
+  content: string,
+): Result<SnippetCompareQuery[], SnippetCompareFileError> => {
+  const json = Result.try({
+    try: (): unknown => JSON.parse(content),
+    catch: (cause) =>
+      new SnippetCompareFileError({
+        message: `query file is not valid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+      }),
+  });
+  if (Result.isError(json)) {
+    return Result.err(json.error);
+  }
+  const parsed = v.safeParse(snippetCompareQueryFileSchema, json.value);
+  if (!parsed.success) {
+    const issues = parsed.issues
+      .map((issue) => `${v.getDotPath(issue) ?? "$"}: ${issue.message}`)
+      .join("; ");
+    return Result.err(
+      new SnippetCompareFileError({ message: `invalid query file: ${issues}` }),
+    );
+  }
+  return Result.ok(parsed.output);
+};
+
+export const DEFAULT_SNIPPET_COMPARE_LIMIT = 10;
+
+type SnippetCompareArgs = {
+  queriesPath: string;
+  outDir: string;
+  limit: number;
+};
+
+/**
+ * The run this argv asks for, or why it asks for nothing. Unknown flags,
+ * positionals and repeats are refused rather than ignored.
+ */
+type ParsedSnippetCompareArgs =
+  | { type: "parsed"; args: SnippetCompareArgs }
+  | { type: "invalid"; message: string };
+
+const KNOWN_FLAGS = ["queries", "out-dir", "limit"] as const;
+const DECIMAL_INTEGER = /^\d+$/u;
+
+const invalid = (message: string): ParsedSnippetCompareArgs => ({
+  type: "invalid",
+  message,
+});
+
+export const parseSnippetCompareArgs = (
+  argv: readonly string[],
+): ParsedSnippetCompareArgs => {
+  const flags = new Map<string, string>();
+  let index = 0;
+  while (index < argv.length) {
+    const token = argv.at(index);
+    if (token === undefined || !token.startsWith("--")) {
+      return invalid(`unexpected argument: ${String(token)}`);
+    }
+    const name = token.slice(2);
+    if (!KNOWN_FLAGS.some((known) => known === name)) {
+      return invalid(`unknown option: ${token}`);
+    }
+    if (flags.has(name)) {
+      return invalid(`--${name} was given more than once`);
+    }
+    const value = argv.at(index + 1);
+    if (value === undefined || value.startsWith("--")) {
+      return invalid(`--${name} requires a value`);
+    }
+    flags.set(name, value);
+    index += 2;
+  }
+
+  const queriesPath = flags.get("queries");
+  if (queriesPath === undefined) {
+    return invalid("--queries is required");
+  }
+  const outDir = flags.get("out-dir");
+  if (outDir === undefined) {
+    return invalid("--out-dir is required");
+  }
+  const rawLimit = flags.get("limit");
+  const limit =
+    rawLimit === undefined
+      ? DEFAULT_SNIPPET_COMPARE_LIMIT
+      : Number.parseInt(rawLimit, 10);
+  if (
+    rawLimit !== undefined &&
+    (!DECIMAL_INTEGER.test(rawLimit) ||
+      !Number.isSafeInteger(limit) ||
+      limit <= 0)
+  ) {
+    return invalid(`--limit must be a positive integer, got: ${rawLimit}`);
+  }
+  return { type: "parsed", args: { queriesPath, outDir, limit } };
+};
+
+/** How the two sides' marked terms relate. */
+const MARK_AGREEMENTS = [
+  "identical",
+  "api_superset",
+  "engine_superset",
+  "divergent",
+] as const;
+type MarkAgreement = (typeof MARK_AGREEMENTS)[number];
+
+/** Why a hit was not compared; the passage statuses come from the reader. */
+const SNIPPET_COMPARE_SKIPS = [
+  "unanchored",
+  "no_payload",
+  "anchor_not_found",
+  "no_engine_snippet",
+] as const;
+type SnippetCompareSkip = (typeof SNIPPET_COMPARE_SKIPS)[number];
+
+const SKIP_COVERAGE = {
+  unanchored: "unanchored",
+  no_payload: "no_payload",
+  anchor_not_found: "anchor_not_found",
+} as const satisfies Record<
+  Exclude<CorpusPassageResult["status"], "found">,
+  SnippetCompareSkip
+>;
+
+/** The skip a passage miss reports as. Total over the reader's statuses. */
+export const passageSkipReason = (
+  status: Exclude<CorpusPassageResult["status"], "found">,
+): SnippetCompareSkip => SKIP_COVERAGE[status];
+
+type FragmentComparison = {
+  /**
+   * Jaccard index of the fragments' folded word multisets: 1 when they hold
+   * the same words, 0 when they share none.
+   */
+  overlap: number;
+  /** Distinct folded terms each side marked. */
+  engineMarks: string[];
+  apiMarks: string[];
+  marks: MarkAgreement;
+};
+
+const foldedWords = (text: string): string[] =>
+  corpusTokens(text).map(foldCorpusTerm);
+
+const multisetOverlap = (left: string[], right: string[]): number => {
+  if (left.length === 0 && right.length === 0) {
+    return 1;
+  }
+  const counts = new Map<string, number>();
+  for (const word of left) {
+    counts.set(word, (counts.get(word) ?? 0) + 1);
+  }
+  let shared = 0;
+  for (const word of right) {
+    const available = counts.get(word) ?? 0;
+    if (available > 0) {
+      counts.set(word, available - 1);
+      shared += 1;
+    }
+  }
+  return shared / (left.length + right.length - shared);
+};
+
+const markedTerms = (snippet: string): Set<string> =>
+  new Set(searchHighlightMarks(snippet).flatMap(foldedWords));
+
+const markAgreement = (
+  engine: Set<string>,
+  api: Set<string>,
+): MarkAgreement => {
+  const apiCoversEngine = [...engine].every((term) => api.has(term));
+  const engineCoversApi = [...api].every((term) => engine.has(term));
+  if (apiCoversEngine && engineCoversApi) {
+    return "identical";
+  }
+  if (apiCoversEngine) {
+    return "api_superset";
+  }
+  return engineCoversApi ? "engine_superset" : "divergent";
+};
+
+/** One hit's two fragments, compared. Both are `<mark>`-format snippets. */
+export const compareSnippetFragments = ({
+  engineSnippet,
+  apiSnippet,
+}: {
+  engineSnippet: string;
+  apiSnippet: string;
+}): FragmentComparison => {
+  const engineMarks = markedTerms(engineSnippet);
+  const apiMarks = markedTerms(apiSnippet);
+  return {
+    overlap: multisetOverlap(
+      foldedWords(stripSearchHighlightMarkup(engineSnippet)),
+      foldedWords(stripSearchHighlightMarkup(apiSnippet)),
+    ),
+    engineMarks: [...engineMarks].sort(),
+    apiMarks: [...apiMarks].sort(),
+    marks: markAgreement(engineMarks, apiMarks),
+  };
+};
+
+export type SnippetCompareOutcome =
+  | {
+      status: "compared";
+      /** The snippet the search returned for this hit. */
+      engineFragment: string;
+      /** The fragment cut here from the same passage. */
+      apiFragment: string;
+      comparison: FragmentComparison;
+      /** Wall time of the cut alone, storage reads excluded. */
+      highlightMs: number;
+    }
+  | { status: "skipped"; reason: SnippetCompareSkip };
+
+export type SnippetCompareHit = {
+  decisionId: string;
+  anchorId: string | null;
+  outcome: SnippetCompareOutcome;
+};
+
+export type SnippetCompareQueryRow = {
+  query: SnippetCompareQuery;
+  /** Wall time of the whole search call. */
+  searchMs: number;
+  /** Wall time of reading the page's passages from storage. */
+  passageReadMs: number;
+  hits: SnippetCompareHit[];
+};
+
+type SnippetCompareSummary = {
+  queries: number;
+  hits: number;
+  compared: number;
+  skipped: Record<SnippetCompareSkip, number>;
+  marks: Record<MarkAgreement, number>;
+  /** Share of compared hits, so an empty run reports 0 rather than NaN. */
+  overlapAtLeastHalfShare: number;
+  apiMarksCoverEngineShare: number;
+  medianOverlap: number;
+  timings: {
+    searchMsMedian: number;
+    passageReadMsMedian: number;
+    highlightMsMedian: number;
+    searchMsTotal: number;
+    passageReadMsTotal: number;
+    highlightMsTotal: number;
+  };
+};
+
+const median = (values: readonly number[]): number => {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const upper = sorted.at(middle) ?? panic("median index is out of range");
+  if (sorted.length % 2 === 1) {
+    return upper;
+  }
+  const lower = sorted.at(middle - 1) ?? panic("median index is out of range");
+  return (lower + upper) / 2;
+};
+
+const sum = (values: readonly number[]): number =>
+  values.reduce((total, value) => total + value, 0);
+
+const OVERLAP_AGREEMENT_THRESHOLD = 0.5;
+
+export const summarizeSnippetComparison = (
+  rows: readonly SnippetCompareQueryRow[],
+): SnippetCompareSummary => {
+  // Written out rather than built from the lists: the record type is what
+  // makes every member counted, and a builder would need a cast to claim it.
+  const skipped: Record<SnippetCompareSkip, number> = {
+    unanchored: 0,
+    no_payload: 0,
+    anchor_not_found: 0,
+    no_engine_snippet: 0,
+  };
+  const marks: Record<MarkAgreement, number> = {
+    identical: 0,
+    api_superset: 0,
+    engine_superset: 0,
+    divergent: 0,
+  };
+  const overlaps: number[] = [];
+  const highlightMs: number[] = [];
+  let hits = 0;
+  let overlapAtLeastHalf = 0;
+  let apiMarksCoverEngine = 0;
+
+  for (const row of rows) {
+    for (const { outcome } of row.hits) {
+      hits += 1;
+      if (outcome.status === "skipped") {
+        skipped[outcome.reason] += 1;
+        continue;
+      }
+      marks[outcome.comparison.marks] += 1;
+      overlaps.push(outcome.comparison.overlap);
+      highlightMs.push(outcome.highlightMs);
+      if (outcome.comparison.overlap >= OVERLAP_AGREEMENT_THRESHOLD) {
+        overlapAtLeastHalf += 1;
+      }
+      if (
+        outcome.comparison.marks === "identical" ||
+        outcome.comparison.marks === "api_superset"
+      ) {
+        apiMarksCoverEngine += 1;
+      }
+    }
+  }
+
+  const compared = overlaps.length;
+  const share = (count: number): number =>
+    compared === 0 ? 0 : count / compared;
+  return {
+    queries: rows.length,
+    hits,
+    compared,
+    skipped,
+    marks,
+    overlapAtLeastHalfShare: share(overlapAtLeastHalf),
+    apiMarksCoverEngineShare: share(apiMarksCoverEngine),
+    medianOverlap: median(overlaps),
+    timings: {
+      searchMsMedian: median(rows.map(({ searchMs }) => searchMs)),
+      passageReadMsMedian: median(
+        rows.map(({ passageReadMs }) => passageReadMs),
+      ),
+      highlightMsMedian: median(highlightMs),
+      searchMsTotal: sum(rows.map(({ searchMs }) => searchMs)),
+      passageReadMsTotal: sum(rows.map(({ passageReadMs }) => passageReadMs)),
+      highlightMsTotal: sum(highlightMs),
+    },
+  };
+};
+
+type SnippetCompareReport = {
+  summary: SnippetCompareSummary;
+  queries: readonly SnippetCompareQueryRow[];
+};
+
+export const snippetCompareReport = (
+  rows: readonly SnippetCompareQueryRow[],
+): SnippetCompareReport => ({
+  summary: summarizeSnippetComparison(rows),
+  queries: rows,
+});
+
+const percent = (share: number): string => `${(share * 100).toFixed(1)}%`;
+const ms = (value: number): string => `${value.toFixed(1)} ms`;
+const ratio = (value: number): string => value.toFixed(2);
+
+/** A fragment as one Markdown table cell: no pipes, no line breaks. */
+const cell = (text: string): string =>
+  text.replaceAll("|", "\\|").replaceAll(/\s+/gu, " ").trim();
+
+/** The Markdown report: the summary tables, then both fragments per hit. */
+export const renderSnippetCompareMarkdown = (
+  report: SnippetCompareReport,
+): string => {
+  const { summary } = report;
+  const lines: string[] = [
+    "# Passage fragments per hit",
+    "",
+    "Overlap is the Jaccard index of the fragments' folded word multisets;",
+    "marks are compared as folded terms.",
+    "",
+    "## Summary",
+    "",
+    `- queries: ${summary.queries}`,
+    `- hits: ${summary.hits}, compared: ${summary.compared}`,
+    `- overlap >= 0.5: ${percent(summary.overlapAtLeastHalfShare)} of compared hits`,
+    `- api marks cover engine marks: ${percent(summary.apiMarksCoverEngineShare)}`,
+    `- median overlap: ${ratio(summary.medianOverlap)}`,
+    "",
+    "| measure | median | total |",
+    "| --- | ---: | ---: |",
+    `| search, per query | ${ms(summary.timings.searchMsMedian)} | ${ms(summary.timings.searchMsTotal)} |`,
+    `| passage read, per query | ${ms(summary.timings.passageReadMsMedian)} | ${ms(summary.timings.passageReadMsTotal)} |`,
+    `| fragment cut, per hit | ${ms(summary.timings.highlightMsMedian)} | ${ms(summary.timings.highlightMsTotal)} |`,
+    "",
+    "| marks | hits |",
+    "| --- | ---: |",
+    ...MARK_AGREEMENTS.map((mark) => `| ${mark} | ${summary.marks[mark]} |`),
+    "",
+    "| not compared | hits |",
+    "| --- | ---: |",
+    ...SNIPPET_COMPARE_SKIPS.map(
+      (skip) => `| ${skip} | ${summary.skipped[skip]} |`,
+    ),
+    "",
+  ];
+
+  for (const row of report.queries) {
+    lines.push(
+      `## ${row.query.id} — ${row.query.country}: ${cell(row.query.text)}`,
+      "",
+      `search ${ms(row.searchMs)}, passage read ${ms(row.passageReadMs)}`,
+      "",
+      "| hit | side | overlap | marks | fragment |",
+      "| --- | --- | ---: | --- | --- |",
+    );
+    for (const [index, hit] of row.hits.entries()) {
+      const rank = index + 1;
+      if (hit.outcome.status === "skipped") {
+        lines.push(
+          `| ${rank} | — | — | — | not compared: ${hit.outcome.reason} |`,
+        );
+        continue;
+      }
+      const { comparison, engineFragment, apiFragment } = hit.outcome;
+      lines.push(
+        `| ${rank} | engine | ${ratio(comparison.overlap)} | ${comparison.marks} | ${cell(engineFragment)} |`,
+        `| ${rank} | api | | | ${cell(apiFragment)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+};

--- a/apps/api/src/scripts/corpus-snippet-compare.sample.json
+++ b/apps/api/src/scripts/corpus-snippet-compare.sample.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "cze-two-terms",
+    "text": "náhrada škody z prodlení",
+    "country": "cze"
+  },
+  {
+    "id": "cze-diacritics-stripped",
+    "text": "nahrada skody z prodleni",
+    "country": "cze"
+  },
+  {
+    "id": "cze-quoted-phrase",
+    "text": "\"dobré mravy\" výpověď",
+    "country": "cze"
+  },
+  {
+    "id": "cze-inflected-term",
+    "text": "nájemního bytu",
+    "country": "cze"
+  },
+  {
+    "id": "svk-two-terms",
+    "text": "bezdôvodné obohatenie premlčanie",
+    "country": "svk"
+  },
+  {
+    "id": "pol-single-term",
+    "text": "zadośćuczynienie",
+    "country": "pol"
+  }
+]

--- a/apps/api/src/scripts/corpus-snippet-compare.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare.ts
@@ -1,0 +1,184 @@
+import { panic, Result } from "better-result";
+import { mkdir } from "node:fs/promises";
+
+import { envBase } from "@/api/env-base";
+import { openCaseLawReadOnlySession } from "@/api/lib/case-law/maintenance-lane";
+import { highlightCorpusPassage } from "@/api/lib/legal-search/corpus-passage-highlight";
+import type { CorpusPassageResult } from "@/api/lib/legal-search/corpus-passage-reader";
+import {
+  readCaseLawPassagePointersTx,
+  readCorpusPassages,
+} from "@/api/lib/legal-search/corpus-passage-reader";
+import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
+import { documentMorphologyLanguage } from "@/api/lib/legal-search/morphology/corpus-language";
+import { getLegalSearchProvider } from "@/api/lib/legal-search/provider";
+import type { LegalSearchHit } from "@/api/lib/legal-search/types";
+import {
+  compareSnippetFragments,
+  parseSnippetCompareArgs,
+  parseSnippetCompareQueryFile,
+  passageSkipReason,
+  renderSnippetCompareMarkdown,
+  snippetCompareReport,
+  type SnippetCompareHit,
+  type SnippetCompareOutcome,
+  type SnippetCompareQueryRow,
+} from "@/api/scripts/corpus-snippet-compare-report";
+
+/**
+ * Runs each query of a query set, cuts a fragment from every hit's passage and
+ * writes a JSON and a Markdown report of both fragments per hit to `--out-dir`.
+ *
+ * The query file is JSON: an array of `{ id, text, country }`; a sample is
+ * committed as corpus-snippet-compare.sample.json. Reads only (read-only
+ * session, no maintenance lane) and requires
+ * `LEGAL_SEARCH_PROVIDER=corpus-index`.
+ *
+ *   bun run --env-file=.env src/scripts/corpus-snippet-compare.ts \
+ *     --queries src/scripts/corpus-snippet-compare.sample.json --out-dir .cache/snippets
+ */
+
+const USAGE = `Usage: bun run src/scripts/corpus-snippet-compare.ts [options]
+
+  --queries <path>   Query set file (JSON: [{ id, text, country }]). Required.
+  --out-dir <path>   Directory the JSON and Markdown reports are written to. Required.
+  --limit <n>        Hits per query (default 10).`;
+
+const USAGE_EXIT_CODE = 2;
+
+// The explicit function-type annotation (not just a return annotation) is what
+// lets control-flow analysis treat a `fail(...)` statement as unreachable-after
+// and narrow past it.
+const fail: (message: string) => never = (message) => {
+  console.error(message);
+  console.error(USAGE);
+  process.exit(USAGE_EXIT_CODE);
+};
+
+/** Runtime failure: same exit code as `fail`, without re-printing usage. */
+const abort: (message: string) => never = (message) => {
+  console.error(message);
+  process.exit(USAGE_EXIT_CODE);
+};
+
+const parsedArgs = parseSnippetCompareArgs(process.argv.slice(2));
+if (parsedArgs.type === "invalid") {
+  fail(parsedArgs.message);
+}
+const { queriesPath, outDir, limit } = parsedArgs.args;
+
+if (envBase.LEGAL_SEARCH_PROVIDER !== "corpus-index") {
+  abort(
+    `LEGAL_SEARCH_PROVIDER is ${envBase.LEGAL_SEARCH_PROVIDER}; this comparison needs corpus-index`,
+  );
+}
+
+const content = await Result.tryPromise({
+  try: async () => await Bun.file(queriesPath).text(),
+  catch: (cause) =>
+    cause instanceof Error ? cause.message : "query file is not readable",
+});
+if (Result.isError(content)) {
+  abort(`cannot read ${queriesPath}: ${content.error}`);
+}
+const queries = parseSnippetCompareQueryFile(content.value);
+if (Result.isError(queries)) {
+  fail(queries.error.message);
+}
+
+const provider = getLegalSearchProvider();
+const { rootDb } = await openCaseLawReadOnlySession();
+
+/**
+ * One hit's fragment, timed, and its comparison with the returned snippet. A
+ * hit whose passage or snippet is absent is reported as skipped.
+ */
+const compareHit = ({
+  hit,
+  passage,
+  tokens,
+}: {
+  hit: LegalSearchHit;
+  /** The reader answers in request order, so this is the hit's own passage. */
+  passage: CorpusPassageResult;
+  tokens: ReturnType<typeof tokenizeCorpusFreeText>;
+}): SnippetCompareOutcome => {
+  if (passage.status !== "found") {
+    return { status: "skipped", reason: passageSkipReason(passage.status) };
+  }
+  if (hit.headline === null) {
+    return { status: "skipped", reason: "no_engine_snippet" };
+  }
+  const startedAt = performance.now();
+  const fragment = highlightCorpusPassage({
+    passage: passage.text,
+    tokens,
+    language: documentMorphologyLanguage(hit.language),
+  });
+  const highlightMs = performance.now() - startedAt;
+  return {
+    status: "compared",
+    engineFragment: hit.headline,
+    apiFragment: fragment.html,
+    comparison: compareSnippetFragments({
+      engineSnippet: hit.headline,
+      apiSnippet: fragment.html,
+    }),
+    highlightMs,
+  };
+};
+
+const rows: SnippetCompareQueryRow[] = [];
+for (const query of queries.value) {
+  const searchStartedAt = performance.now();
+  const searched = await provider.search({
+    query: query.text,
+    jurisdiction: query.country,
+    limit,
+  });
+  const searchMs = performance.now() - searchStartedAt;
+  if (Result.isError(searched)) {
+    abort(`search for ${query.id} failed: ${searched.error.message}`);
+  }
+
+  const hits = searched.value.hits;
+  const requests = hits.map((hit) => ({
+    documentId: hit.decisionId,
+    anchorId: hit.anchorId,
+  }));
+  const readStartedAt = performance.now();
+  // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- one read per query in the run's own set; the page's pointers are already one `inArray`
+  const pointers = await rootDb.transaction(
+    async (tx) =>
+      await readCaseLawPassagePointersTx(
+        tx,
+        requests.map(({ documentId }) => documentId),
+      ),
+  );
+  const passages = await readCorpusPassages({ requests, pointers });
+  const passageReadMs = performance.now() - readStartedAt;
+
+  const tokens = tokenizeCorpusFreeText(query.text);
+  const compared: SnippetCompareHit[] = hits.map((hit, index) => {
+    const passage =
+      passages.at(index) ??
+      panic(`passage result missing for hit ${hit.decisionId}`);
+    return {
+      decisionId: hit.decisionId,
+      anchorId: hit.anchorId,
+      outcome: compareHit({ hit, passage, tokens }),
+    };
+  });
+
+  rows.push({ query, searchMs, passageReadMs, hits: compared });
+  console.error(`compared ${rows.length}/${queries.value.length}…`);
+}
+
+const report = snippetCompareReport(rows);
+await mkdir(outDir, { recursive: true });
+const jsonPath = `${outDir}/corpus-snippet-compare.json`;
+const markdownPath = `${outDir}/corpus-snippet-compare.md`;
+await Bun.write(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+await Bun.write(markdownPath, `${renderSnippetCompareMarkdown(report)}\n`);
+console.log(`wrote ${jsonPath} and ${markdownPath}`);
+process.exit(0);

--- a/apps/api/src/scripts/corpus-snippet-compare.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare.ts
@@ -186,6 +186,9 @@ for (const { query, hits, searchMs } of searched) {
   const { stemming } = caseLawCorpusQueryFields({
     generation,
     jurisdiction: query.country,
+    // A query set carries no language filter, which is the request shape the
+    // search was run with.
+    language: undefined,
   });
   const compared: SnippetCompareHit[] = hits.map((hit, index) => {
     const passage =

--- a/apps/api/src/scripts/corpus-snippet-compare.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare.ts
@@ -3,6 +3,8 @@ import { mkdir } from "node:fs/promises";
 
 import { envBase } from "@/api/env-base";
 import { openCaseLawReadOnlySession } from "@/api/lib/case-law/maintenance-lane";
+import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
+import { caseLawCorpusQueryFields } from "@/api/lib/legal-search/corpus-index-read-contract";
 import { highlightCorpusPassage } from "@/api/lib/legal-search/corpus-passage-highlight";
 import type { CorpusPassageResult } from "@/api/lib/legal-search/corpus-passage-reader";
 import {
@@ -10,7 +12,7 @@ import {
   readCorpusPassages,
 } from "@/api/lib/legal-search/corpus-passage-reader";
 import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
-import { documentMorphologyLanguage } from "@/api/lib/legal-search/morphology/corpus-language";
+import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
 import { getLegalSearchProvider } from "@/api/lib/legal-search/provider";
 import type { LegalSearchHit } from "@/api/lib/legal-search/types";
 import {
@@ -22,6 +24,7 @@ import {
   snippetCompareReport,
   type SnippetCompareHit,
   type SnippetCompareOutcome,
+  type SnippetCompareQuery,
   type SnippetCompareQueryRow,
 } from "@/api/scripts/corpus-snippet-compare-report";
 
@@ -97,11 +100,14 @@ const compareHit = ({
   hit,
   passage,
   tokens,
+  language,
 }: {
   hit: LegalSearchHit;
   /** The reader answers in request order, so this is the hit's own passage. */
   passage: CorpusPassageResult;
   tokens: ReturnType<typeof tokenizeCorpusFreeText>;
+  /** The language the engine query stemmed in, or null when it stemmed none. */
+  language: MorphologyLanguage | null;
 }): SnippetCompareOutcome => {
   if (passage.status !== "found") {
     return { status: "skipped", reason: passageSkipReason(passage.status) };
@@ -113,7 +119,7 @@ const compareHit = ({
   const fragment = highlightCorpusPassage({
     passage: passage.text,
     tokens,
-    language: documentMorphologyLanguage(hit.language),
+    language,
   });
   const highlightMs = performance.now() - startedAt;
   return {
@@ -128,37 +134,59 @@ const compareHit = ({
   };
 };
 
-const rows: SnippetCompareQueryRow[] = [];
+/** One query's page, and what the run measured getting it. */
+type SearchedQuery = {
+  query: SnippetCompareQuery;
+  hits: readonly LegalSearchHit[];
+  searchMs: number;
+};
+
+const searched: SearchedQuery[] = [];
 for (const query of queries.value) {
-  const searchStartedAt = performance.now();
-  const searched = await provider.search({
+  const startedAt = performance.now();
+  const page = await provider.search({
     query: query.text,
     jurisdiction: query.country,
     limit,
   });
-  const searchMs = performance.now() - searchStartedAt;
-  if (Result.isError(searched)) {
-    abort(`search for ${query.id} failed: ${searched.error.message}`);
+  const searchMs = performance.now() - startedAt;
+  if (Result.isError(page)) {
+    abort(`search for ${query.id} failed: ${page.error.message}`);
   }
+  searched.push({ query, hits: page.value.hits, searchMs });
+  console.error(`searched ${searched.length}/${queries.value.length}…`);
+}
 
-  const hits = searched.value.hits;
+// One statement for the whole run: every page's decisions at once, so the
+// pointer read does not scale with the query set.
+const { generation } = await rootDb.transaction(
+  async (tx) => await readServingCorpusIndexGenerationTx(tx, "case_law"),
+);
+const pointers = await rootDb.transaction(
+  async (tx) =>
+    await readCaseLawPassagePointersTx(
+      tx,
+      searched.flatMap(({ hits }) => hits.map((hit) => hit.decisionId)),
+    ),
+);
+
+const rows: SnippetCompareQueryRow[] = [];
+for (const { query, hits, searchMs } of searched) {
   const requests = hits.map((hit) => ({
     documentId: hit.decisionId,
     anchorId: hit.anchorId,
   }));
   const readStartedAt = performance.now();
-  // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- one read per query in the run's own set; the page's pointers are already one `inArray`
-  const pointers = await rootDb.transaction(
-    async (tx) =>
-      await readCaseLawPassagePointersTx(
-        tx,
-        requests.map(({ documentId }) => documentId),
-      ),
-  );
   const passages = await readCorpusPassages({ requests, pointers });
   const passageReadMs = performance.now() - readStartedAt;
 
   const tokens = tokenizeCorpusFreeText(query.text);
+  // The stemming the engine query carried, not the hit's own language: a
+  // query whose route stems nothing must be matched here without stemming.
+  const { stemming } = caseLawCorpusQueryFields({
+    generation,
+    jurisdiction: query.country,
+  });
   const compared: SnippetCompareHit[] = hits.map((hit, index) => {
     const passage =
       passages.at(index) ??
@@ -166,12 +194,16 @@ for (const query of queries.value) {
     return {
       decisionId: hit.decisionId,
       anchorId: hit.anchorId,
-      outcome: compareHit({ hit, passage, tokens }),
+      outcome: compareHit({
+        hit,
+        passage,
+        tokens,
+        language: stemming?.language ?? null,
+      }),
     };
   });
 
   rows.push({ query, searchMs, passageReadMs, hits: compared });
-  console.error(`compared ${rows.length}/${queries.value.length}…`);
 }
 
 const report = snippetCompareReport(rows);


### PR DESCRIPTION
Adds a passage highlighter that cuts a fragment around matched terms, a passage reader by anchor id, and a script that reports fragments per hit for a query set. Tests included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Legal search results now provide more relevant, concise passage snippets with matching terms highlighted.
  - Highlighting supports phrases, overlapping matches, diacritics, stemming and multiple languages.
  - Search snippets are safely escaped and can be converted to clean plain text.
  - Passage retrieval now handles missing or unanchored content gracefully while preserving result order.

- **Bug Fixes**
  - Improved handling of long search terms and passages.
  - Prevented malformed HTML from appearing in highlighted search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->