### PR TITLE
fix(api): page the court repair's selection

### DIFF
--- a/apps/api/src/scripts/repair-cz-ns-court-plan.db.test.ts
+++ b/apps/api/src/scripts/repair-cz-ns-court-plan.db.test.ts
@@ -1,12 +1,17 @@
 /**
- * The repair's two halves against a real PostgreSQL: the predicate, which
- * decides which stored rows are looked at at all, and the write, which decides
- * what a looked-at row becomes. Neither is exercised anywhere else — an
- * operator script's SQL is never executed by CI — and a predicate that selects
- * the wrong population is a repair that rewrites decisions nobody asked it to.
+ * The repair's two halves against a real PostgreSQL: the walk, which decides
+ * which stored rows are looked at at all, and the write, which decides what a
+ * looked-at row becomes. Neither is exercised anywhere else — an operator
+ * script's SQL is never executed by CI — and a walk that reads the wrong
+ * population is a repair that rewrites decisions nobody asked it to.
+ *
+ * The source fixture is deliberately larger than a page. The fault this walk
+ * was rebuilt for only appears at scale: a selection bounded by matches reads
+ * to the end of a source looking for rows that are not there, which a handful
+ * of fixtures can never show.
  */
 
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
@@ -17,9 +22,16 @@ import { executedRows } from "@/api/lib/db/executed-rows";
 import {
   applyCzNsCourtRepairStatement,
   CZ_NS_COURT_REPAIR_OUTCOMES,
+  czNsSourceIdStatement,
   decideCzNsCourtRepair,
-  parseCzNsCourtRow,
-  selectCzNsForeignCourtRowsStatement,
+  parseCzNsCourtPage,
+  parseCzNsSourceId,
+  selectCzNsCourtPageStatement,
+} from "@/api/scripts/repair-cz-ns-court-plan";
+import type {
+  CzNsCourtCursor,
+  CzNsCourtPage,
+  CzNsCourtRow,
 } from "@/api/scripts/repair-cz-ns-court-plan";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
@@ -30,66 +42,88 @@ const nsSourceId = createSafeId<"caseLawSource">();
 const nssSourceId = createSafeId<"caseLawSource">();
 
 const PUBLISHER_COURT = "Nejvyšší soud";
+const PUBLISHER_ECLI_CODE = "NS";
 
 /** When the fixtures were last written, long before any run of the repair. */
 const STORED_AT = new Date("2020-01-01T00:00:00.000Z");
 
-type Fixture = {
-  ecli: string | null;
-  id: SafeId<"caseLawDecision">;
-  label: string;
-  sourceId: SafeId<"caseLawSource">;
+/** Rows the source holds. Several pages' worth at the size the walk uses. */
+const SOURCE_ROWS = 240;
+
+/**
+ * Where the rows carrying another court's ECLI sit. Spread on purpose, and
+ * with a long run of publisher rows after the last of them: a walk that only
+ * advanced on a match would stall exactly there.
+ */
+const FOREIGN_ROWS = new Map<number, string>([
+  [3, "KSOS"],
+  [4, "VSPH"],
+  [97, "KSBR"],
+  [98, "MSPH"],
+  [140, "OSOV"],
+]);
+
+const fixtureIds = Array.from({ length: SOURCE_ROWS }, () =>
+  createSafeId<"caseLawDecision">(),
+);
+
+/** The id at `index`, which the fixture array is built to hold. */
+const fixtureId = (index: number): SafeId<"caseLawDecision"> => {
+  const id = fixtureIds[index];
+  if (id === undefined) {
+    throw new Error(`no fixture at ${String(index)}`);
+  }
+  return id;
 };
 
-const fixtures: readonly Fixture[] = [
-  {
-    ecli: "ECLI:CZ:KSOS:2011:75.CO.19.2011.1",
-    id: createSafeId<"caseLawDecision">(),
-    label: "regional court published by the Supreme Court",
-    sourceId: nsSourceId,
-  },
-  {
-    ecli: "ECLI:CZ:VSPH:2015:1.VSPH.9.2015.1",
-    id: createSafeId<"caseLawDecision">(),
-    label: "high court published by the Supreme Court",
-    sourceId: nsSourceId,
-  },
-  {
-    ecli: "ECLI:CZ:NS:2015:23.CDO.3470.2015.1",
-    id: createSafeId<"caseLawDecision">(),
-    label: "the publisher's own decision",
-    sourceId: nsSourceId,
-  },
-  {
-    ecli: null,
-    id: createSafeId<"caseLawDecision">(),
-    label: "no ECLI, so no court signal in the row",
-    sourceId: nsSourceId,
-  },
-  {
-    ecli: "ECLI:CZ:KSBR:2020:62.A.1.2020.1",
-    id: createSafeId<"caseLawDecision">(),
-    label: "another source's row, which this repair does not own",
-    sourceId: nssSourceId,
-  },
-];
+/** The ECLI row `index` carries: the publisher's own, unless planted. */
+const ecliOf = (index: number): string =>
+  `ECLI:CZ:${FOREIGN_ROWS.get(index) ?? PUBLISHER_ECLI_CODE}:2011:${String(index)}.CO.19.2011.1`;
 
-const labelOf = new Map(fixtures.map((fixture) => [fixture.id, fixture.label]));
+const foreignIds = new Set([...FOREIGN_ROWS.keys()].map(fixtureId));
 
-const selection = async (
-  after: SafeId<"caseLawDecision"> | null,
-  limit: number,
-) =>
-  executedRows(
-    await db.execute(
-      selectCzNsForeignCourtRowsStatement({
-        adapterKey: "cz-ns",
-        after,
-        limit,
-        publisherEcliCode: "NS",
-      }),
+/** Read one page, exactly as the script reads it. */
+const readPage = async (
+  after: CzNsCourtCursor | null,
+  pageSize: number,
+): Promise<CzNsCourtPage> =>
+  parseCzNsCourtPage(
+    executedRows(
+      await db.execute(
+        selectCzNsCourtPageStatement({
+          after,
+          pageSize,
+          publisherEcliCode: PUBLISHER_ECLI_CODE,
+          sourceId: nsSourceId,
+        }),
+      ),
     ),
-  ).map(parseCzNsCourtRow);
+  );
+
+type Walk = {
+  /** Every page the walk read, in order. */
+  pages: CzNsCourtPage[];
+  rows: CzNsCourtRow[];
+};
+
+/** Walk the source to its end, as the script's loop does. */
+const walk = async (pageSize: number): Promise<Walk> => {
+  const pages: CzNsCourtPage[] = [];
+  const rows: CzNsCourtRow[] = [];
+  let cursor: CzNsCourtCursor | null = null;
+  // A walk that does not terminate is the failure this test exists to catch,
+  // so the loop is bounded and the bound is asserted rather than trusted.
+  for (let read = 0; read <= SOURCE_ROWS + 2; read += 1) {
+    const page = await readPage(cursor, pageSize);
+    pages.push(page);
+    rows.push(...page.rows);
+    if (page.cursor === null) {
+      return { pages, rows };
+    }
+    cursor = page.cursor;
+  }
+  throw new Error("the walk did not reach the end of the source");
+};
 
 beforeAll(
   async () => {
@@ -101,28 +135,43 @@ beforeAll(
       { id: nssSourceId, adapterKey: "cz-nss", name: "cz-nss source" },
     ]);
 
-    await db.insert(caseLawDecisions).values(
-      fixtures.map((fixture, index) => ({
-        id: fixture.id,
-        sourceId: fixture.sourceId,
+    await db.insert(caseLawDecisions).values([
+      ...fixtureIds.map((id, index) => ({
+        id,
+        sourceId: nsSourceId,
         caseNumber: `${String(index)} C ${String(index)}/2020`,
         // Every row carries the publisher's name, which is the fault.
         court: PUBLISHER_COURT,
         country: "CZE",
         language: "cs",
-        ecli: fixture.ecli,
-        metadata: { court: PUBLISHER_COURT, ecli: fixture.ecli },
-        // Both hashes present and equal: the row reads as projected and up to
-        // date, which is the state a court-only change has to disturb.
+        ecli: ecliOf(index),
+        metadata: { court: PUBLISHER_COURT },
         contentHash: "a".repeat(64),
         indexedHash: "a".repeat(64),
-        // Stamped in the past rather than at insert time, so "the repair moved
-        // this" is a fact about the row and not about how fast the test ran.
+        slug: `ns-${String(index)}`,
+        languageGroupKey: `ns-${String(index)}`,
+        // Distinct and increasing, so the walk's order is the one the index
+        // serves and a page boundary falls where this test says it does.
+        createdAt: new Date(STORED_AT.getTime() + index * 1000),
         updatedAt: STORED_AT,
-        slug: `fixture-${String(index)}`,
-        languageGroupKey: `fixture-${String(index)}`,
       })),
-    );
+      // Another source's row, carrying a foreign ECLI: this repair owns its
+      // own source and must not read, let alone rewrite, anyone else's.
+      {
+        id: createSafeId<"caseLawDecision">(),
+        sourceId: nssSourceId,
+        caseNumber: "62 A 1/2020",
+        court: PUBLISHER_COURT,
+        country: "CZE",
+        language: "cs",
+        ecli: "ECLI:CZ:KSBR:2020:62.A.1.2020.1",
+        metadata: { court: PUBLISHER_COURT },
+        slug: "nss-1",
+        languageGroupKey: "nss-1",
+        createdAt: STORED_AT,
+        updatedAt: STORED_AT,
+      },
+    ]);
   },
   { timeout: 120_000 },
 );
@@ -131,90 +180,127 @@ afterAll(async () => {
   await client.close();
 });
 
-test("selects the source's rows whose own ECLI names another court", async () => {
-  const selected = await selection(null, 100);
-  expect(new Set(selected.map(({ id }) => labelOf.get(id)))).toEqual(
-    new Set([
-      "regional court published by the Supreme Court",
-      "high court published by the Supreme Court",
-    ]),
-  );
-});
-
-test("pages on the primary key, so a held row is not read forever", async () => {
-  const first = await selection(null, 1);
-  expect(first).toHaveLength(1);
-  const firstRow = first.at(0);
-  if (firstRow === undefined) {
-    throw new Error("Expected a first page");
-  }
-  const second = await selection(firstRow.id, 1);
-  expect(second.at(0)?.id).not.toBe(firstRow.id);
-  expect(await selection(second.at(0)?.id ?? null, 1)).toEqual([]);
-});
-
-test("writes the court and the copy the row's metadata carries", async () => {
-  const rows = await selection(null, 100);
-  for (const row of rows) {
-    const repair = decideCzNsCourtRepair(row);
-    if (repair.outcome !== CZ_NS_COURT_REPAIR_OUTCOMES.REATTRIBUTED) {
-      throw new Error(`Expected a re-attribution, got ${repair.outcome}`);
-    }
-    const written = executedRows(
-      await db.execute(
-        applyCzNsCourtRepairStatement({
-          court: repair.court,
-          from: repair.from,
-          id: repair.id,
-        }),
+describe("the walk", () => {
+  test("finds the source by the adapter that wrote it", async () => {
+    expect(
+      parseCzNsSourceId(
+        executedRows(await db.execute(czNsSourceIdStatement("cz-ns"))),
       ),
-    );
-    expect(written).toHaveLength(1);
+    ).toBe(nsSourceId);
+    expect(
+      parseCzNsSourceId(
+        executedRows(await db.execute(czNsSourceIdStatement("cz-none"))),
+      ),
+    ).toBeNull();
+  });
 
-    const stored = (
-      await db
-        .select({
-          court: caseLawDecisions.court,
-          indexedHash: caseLawDecisions.indexedHash,
-          metadata: caseLawDecisions.metadata,
-          updatedAt: caseLawDecisions.updatedAt,
-        })
-        .from(caseLawDecisions)
-        .where(eq(caseLawDecisions.id, repair.id))
-    ).at(0);
-    expect(stored?.court).toBe(repair.court);
-    expect(stored?.metadata?.["court"]).toBe(repair.court);
-    // Both search projections read a mark rather than the court itself: the
-    // full-text one compares this timestamp against its own, and the legacy
-    // corpus index treats a cleared hash as work. A row whose court moved and
-    // whose marks did not is served under its old court for good.
-    expect(stored?.indexedHash).toBeNull();
-    expect(stored?.updatedAt.getTime() ?? 0).toBeGreaterThan(
-      STORED_AT.getTime(),
-    );
-  }
+  test("examines one bounded page per statement", async () => {
+    const pageSize = 50;
+    const { pages } = await walk(pageSize);
 
-  // Idempotent: the repaired rows have left the decision's re-attribution
-  // branch, so a second pass writes nothing.
-  const second = await selection(null, 100);
-  expect(second.map((row) => decideCzNsCourtRepair(row).outcome)).toEqual(
-    second.map(() => CZ_NS_COURT_REPAIR_OUTCOMES.HELD),
-  );
+    // What bounds a statement is rows examined, so that is what is asserted:
+    // no page may read more than it was given, however few of its rows match.
+    expect(pages.every((page) => page.scanned <= pageSize)).toBe(true);
+    // Every row of the source is examined exactly once, and the walk stops on
+    // the empty page that follows the last full one.
+    expect(pages.reduce((total, page) => total + page.scanned, 0)).toBe(
+      SOURCE_ROWS,
+    );
+    expect(pages).toHaveLength(Math.ceil(SOURCE_ROWS / pageSize) + 1);
+    expect(pages.at(-1)?.cursor).toBeNull();
+  });
+
+  test("advances over a page whose rows all hold", async () => {
+    const { pages } = await walk(50);
+    const barren = pages.filter(
+      (page) => page.scanned > 0 && page.rows.length === 0,
+    );
+    // The fixture puts a long run of publisher rows after the last planted
+    // one, so this is not a vacuous filter: a page that matched nothing still
+    // states where the next one starts.
+    expect(barren.length).toBeGreaterThan(0);
+    expect(barren.every((page) => page.cursor !== null)).toBe(true);
+  });
+
+  test("reads the same rows however it is paged", async () => {
+    const finely = await walk(7);
+    const coarsely = await walk(SOURCE_ROWS * 2);
+
+    expect(finely.rows.map((row) => row.id).sort()).toEqual(
+      coarsely.rows.map((row) => row.id).sort(),
+    );
+    expect(coarsely.pages).toHaveLength(2);
+  });
+
+  test("reads this source's rows whose own ECLI names another court", async () => {
+    const { rows } = await walk(50);
+    expect(new Set(rows.map((row) => row.id))).toEqual(foreignIds);
+  });
 });
 
-test("refuses a write whose row changed under the run", async () => {
-  const row = (await selection(null, 100)).at(0);
-  if (row === undefined) {
-    throw new Error("Expected a selected row");
-  }
-  const written = executedRows(
-    await db.execute(
-      applyCzNsCourtRepairStatement({
-        court: "Krajský soud v Brně",
-        from: PUBLISHER_COURT,
-        id: row.id,
-      }),
-    ),
-  );
-  expect(written).toEqual([]);
+describe("the write", () => {
+  test("writes the court and the copy the row's metadata carries", async () => {
+    const { rows } = await walk(50);
+    for (const row of rows) {
+      const repair = decideCzNsCourtRepair(row);
+      if (repair.outcome !== CZ_NS_COURT_REPAIR_OUTCOMES.REATTRIBUTED) {
+        throw new Error(`Expected a re-attribution, got ${repair.outcome}`);
+      }
+      const written = executedRows(
+        await db.execute(
+          applyCzNsCourtRepairStatement({
+            court: repair.court,
+            from: repair.from,
+            id: repair.id,
+          }),
+        ),
+      );
+      expect(written).toHaveLength(1);
+
+      const stored = (
+        await db
+          .select({
+            court: caseLawDecisions.court,
+            indexedHash: caseLawDecisions.indexedHash,
+            metadata: caseLawDecisions.metadata,
+            updatedAt: caseLawDecisions.updatedAt,
+          })
+          .from(caseLawDecisions)
+          .where(eq(caseLawDecisions.id, repair.id))
+      ).at(0);
+      expect(stored?.court).toBe(repair.court);
+      expect(stored?.metadata?.["court"]).toBe(repair.court);
+      // Both search projections read a mark rather than the court itself: the
+      // full-text one compares this timestamp against its own, and the legacy
+      // corpus index treats a cleared hash as work. A row whose court moved
+      // and whose marks did not is served under its old court for good.
+      expect(stored?.indexedHash).toBeNull();
+      expect(stored?.updatedAt.getTime()).toBeGreaterThan(STORED_AT.getTime());
+    }
+
+    // Idempotent: the repaired rows still come back from the walk, and the
+    // decision now holds them rather than re-attributing them again.
+    const second = await walk(50);
+    expect(
+      second.rows.map((row) => decideCzNsCourtRepair(row).outcome),
+    ).toEqual(second.rows.map(() => CZ_NS_COURT_REPAIR_OUTCOMES.HELD));
+  });
+
+  test("refuses a write whose row changed under the run", async () => {
+    const row = (await walk(50)).rows.at(0);
+    if (row === undefined) {
+      throw new Error("Expected a row to write");
+    }
+    expect(
+      executedRows(
+        await db.execute(
+          applyCzNsCourtRepairStatement({
+            court: "Krajský soud v Brně",
+            from: PUBLISHER_COURT,
+            id: row.id,
+          }),
+        ),
+      ),
+    ).toEqual([]);
+  });
 });

--- a/apps/api/src/scripts/repair-cz-ns-court-plan.db.test.ts
+++ b/apps/api/src/scripts/repair-cz-ns-court-plan.db.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
@@ -58,10 +58,20 @@ const SOURCE_ROWS = 240;
 const FOREIGN_ROWS = new Map<number, string>([
   [3, "KSOS"],
   [4, "VSPH"],
+  [50, "KSPL"],
   [97, "KSBR"],
   [98, "MSPH"],
   [140, "OSOV"],
 ]);
+
+/**
+ * Rows the fixture puts inside one millisecond, straddling the boundary of a
+ * fifty-row page. `created_at` is microsecond-precision, and a cursor carried
+ * through a JavaScript `Date` holds milliseconds: it would land before the row
+ * it was taken from, so the next page would read this whole group again — and
+ * the last row of the source would come back on every page after it.
+ */
+const SAME_MILLISECOND_ROWS = [48, 49, 50, 51];
 
 const fixtureIds = Array.from({ length: SOURCE_ROWS }, () =>
   createSafeId<"caseLawDecision">(),
@@ -172,6 +182,22 @@ beforeAll(
         updatedAt: STORED_AT,
       },
     ]);
+
+    // Written as microseconds inside a single millisecond, which drizzle
+    // cannot express through a `Date` — which is the point. The offsets are
+    // added as an interval so the fixture states no timestamp format of its
+    // own; the one the cursor uses belongs to the pagination helpers.
+    const sameMillisecond = new Date(
+      STORED_AT.getTime() + (SAME_MILLISECOND_ROWS[0] ?? 0) * 1000,
+    );
+    for (const [offset, index] of SAME_MILLISECOND_ROWS.entries()) {
+      await db.execute(
+        sql`UPDATE case_law_decisions
+               SET created_at = ${sameMillisecond}::timestamptz
+                              + make_interval(secs => ${(offset + 1) / 1_000_000})
+             WHERE id = ${fixtureId(index)}::uuid`,
+      );
+    }
   },
   { timeout: 120_000 },
 );
@@ -230,6 +256,20 @@ describe("the walk", () => {
       coarsely.rows.map((row) => row.id).sort(),
     );
     expect(coarsely.pages).toHaveLength(2);
+  });
+
+  test("visits rows sharing a millisecond once across a page boundary", async () => {
+    const inTheMillisecond = new Set(SAME_MILLISECOND_ROWS.map(fixtureId));
+    // The boundary of a fifty-row page falls inside the group, so the cursor
+    // this page hands on is one of its rows: a millisecond-precision cursor
+    // re-admits the rest of the group, and the walk stops terminating.
+    const { pages, rows } = await walk(50);
+
+    expect(pages.reduce((total, page) => total + page.scanned, 0)).toBe(
+      SOURCE_ROWS,
+    );
+    const matchedInside = rows.filter((row) => inTheMillisecond.has(row.id));
+    expect(matchedInside).toHaveLength(1);
   });
 
   test("reads this source's rows whose own ECLI names another court", async () => {

--- a/apps/api/src/scripts/repair-cz-ns-court-plan.ts
+++ b/apps/api/src/scripts/repair-cz-ns-court-plan.ts
@@ -15,6 +15,10 @@ import { sql } from "drizzle-orm";
 import type { SafeId } from "@/api/lib/branded-types";
 import { czCourtFromEcli } from "@/api/lib/case-law/cz-ecli-courts";
 import {
+  pgTimestampCursorBoundary,
+  pgTimestampCursorValue,
+} from "@/api/lib/db-pagination";
+import {
   brandPersistedCaseLawDecisionId,
   brandPersistedCaseLawSourceId,
 } from "@/api/lib/safe-id-boundaries";
@@ -29,7 +33,16 @@ export type CzNsCourtRow = {
 
 /** Where a walk of the source stands: the last row a page examined. */
 export type CzNsCourtCursor = {
-  /** The row's `created_at`, the leading key of the index the walk uses. */
+  /**
+   * The row's `created_at`, the leading key of the index the walk uses, as
+   * the database's own microsecond text.
+   *
+   * Never a `Date`: the column is microsecond-precision and a `Date` holds
+   * milliseconds, so a cursor round-tripped through one lands before the row
+   * it was taken from. The rows sharing that millisecond are then read again
+   * by the next page — and the last row of the source is read by every page
+   * after it, which is a walk that never ends.
+   */
   createdAt: string;
   id: SafeId<"caseLawDecision">;
 };
@@ -91,7 +104,11 @@ export const selectCzNsCourtPageStatement = ({
        ${
          after === null
            ? sql``
-           : sql`AND (d.created_at, d.id) > (${after.createdAt}::timestamptz, ${after.id}::uuid)`
+           : sql`AND (d.created_at, d.id) > (${pgTimestampCursorBoundary({
+               type: "pgTimestampCursor",
+               value: after.createdAt,
+               precision: "microseconds",
+             })}, ${after.id}::uuid)`
        }
      ORDER BY d.created_at, d.id
      LIMIT ${pageSize}
@@ -102,7 +119,7 @@ export const selectCzNsCourtPageStatement = ({
      ORDER BY created_at DESC, id DESC
      LIMIT 1
   )
-  SELECT b.created_at AS cursor_created_at,
+  SELECT ${pgTimestampCursorValue(sql`b.created_at`)} AS cursor_created_at,
          b.id AS cursor_id,
          b.scanned AS scanned,
          p.id AS match_id,
@@ -136,12 +153,12 @@ export const parseCzNsCourtPage = (rows: readonly unknown[]): CzNsCourtPage => {
   if (!isRecord(first) || typeof first["scanned"] !== "number") {
     return panic(`Unreadable cz-ns court page: ${JSON.stringify(first)}`);
   }
-  const createdAt = first["cursor_created_at"];
   const cursor: CzNsCourtCursor = {
-    createdAt:
-      createdAt instanceof Date
-        ? createdAt.toISOString()
-        : requiredString(createdAt, "cursor_created_at"),
+    // The statement projects this as text at microsecond precision, so it
+    // arrives as the database's own value rather than as a driver's `Date`.
+    // Reading it as anything else is a statement this parser no longer
+    // matches, not a value to coerce.
+    createdAt: requiredString(first["cursor_created_at"], "cursor_created_at"),
     id: brandPersistedCaseLawDecisionId(
       requiredString(first["cursor_id"], "cursor_id"),
     ),

--- a/apps/api/src/scripts/repair-cz-ns-court-plan.ts
+++ b/apps/api/src/scripts/repair-cz-ns-court-plan.ts
@@ -14,7 +14,10 @@ import { sql } from "drizzle-orm";
 
 import type { SafeId } from "@/api/lib/branded-types";
 import { czCourtFromEcli } from "@/api/lib/case-law/cz-ecli-courts";
-import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
+import {
+  brandPersistedCaseLawDecisionId,
+  brandPersistedCaseLawSourceId,
+} from "@/api/lib/safe-id-boundaries";
 import { isRecord } from "@/api/lib/type-guards";
 
 /** One stored decision, as the selection reads it. */
@@ -24,42 +27,142 @@ export type CzNsCourtRow = {
   court: string;
 };
 
-/**
- * Rows of one adapter whose stored ECLI names a court other than the
- * publisher's own, newest id last.
- *
- * The publisher's own code is excluded in SQL rather than in the decision
- * below, because it is what makes this a bounded selection over a
- * multi-million-row table instead of a walk of every decision the source
- * holds. Everything the exclusion lets through is decided in TypeScript, off
- * the one map every Czech adapter resolves a court through.
- *
- * Keyset paging on the primary key, and not on the repair predicate: a
- * repaired row stops matching, but a row this run decides to leave alone does
- * not, and a self-consuming walk would read those again on every batch.
- */
-export const selectCzNsForeignCourtRowsStatement = ({
-  adapterKey,
-  after,
-  limit,
-  publisherEcliCode,
-}: {
-  adapterKey: string;
-  after: SafeId<"caseLawDecision"> | null;
-  limit: number;
-  publisherEcliCode: string;
-}): SQL => sql`
-  SELECT d.id, d.ecli, d.court
-    FROM case_law_decisions d
-    JOIN case_law_sources s ON s.id = d.source_id
-   WHERE s.adapter_key = ${adapterKey}
-     AND d.ecli IS NOT NULL
-     AND d.ecli LIKE 'ECLI:CZ:%'
-     AND d.ecli NOT LIKE ${`ECLI:CZ:${publisherEcliCode}:%`}
-     ${after === null ? sql`` : sql`AND d.id > ${after}::uuid`}
-   ORDER BY d.id
-   LIMIT ${limit}
+/** Where a walk of the source stands: the last row a page examined. */
+export type CzNsCourtCursor = {
+  /** The row's `created_at`, the leading key of the index the walk uses. */
+  createdAt: string;
+  id: SafeId<"caseLawDecision">;
+};
+
+/** What one page of the walk examined, and which of it needs repairing. */
+export type CzNsCourtPage = {
+  /** Rows on this page whose ECLI names a court other than the publisher's. */
+  rows: CzNsCourtRow[];
+  /** Rows the page examined, matching or not. Zero ends the walk. */
+  scanned: number;
+  /** Where the next page starts, or null when the source is exhausted. */
+  cursor: CzNsCourtCursor | null;
+};
+
+/** The source a repair owns, looked up once by the adapter that wrote it. */
+export const czNsSourceIdStatement = (adapterKey: string): SQL => sql`
+  SELECT id FROM case_law_sources WHERE adapter_key = ${adapterKey}
 `;
+
+/**
+ * One page of a walk of the source, and whichever of its rows carry an ECLI
+ * naming a court other than the publisher's own.
+ *
+ * The bound is on rows examined, not on rows matched, and that is the whole
+ * point. The population is a few hundred rows among the source's many
+ * thousands, so a statement whose `LIMIT` counts matches scans forward until
+ * it finds them — and the last such statement, with no matches left to find,
+ * reads every remaining row of the source and is cancelled by the lane's
+ * statement timeout. Here the page takes a fixed number of rows in index
+ * order and the filter runs over those rows alone, so every statement of the
+ * walk costs the same bounded amount whatever the data holds.
+ *
+ * The order is the source's own cursor index (`source_id, created_at, id`),
+ * so a page is an index range rather than a sort of everything the source
+ * holds. The primary key would have been the obvious cursor and the wrong
+ * one: it is random per row, so ordering by it reads the whole partition
+ * before serving the first page.
+ *
+ * The bound comes back on every row, including on a page that matched
+ * nothing, because a page that advances no cursor is a walk that never ends.
+ * A source with no rows past the cursor returns nothing at all, which is the
+ * one way the walk finishes.
+ */
+export const selectCzNsCourtPageStatement = ({
+  after,
+  pageSize,
+  publisherEcliCode,
+  sourceId,
+}: {
+  after: CzNsCourtCursor | null;
+  pageSize: number;
+  publisherEcliCode: string;
+  sourceId: SafeId<"caseLawSource">;
+}): SQL => sql`
+  WITH page AS (
+    SELECT d.id, d.ecli, d.court, d.created_at
+      FROM case_law_decisions d
+     WHERE d.source_id = ${sourceId}::uuid
+       ${
+         after === null
+           ? sql``
+           : sql`AND (d.created_at, d.id) > (${after.createdAt}::timestamptz, ${after.id}::uuid)`
+       }
+     ORDER BY d.created_at, d.id
+     LIMIT ${pageSize}
+  ),
+  bound AS (
+    SELECT created_at, id, (SELECT count(*) FROM page)::int AS scanned
+      FROM page
+     ORDER BY created_at DESC, id DESC
+     LIMIT 1
+  )
+  SELECT b.created_at AS cursor_created_at,
+         b.id AS cursor_id,
+         b.scanned AS scanned,
+         p.id AS match_id,
+         p.ecli AS match_ecli,
+         p.court AS match_court
+    FROM bound b
+    LEFT JOIN page p
+      ON p.ecli IS NOT NULL
+     AND p.ecli LIKE 'ECLI:CZ:%'
+     AND split_part(p.ecli, ':', 3) <> ${publisherEcliCode}
+`;
+
+const requiredString = (value: unknown, column: string): string => {
+  if (typeof value !== "string") {
+    return panic(`cz-ns court page column ${column} is not a string`);
+  }
+  return value;
+};
+
+/**
+ * A page read back from a driver result that is untyped by construction.
+ *
+ * An empty result is the end of the walk; anything else states the bound on
+ * every row, so the first row is enough to read it from.
+ */
+export const parseCzNsCourtPage = (rows: readonly unknown[]): CzNsCourtPage => {
+  const first = rows.at(0);
+  if (first === undefined) {
+    return { rows: [], scanned: 0, cursor: null };
+  }
+  if (!isRecord(first) || typeof first["scanned"] !== "number") {
+    return panic(`Unreadable cz-ns court page: ${JSON.stringify(first)}`);
+  }
+  const createdAt = first["cursor_created_at"];
+  const cursor: CzNsCourtCursor = {
+    createdAt:
+      createdAt instanceof Date
+        ? createdAt.toISOString()
+        : requiredString(createdAt, "cursor_created_at"),
+    id: brandPersistedCaseLawDecisionId(
+      requiredString(first["cursor_id"], "cursor_id"),
+    ),
+  };
+
+  const matched: CzNsCourtRow[] = [];
+  for (const row of rows) {
+    if (!isRecord(row) || row["match_id"] === null) {
+      continue;
+    }
+    matched.push({
+      id: brandPersistedCaseLawDecisionId(
+        requiredString(row["match_id"], "match_id"),
+      ),
+      ecli: requiredString(row["match_ecli"], "match_ecli"),
+      court: requiredString(row["match_court"], "match_court"),
+    });
+  }
+
+  return { rows: matched, scanned: first["scanned"], cursor };
+};
 
 export const CZ_NS_COURT_REPAIR_OUTCOMES = {
   /** The stored court is not what the decision's ECLI names. */
@@ -176,19 +279,16 @@ export const applyCzNsCourtRepairStatement = ({
   RETURNING d.id
 `;
 
-/** One selected row, from a driver result that is untyped by construction. */
-export const parseCzNsCourtRow = (value: unknown): CzNsCourtRow => {
-  if (
-    !isRecord(value) ||
-    typeof value["id"] !== "string" ||
-    typeof value["ecli"] !== "string" ||
-    typeof value["court"] !== "string"
-  ) {
-    return panic(`Unreadable cz-ns court row: ${JSON.stringify(value)}`);
+/** The source id a lookup answered with, or null when no source matches. */
+export const parseCzNsSourceId = (
+  rows: readonly unknown[],
+): SafeId<"caseLawSource"> | null => {
+  const row = rows.at(0);
+  if (row === undefined) {
+    return null;
   }
-  return {
-    id: brandPersistedCaseLawDecisionId(value["id"]),
-    ecli: value["ecli"],
-    court: value["court"],
-  };
+  if (!isRecord(row) || typeof row["id"] !== "string") {
+    return panic(`Unreadable case-law source row: ${JSON.stringify(row)}`);
+  }
+  return brandPersistedCaseLawSourceId(row["id"]);
 };

--- a/apps/api/src/scripts/repair-cz-ns-court.ts
+++ b/apps/api/src/scripts/repair-cz-ns-court.ts
@@ -32,17 +32,24 @@
  * Idempotent: a re-attributed row matches the stored court the next run
  * derives, and is counted as held.
  *
+ * **How it walks.** A page at a time, bounded by rows examined rather than by
+ * rows matched, in the order of the source's own cursor index. The population
+ * is a few hundred rows among the source's many thousands, so a selection
+ * bounded by matches reads to the end of the source looking for the ones that
+ * are not there, and is cancelled by the lane's statement timeout before it
+ * reports anything. Both modes read through the same statement, so what a
+ * report says it would change is what an apply changes.
+ *
  *   # what the repair would change, writing nothing
  *   bun run src/scripts/repair-cz-ns-court.ts
  *
  *   # re-attribute, bounded and resumable by re-running
- *   bun run src/scripts/repair-cz-ns-court.ts --apply [--limit 5000]
+ *   bun run src/scripts/repair-cz-ns-court.ts --apply [--limit 5000] [--page 2000]
  */
 
 import { panic } from "better-result";
 
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
-import type { SafeId } from "@/api/lib/branded-types";
 import {
   enterCaseLawMaintenanceLane,
   openCaseLawReadOnlySession,
@@ -55,21 +62,33 @@ import {
 import {
   applyCzNsCourtRepairStatement,
   CZ_NS_COURT_REPAIR_OUTCOMES,
+  czNsSourceIdStatement,
   decideCzNsCourtRepair,
-  parseCzNsCourtRow,
-  selectCzNsForeignCourtRowsStatement,
+  parseCzNsCourtPage,
+  parseCzNsSourceId,
+  selectCzNsCourtPageStatement,
 } from "@/api/scripts/repair-cz-ns-court-plan";
 import type {
+  CzNsCourtCursor,
+  CzNsCourtPage,
   CzNsCourtReattribution,
-  CzNsCourtRow,
 } from "@/api/scripts/repair-cz-ns-court-plan";
 import { flagInteger, readApplyFlag } from "@/api/scripts/repair-flags";
 
 /** The publisher's own ECLI court code; its rows need no re-attribution. */
 const CZ_NS_PUBLISHER_ECLI_CODE = "NS";
 
-/** Rows read per selection round trip. */
-const BATCH = 200;
+/**
+ * Rows one page of the walk examines, matching or not.
+ *
+ * This is what bounds a statement, so it is the number that keeps the walk
+ * inside the lane's statement timeout: the population is a few hundred rows
+ * among the source's many thousands, and a selection bounded by matches
+ * instead reads to the end of the source looking for the ones that are not
+ * there. An operator meeting a slower database lowers it rather than raising
+ * a timeout.
+ */
+const DEFAULT_PAGE_SIZE = 2000;
 
 /**
  * Rows this run may re-attribute. The affected population is a few hundred,
@@ -83,7 +102,8 @@ const USAGE = `Usage: bun run src/scripts/repair-cz-ns-court.ts [options]
   --apply        Write the re-attributions. Omitted, the run only reports.
   --dry-run      Report only, the default. Accepted so it cannot be mistaken
                  for a flag this script ignores; contradicts --apply.
-  --limit <n>    Rows this run may re-attribute (default ${String(DEFAULT_LIMIT)}).`;
+  --limit <n>    Rows this run may re-attribute (default ${String(DEFAULT_LIMIT)}).
+  --page <n>     Rows one statement examines (default ${String(DEFAULT_PAGE_SIZE)}).`;
 
 const apply = readApplyFlag(USAGE);
 
@@ -97,21 +117,39 @@ const limit = flagInteger({
   name: "limit",
   usage: USAGE,
 });
+const pageSize = flagInteger({
+  fallback: DEFAULT_PAGE_SIZE,
+  name: "page",
+  usage: USAGE,
+});
 
-/** One keyset page of the selection, strictly after `after`. */
+// Resolved once, by the adapter that wrote the rows: the walk below filters on
+// the source id, which is the leading column of the index it reads in, rather
+// than joining the source table on every page.
+const sourceId = parseCzNsSourceId(
+  executedRows(await rootDb.execute(czNsSourceIdStatement(ADAPTER_KEYS.CZ_NS))),
+);
+if (sourceId === null) {
+  console.info(`No ${ADAPTER_KEYS.CZ_NS} source is registered; nothing to do.`);
+  process.exit(0);
+}
+
+/** One page of the walk, strictly after `after`. */
 const readPage = async (
-  after: SafeId<"caseLawDecision"> | null,
-): Promise<CzNsCourtRow[]> =>
-  executedRows(
-    await rootDb.execute(
-      selectCzNsForeignCourtRowsStatement({
-        adapterKey: ADAPTER_KEYS.CZ_NS,
-        after,
-        limit: BATCH,
-        publisherEcliCode: CZ_NS_PUBLISHER_ECLI_CODE,
-      }),
+  after: CzNsCourtCursor | null,
+): Promise<CzNsCourtPage> =>
+  parseCzNsCourtPage(
+    executedRows(
+      await rootDb.execute(
+        selectCzNsCourtPageStatement({
+          after,
+          pageSize,
+          publisherEcliCode: CZ_NS_PUBLISHER_ECLI_CODE,
+          sourceId,
+        }),
+      ),
     ),
-  ).map(parseCzNsCourtRow);
+  );
 
 /**
  * Re-attribute one row, and re-enqueue the projection that carries it.
@@ -155,7 +193,7 @@ const reattributeRow = async (
     return written;
   });
 
-let cursor: SafeId<"caseLawDecision"> | null = null;
+let cursor: CzNsCourtCursor | null = null;
 let scanned = 0;
 let reattributed = 0;
 let superseded = 0;
@@ -166,14 +204,16 @@ const courts = new Map<string, number>();
 while (reattributed + superseded < limit) {
   const page = await readPage(cursor);
 
-  const last = page.at(-1);
-  if (last === undefined) {
+  // The cursor advances by rows examined, not by rows matched. A page whose
+  // rows all held is still progress, and a walk that only moved on a match
+  // would read the same page forever once the last one was behind it.
+  if (page.cursor === null) {
     break;
   }
-  cursor = last.id;
-  scanned += page.length;
+  cursor = page.cursor;
+  scanned += page.scanned;
 
-  for (const row of page) {
+  for (const row of page.rows) {
     // The allowance is per row, not per page: a page is read whole, so a run
     // with one slot left would otherwise write every re-attributable row on
     // it. What an operator authorised is the number of rows changed.
@@ -213,7 +253,7 @@ while (reattributed + superseded < limit) {
 }
 
 console.info(
-  `${scanned.toLocaleString()} rows carry a non-publisher ECLI: ` +
+  `${scanned.toLocaleString()} rows of the source examined: ` +
     `${reattributed.toLocaleString()} ${apply ? "re-attributed" : "would be re-attributed"}, ` +
     `${held.toLocaleString()} already correct, ` +
     `${superseded.toLocaleString()} changed under the run.`,


### PR DESCRIPTION
Bounds the walk by rows examined rather than rows matched, so no statement reads to the end of the source looking for the few rows that need repairing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Czech court-plan repair process to handle large datasets reliably through bounded, paginated processing.
  * Ensured repairs examine only records belonging to the intended source and correctly skip pages without matching records.
  * Prevented duplicate processing when records share closely spaced timestamps across page boundaries.
  * Added safer re-attribution handling, including idempotent updates and protection against stale writes.
  * The repair exits cleanly when the expected source is not registered and reports records examined.
* **Tests**
  * Expanded coverage for pagination, filtering, repeatability and stale-update protection using a larger database fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->