### PR TITLE
fix: keep exception grouping stable without stack symbols

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -37,6 +37,15 @@ runs:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
 
+    # Playwright installs pinned browsers; the runner's Chrome channel is unrelated.
+    - name: Disable runner Chrome apt source
+      shell: bash
+      run: |
+        chrome_apt_source=/etc/apt/sources.list.d/google-chrome.list
+        if [[ -f "$chrome_apt_source" ]]; then
+          sudo mv "$chrome_apt_source" "$chrome_apt_source.disabled"
+        fi
+
     - name: Install Chromium on cache miss
       if: steps.browser-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1979,6 +1979,14 @@ jobs:
         env:
           NPM_TOKEN: ""
 
+      # Playwright installs pinned browsers; the runner's Chrome channel is unrelated.
+      - name: Disable runner Chrome apt source
+        run: |
+          chrome_apt_source=/etc/apt/sources.list.d/google-chrome.list
+          if [[ -f "$chrome_apt_source" ]]; then
+            sudo mv "$chrome_apt_source" "$chrome_apt_source.disabled"
+          fi
+
       - name: Install Firefox and WebKit
         run: bunx playwright install --with-deps firefox webkit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2433,6 +2433,7 @@ jobs:
             --no-compile-autoload-dotenv \
             --minify-whitespace \
             --minify-syntax \
+            --sourcemap=inline \
             --target bun \
             --outfile /tmp/server \
             apps/api/src/server.ts
@@ -2453,6 +2454,12 @@ jobs:
             --outfile /tmp/better-auth-migration-audit.js \
             apps/api/src/scripts/better-auth-migration-audit.ts
           test -s /tmp/better-auth-migration-audit.js
+          bun build \
+            --target bun \
+            --sourcemap=inline \
+            --outfile /tmp/document-processing-worker.js \
+            apps/api/src/scripts/document-processing-worker.ts
+          test -s /tmp/document-processing-worker.js
           mkdir -p /tmp/runtime-workers
           bun build \
             --target bun \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -466,6 +466,15 @@ jobs:
         env:
           NPM_TOKEN: ""
 
+      # Playwright installs its pinned browser; the runner's Chrome channel is unrelated.
+      - name: Disable runner Chrome apt source
+        if: steps.current.outputs.promoted == 'true'
+        run: |
+          chrome_apt_source=/etc/apt/sources.list.d/google-chrome.list
+          if [[ -f "$chrome_apt_source" ]]; then
+            sudo mv "$chrome_apt_source" "$chrome_apt_source.disabled"
+          fi
+
       - name: Install Playwright browser
         if: steps.current.outputs.promoted == 'true'
         run: cd apps/web && bunx playwright install --with-deps chromium

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -48,6 +48,7 @@ COPY --from=pruner /app/out/full/ .
 RUN bun build \
     --compile \
     --no-compile-autoload-dotenv \
+    --sourcemap=inline \
     --target bun \
     --outfile /app/server \
     apps/api/src/server.ts
@@ -160,6 +161,7 @@ RUN bun build \
 # in-image through the isolated local ONNX worker.
 RUN bun build \
     --target bun \
+    --sourcemap=inline \
     --outfile /app/document-processing-worker.js \
     apps/api/src/scripts/document-processing-worker.ts
 # Bundle the migration entrypoint so its full transitive @/api import graph is

--- a/apps/api/src/lib/analytics/capture.ts
+++ b/apps/api/src/lib/analytics/capture.ts
@@ -151,7 +151,11 @@ const captureErrorWithOptions = (
     // Group by the structural fingerprint instead: same non-PII components,
     // one issue per distinct defect. Positions are fixed (empty stays empty)
     // so a frameless error's cause frame can never collide with another
-    // error's primary frame — the same shape `captureWindowKey` uses.
+    // error's primary frame — the same shape `captureWindowKey` uses. The
+    // production server and long-running worker embed source maps, so these
+    // are source positions rather than bundle positions; the artifact test
+    // guards that build contract. Stack symbols are deliberately absent:
+    // engines can infer one from a data-derived computed property key.
     $exception_fingerprint: [
       fingerprint["error.class"] ?? "",
       fingerprint["error.code"] ?? "",

--- a/apps/api/src/lib/analytics/source-map.artifact.test.ts
+++ b/apps/api/src/lib/analytics/source-map.artifact.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+type StackFrame = {
+  location: string;
+  symbol: string;
+};
+
+const buildAndReadFrame = ({
+  entrypoint,
+  executable,
+}: {
+  entrypoint: string;
+  executable: string;
+}): StackFrame => {
+  const build = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "build",
+      "--compile",
+      "--no-compile-autoload-dotenv",
+      "--sourcemap=inline",
+      "--target",
+      "bun",
+      "--outfile",
+      executable,
+      entrypoint,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(build.exitCode, new TextDecoder().decode(build.stderr)).toBe(0);
+
+  const run = Bun.spawnSync({
+    cmd: [executable],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(run.exitCode, new TextDecoder().decode(run.stderr)).toBe(0);
+  const line = new TextDecoder().decode(run.stdout).trim();
+  const frame = /^at ([^ ]+) \((.+:\d+:\d+)\)$/u.exec(line);
+  expect(frame, line).not.toBeNull();
+  return {
+    symbol: frame?.at(1) ?? "",
+    location: frame?.at(2) ?? "",
+  };
+};
+
+test("compiled source positions survive an unrelated bundler symbol collision", () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), "stella-source-map-"));
+  const target = path.join(testDir, "target.ts");
+  const collider = path.join(testDir, "collider.ts");
+  const entryA = path.join(testDir, "entry-a.ts");
+  const entryB = path.join(testDir, "entry-b.ts");
+
+  try {
+    writeFileSync(
+      target,
+      'export const run = (): void => { throw new Error("target"); };\n',
+    );
+    writeFileSync(collider, "export const run = (): void => {};\n");
+    writeFileSync(
+      entryA,
+      [
+        'import { run } from "./target";',
+        "try { run(); } catch (error) {",
+        "  const frame = error instanceof Error ? error.stack?.split('\\n').at(1) : undefined;",
+        "  process.stdout.write(frame?.trim() ?? '');",
+        "}",
+      ].join("\n"),
+    );
+    writeFileSync(
+      entryB,
+      [
+        'import { run as collidingRun } from "./collider";',
+        'import { run } from "./target";',
+        "collidingRun();",
+        "try { run(); } catch (error) {",
+        "  const frame = error instanceof Error ? error.stack?.split('\\n').at(1) : undefined;",
+        "  process.stdout.write(frame?.trim() ?? '');",
+        "}",
+      ].join("\n"),
+    );
+
+    const withoutCollision = buildAndReadFrame({
+      entrypoint: entryA,
+      executable: path.join(testDir, "without-collision"),
+    });
+    const withCollision = buildAndReadFrame({
+      entrypoint: entryB,
+      executable: path.join(testDir, "with-collision"),
+    });
+
+    // Prove the fixture reaches Bun's rename boundary before asserting that
+    // the source position, which is what telemetry keeps, stays fixed.
+    expect(withoutCollision.symbol).not.toBe(withCollision.symbol);
+    expect(withoutCollision.location).toBe(withCollision.location);
+    expect(withCollision.location).toMatch(/target\.ts:1:\d+$/u);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -117,6 +117,28 @@ describe("errorFingerprint", () => {
     expect(fingerprint["error.frame"]).not.toContain("(");
   });
 
+  test("never includes a data-derived stack symbol", () => {
+    const error = new Error("boom");
+    error.stack =
+      "Error: boom\n    at jana_novakova (/repo/apps/api/src/server.ts:12:34)";
+    const fingerprint = errorFingerprint(error);
+
+    expect(fingerprint["error.frame"]).toBe(
+      "/repo/apps/api/src/server.ts:12:34",
+    );
+    expect(Object.values(fingerprint).join("|")).not.toContain("jana_novakova");
+  });
+
+  test("ignores a bundler rename at the same source position", () => {
+    const raisedIn = (symbol: string) => {
+      const error = new Error("boom");
+      error.stack = `Error: boom\n    at ${symbol} (apps/api/src/worker.ts:12:34)`;
+      return errorFingerprint(error);
+    };
+
+    expect(raisedIn("run")).toEqual(raisedIn("run2"));
+  });
+
   test("prefers a `.code` string when present", () => {
     const error = Object.assign(new Error("socket hang up"), {
       code: "ECONNRESET",

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -262,6 +262,10 @@ const frameLocation = (line: string): string | undefined => {
   if (!location || hasWhitespace(location)) {
     return undefined;
   }
+  // Keep only the code location. A stack symbol can be inferred from a
+  // computed property key and therefore carry matter or personal data; Bun
+  // also suffixes colliding symbols during bundling, so it is neither safe
+  // telemetry nor a stable identity.
   return location;
 };
 

--- a/apps/web/src/lib/analytics/exception-fingerprint.test.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { fingerprintExceptionEvent } from "@/lib/analytics/exception-fingerprint";
+import { fingerprintExceptionEvent as fingerprintExceptionEventWithOrigin } from "@/lib/analytics/exception-fingerprint";
+
+const FIRST_PARTY_ORIGIN = "https://my.stll.app";
+const fingerprintExceptionEvent = (
+  input: Omit<
+    Parameters<typeof fingerprintExceptionEventWithOrigin>[0],
+    "firstPartyOrigin"
+  >,
+) =>
+  fingerprintExceptionEventWithOrigin({
+    ...input,
+    firstPartyOrigin: FIRST_PARTY_ORIGIN,
+  });
 
 // Production-shaped frames: bundled asset URLs as posthog-js reports them,
 // crash frame last (caller-first ordering).
@@ -63,14 +75,14 @@ describe("fingerprintExceptionEvent", () => {
     ).toBe(fingerprintExceptionEvent({ area: "pdf-viewer", entries: [entry] }));
   });
 
-  test("keeps only asset basename and symbol name from each frame", () => {
+  test("keeps only the asset basename from each frame", () => {
     expect(
       fingerprintExceptionEvent({
         entries: [
           { type: "TypeError", stacktrace: { frames: matterViewFrames } },
         ],
       }),
-    ).toBe("TypeError||root.js:dispatchEvent;matter-view.js:renderMatter|");
+    ).toBe("TypeError||root.js;matter-view.js|");
   });
 
   test("the area slug and cause-chain classes separate otherwise identical errors", () => {
@@ -84,7 +96,7 @@ describe("fingerprintExceptionEvent", () => {
       entries,
     });
     expect(fingerprint).toBe(
-      "ClientTelemetryError|pdf-viewer|root.js:dispatchEvent;matter-view.js:renderMatter|RangeError",
+      "ClientTelemetryError|pdf-viewer|root.js;matter-view.js|RangeError",
     );
     expect(fingerprint).not.toBe(fingerprintExceptionEvent({ entries }));
     expect(fingerprint).not.toBe(
@@ -105,14 +117,14 @@ describe("fingerprintExceptionEvent", () => {
               {
                 filename:
                   "https://my.stll.app/assets/matter-view-D3kfQx9a.js?token=phx_9f3b2c&email=jana.novakova@example.com#L4",
-                function: "renderMatter",
+                in_app: true,
               },
             ],
           },
         },
       ],
     });
-    expect(fingerprint).toBe("TypeError||matter-view.js:renderMatter|");
+    expect(fingerprint).toBe("TypeError||matter-view.js|");
     expect(fingerprint).not.toContain("?");
     expect(fingerprint).not.toContain("@");
   });
@@ -122,6 +134,7 @@ describe("fingerprintExceptionEvent", () => {
       ...Array.from({ length: 8 }, (_, index) => ({
         filename: "https://my.stll.app/assets/root-BOq2mF3k.js",
         function: `frame${index}`,
+        in_app: true,
       })),
       ...matterViewFrames,
     ];
@@ -129,9 +142,7 @@ describe("fingerprintExceptionEvent", () => {
       fingerprintExceptionEvent({
         entries: [{ type: "TypeError", stacktrace: { frames: deepStack } }],
       }),
-    ).toBe(
-      "TypeError||root.js:frame7;root.js:dispatchEvent;matter-view.js:renderMatter|",
-    );
+    ).toBe("TypeError||root.js;root.js;matter-view.js|");
   });
 
   test("frameless and entryless events still yield a stable class-level identity", () => {
@@ -150,23 +161,23 @@ test("fingerprint is stable across content-hashed chunk renames", () => {
       {
         type: "TypeError",
         stacktrace: {
-          frames: [{ filename, function: "renderMatter" }],
+          frames: [{ filename, function: "renderMatter", in_app: true }],
         },
       },
     ],
   });
   const a = fingerprintExceptionEvent(
-    input("https://app.example/assets/matter-view-D3kfQx9a.js"),
+    input("https://my.stll.app/assets/matter-view-D3kfQx9a.js"),
   );
   const b = fingerprintExceptionEvent(
-    input("https://app.example/assets/matter-view-Bx91kQwe.js"),
+    input("https://my.stll.app/assets/matter-view-Bx91kQwe.js"),
   );
   // Different content hashes must not split the issue; the fixture differs
   // before the equivalence is asserted.
   expect("matter-view-D3kfQx9a.js").not.toBe("matter-view-Bx91kQwe.js");
   expect(a).toBe(b);
   const c = fingerprintExceptionEvent(
-    input("https://app.example/assets/other-view-D3kfQx9a.js"),
+    input("https://my.stll.app/assets/other-view-D3kfQx9a.js"),
   );
   expect(a).not.toBe(c);
 });
@@ -179,7 +190,7 @@ test("an API error carries its response identity as a trailing component", () =>
     },
   ];
   const withoutHttp = fingerprintExceptionEvent({ entries });
-  expect(withoutHttp).toBe("ApiError||matter-view.js:renderMatter|");
+  expect(withoutHttp).toBe("ApiError||matter-view.js|");
   expect(fingerprintExceptionEvent({ entries, http: { status: 404 } })).toBe(
     `${withoutHttp}|404`,
   );
@@ -193,4 +204,73 @@ test("an API error carries its response identity as a trailing component", () =>
   expect(
     fingerprintExceptionEvent({ entries, http: { status: 503 } }),
   ).not.toBe(fingerprintExceptionEvent({ entries, http: { status: 404 } }));
+});
+
+test("hash-shaped suffixes outside first-party assets remain identity", () => {
+  const fingerprint = (filename: string) =>
+    fingerprintExceptionEvent({
+      entries: [
+        {
+          type: "TypeError",
+          stacktrace: {
+            frames: [
+              {
+                filename,
+                // PostHog's parser reports ordinary external URLs as true,
+                // so this flag cannot grant the first-party build contract.
+                in_app: true,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+  expect(fingerprint("https://cdn.example/document-12345678.js")).toBe(
+    "TypeError||document-12345678.js|",
+  );
+  expect(fingerprint("https://my.stll.app/vendor/document-12345678.js")).toBe(
+    "TypeError||document-12345678.js|",
+  );
+});
+
+test("data-derived symbols and deployed positions never enter identity", () => {
+  const fingerprint = ({
+    colno,
+    lineno,
+    symbol,
+  }: {
+    colno: number;
+    lineno: number;
+    symbol: string;
+  }) => {
+    const frame = {
+      filename: "https://my.stll.app/assets/matter-view-A1b2C3d4.js",
+      function: symbol,
+      in_app: true,
+      lineno,
+      colno,
+    };
+    return fingerprintExceptionEvent({
+      entries: [
+        {
+          type: "TypeError",
+          stacktrace: { frames: [frame] },
+        },
+      ],
+    });
+  };
+
+  const dataDerived = fingerprint({
+    colno: 7,
+    lineno: 1,
+    symbol: "jana_novakova",
+  });
+  const renamedAndShifted = fingerprint({
+    colno: 18_733,
+    lineno: 42,
+    symbol: "renderMatter2",
+  });
+  expect(dataDerived).toBe(renamedAndShifted);
+  expect(dataDerived).toBe("TypeError||matter-view.js|");
 });

--- a/apps/web/src/lib/analytics/exception-fingerprint.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.ts
@@ -11,7 +11,7 @@ const FRAME_IDENTITY_LIMIT = 3;
 
 type FingerprintFrame = {
   filename?: string;
-  function?: string;
+  in_app?: boolean;
 };
 
 type FingerprintEntry = {
@@ -38,6 +38,8 @@ type ExceptionFingerprintInput = {
   entries: readonly FingerprintEntry[];
   /** Validated telemetry area slug, when an error boundary declared one. */
   area?: string | undefined;
+  /** Configured origin whose Vite assets may have content hashes removed. */
+  firstPartyOrigin: string;
   /** Validated API response identity, when the error is an `ApiError`. */
   http?: ApiErrorIdentity | undefined;
 };
@@ -51,53 +53,85 @@ const assetBasename = (filename: string): string => {
   return path.slice(path.lastIndexOf("/") + 1);
 };
 
-// Vite content-hashes chunk basenames (`matter-view-D3kfQx9a.js`), so a
-// rebuild renames the chunk without the defect changing. Strip the hash
-// segment so a fingerprint survives deployments; a basename with no hash
-// passes through unchanged.
+// Vite content-hashes first-party chunk basenames
+// (`matter-view-D3kfQx9a.js`), so a rebuild renames the chunk without the
+// defect changing. PostHog's parser marks ordinary external URLs `in_app`,
+// so trust only the configured app origin and Vite's owned asset directory.
 const CHUNK_HASH_SUFFIX = /-[A-Za-z0-9_-]{8}(?=\.[a-z]+$)/u;
 const stableBasename = (basename: string): string =>
   basename.replace(CHUNK_HASH_SUFFIX, "");
 
-const frameIdentity = (frame: FingerprintFrame): string => {
-  const basename =
-    frame.filename === undefined
-      ? ""
-      : stableBasename(assetBasename(frame.filename));
-  const symbol = frame.function ?? "";
-  return basename === "" && symbol === "" ? "" : `${basename}:${symbol}`;
+type FirstPartyAssetOptions = {
+  filename: string;
+  firstPartyOrigin: string;
+};
+
+const isFirstPartyAsset = ({
+  filename,
+  firstPartyOrigin,
+}: FirstPartyAssetOptions): boolean => {
+  if (
+    !URL.canParse(firstPartyOrigin) ||
+    !URL.canParse(filename, firstPartyOrigin)
+  ) {
+    return false;
+  }
+  const appOrigin = new URL(firstPartyOrigin).origin;
+  const frameUrl = new URL(filename, firstPartyOrigin);
+  return (
+    frameUrl.origin === appOrigin && frameUrl.pathname.startsWith("/assets/")
+  );
+};
+
+const frameIdentity = (
+  frame: FingerprintFrame,
+  firstPartyOrigin: string,
+): string => {
+  if (frame.filename === undefined) {
+    return "";
+  }
+  const basename = assetBasename(frame.filename);
+  return isFirstPartyAsset({ filename: frame.filename, firstPartyOrigin })
+    ? stableBasename(basename)
+    : basename;
 };
 
 // Frames are ordered caller-first, so the tail of the list is the crash
 // site. A frameless error legitimately yields no identities.
-const frameIdentities = (entry: FingerprintEntry | undefined): string[] => {
+const frameIdentities = (
+  entry: FingerprintEntry | undefined,
+  firstPartyOrigin: string,
+): string[] => {
   if (entry?.stacktrace === undefined) {
     return [];
   }
   return entry.stacktrace.frames
-    .map(frameIdentity)
+    .map((frame) => frameIdentity(frame, firstPartyOrigin))
     .filter((identity) => identity !== "")
     .slice(-FRAME_IDENTITY_LIMIT);
 };
 
 /**
- * Positions are fixed (an empty component stays empty) so one component can
- * never collide with another — the same shape the server-side capture
- * wrapper uses for its `$exception_fingerprint`. The API identity is a
- * trailing fifth component present only for API errors: appending rather
- * than reserving keeps every existing identity byte-for-byte stable, and a
- * class list can never start with a digit, so the two shapes cannot collide.
+ * Component slots are fixed (an empty component stays empty), so one cannot
+ * collide with another. Function names are deliberately absent: an engine
+ * can infer one from a data-derived computed property key, and a bundler can
+ * rename it while the source stays unchanged. Bundle line and column numbers
+ * also shift between builds. Errors in the same asset chain may therefore
+ * group together; area, class and cause identity split them when available.
+ * The API identity is a trailing fifth component present only for API errors:
+ * a class list can never start with a digit, so the two shapes cannot collide.
  */
 export const fingerprintExceptionEvent = ({
   area,
   entries,
+  firstPartyOrigin,
   http,
 }: ExceptionFingerprintInput): string => {
   const classes = entries.map((entry) => entry.type);
   const identity = [
     classes.at(0) ?? "UnknownError",
     area ?? "",
-    frameIdentities(entries.at(0)).join(";"),
+    frameIdentities(entries.at(0), firstPartyOrigin).join(";"),
     classes.slice(1).join(";"),
   ].join("|");
   if (http === undefined) {

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { env } from "@/env";
 import { INGESTION_REQUIRED_KEYS } from "@/lib/analytics/posthog-ingestion";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 import { APIError } from "@/lib/errors/api";
@@ -414,7 +415,7 @@ describe("PostHog browser analytics adapter", () => {
     expect(initOptions?.before_send(event)).toEqual({
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
-        $exception_fingerprint: "TypeError||app.js:|",
+        $exception_fingerprint: "TypeError||app.js|",
         $exception_list: [
           {
             type: "TypeError",
@@ -471,7 +472,6 @@ describe("PostHog browser analytics adapter", () => {
             {
               platform: "web:javascript",
               filename: "https://my.stll.app/assets/app.js",
-              function: "renderMatter",
               in_app: true,
               lineno: 42,
               colno: 7,
@@ -801,7 +801,7 @@ describe("PostHog browser analytics adapter", () => {
     expect(captureExceptionMock.mock.calls.at(-1)?.[0]).toBeInstanceOf(Error);
   });
 
-  test("drops frame function names that are not symbol-shaped", () => {
+  test("drops every frame function name", () => {
     createPostHogAnalytics({ host: "https://posthog.test", key: "phc_test" });
     const sanitized = initOptions?.before_send({
       event: WEB_ANALYTICS_EVENTS.exception,
@@ -812,8 +812,12 @@ describe("PostHog browser analytics adapter", () => {
             value: "boom",
             stacktrace: {
               frames: [
-                { filename: "app.js", function: "Client Smith", lineno: 1 },
-                { filename: "app.js", function: "renderMatter", lineno: 2 },
+                {
+                  filename: "app.js",
+                  function: "jana_novakova",
+                  lineno: 1,
+                },
+                { filename: "app.js", function: "renderMatter2", lineno: 2 },
               ],
             },
           },
@@ -829,7 +833,7 @@ describe("PostHog browser analytics adapter", () => {
           type: "raw",
           frames: [
             { filename: "app.js", lineno: 1 },
-            { filename: "app.js", function: "renderMatter", lineno: 2 },
+            { filename: "app.js", lineno: 2 },
           ],
         },
       },
@@ -922,8 +926,10 @@ describe("PostHog browser analytics adapter", () => {
             stacktrace: {
               frames: [
                 {
-                  filename:
-                    "https://my.stll.app/assets/matter-view-D3kfQx9a.js?token=phx_9f3b2c&email=jana.novakova@example.com",
+                  filename: new URL(
+                    "/assets/matter-view-D3kfQx9a.js?token=phx_9f3b2c&email=jana.novakova@example.com",
+                    env.VITE_PUBLIC_APP_URL,
+                  ).toString(),
                   function: "renderMatter",
                   in_app: true,
                   lineno: 4,
@@ -944,7 +950,7 @@ describe("PostHog browser analytics adapter", () => {
         "$exception_fingerprint"
       ];
     expect(fingerprint).toBe(
-      "ClientTelemetryError|pdf-viewer|matter-view.js:renderMatter|RangeError",
+      "ClientTelemetryError|pdf-viewer|matter-view.js|RangeError",
     );
 
     // Deterministic: the same defect groups into the same issue.
@@ -967,8 +973,10 @@ describe("PostHog browser analytics adapter", () => {
               stacktrace: {
                 frames: [
                   {
-                    filename:
-                      "https://my.stll.app/assets/document-panel-Ck2pW7dm.js",
+                    filename: new URL(
+                      "/assets/document-panel-Ck2pW7dm.js",
+                      env.VITE_PUBLIC_APP_URL,
+                    ).toString(),
                     function: "openDocument",
                     in_app: true,
                     lineno: 2,
@@ -1153,7 +1161,7 @@ describe("PostHog browser analytics adapter", () => {
       properties: {
         token: "phc_test",
         distinct_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
-        $exception_fingerprint: "TypeError||app.js:|",
+        $exception_fingerprint: "TypeError||app.js|",
         $exception_list: [
           {
             type: "TypeError",

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -235,22 +235,17 @@ const apiErrorIdentity = (
   };
 };
 
-// Structural frame fields only: code locations and symbol names from the
-// deployed bundle. Free-text fields (context lines, local variables) never
-// pass through.
+// Structural frame fields only: code locations from the deployed bundle.
+// Free-text fields (context lines, local variables, function names) never
+// pass through. Function names are unsafe even when identifier-shaped:
+// engines infer them from computed property keys, which can be user data.
 type SanitizedFrame = {
   platform?: string;
   filename?: string;
-  function?: string;
   in_app?: boolean;
   lineno?: number;
   colno?: number;
 };
-
-// Symbol-shaped frame function names only. V8 embeds computed property keys
-// verbatim in stacks (`at Client Smith (…)`), so anything with whitespace or
-// beyond identifier punctuation is treated as untrusted and dropped.
-const FRAME_SYMBOL = /^[\w$.<>[\]#~]{1,120}$/u;
 
 const stripUrlMetadata = (url: string): string => {
   const terminator = url.search(/[?#]/u);
@@ -262,7 +257,6 @@ const sanitizeFrame = (frame: unknown): SanitizedFrame => {
     return {};
   }
   const filename = frame["filename"];
-  const functionName = frame["function"];
   const platform = frame["platform"];
   const inApp = frame["in_app"];
   const lineno = frame["lineno"];
@@ -272,9 +266,6 @@ const sanitizeFrame = (frame: unknown): SanitizedFrame => {
     // URL metadata on asset URLs can carry tokens; keep only the path.
     ...(typeof filename === "string"
       ? { filename: stripUrlMetadata(filename) }
-      : {}),
-    ...(typeof functionName === "string" && FRAME_SYMBOL.test(functionName)
-      ? { function: functionName }
       : {}),
     ...(typeof inApp === "boolean" ? { in_app: inApp } : {}),
     ...(typeof lineno === "number" ? { lineno } : {}),
@@ -323,6 +314,7 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
       $exception_fingerprint: fingerprintExceptionEvent({
         area: safeArea,
         entries: sanitizedList,
+        firstPartyOrigin: env.VITE_PUBLIC_APP_URL,
         http,
       }),
       $exception_list: sanitizedList,

--- a/scripts/api-dockerfile-entrypoints.test.ts
+++ b/scripts/api-dockerfile-entrypoints.test.ts
@@ -11,6 +11,10 @@ const dockerfile = readFileSync(
   nodePath.resolve(import.meta.dirname, "../apps/api/Dockerfile"),
   "utf-8",
 );
+const workflow = readFileSync(
+  nodePath.resolve(import.meta.dirname, "../.github/workflows/ci.yml"),
+  "utf-8",
+);
 
 const stage = (name: string): string => {
   const start = dockerfile.search(new RegExp(`^FROM .* AS ${name}$`, "mu"));
@@ -19,6 +23,37 @@ const stage = (name: string): string => {
   const next = rest.search(/^FROM /mu);
   return next === -1 ? rest : rest.slice(0, next);
 };
+
+const logicalInstructions = (body: string): string[] => {
+  const instructions: string[] = [];
+  let current = "";
+  for (const line of body.split("\n")) {
+    current += `${current ? " " : ""}${line.trim()}`;
+    if (current.endsWith("\\")) {
+      current = current.slice(0, -1).trimEnd();
+      continue;
+    }
+    if (current) {
+      instructions.push(current);
+    }
+    current = "";
+  }
+  return instructions;
+};
+
+const buildForOutput = (output: string): string | undefined =>
+  logicalInstructions(stage("builder")).find(
+    (instruction) =>
+      instruction.startsWith("RUN bun build ") &&
+      instruction.includes(`--outfile ${output} `),
+  );
+
+const smokeBuildForOutput = (output: string): string | undefined =>
+  logicalInstructions(workflow).find(
+    (instruction) =>
+      instruction.startsWith("bun build ") &&
+      instruction.includes(`--outfile ${output} `),
+  );
 
 test("every bundled /app entrypoint reaches the runner stage", () => {
   const built = [
@@ -35,4 +70,13 @@ test("every bundled /app entrypoint reaches the runner stage", () => {
     ].map((match) => match[1] ?? ""),
   );
   expect(built.filter((name) => !copied.has(name))).toEqual([]);
+});
+
+test("long-running API builds and their CI smoke map frames to source", () => {
+  for (const output of ["/app/server", "/app/document-processing-worker.js"]) {
+    expect(buildForOutput(output), output).toContain("--sourcemap=inline");
+  }
+  for (const output of ["/tmp/server", "/tmp/document-processing-worker.js"]) {
+    expect(smokeBuildForOutput(output), output).toContain("--sourcemap=inline");
+  }
 });

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -72,6 +72,11 @@ describe("API deployment health receipt", () => {
     expect(apiBuildStart).toBeGreaterThan(healthJobStart);
     expect(webBuildStart).toBeGreaterThan(apiBuildStart);
     expect(promoteStart).toBeGreaterThan(webBuildStart);
+    expect(promoteJob).toContain("/etc/apt/sources.list.d/google-chrome.list");
+    expect(promoteJob).toContain("Disable runner Chrome apt source");
+    expect(promoteJob.indexOf("Disable runner Chrome apt source")).toBeLessThan(
+      promoteJob.indexOf("Install Playwright browser"),
+    );
     // The gate only reads: it decides whether to promote, never promotes.
     // Both delimiters are asserted so a missing block cannot slice to "" and
     // satisfy the write check by being empty.

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const script = path.join(import.meta.dirname, "detect-e2e-changes.sh");
+const runnerChromeAptSource = "/etc/apt/sources.list.d/google-chrome.list";
 const githubExpression = (value: string) => ["$", "{{ ", value, " }}"].join("");
 // Built, not written literally: a `${...}` in a plain string reads as a
 // broken template literal to the linter.
@@ -716,6 +717,12 @@ describe("detect-e2e-changes", () => {
     );
     expect(playwrightSetup).toContain("if verify_chromium; then");
     expect(playwrightSetup).toContain("bunx playwright install-deps chromium");
+    expect(
+      actionStep(playwrightSetup, "Disable runner Chrome apt source"),
+    ).toContain(runnerChromeAptSource);
+    expect(
+      playwrightSetup.indexOf("Disable runner Chrome apt source"),
+    ).toBeLessThan(playwrightSetup.indexOf("Install Chromium on cache miss"));
   });
 
   test("isolates cross-engine stack redaction from Chromium E2E", () => {
@@ -759,6 +766,12 @@ describe("detect-e2e-changes", () => {
     expect(stackRedaction).toContain(
       "bunx playwright install --with-deps firefox webkit",
     );
+    expect(
+      workflowStep(stackRedaction, "Disable runner Chrome apt source"),
+    ).toContain(runnerChromeAptSource);
+    expect(
+      stackRedaction.indexOf("Disable runner Chrome apt source"),
+    ).toBeLessThan(stackRedaction.indexOf("Install Firefox and WebKit"));
     expect(stackRedaction).toContain(
       "bun --filter @stll/web test:e2e:stack-redaction",
     );


### PR DESCRIPTION
## Summary

- Keep API exception fingerprints location-only, then embed inline source maps in the production server and long-running document worker so those locations resolve to stable source positions.
- Drop browser stack symbols and deployed positions from issue identity. Normalize Vite content hashes only for URLs under the configured first-party `/assets/` origin.
- Guard the build contract with a compiled-artifact test that reproduces Bun's `run`/`run2` symbol collision, plus Dockerfile invariant and telemetry privacy regressions.

## Why

Built positions and Bun-renamed symbols can split one defect across releases. Function names are also unsafe telemetry because JavaScript engines can infer them from data-derived computed property keys. This keeps grouping stable without transmitting stack symbols.

Errors in the same browser asset chain can now group together when class, area, cause chain, and optional HTTP identity are also equal. That is the deliberate stability and data-minimization tradeoff.

## Artifact-size tradeoff

Measured with Bun 1.4.2, with the server using the CI compile flags:

- compiled server: +27.7 MB raw, +21.2 MB gzip
- document worker: +18.4 MB raw, +4.0 MB gzip

This is the cost of retaining source-position identity at runtime without transmitting stack symbols.

## Validation

- `bun run verify`
- 119 focused API, web, artifact, and Dockerfile regression tests
- affected pre-push lint, typecheck, formatting, i18n, and query-cache guards

No user-facing UI changes; dark-mode and screenshot checks do not apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception fingerprint consistency by excluding function names and deployed line positions from fingerprint identities.
  * Preserved relevant asset identity while removing content-hash suffixes only from first-party assets.
  * Ensured compiled API and document-processing worker errors map back to their original source locations.
  * Improved Playwright browser installation reliability by disabling conflicting runner Chrome sources.

* **Tests**
  * Added coverage for source-map accuracy, fingerprint stability, and Docker build configuration.
  * Added validation for browser installation workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->