### PR TITLE
fix(api): accept a private-host search endpoint and a lane suffix for the 0.9 cluster

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -264,8 +264,9 @@ S3_SCOPED_SIGNING_ROLE_ARN=""
 # [internal] Optional. Corpus index endpoint.
 # CORPUS_INDEX_ENDPOINT=""
 
-# [internal] Optional. Local-development-only read endpoint for Quickwit 0.9.
-# Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
+# [internal] Optional. Read endpoint for Quickwit 0.9, accepted on a private
+# corpus-index-v09 service host and otherwise only in local development. Unset
+# uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
 # CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
 
 # [internal] Conditionally required when CORPUS_INDEXING_ENABLED is true and

--- a/apps/api/src/env-base-schema.test.ts
+++ b/apps/api/src/env-base-schema.test.ts
@@ -86,6 +86,42 @@ describe("corpus cluster endpoint transport", () => {
     ).toBeNull();
   });
 
+  test("rejects a private search host on a non-HTTP scheme", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT:
+          "ftp://corpus-index-v09-search.stella-staging.local:7280",
+      }),
+    ).toBe(
+      "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address or the private corpus-index-v09 Cloud Map service.",
+    );
+  });
+
+  test("rejects a private search host carrying credentials", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT:
+          "http://user:pw@corpus-index-v09-search.stella-staging.local:7280",
+      }),
+    ).toBe(
+      "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address or the private corpus-index-v09 Cloud Map service.",
+    );
+  });
+
+  test("rejects a private mutation host carrying credentials", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_ENDPOINT:
+          "http://user:pw@corpus-index-v09.stella-staging.local:7280",
+      }),
+    ).toBe(
+      "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets loopback or the private corpus-index-v09 Cloud Map service.",
+    );
+  });
+
   test("keeps a remote plaintext search override forbidden", () => {
     expect(
       envBaseInvariantViolation({

--- a/apps/api/src/env-base-schema.test.ts
+++ b/apps/api/src/env-base-schema.test.ts
@@ -54,6 +54,38 @@ describe("corpus cluster endpoint transport", () => {
     ).toBeNull();
   });
 
+  test("accepts a lane-suffixed q09 mutation endpoint", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_ENDPOINT:
+          "http://corpus-index-v09-append.stella-staging.local:7280",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects a q09 mutation endpoint under another service name", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_ENDPOINT:
+          "http://corpus-index-v10.stella-staging.local:7280",
+      }),
+    ).toBe(
+      "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets loopback or the private corpus-index-v09 Cloud Map service.",
+    );
+  });
+
+  test("accepts a private-host q09 search endpoint outside local development", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT:
+          "http://corpus-index-v09-search.stella-staging.local:7280",
+      }),
+    ).toBeNull();
+  });
+
   test("keeps a remote plaintext search override forbidden", () => {
     expect(
       envBaseInvariantViolation({
@@ -61,7 +93,18 @@ describe("corpus cluster endpoint transport", () => {
         CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "http://search.example.com",
       }),
     ).toBe(
-      "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.",
+      "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address or the private corpus-index-v09 Cloud Map service.",
+    );
+  });
+
+  test("keeps a public search endpoint forbidden outside local development", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "https://search.example.com",
+      }),
+    ).toBe(
+      "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development or against the private corpus-index-v09 Cloud Map service.",
     );
   });
 

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -140,7 +140,16 @@ const BACKPRESSURE_DIMENSIONS_PATTERN =
   /^[^=,\s]+=[^=,]+(?:,[^=,\s]+=[^=,]+)*$/u;
 
 const Q09_PRIVATE_SERVICE_HOSTNAME_PATTERN =
-  /^corpus-index-v09\.[a-z0-9-]+\.local$/u;
+  /^corpus-index-v09(-[a-z0-9]+)?\.[a-z0-9-]+\.local$/u;
+
+const isPrivateQ09ServiceEndpoint = (value: string) => {
+  if (!URL.canParse(value)) {
+    return false;
+  }
+  return Q09_PRIVATE_SERVICE_HOSTNAME_PATTERN.test(
+    new URL(value).hostname.toLowerCase(),
+  );
+};
 
 const isSecureOrPrivateQ09MutationEndpoint = (value: string) => {
   if (!URL.canParse(value)) {
@@ -150,8 +159,7 @@ const isSecureOrPrivateQ09MutationEndpoint = (value: string) => {
   return (
     url.protocol === "https:" ||
     (url.protocol === "http:" &&
-      (isLoopbackHostname(url.hostname) ||
-        Q09_PRIVATE_SERVICE_HOSTNAME_PATTERN.test(url.hostname.toLowerCase())))
+      (isLoopbackHostname(url.hostname) || isPrivateQ09ServiceEndpoint(value)))
   );
 };
 
@@ -467,17 +475,25 @@ const corpusEndpointInvariantViolation = ({
   if (!isDev && CORPUS_INDEX_SEARCH_ENDPOINT !== undefined) {
     return "CORPUS_INDEX_SEARCH_ENDPOINT is only supported in local development.";
   }
+  const q09SearchTargetsPrivateService =
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined &&
+    isPrivateQ09ServiceEndpoint(CORPUS_INDEX_Q09_SEARCH_ENDPOINT);
   if (
     CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined &&
+    !q09SearchTargetsPrivateService &&
     !isTlsOrLoopbackUrl(CORPUS_INDEX_Q09_SEARCH_ENDPOINT, {
       plaintextProtocol: "http:",
       tlsProtocol: "https:",
     })
   ) {
-    return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.";
+    return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address or the private corpus-index-v09 Cloud Map service.";
   }
-  if (!isDev && CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined) {
-    return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development.";
+  if (
+    !isDev &&
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined &&
+    !q09SearchTargetsPrivateService
+  ) {
+    return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development or against the private corpus-index-v09 Cloud Map service.";
   }
   if (
     CORPUS_INDEX_Q09_ENDPOINT !== undefined &&

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -146,8 +146,12 @@ const isPrivateQ09ServiceEndpoint = (value: string) => {
   if (!URL.canParse(value)) {
     return false;
   }
-  return Q09_PRIVATE_SERVICE_HOSTNAME_PATTERN.test(
-    new URL(value).hostname.toLowerCase(),
+  const url = new URL(value);
+  return (
+    (url.protocol === "http:" || url.protocol === "https:") &&
+    url.username.length === 0 &&
+    url.password.length === 0 &&
+    Q09_PRIVATE_SERVICE_HOSTNAME_PATTERN.test(url.hostname.toLowerCase())
   );
 };
 

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -270,8 +270,9 @@ S3_REGION="us-east-1"
 # [internal] Optional. Corpus index endpoint.
 # CORPUS_INDEX_ENDPOINT=""
 
-# [internal] Optional. Local-development-only read endpoint for Quickwit 0.9.
-# Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
+# [internal] Optional. Read endpoint for Quickwit 0.9, accepted on a private
+# corpus-index-v09 service host and otherwise only in local development. Unset
+# uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
 # CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
 
 # [internal] Conditionally required when CORPUS_INDEXING_ENABLED is true and

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -285,7 +285,7 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
   CORPUS_INDEX_Q09_ENDPOINT:
     "Isolated Quickwit 0.9 mutation endpoint. Final generations registered on q09 use this endpoint; it never falls back to the legacy cluster.",
   CORPUS_INDEX_Q09_SEARCH_ENDPOINT:
-    "Local-development-only read endpoint for Quickwit 0.9. Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.",
+    "Read endpoint for Quickwit 0.9, accepted on a private corpus-index-v09 service host and otherwise only in local development. Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.",
   CORPUS_INDEX_SEARCH_ENDPOINT:
     "Local-development-only search endpoint for a shared corpus index. Unset uses CORPUS_INDEX_ENDPOINT; this endpoint is never used for index mutations.",
   DATABASE_URL:

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -605,14 +605,14 @@ describe("environment doctor output", () => {
     },
     {
       expected:
-        "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.",
+        "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address or the private corpus-index-v09 Cloud Map service.",
       overrides: {
         CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "http://quickwit-search.example.com",
       },
     },
     {
       expected:
-        "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development.",
+        "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development or against the private corpus-index-v09 Cloud Map service.",
       overrides: {
         CONTENT_ENCRYPTION_KEY: "a".repeat(64),
         CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "https://quickwit-search.example.com",


### PR DESCRIPTION
`CORPUS_INDEX_Q09_SEARCH_ENDPOINT` is accepted in any environment when its host matches the private `corpus-index-v09` service-discovery pattern; other hosts keep the HTTPS and local-development refusals.
`CORPUS_INDEX_Q09_ENDPOINT` accepts a hyphenated suffix after the cluster name in that same pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Read-only corpus index v09 endpoints are now supported on private service hosts, in addition to local development.
  - Validation recognises approved private service host variants while retaining restrictions on mutation endpoints and public search endpoints.

- **Documentation**
  - Configuration guidance now explains private-host support, local-development fallback behaviour, and continued mutation restrictions.

- **Tests**
  - Added coverage for accepted private endpoints and rejected invalid or public configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->