### PR TITLE
fix(api): page the absent-text repair's selection

### DIFF
--- a/apps/api/src/scripts/repair-flags.test.ts
+++ b/apps/api/src/scripts/repair-flags.test.ts
@@ -5,12 +5,13 @@
  * default is thousands of rows.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 
 import {
   flagInteger,
   hasFlag,
   readApplyFlag,
+  rejectUnknownFlags,
 } from "@/api/scripts/repair-flags";
 
 const originalArgv = process.argv;
@@ -61,5 +62,81 @@ describe("readApplyFlag", () => {
     withArgs("--dry-run", "--limit=10");
     expect(hasFlag("apply")).toBe(false);
     expect(readApplyFlag("usage")).toBe(false);
+  });
+});
+
+/** How a stubbed `process.exit` stops its caller, since the real one does not return. */
+class ProcessExitedError extends Error {
+  constructor() {
+    super("process.exit");
+    this.name = "ProcessExitedError";
+  }
+}
+
+/**
+ * The exit code a reader took instead of answering, or `"returned"` when it
+ * answered. A reader that rejects an argument ends the run, so what it does
+ * with a bad spelling cannot be observed through its return value.
+ */
+const exitedWith = (read: () => unknown): number | "returned" => {
+  let code: number | "returned" = "returned";
+  const exit = spyOn(process, "exit").mockImplementation((value) => {
+    code = typeof value === "number" ? value : 0;
+    throw new ProcessExitedError();
+  });
+  const silenced = spyOn(console, "error").mockImplementation(() => undefined);
+  try {
+    read();
+  } catch (error) {
+    // Anything else is a real failure of the reader under test.
+    if (!(error instanceof ProcessExitedError)) {
+      throw error;
+    }
+  } finally {
+    exit.mockRestore();
+    silenced.mockRestore();
+  }
+  return code;
+};
+
+describe("a stated flag takes no value", () => {
+  test("an assigned --apply does not quietly become a report", () => {
+    // The name alone is recognised, so the value would be dropped and the run
+    // would report — the opposite of what was asked for, and silently.
+    withArgs("--apply=true", "--limit=10");
+    expect(exitedWith(() => readApplyFlag("usage"))).toBe(1);
+  });
+
+  test("an assigned --dry-run is refused on its own", () => {
+    // Nobody passes this one beside --apply, so a reader that only looked
+    // while --apply was present would never look at all.
+    withArgs("--dry-run=false");
+    expect(exitedWith(() => readApplyFlag("usage"))).toBe(1);
+  });
+
+  test("the bare spellings still read", () => {
+    withArgs("--apply", "--limit=10");
+    expect(readApplyFlag("usage")).toBe(true);
+    withArgs("--dry-run", "--limit=10");
+    expect(readApplyFlag("usage")).toBe(false);
+  });
+});
+
+describe("rejectUnknownFlags", () => {
+  const reject = (): void =>
+    rejectUnknownFlags({ known: ["limit", "page"], usage: "usage" });
+
+  test("a flag this repair does not have stops the run", () => {
+    // The command an earlier revision documented, repeated after the flag was
+    // removed: accepting it silently would widen the run.
+    withArgs("--apply", "--adapter=cz-us");
+    expect(exitedWith(reject)).toBe(1);
+    withArgs("--apply", "--after", "some-id");
+    expect(exitedWith(reject)).toBe(1);
+  });
+
+  test("a flag it does have, in either spelling, passes", () => {
+    withArgs("--apply", "--limit", "10", "--page=500");
+    expect(exitedWith(reject)).toBe("returned");
   });
 });

--- a/apps/api/src/scripts/repair-flags.ts
+++ b/apps/api/src/scripts/repair-flags.ts
@@ -109,13 +109,38 @@ export const rejectUnknownFlags = ({
 };
 
 /**
+ * A flag that is a statement rather than a setting: present or absent, never
+ * assigned.
+ *
+ * `--apply=true` is refused rather than read, and the reason is the direction
+ * a misreading fails in. The name alone is recognised, so the value would be
+ * dropped and the run would report instead of write — the opposite of what an
+ * operator who spelled out `true` asked for, and silently. What the reader
+ * cannot represent it does not accept.
+ */
+const readStatedFlag = (name: string, usage: string): boolean => {
+  if (process.argv.some((argument) => argument.startsWith(`--${name}=`))) {
+    console.error(
+      `--${name} takes no value; pass it on its own or leave it out.`,
+    );
+    console.error(usage);
+    process.exit(1);
+  }
+  return hasFlag(name);
+};
+
+/**
  * Whether this run writes. `--dry-run` is the default and is accepted so it
  * cannot be mistaken for a flag the script ignores; stating both is an error
  * rather than a silent preference for one of them.
  */
 export const readApplyFlag = (usage: string): boolean => {
-  const apply = hasFlag("apply");
-  if (apply && hasFlag("dry-run")) {
+  // Both read before either is judged: short-circuiting past `--dry-run`
+  // would let an assigned value through on the flag nobody passes with
+  // `--apply`, which is the one an operator states on its own.
+  const apply = readStatedFlag("apply", usage);
+  const dryRun = readStatedFlag("dry-run", usage);
+  if (apply && dryRun) {
     console.error("--apply and --dry-run contradict each other; pass one.");
     console.error(usage);
     process.exit(1);

--- a/apps/api/src/scripts/repair-flags.ts
+++ b/apps/api/src/scripts/repair-flags.ts
@@ -70,6 +70,44 @@ export const flagInteger = ({
   return parsed;
 };
 
+/** Flags every repair takes, so a caller lists only its own. */
+const SHARED_FLAGS = ["apply", "dry-run"] as const;
+
+/**
+ * Refuse a flag this repair does not have.
+ *
+ * Silence is the dangerous reading: an operator repeating a command a script
+ * used to document — a flag that scoped a run to one source, or resumed it
+ * from a cursor — would otherwise be told nothing and get a run over a wider
+ * population than they asked for. What a repair does not understand it must
+ * not accept, so an unrecognised `--flag` stops the run before it takes a lane
+ * or writes anything.
+ *
+ * Values are not flags: only arguments opening with `--` are inspected, in
+ * both the separate and the `--flag=value` spelling.
+ */
+export const rejectUnknownFlags = ({
+  known,
+  usage,
+}: {
+  known: readonly string[];
+  usage: string;
+}): void => {
+  const recognised = new Set<string>([...SHARED_FLAGS, ...known]);
+  const unknown = process.argv
+    .filter((argument) => argument.startsWith("--"))
+    .map((argument) => argument.slice(2).split("=")[0] ?? "")
+    .filter((name) => !recognised.has(name));
+  if (unknown.length === 0) {
+    return;
+  }
+  console.error(
+    `This repair has no ${unknown.map((name) => `--${name}`).join(", ")}.`,
+  );
+  console.error(usage);
+  process.exit(1);
+};
+
 /**
  * Whether this run writes. `--dry-run` is the default and is accepted so it
  * cannot be mistaken for a flag the script ignores; stating both is an error

--- a/apps/api/src/scripts/repair-publisher-absent-text-plan.db.test.ts
+++ b/apps/api/src/scripts/repair-publisher-absent-text-plan.db.test.ts
@@ -1,5 +1,26 @@
-import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
-import { and, count, eq, inArray } from "drizzle-orm";
+/**
+ * The repair's two halves against a real PostgreSQL: the walk, which decides
+ * which stored rows are looked at at all, and the write, which decides what a
+ * looked-at row becomes. Neither is exercised anywhere else — an operator
+ * script's SQL is never executed by CI — and the SQL reading of a marker has
+ * to agree with the TypeScript one the adapters write through, or the two
+ * paths disagree about what absence is.
+ *
+ * The source fixture is deliberately larger than a page. The fault this walk
+ * was rebuilt for only appears at scale: a selection bounded by matches reads
+ * to the end of a source looking for rows that are not there, which a handful
+ * of fixtures can never show.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
@@ -11,21 +32,20 @@ import {
 import type { SafeId } from "@/api/lib/branded-types";
 import { createSafeId } from "@/api/lib/branded-types";
 import { publisherHeadnoteOf } from "@/api/lib/case-law/publisher-summary";
+import { executedRows } from "@/api/lib/db/executed-rows";
 import {
+  absentTextSourcesStatement,
   carriesAbsentPublisherText,
-  carriesDeclaredAbsentPublisherText,
+  parseAbsentTextPage,
+  parseAbsentTextSources,
+  selectAbsentTextPageStatement,
   strippedPublisherMetadata,
 } from "@/api/scripts/repair-publisher-absent-text-plan";
+import type {
+  AbsentTextCursor,
+  AbsentTextPage,
+} from "@/api/scripts/repair-publisher-absent-text-plan";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
-
-/**
- * The repair recognises a marker in SQL while the adapters recognise it in
- * TypeScript, and the two readings have to be the same reading: a row the
- * write path would now store without the sentence but the repair does not
- * strip keeps serving it forever, and a row the repair strips that the write
- * path would have kept loses a real headnote. Both directions are checked
- * here against a real PostgreSQL, over the value shapes the sources publish.
- */
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
@@ -36,105 +56,124 @@ const nsSourceId = createSafeId<"caseLawSource">();
 const HEADNOTE = "Uloží-li soud rodičům povinnost účastnit se mediace.";
 const LEGAL_SENTENCE_MARKER = "Právní věta není k dispozici.";
 const ABSTRACT_MARKER = "Abstrakt není k dispozici.";
+const NEAR_MISS = "Právní věta není k dispozici v tomto jazyce.";
 
-type Fixture = {
-  id: SafeId<"caseLawDecision">;
-  label: string;
-  metadata: Record<string, unknown>;
-  sourceId: SafeId<"caseLawSource">;
-  /** Metadata keys the repair must remove from this row. */
-  stripped: readonly string[];
-};
+/** When the fixtures were last written, long before any run of the repair. */
+const STORED_AT = new Date("2020-01-01T00:00:00.000Z");
 
-const bothMarkers: Fixture = {
-  id: createSafeId<"caseLawDecision">(),
-  label: "both fields carry the court's own absence sentence",
-  metadata: {
-    abstract: ABSTRACT_MARKER,
-    legalSentence: LEGAL_SENTENCE_MARKER,
-    keywords: ["Daně", "Správní řízení"],
-  },
-  sourceId: usSourceId,
-  stripped: ["abstract", "legalSentence"],
-};
+/** Rows the source holds. Several pages' worth at the size the walk uses. */
+const SOURCE_ROWS = 240;
 
-const wrappedMarker: Fixture = {
-  id: createSafeId<"caseLawDecision">(),
-  label: "the marker as the page indents and wraps it",
-  metadata: { legalSentence: "  Právní   věta\nnení k dispozici.  " },
-  sourceId: usSourceId,
-  stripped: ["legalSentence"],
-};
-
-const writtenHeadnote: Fixture = {
-  id: createSafeId<"caseLawDecision">(),
-  label: "a headnote the court wrote, beside an empty abstract",
-  metadata: { legalSentence: HEADNOTE, abstract: ABSTRACT_MARKER },
-  sourceId: usSourceId,
-  stripped: ["abstract"],
-};
-
-const nearMiss: Fixture = {
-  id: createSafeId<"caseLawDecision">(),
-  label: "a sentence that only opens like the marker",
-  metadata: {
-    legalSentence: `${LEGAL_SENTENCE_MARKER.slice(0, -1)} v tomto jazyce.`,
-  },
-  sourceId: usSourceId,
-  stripped: [],
-};
-
-const nothingPublished: Fixture = {
-  id: createSafeId<"caseLawDecision">(),
-  label: "a decision the publisher filled nothing in for",
-  metadata: {},
-  sourceId: usSourceId,
-  stripped: [],
-};
-
-const wrongShape: Fixture = {
-  id: createSafeId<"caseLawDecision">(),
-  label: "a value of the wrong JSON shape under a summary key",
-  metadata: { legalSentence: 42, summary: ["not prose"] },
-  sourceId: usSourceId,
-  stripped: [],
-};
+const US_MARKERS = absentTextComparisonsFor(ADAPTER_KEYS.CZ_US);
+const NS_MARKERS = absentTextComparisonsFor(ADAPTER_KEYS.CZ_NS);
 
 /**
- * A marker belongs to the source that prints it. Another source's row holding
- * the same words is left alone: its adapter does not read the sentence as
- * absence, so the next crawl would write it straight back and the repair would
- * never reach a fixed point.
+ * What each interesting row of the source holds under its publisher-summary
+ * keys. Spread on purpose, and with a long run of ordinary rows after the last
+ * of them: a walk that only advanced on a match would stall exactly there.
  */
-const otherSource: Fixture = {
-  id: createSafeId<"caseLawDecision">(),
-  label: "another source's row carrying the same sentence",
-  metadata: { summary: LEGAL_SENTENCE_MARKER },
-  sourceId: nsSourceId,
-  stripped: [],
+const PLANTED = new Map<number, Record<string, unknown>>([
+  [
+    3,
+    {
+      abstract: ABSTRACT_MARKER,
+      legalSentence: LEGAL_SENTENCE_MARKER,
+      keywords: ["Daně", "Správní řízení"],
+    },
+  ],
+  [4, { legalSentence: "  Právní   věta\nnení k dispozici.  " }],
+  [97, { legalSentence: HEADNOTE, abstract: ABSTRACT_MARKER }],
+  [98, { legalSentence: NEAR_MISS }],
+  [140, { legalSentence: 42, summary: ["not prose"] }],
+  [141, { abstract: ABSTRACT_MARKER }],
+]);
+
+/** Which keys the repair must remove from each planted row. */
+const STRIPPED = new Map<number, readonly string[]>([
+  [3, ["abstract", "legalSentence"]],
+  [4, ["legalSentence"]],
+  [97, ["abstract"]],
+  [98, []],
+  [140, []],
+  [141, ["abstract"]],
+]);
+
+const fixtureIds = Array.from({ length: SOURCE_ROWS }, () =>
+  createSafeId<"caseLawDecision">(),
+);
+
+/** The id at `index`, which the fixture array is built to hold. */
+const fixtureId = (index: number): SafeId<"caseLawDecision"> => {
+  const id = fixtureIds[index];
+  if (id === undefined) {
+    throw new Error(`no fixture at ${String(index)}`);
+  }
+  return id;
 };
 
-const fixtures: readonly Fixture[] = [
-  bothMarkers,
-  wrappedMarker,
-  writtenHeadnote,
-  nearMiss,
-  nothingPublished,
-  wrongShape,
-  otherSource,
-];
+/** The metadata row `index` holds: a headnote the court wrote, unless planted. */
+const metadataOf = (index: number): Record<string, unknown> =>
+  PLANTED.get(index) ?? { legalSentence: `${HEADNOTE} (${String(index)})` };
+
+const strippedOf = (index: number): readonly string[] =>
+  STRIPPED.get(index) ?? [];
+
+const markerIds = new Set(
+  [...STRIPPED.entries()]
+    .filter(([, keys]) => keys.length > 0)
+    .map(([index]) => fixtureId(index)),
+);
+
+/**
+ * The other source's row, holding the same words under a summary key. Its
+ * adapter declares no marker, so nothing about it is absence.
+ */
+const otherSourceId = createSafeId<"caseLawDecision">();
+const OTHER_SOURCE_METADATA = { summary: LEGAL_SENTENCE_MARKER };
 
 const INDEXED_HASH = "a".repeat(64);
 
-/** Which adapter each seeded source belongs to, and so which markers it has. */
-const ADAPTER_OF_SOURCE = new Map([
-  [usSourceId, ADAPTER_KEYS.CZ_US],
-  [nsSourceId, ADAPTER_KEYS.CZ_NS],
-]);
+/** Read one page, exactly as the script reads it. */
+const readPage = async (
+  after: AbsentTextCursor | null,
+  pageSize: number,
+): Promise<AbsentTextPage> =>
+  parseAbsentTextPage(
+    executedRows(
+      await db.execute(
+        selectAbsentTextPageStatement({
+          after,
+          markers: US_MARKERS,
+          pageSize,
+          sourceId: usSourceId,
+        }),
+      ),
+    ),
+  );
 
-const markersOf = (sourceId: SafeId<"caseLawSource">): readonly string[] => {
-  const adapter = ADAPTER_OF_SOURCE.get(sourceId);
-  return adapter === undefined ? [] : absentTextComparisonsFor(adapter);
+type Walk = {
+  /** Every page the walk read, in order. */
+  pages: AbsentTextPage[];
+  ids: SafeId<"caseLawDecision">[];
+};
+
+/** Walk the source to its end, as the script's loop does. */
+const walk = async (pageSize: number): Promise<Walk> => {
+  const pages: AbsentTextPage[] = [];
+  const ids: SafeId<"caseLawDecision">[] = [];
+  let cursor: AbsentTextCursor | null = null;
+  // A walk that does not terminate is the failure this test exists to catch,
+  // so the loop is bounded and the bound is asserted rather than trusted.
+  for (let read = 0; read <= SOURCE_ROWS + 2; read += 1) {
+    const page = await readPage(cursor, pageSize);
+    pages.push(page);
+    ids.push(...page.ids);
+    if (page.cursor === null) {
+      return { pages, ids };
+    }
+    cursor = page.cursor;
+  }
+  throw new Error("the walk did not reach the end of the source");
 };
 
 beforeAll(
@@ -153,30 +192,45 @@ beforeAll(
 // Every test seeds its own rows, so each states its whole precondition and one
 // selected by name behaves as it does in a whole run.
 beforeEach(async () => {
-  await db.delete(caseLawDecisions).where(
-    inArray(
-      caseLawDecisions.id,
-      fixtures.map(({ id }) => id),
-    ),
-  );
-  await db.insert(caseLawDecisions).values(
-    fixtures.map((fixture, index) => ({
-      id: fixture.id,
-      sourceId: fixture.sourceId,
+  await db
+    .delete(caseLawDecisions)
+    .where(inArray(caseLawDecisions.id, [...fixtureIds, otherSourceId]));
+  await db.insert(caseLawDecisions).values([
+    ...fixtureIds.map((id, index) => ({
+      id,
+      sourceId: usSourceId,
       caseNumber: `${String(index)} C ${String(index)}/2020`,
       court: "Ústavní soud",
       country: "CZE",
       language: "cs",
       decisionDate: "2024-01-01",
-      metadata: fixture.metadata,
+      metadata: metadataOf(index),
       // Both hashes present and equal: the row reads as projected and up to
       // date, which is the state a metadata-only change has to disturb.
       contentHash: INDEXED_HASH,
       indexedHash: INDEXED_HASH,
-      slug: `fixture-${String(index)}`,
-      languageGroupKey: `fixture-${String(index)}`,
+      slug: `us-${String(index)}`,
+      languageGroupKey: `us-${String(index)}`,
+      // Distinct and increasing, so the walk's order is the one the index
+      // serves and a page boundary falls where this test says it does.
+      createdAt: new Date(STORED_AT.getTime() + index * 1000),
     })),
-  );
+    {
+      id: otherSourceId,
+      sourceId: nsSourceId,
+      caseNumber: "1 C 1/2020",
+      court: "Nejvyšší soud",
+      country: "CZE",
+      language: "cs",
+      decisionDate: "2024-01-01",
+      metadata: OTHER_SOURCE_METADATA,
+      contentHash: INDEXED_HASH,
+      indexedHash: INDEXED_HASH,
+      slug: "ns-1",
+      languageGroupKey: "ns-1",
+      createdAt: STORED_AT,
+    },
+  ]);
 });
 
 afterAll(async () => {
@@ -193,12 +247,7 @@ const storedRows = async (): Promise<
       indexedHash: caseLawDecisions.indexedHash,
     })
     .from(caseLawDecisions)
-    .where(
-      inArray(
-        caseLawDecisions.id,
-        fixtures.map(({ id }) => id),
-      ),
-    );
+    .where(inArray(caseLawDecisions.id, [...fixtureIds, otherSourceId]));
   return new Map(
     rows.map((row) => [
       row.id,
@@ -208,8 +257,10 @@ const storedRows = async (): Promise<
 };
 
 /** The repair's own write over one source's rows, with that source's markers. */
-const repair = async (sourceId: SafeId<"caseLawSource">): Promise<string[]> => {
-  const markers = markersOf(sourceId);
+const repair = async (
+  sourceId: SafeId<"caseLawSource">,
+  markers: readonly string[],
+): Promise<string[]> => {
   const repaired = await db
     .update(caseLawDecisions)
     .set({
@@ -228,109 +279,152 @@ const repair = async (sourceId: SafeId<"caseLawSource">): Promise<string[]> => {
 
 /** Both sources, as one run of the script would walk them. */
 const repairEverySource = async (): Promise<Set<string>> =>
-  new Set([...(await repair(usSourceId)), ...(await repair(nsSourceId))]);
+  new Set([
+    ...(await repair(usSourceId, US_MARKERS)),
+    ...(await repair(nsSourceId, NS_MARKERS)),
+  ]);
 
-/** The survey the script reads before it writes anything. */
-const surveyed = async (): Promise<{ adapterKey: string; rows: number }[]> =>
-  await db
-    .select({ adapterKey: caseLawSources.adapterKey, rows: count() })
-    .from(caseLawDecisions)
-    .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
-    .where(carriesDeclaredAbsentPublisherText)
-    .groupBy(caseLawSources.id, caseLawSources.adapterKey);
+describe("the walk", () => {
+  test("finds the sources by the adapters that declare a marker", async () => {
+    const sources = parseAbsentTextSources(
+      executedRows(
+        await db.execute(absentTextSourcesStatement([ADAPTER_KEYS.CZ_US])),
+      ),
+    );
+    expect(sources).toEqual([
+      { adapterKey: ADAPTER_KEYS.CZ_US, sourceId: usSourceId },
+    ]);
+    expect(
+      parseAbsentTextSources(
+        executedRows(await db.execute(absentTextSourcesStatement([]))),
+      ),
+    ).toEqual([]);
+  });
 
-test("the survey counts the rows a repair would touch, per source", async () => {
-  const perSource = new Map(
-    (await surveyed()).map(({ adapterKey, rows }) => [adapterKey, rows]),
-  );
+  test("examines one bounded page per statement", async () => {
+    const pageSize = 50;
+    const { pages } = await walk(pageSize);
 
-  expect(perSource.get(ADAPTER_KEYS.CZ_US)).toBe(
-    fixtures.filter(
-      ({ sourceId, stripped }) =>
-        sourceId === usSourceId && stripped.length > 0,
-    ).length,
-  );
-  // The other source's row holds the same sentence and is still not counted:
-  // its adapter declares no marker, so nothing about it is absence.
-  expect(perSource.has(ADAPTER_KEYS.CZ_NS)).toBe(false);
+    // What bounds a statement is rows examined, so that is what is asserted:
+    // no page may read more than it was given, however few of its rows match.
+    expect(pages.every((page) => page.scanned <= pageSize)).toBe(true);
+    // Every row of the source is examined exactly once, and the walk stops on
+    // the empty page that follows the last full one.
+    expect(pages.reduce((total, page) => total + page.scanned, 0)).toBe(
+      SOURCE_ROWS,
+    );
+    expect(pages).toHaveLength(Math.ceil(SOURCE_ROWS / pageSize) + 1);
+    expect(pages.at(-1)?.cursor).toBeNull();
+  });
+
+  test("advances over a page whose rows all hold", async () => {
+    const { pages } = await walk(50);
+    const barren = pages.filter(
+      (page) => page.scanned > 0 && page.ids.length === 0,
+    );
+    // The fixture puts a long run of ordinary rows after the last planted one,
+    // so this is not a vacuous filter: a page that matched nothing still
+    // states where the next one starts.
+    expect(barren.length).toBeGreaterThan(0);
+    expect(barren.every((page) => page.cursor !== null)).toBe(true);
+  });
+
+  test("reads the same rows however it is paged", async () => {
+    const finely = await walk(7);
+    const coarsely = await walk(SOURCE_ROWS * 2);
+
+    expect(finely.ids.toSorted()).toEqual(coarsely.ids.toSorted());
+    expect(coarsely.pages).toHaveLength(2);
+  });
+
+  test("reads this source's rows carrying one of its own markers", async () => {
+    const { ids } = await walk(50);
+    expect(new Set(ids)).toEqual(markerIds);
+  });
+
+  test("does not read another source's rows", async () => {
+    const { ids } = await walk(50);
+    expect(ids).not.toContain(otherSourceId);
+  });
 });
 
-test("a marker is only absence for the source that prints it", async () => {
-  expect(await repair(nsSourceId)).toEqual([]);
-  const stored = await storedRows();
-  expect(stored.get(otherSource.id)?.metadata).toEqual(otherSource.metadata);
-  expect(stored.get(otherSource.id)?.indexed).toBe(true);
-  // The same words at the source that does declare them are absence, so the
-  // assertion above is scope rather than a predicate that matches nothing.
-  expect(await repair(usSourceId)).toContain(bothMarkers.id);
-});
+describe("the write", () => {
+  test("strips exactly the keys the write path would now leave absent", async () => {
+    const repaired = await repairEverySource();
+    const stored = await storedRows();
 
-test("the repair strips exactly the keys the write path would now leave absent", async () => {
-  const repaired = await repairEverySource();
-  const stored = await storedRows();
+    for (const [index, id] of fixtureIds.entries()) {
+      const row = stored.get(id);
+      expect(row).toBeDefined();
+      const metadata: Record<string, unknown> = row?.metadata ?? {};
+      const stripped = strippedOf(index);
 
-  for (const fixture of fixtures) {
-    const row = stored.get(fixture.id);
-    expect(row).toBeDefined();
-    const metadata: Record<string, unknown> = row?.metadata ?? {};
-
-    for (const key of fixture.stripped) {
-      expect(metadata).not.toHaveProperty(key);
-    }
-    // Everything the row held besides the stripped keys is still there, with
-    // the value the publisher published.
-    for (const [key, value] of Object.entries(fixture.metadata)) {
-      if (fixture.stripped.includes(key)) {
-        continue;
+      for (const key of stripped) {
+        expect(metadata).not.toHaveProperty(key);
       }
-      expect(metadata[key]).toEqual(value);
-    }
-    // A changed row is re-enqueued for the index; an untouched one is left
-    // exactly as it was, so the repair cannot re-project the whole corpus.
-    expect(repaired.has(fixture.id)).toBe(fixture.stripped.length > 0);
-    expect(row?.indexed).toBe(fixture.stripped.length === 0);
-  }
-});
-
-test("what the repair strips is what that source's adapter reads as absent", async () => {
-  // The binding: the SQL reading and `sourceTextOrAbsent` decide the same way
-  // about the same stored values, under the same adapter, so a marker declared
-  // once is recognised on both the write path and the repair path.
-  await repairEverySource();
-  const stored = await storedRows();
-  for (const fixture of fixtures) {
-    const adapter = ADAPTER_OF_SOURCE.get(fixture.sourceId);
-    expect(adapter).toBeDefined();
-    const after: Record<string, unknown> =
-      stored.get(fixture.id)?.metadata ?? {};
-    for (const [key, value] of Object.entries(fixture.metadata)) {
-      if (typeof value !== "string" || adapter === undefined) {
-        continue;
+      // Everything the row held besides the stripped keys is still there, with
+      // the value the publisher published.
+      for (const [key, value] of Object.entries(metadataOf(index))) {
+        if (stripped.includes(key)) {
+          continue;
+        }
+        expect(metadata[key]).toEqual(value);
       }
-      expect(key in after).toBe(
-        sourceTextOrAbsent(adapter, value) !== undefined,
-      );
+      // A changed row is re-enqueued for the index; an untouched one is left
+      // exactly as it was, so the repair cannot re-project the whole corpus.
+      expect(repaired.has(id)).toBe(stripped.length > 0);
+      expect(row?.indexed).toBe(stripped.length === 0);
     }
-  }
-});
+  });
 
-test("a repaired row shows the next headnote the publisher wrote, or none", async () => {
-  await repairEverySource();
-  const stored = await storedRows();
-  const headnoteOf = (id: SafeId<"caseLawDecision">): string | null =>
-    publisherHeadnoteOf({
-      documentAst: null,
-      metadata: stored.get(id)?.metadata ?? null,
-    });
+  test("a marker is only absence for the source that prints it", async () => {
+    expect(await repair(nsSourceId, NS_MARKERS)).toEqual([]);
+    const stored = await storedRows();
+    expect(stored.get(otherSourceId)?.metadata).toEqual(OTHER_SOURCE_METADATA);
+    expect(stored.get(otherSourceId)?.indexed).toBe(true);
+    // The same words at the source that does declare them are absence, so the
+    // assertion above is scope rather than a predicate that matches nothing.
+    expect(await repair(usSourceId, US_MARKERS)).toContain(fixtureId(3));
+  });
 
-  expect(headnoteOf(bothMarkers.id)).toBeNull();
-  expect(headnoteOf(wrappedMarker.id)).toBeNull();
-  expect(headnoteOf(writtenHeadnote.id)).toBe(HEADNOTE);
-});
+  test("what the repair strips is what that source's adapter reads as absent", async () => {
+    // The binding: the SQL reading and `sourceTextOrAbsent` decide the same
+    // way about the same stored values, under the same adapter, so a marker
+    // declared once is recognised on both the write path and the repair path.
+    await repairEverySource();
+    const stored = await storedRows();
+    for (const [index, id] of fixtureIds.entries()) {
+      const after: Record<string, unknown> = stored.get(id)?.metadata ?? {};
+      for (const [key, value] of Object.entries(metadataOf(index))) {
+        if (typeof value !== "string") {
+          continue;
+        }
+        expect(key in after).toBe(
+          sourceTextOrAbsent(ADAPTER_KEYS.CZ_US, value) !== undefined,
+        );
+      }
+    }
+  });
 
-test("a second pass finds nothing left to repair", async () => {
-  await repairEverySource();
-  expect(await repair(usSourceId)).toEqual([]);
-  expect(await repair(nsSourceId)).toEqual([]);
-  expect(await surveyed()).toEqual([]);
+  test("a repaired row shows the next headnote the publisher wrote, or none", async () => {
+    await repairEverySource();
+    const stored = await storedRows();
+    const headnoteOf = (id: SafeId<"caseLawDecision">): string | null =>
+      publisherHeadnoteOf({
+        documentAst: null,
+        metadata: stored.get(id)?.metadata ?? null,
+      });
+
+    expect(headnoteOf(fixtureId(3))).toBeNull();
+    expect(headnoteOf(fixtureId(4))).toBeNull();
+    expect(headnoteOf(fixtureId(97))).toBe(HEADNOTE);
+    expect(headnoteOf(fixtureId(98))).toBe(NEAR_MISS);
+  });
+
+  test("a second pass finds nothing left to repair", async () => {
+    await repairEverySource();
+    expect(await repair(usSourceId, US_MARKERS)).toEqual([]);
+    expect(await repair(nsSourceId, NS_MARKERS)).toEqual([]);
+    expect((await walk(50)).ids).toEqual([]);
+  });
 });

--- a/apps/api/src/scripts/repair-publisher-absent-text-plan.db.test.ts
+++ b/apps/api/src/scripts/repair-publisher-absent-text-plan.db.test.ts
@@ -20,7 +20,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
@@ -340,6 +340,59 @@ describe("the walk", () => {
   test("reads this source's rows carrying one of its own markers", async () => {
     const { ids } = await walk(50);
     expect(new Set(ids)).toEqual(markerIds);
+  });
+
+  test("pages across rows that share a millisecond", async () => {
+    // `created_at` holds microseconds. A cursor carried at millisecond
+    // precision compares as the start of its millisecond, so every row sharing
+    // that millisecond is read again on the next page — a page boundary inside
+    // one never advances, and the walk does not end. Ten rows are moved into a
+    // single millisecond, two of them carrying markers, and the page size is
+    // small enough that a boundary lands among them.
+    const shared = Array.from({ length: 10 }, (_, offset) => 95 + offset);
+    await db.execute(sql`
+      UPDATE case_law_decisions AS d
+         SET created_at = timestamptz '2020-01-01 00:01:35Z'
+                        + (v.micros * interval '1 microsecond')
+        FROM (VALUES ${sql.join(
+          shared.map(
+            (index, position) =>
+              sql`(${fixtureId(index)}::uuid, ${position + 1}::int)`,
+          ),
+          sql`, `,
+        )}) AS v(id, micros)
+       WHERE d.id = v.id
+    `);
+
+    // The walk terminates — its own bound throws otherwise — and every row is
+    // examined exactly once: a re-read would push the total above the source,
+    // a skip would leave it below.
+    const { pages, ids } = await walk(3);
+    expect(pages.reduce((total, page) => total + page.scanned, 0)).toBe(
+      SOURCE_ROWS,
+    );
+    // The markers inside the shared millisecond are still each found once.
+    expect(new Set(ids)).toEqual(markerIds);
+    expect(ids).toHaveLength(markerIds.size);
+  });
+
+  test("refuses a cursor that is not the database's own text form", () => {
+    // The precision has to be pinned at the parser, because whether a driver
+    // hands back text or a date object is a driver's choice: `pglite` returns
+    // the microseconds as text, and a driver that returns a date instead would
+    // round them away and page from the start of the millisecond. The
+    // statement asks for text, so anything else is a page this walk must not
+    // continue from.
+    expect(() =>
+      parseAbsentTextPage([
+        {
+          cursor_created_at: new Date(),
+          cursor_id: fixtureId(0),
+          scanned: 1,
+          match_id: null,
+        },
+      ]),
+    ).toThrow(/cursor_created_at/u);
   });
 
   test("does not read another source's rows", async () => {

--- a/apps/api/src/scripts/repair-publisher-absent-text-plan.ts
+++ b/apps/api/src/scripts/repair-publisher-absent-text-plan.ts
@@ -1,13 +1,15 @@
+import { panic } from "better-result";
 import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
-import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
-import {
-  ADAPTERS_DECLARING_ABSENT_TEXT,
-  absentTextComparisonsFor,
-} from "@/api/handlers/case-law/ingestion/adapters/absent-source-text";
+import { caseLawDecisions } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
 import { PUBLISHER_SUMMARY_SOURCES } from "@/api/lib/case-law/publisher-summary";
-import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
+import {
+  brandPersistedCaseLawDecisionId,
+  brandPersistedCaseLawSourceId,
+} from "@/api/lib/safe-id-boundaries";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * The reading behind `repair-publisher-absent-text.ts`, apart from the script
@@ -45,7 +47,7 @@ const PUBLISHER_TEXT_KEYS_SQL = textArray(PUBLISHER_TEXT_METADATA_KEYS);
 
 /**
  * The publisher-summary keys of one row whose value is one of the given
- * markers.
+ * markers, as an expression over a metadata column named by the caller.
  *
  * `btrim(regexp_replace(…))` is `absentTextComparison` in SQL, and the database
  * test holds the two readings to the same answer over the same stored values.
@@ -53,44 +55,194 @@ const PUBLISHER_TEXT_KEYS_SQL = textArray(PUBLISHER_TEXT_METADATA_KEYS);
  * it, which changes nothing here: no number or array renders as one of the
  * sentences.
  */
-const absentPublisherTextKeys = (markers: readonly string[]): SQL => sql`(
+const absentPublisherTextKeys = (
+  metadata: SQL,
+  markers: readonly string[],
+): SQL => sql`(
   SELECT coalesce(array_agg(candidate.key), ARRAY[]::text[])
     FROM unnest(${PUBLISHER_TEXT_KEYS_SQL}) AS candidate(key)
    WHERE btrim(
-           regexp_replace(
-             ${caseLawDecisions.metadata} ->> candidate.key,
-             '\\s+',
-             ' ',
-             'g'
-           )
+           regexp_replace(${metadata} ->> candidate.key, '\\s+', ' ', 'g')
          ) = ANY(${textArray(markers)})
 )`;
 
+/** Where a walk of one source stands: the last row a page examined. */
+export type AbsentTextCursor = {
+  /** The row's `created_at`, the leading key of the index the walk uses. */
+  createdAt: string;
+  id: SafeId<"caseLawDecision">;
+};
+
+/** What one page of the walk examined, and which of it needs repairing. */
+export type AbsentTextPage = {
+  /** Ids on this page whose publisher text is one of the source's markers. */
+  ids: SafeId<"caseLawDecision">[];
+  /** Rows the page examined, matching or not. Zero ends the walk. */
+  scanned: number;
+  /** Where the next page starts, or null when the source is exhausted. */
+  cursor: AbsentTextCursor | null;
+};
+
+/** The sources a walk owns, looked up once by the adapters that declare a marker. */
+export const absentTextSourcesStatement = (
+  adapterKeys: readonly string[],
+): SQL =>
+  adapterKeys.length === 0
+    ? sql`SELECT id, adapter_key FROM case_law_sources WHERE false`
+    : sql`
+        SELECT id, adapter_key
+          FROM case_law_sources
+         WHERE adapter_key = ANY(${textArray(adapterKeys)})
+      `;
+
+/** One source a walk visits, with the markers its adapter declares. */
+export type AbsentTextSource = {
+  adapterKey: string;
+  sourceId: SafeId<"caseLawSource">;
+};
+
+const requiredString = (value: unknown, column: string): string => {
+  if (typeof value !== "string") {
+    return panic(`absent-text page column ${column} is not a string`);
+  }
+  return value;
+};
+
+export const parseAbsentTextSources = (
+  rows: readonly unknown[],
+): AbsentTextSource[] =>
+  rows.map((row) => {
+    if (!isRecord(row)) {
+      return panic(`Unreadable case-law source row: ${JSON.stringify(row)}`);
+    }
+    return {
+      adapterKey: requiredString(row["adapter_key"], "adapter_key"),
+      sourceId: brandPersistedCaseLawSourceId(requiredString(row["id"], "id")),
+    };
+  });
+
 /**
- * A row still carrying one of the given adapter's markers.
+ * One page of a walk of a source, and whichever of its rows carry one of that
+ * source's markers under a publisher-summary key.
  *
- * Self-consuming: a repaired row no longer matches, so a walk converges, and a
- * re-check at write time leaves a decision the crawl re-observed in between
- * exactly as the crawl wrote it.
+ * The bound is on rows examined, not on rows matched, and that is the whole
+ * point. The population thins out as a repair proceeds, so a statement whose
+ * `LIMIT` counts matches scans forward until it finds them — and the last such
+ * statement, with no matches left to find, reads every remaining row of the
+ * source and is cancelled by the lane's statement timeout. Here the page takes
+ * a fixed number of rows in index order and the marker predicate runs over
+ * those rows alone, so every statement of the walk costs the same bounded
+ * amount whatever the data holds.
+ *
+ * The order is the source's own cursor index (`source_id, created_at, id`), so
+ * a page is an index range rather than a sort of everything the source holds.
+ * The primary key would have been the obvious cursor and the wrong one: it is
+ * random per row, so ordering by it reads the whole partition before serving
+ * the first page.
+ *
+ * The bound comes back on every row, including on a page that matched nothing,
+ * because a page that advances no cursor is a walk that never ends. A source
+ * with no rows past the cursor returns nothing at all, which is the one way
+ * the walk finishes.
+ *
+ * A report and an apply read this same statement, so what a run says it would
+ * change is what a run with `--apply` changes.
+ */
+export const selectAbsentTextPageStatement = ({
+  after,
+  markers,
+  pageSize,
+  sourceId,
+}: {
+  after: AbsentTextCursor | null;
+  markers: readonly string[];
+  pageSize: number;
+  sourceId: SafeId<"caseLawSource">;
+}): SQL => sql`
+  WITH page AS (
+    SELECT d.id, d.created_at, d.metadata
+      FROM case_law_decisions d
+     WHERE d.source_id = ${sourceId}::uuid
+       ${
+         after === null
+           ? sql``
+           : sql`AND (d.created_at, d.id) > (${after.createdAt}::timestamptz, ${after.id}::uuid)`
+       }
+     ORDER BY d.created_at, d.id
+     LIMIT ${pageSize}
+  ),
+  bound AS (
+    SELECT created_at, id, (SELECT count(*) FROM page)::int AS scanned
+      FROM page
+     ORDER BY created_at DESC, id DESC
+     LIMIT 1
+  )
+  SELECT b.created_at AS cursor_created_at,
+         b.id AS cursor_id,
+         b.scanned AS scanned,
+         p.id AS match_id
+    FROM bound b
+    LEFT JOIN page p
+      ON cardinality(${
+        markers.length === 0
+          ? sql`ARRAY[]::text[]`
+          : absentPublisherTextKeys(sql`p.metadata`, markers)
+      }) > 0
+`;
+
+/**
+ * A page read back from a driver result that is untyped by construction.
+ *
+ * An empty result is the end of the walk; anything else states the bound on
+ * every row, so the first row is enough to read it from.
+ */
+export const parseAbsentTextPage = (
+  rows: readonly unknown[],
+): AbsentTextPage => {
+  const first = rows.at(0);
+  if (first === undefined) {
+    return { ids: [], scanned: 0, cursor: null };
+  }
+  if (!isRecord(first) || typeof first["scanned"] !== "number") {
+    return panic(`Unreadable absent-text page: ${JSON.stringify(first)}`);
+  }
+  const createdAt = first["cursor_created_at"];
+  const cursor: AbsentTextCursor = {
+    createdAt:
+      createdAt instanceof Date
+        ? createdAt.toISOString()
+        : requiredString(createdAt, "cursor_created_at"),
+    id: brandPersistedCaseLawDecisionId(
+      requiredString(first["cursor_id"], "cursor_id"),
+    ),
+  };
+
+  const ids: SafeId<"caseLawDecision">[] = [];
+  for (const row of rows) {
+    if (!isRecord(row) || row["match_id"] === null) {
+      continue;
+    }
+    ids.push(
+      brandPersistedCaseLawDecisionId(
+        requiredString(row["match_id"], "match_id"),
+      ),
+    );
+  }
+
+  return { ids, scanned: first["scanned"], cursor };
+};
+
+/**
+ * A row still carrying one of the given markers, for the write's own re-check
+ * against the row as it stands rather than as a page read it.
  */
 export const carriesAbsentPublisherText = (markers: readonly string[]): SQL =>
   markers.length === 0
     ? sql`false`
-    : sql`cardinality(${absentPublisherTextKeys(markers)}) > 0`;
-
-/**
- * The same reading for a query that spans sources: each row judged by the
- * markers its own adapter declares, and no row judged by another adapter's.
- */
-export const carriesDeclaredAbsentPublisherText: SQL = sqlCaseFragment({
-  branches: ADAPTERS_DECLARING_ABSENT_TEXT.map(
-    (adapter) =>
-      sql`WHEN ${caseLawSources.adapterKey} = ${adapter} THEN ${carriesAbsentPublisherText(
-        absentTextComparisonsFor(adapter),
-      )}`,
-  ),
-  fallback: sql`false`,
-});
+    : sql`cardinality(${absentPublisherTextKeys(
+        sql`${caseLawDecisions.metadata}`,
+        markers,
+      )}) > 0`;
 
 /**
  * The row's metadata with the marker keys removed.
@@ -105,4 +257,7 @@ export const carriesDeclaredAbsentPublisherText: SQL = sqlCaseFragment({
 export const strippedPublisherMetadata = (
   markers: readonly string[],
 ): SQL<Record<string, unknown>> =>
-  sql`${caseLawDecisions.metadata} - ${absentPublisherTextKeys(markers)}`;
+  sql`${caseLawDecisions.metadata} - ${absentPublisherTextKeys(
+    sql`${caseLawDecisions.metadata}`,
+    markers,
+  )}`;

--- a/apps/api/src/scripts/repair-publisher-absent-text-plan.ts
+++ b/apps/api/src/scripts/repair-publisher-absent-text-plan.ts
@@ -68,7 +68,11 @@ const absentPublisherTextKeys = (
 
 /** Where a walk of one source stands: the last row a page examined. */
 export type AbsentTextCursor = {
-  /** The row's `created_at`, the leading key of the index the walk uses. */
+  /**
+   * The row's `created_at` as the database rendered it, at the microsecond
+   * precision the column stores. Never a date object: milliseconds are not
+   * enough to page inside one.
+   */
   createdAt: string;
   id: SafeId<"caseLawDecision">;
 };
@@ -145,6 +149,13 @@ export const parseAbsentTextSources = (
  * with no rows past the cursor returns nothing at all, which is the one way
  * the walk finishes.
  *
+ * The cursor timestamp is rendered `::text` by the database rather than carried
+ * as a driver value: `created_at` holds microseconds, a JavaScript date holds
+ * milliseconds, and a cursor rounded down to the millisecond re-reads every row
+ * that shares it — at a page boundary inside one millisecond, forever. The text
+ * goes back in as `::timestamptz`, so the comparison is made at the precision
+ * the column is stored in.
+ *
  * A report and an apply read this same statement, so what a run says it would
  * change is what a run with `--apply` changes.
  */
@@ -177,7 +188,7 @@ export const selectAbsentTextPageStatement = ({
      ORDER BY created_at DESC, id DESC
      LIMIT 1
   )
-  SELECT b.created_at AS cursor_created_at,
+  SELECT b.created_at::text AS cursor_created_at,
          b.id AS cursor_id,
          b.scanned AS scanned,
          p.id AS match_id
@@ -206,12 +217,8 @@ export const parseAbsentTextPage = (
   if (!isRecord(first) || typeof first["scanned"] !== "number") {
     return panic(`Unreadable absent-text page: ${JSON.stringify(first)}`);
   }
-  const createdAt = first["cursor_created_at"];
   const cursor: AbsentTextCursor = {
-    createdAt:
-      createdAt instanceof Date
-        ? createdAt.toISOString()
-        : requiredString(createdAt, "cursor_created_at"),
+    createdAt: requiredString(first["cursor_created_at"], "cursor_created_at"),
     id: brandPersistedCaseLawDecisionId(
       requiredString(first["cursor_id"], "cursor_id"),
     ),

--- a/apps/api/src/scripts/repair-publisher-absent-text.ts
+++ b/apps/api/src/scripts/repair-publisher-absent-text.ts
@@ -295,7 +295,9 @@ console.info(
 );
 if (repaired + superseded >= limit) {
   console.info(
-    `Stopped at --limit ${String(limit)}; re-run to continue where this left off.`,
+    apply
+      ? `Stopped at --limit ${String(limit)}; re-run to continue, because a repaired row no longer matches.`
+      : `Stopped at --limit ${String(limit)}; raise it, or run with --apply, to reach further. A second report reads the same rows: nothing it counts has changed.`,
   );
 }
 

--- a/apps/api/src/scripts/repair-publisher-absent-text.ts
+++ b/apps/api/src/scripts/repair-publisher-absent-text.ts
@@ -35,35 +35,34 @@
  * active there is no lock and no synchronization; the row is repaired either
  * way and the next desired-state pass reads the repaired metadata.
  *
- * **How it walks.** Candidates are read a page at a time by a keyset cursor
- * over the source's ids, so each row is inspected once however many pages a
- * run takes, and a row the page did not repair is not met again. A run
- * reports the resume point it stopped at; passing it back as `--after`
- * continues from there.
+ * **How it walks.** A page at a time, bounded by rows examined rather than by
+ * rows matched, in the order of the source's own cursor index. The population
+ * thins out as the repair proceeds, so a selection bounded by matches reads
+ * further and further into the source looking for rows that are no longer
+ * there, and is cancelled by the lane's statement timeout before it reports
+ * anything. The cursor advances by the last row examined, so a page that
+ * matched nothing is still progress. Both modes read through the same
+ * statement, so what a report says it would change is what an apply changes.
+ * An operator meeting a slower database lowers `--page` rather than raising a
+ * timeout.
  *
- * Without `--apply` nothing is written and nothing is locked: the run reports
- * the affected rows per source and exits. Idempotent either way — a repaired
- * row leaves the selection predicate, so a later run finds nothing.
+ * Idempotent: a repaired row no longer carries a marker, so a later run walks
+ * past it.
  *
- *   # what the repair would touch, writing nothing
+ *   # what the repair would change, writing nothing
  *   bun run src/scripts/repair-publisher-absent-text.ts
  *
  *   # repair, bounded and resumable by re-running
- *   bun run src/scripts/repair-publisher-absent-text.ts --apply [--limit 50000]
- *
- *   # continue one source's walk from where a run stopped
- *   bun run src/scripts/repair-publisher-absent-text.ts --apply \
- *     --adapter cz-us --after <decisionId>
+ *   bun run src/scripts/repair-publisher-absent-text.ts --apply [--limit 50000] [--page 2000]
  *
  * Not a scheduled job: the write path stopped producing these rows when the
  * adapters started reading the markers, so this is a one-shot pass over the
  * rows that predate it, run by an operator who reads the report first.
  */
 
-import { and, count, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
-import type { Transaction } from "@/api/db/root";
-import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { caseLawDecisions } from "@/api/db/schema";
 import type { AdapterKey } from "@/api/handlers/case-law/consts";
 import {
   ADAPTERS_DECLARING_ABSENT_TEXT,
@@ -74,27 +73,35 @@ import {
   enterCaseLawMaintenanceLane,
   openCaseLawReadOnlySession,
 } from "@/api/lib/case-law/maintenance-lane";
+import { executedRows } from "@/api/lib/db/executed-rows";
 import {
   lockActiveCorpusProjectionSourceByIdTx,
   synchronizeLockedCorpusProjectionDesiredStateTx,
 } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { flagInteger, readApplyFlag } from "@/api/scripts/repair-flags";
 import {
-  flagInteger,
-  hasFlag,
-  readApplyFlag,
-} from "@/api/scripts/repair-flags";
-import {
+  absentTextSourcesStatement,
   carriesAbsentPublisherText,
-  carriesDeclaredAbsentPublisherText,
+  parseAbsentTextPage,
+  parseAbsentTextSources,
+  selectAbsentTextPageStatement,
   strippedPublisherMetadata,
+} from "@/api/scripts/repair-publisher-absent-text-plan";
+import type {
+  AbsentTextCursor,
+  AbsentTextPage,
 } from "@/api/scripts/repair-publisher-absent-text-plan";
 
 /**
- * Ids read per keyset page. The page is a plain id-range read; the writes it
- * leads to are one short transaction each, so the page size trades round trips
- * against how much of a walk an interrupted run loses.
+ * Rows one page of the walk examines, matching or not.
+ *
+ * This is what bounds a statement, so it is the number that keeps the walk
+ * inside the lane's statement timeout: the rows still carrying a marker thin
+ * out as a run proceeds, and a selection bounded by matches instead reads to
+ * the end of the source looking for the ones that are not there. An operator
+ * meeting a slower database lowers it rather than raising a timeout.
  */
-const PAGE = 500;
+const DEFAULT_PAGE_SIZE = 2000;
 /** Rows one run may repair unless `--limit` says otherwise. */
 const DEFAULT_LIMIT = 50_000;
 
@@ -104,14 +111,7 @@ const USAGE = `Usage: bun run src/scripts/repair-publisher-absent-text.ts [optio
   --dry-run      Report only, the default. Accepted so it cannot be mistaken
                  for a flag this script ignores; contradicts --apply.
   --limit <n>    Rows this run may repair (default ${String(DEFAULT_LIMIT)}).
-  --after <id>   Resume one source's walk after this decision id. Requires a
-                 single affected source, or --adapter to name one.
-  --adapter <k>  Repair only this adapter's source.`;
-
-const flagValue = (name: string): string | undefined => {
-  const index = process.argv.indexOf(`--${name}`);
-  return index === -1 ? undefined : process.argv[index + 1];
-};
+  --page <n>     Rows one statement examines (default ${String(DEFAULT_PAGE_SIZE)}).`;
 
 const apply = readApplyFlag(USAGE);
 
@@ -125,147 +125,88 @@ const limit = flagInteger({
   name: "limit",
   usage: USAGE,
 });
-const adapterFilter = flagValue("adapter");
-const resumeAfter = flagValue("after");
+const pageSize = flagInteger({
+  fallback: DEFAULT_PAGE_SIZE,
+  name: "page",
+  usage: USAGE,
+});
 
-if (hasFlag("after") && resumeAfter === undefined) {
-  console.error("--after needs a decision id.");
-  console.error(USAGE);
-  process.exit(1);
-}
-
-type AffectedSource = {
+/** One source to walk, with the markers its adapter declares. */
+type MarkedSource = {
   adapter: AdapterKey;
-  rows: number;
-  sourceId: SafeId<"caseLawSource">;
-};
-
-/**
- * The stored adapter key as the declared one it names.
- *
- * Matched against the declarations rather than asserted from the column: the
- * markers to strip are looked up by this value, so a source whose key names no
- * declaring adapter has nothing to strip and drops out of the walk. The survey
- * predicate already judges each row by its own adapter, so this cannot lose an
- * affected source.
- */
-const declaringAdapter = (adapterKey: string): AdapterKey | undefined =>
-  ADAPTERS_DECLARING_ABSENT_TEXT.find((adapter) => adapter === adapterKey);
-
-const survey = async (): Promise<AffectedSource[]> => {
-  const rows = await rootDb.transaction(
-    async (tx) =>
-      await tx
-        .select({
-          adapterKey: caseLawSources.adapterKey,
-          rows: count(),
-          sourceId: caseLawSources.id,
-        })
-        .from(caseLawDecisions)
-        .innerJoin(
-          caseLawSources,
-          eq(caseLawSources.id, caseLawDecisions.sourceId),
-        )
-        .where(carriesDeclaredAbsentPublisherText)
-        .groupBy(caseLawSources.id, caseLawSources.adapterKey),
-  );
-  return rows.flatMap(({ adapterKey, rows: affectedRows, sourceId }) => {
-    const adapter = declaringAdapter(adapterKey);
-    return adapter === undefined
-      ? []
-      : [{ adapter, rows: affectedRows, sourceId }];
-  });
-};
-
-/**
- * One line per source, in a stable order for the report. Adapter keys are
- * identifiers, so they sort by code point rather than by anyone's locale.
- */
-const byAdapterKey = (left: AffectedSource, right: AffectedSource): number => {
-  if (left.adapter === right.adapter) {
-    return 0;
-  }
-  return left.adapter < right.adapter ? -1 : 1;
-};
-
-const printSurvey = (sources: readonly AffectedSource[]): number => {
-  console.info("--- rows carrying their source's absent-text marker ---");
-  let total = 0;
-  for (const { adapter, rows } of sources.toSorted(byAdapterKey)) {
-    total += rows;
-    console.info(`${adapter.padEnd(14)} ${String(rows).padStart(9)}`);
-  }
-  console.info(`${"total".padEnd(14)} ${String(total).padStart(9)}`);
-  return total;
-};
-
-type SourceWalk = {
   markers: readonly string[];
   sourceId: SafeId<"caseLawSource">;
 };
 
-/**
- * The next page of candidate ids after the cursor.
- *
- * The page is bounded by both the cursor and the predicate, so a source's
- * population is read once across a whole walk rather than re-scanned per
- * batch, and an id the page passed over is never met again.
- */
-const nextPage = async (
-  walk: SourceWalk,
-  after: string | null,
-): Promise<SafeId<"caseLawDecision">[]> => {
-  const rows = await rootDb.transaction(
-    async (tx) =>
-      await tx
-        .select({ id: caseLawDecisions.id })
-        .from(caseLawDecisions)
-        .where(
-          and(
-            eq(caseLawDecisions.sourceId, walk.sourceId),
-            carriesAbsentPublisherText(walk.markers),
-            // Compared as SQL rather than through a typed column predicate:
-            // the cursor is either an id this run already visited or the one an
-            // operator passed to `--after`, and the cast is where a value that
-            // is not an id fails loudly.
-            ...(after === null
-              ? []
-              : [sql`${caseLawDecisions.id} > ${after}::uuid`]),
-          ),
-        )
-        .orderBy(caseLawDecisions.id)
-        .limit(PAGE),
+// Resolved once, by the adapters that declare a marker: the walk filters on
+// the source id, which is the leading column of the index it reads in, rather
+// than joining the source table on every page.
+const sources: MarkedSource[] = parseAbsentTextSources(
+  executedRows(
+    await rootDb.execute(
+      absentTextSourcesStatement(ADAPTERS_DECLARING_ABSENT_TEXT),
+    ),
+  ),
+).flatMap(({ adapterKey, sourceId }) => {
+  const adapter = ADAPTERS_DECLARING_ABSENT_TEXT.find(
+    (declared) => declared === adapterKey,
   );
-  return rows.map(({ id }) => id);
-};
+  return adapter === undefined
+    ? []
+    : [{ adapter, markers: absentTextComparisonsFor(adapter), sourceId }];
+});
+
+if (sources.length === 0) {
+  console.info("No source of a declared absent-text marker is registered.");
+  process.exit(0);
+}
+
+/** One page of one source's walk, strictly after `after`. */
+const readPage = async (
+  source: MarkedSource,
+  after: AbsentTextCursor | null,
+): Promise<AbsentTextPage> =>
+  parseAbsentTextPage(
+    executedRows(
+      await rootDb.execute(
+        selectAbsentTextPageStatement({
+          after,
+          markers: source.markers,
+          pageSize,
+          sourceId: source.sourceId,
+        }),
+      ),
+    ),
+  );
 
 /**
- * Repair one decision and tell the projection, in one transaction.
+ * Strip one row's markers and tell the projection, in one transaction.
  *
  * The row is re-read under the predicate rather than trusted from the page: a
  * decision the crawl re-observed in between already carries whatever the write
- * path allowed, and this run must not undo that.
+ * path allowed, and this run must not undo that. A row that changed under the
+ * run is reported as superseded rather than repaired.
  */
-const repairDecision = async (
-  walk: SourceWalk,
+const repairRow = async (
+  source: MarkedSource,
   entityId: SafeId<"caseLawDecision">,
 ): Promise<boolean> =>
-  await rootDb.transaction(async (tx: Transaction) => {
+  await rootDb.transaction(async (tx) => {
     const lock = await lockActiveCorpusProjectionSourceByIdTx(tx, {
       family: "case_law",
-      sourceId: walk.sourceId,
+      sourceId: source.sourceId,
     });
     // audit: skip — operator repair of public case-law metadata; no user action
     const repaired = await tx
       .update(caseLawDecisions)
       .set({
-        metadata: strippedPublisherMetadata(walk.markers),
+        metadata: strippedPublisherMetadata(source.markers),
         indexedHash: null,
       })
       .where(
         and(
           eq(caseLawDecisions.id, entityId),
-          carriesAbsentPublisherText(walk.markers),
+          carriesAbsentPublisherText(source.markers),
         ),
       )
       .returning({ id: caseLawDecisions.id });
@@ -281,125 +222,67 @@ const repairDecision = async (
     return true;
   });
 
-type WalkProgress = {
-  /** Ids the walk has visited, repaired or not. */
-  visited: number;
-  /** Rows this walk actually changed. */
-  repaired: number;
-  /** Last id the walk accounted for, to resume after. */
-  resumeAfter: string | null;
-};
+let scanned = 0;
+let matched = 0;
+let repaired = 0;
+let superseded = 0;
 
-/**
- * Repair one page, id by id. Recursive rather than a loop: each decision is
- * its own transaction, and the next one may only start once the previous has
- * committed, so this is a walk rather than a fan-out.
- */
-const repairPage = async (
-  walk: SourceWalk,
-  ids: readonly SafeId<"caseLawDecision">[],
-  index: number,
-  progress: WalkProgress,
-  budget: number,
-): Promise<WalkProgress> => {
-  const entityId = ids.at(index);
-  if (entityId === undefined || progress.repaired >= budget) {
-    return progress;
-  }
-  const repaired = await repairDecision(walk, entityId);
-  return await repairPage(
-    walk,
-    ids,
-    index + 1,
-    {
-      visited: progress.visited + 1,
-      repaired: progress.repaired + (repaired ? 1 : 0),
-      resumeAfter: entityId,
-    },
-    budget,
-  );
-};
+for (const source of sources) {
+  let cursor: AbsentTextCursor | null = null;
+  let examinedHere = 0;
 
-/** Page after page, from the cursor, until the source or the budget is done. */
-const walkSource = async (
-  walk: SourceWalk,
-  progress: WalkProgress,
-  budget: number,
-): Promise<WalkProgress> => {
-  if (progress.repaired >= budget) {
-    return progress;
-  }
-  const ids = await nextPage(walk, progress.resumeAfter);
-  if (ids.length === 0) {
-    return progress;
-  }
-  const advanced = await repairPage(walk, ids, 0, progress, budget);
-  if (advanced.visited === progress.visited) {
-    return advanced;
-  }
-  return await walkSource(walk, advanced, budget);
-};
+  while (repaired + superseded < limit) {
+    const page = await readPage(source, cursor);
 
-/** Source after source, each its own walk, until the run's budget is spent. */
-const walkSources = async (
-  sources: readonly AffectedSource[],
-  index: number,
-  repaired: number,
-): Promise<number> => {
-  const source = sources.at(index);
-  if (source === undefined || repaired >= limit) {
-    return repaired;
+    // The cursor advances by rows examined, not by rows matched. A page whose
+    // rows all held is still progress, and a walk that only moved on a match
+    // would read the same page forever once the last one was behind it.
+    if (page.cursor === null) {
+      break;
+    }
+    cursor = page.cursor;
+    examinedHere += page.scanned;
+    scanned += page.scanned;
+    matched += page.ids.length;
+
+    for (const entityId of page.ids) {
+      // The allowance is per row, not per page: a page is read whole, so a run
+      // with one slot left would otherwise write every matching row on it.
+      // What an operator authorised is the number of rows changed.
+      if (repaired + superseded >= limit) {
+        break;
+      }
+      if (!apply) {
+        continue;
+      }
+      if (await repairRow(source, entityId)) {
+        repaired += 1;
+      } else {
+        superseded += 1;
+      }
+    }
   }
-  const progress = await walkSource(
-    {
-      markers: absentTextComparisonsFor(source.adapter),
-      sourceId: source.sourceId,
-    },
-    { visited: 0, repaired: 0, resumeAfter: resumeAfter ?? null },
-    limit - repaired,
-  );
+
   console.info(
-    `${source.adapter.padEnd(14)} ${String(progress.repaired).padStart(9)} repaired, ` +
-      `${String(progress.visited)} visited, resume after ${progress.resumeAfter ?? "<start>"}`,
+    `${source.adapter.padEnd(14)} ${examinedHere.toLocaleString()} rows examined`,
   );
-  return await walkSources(sources, index + 1, repaired + progress.repaired);
-};
-
-const affected = (await survey()).filter(
-  ({ adapter }) => adapterFilter === undefined || adapter === adapterFilter,
-);
-const total = printSurvey(affected);
-
-if (!apply) {
-  console.info(
-    "Report only: nothing written. Re-run with --apply to strip the markers " +
-      "and re-enqueue the affected rows for projection.",
-  );
-  process.exit(0);
 }
 
-if (resumeAfter !== undefined && affected.length > 1) {
-  console.error(
-    "--after resumes one source's walk; name it with --adapter, because a " +
-      "decision id orders rows within a source only.",
-  );
-  console.error(USAGE);
-  process.exit(1);
-}
-
-const repaired = await walkSources(affected.toSorted(byAdapterKey), 0, 0);
-
 console.info(
-  `done: ${String(repaired)} rows repaired ` +
-    `(survey reported ${String(total)} before the run).`,
-);
-console.info(
-  "Both index paths are re-enqueued; they settle on their own schedules.",
+  apply
+    ? `${scanned.toLocaleString()} rows examined: ` +
+        `${matched.toLocaleString()} carry a marker, ` +
+        `${repaired.toLocaleString()} repaired, ` +
+        `${superseded.toLocaleString()} changed under the run.`
+    : `${scanned.toLocaleString()} rows examined: ` +
+        `${matched.toLocaleString()} carry a marker and would be repaired.`,
 );
 
-// Re-surveyed rather than inferred from the count above: a run that hit
-// `--limit`, or raced a crawl of a source deployed without the fix, has a count
-// that says otherwise.
-printSurvey(await survey());
+console.info(
+  apply
+    ? "Both index paths are re-enqueued; they settle on their own schedules."
+    : "Report only: nothing written. Re-run with --apply to strip the markers " +
+        "and re-enqueue the affected rows for projection.",
+);
 
 process.exit(0);

--- a/apps/api/src/scripts/repair-publisher-absent-text.ts
+++ b/apps/api/src/scripts/repair-publisher-absent-text.ts
@@ -42,9 +42,9 @@
  * there, and is cancelled by the lane's statement timeout before it reports
  * anything. The cursor advances by the last row examined, so a page that
  * matched nothing is still progress. Both modes read through the same
- * statement, so what a report says it would change is what an apply changes.
- * An operator meeting a slower database lowers `--page` rather than raising a
- * timeout.
+ * statement and stop at the same `--limit`, so what a report says it would
+ * change is what an apply changes. An operator meeting a slower database
+ * lowers `--page` rather than raising a timeout.
  *
  * Idempotent: a repaired row no longer carries a marker, so a later run walks
  * past it.
@@ -78,7 +78,11 @@ import {
   lockActiveCorpusProjectionSourceByIdTx,
   synchronizeLockedCorpusProjectionDesiredStateTx,
 } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
-import { flagInteger, readApplyFlag } from "@/api/scripts/repair-flags";
+import {
+  flagInteger,
+  readApplyFlag,
+  rejectUnknownFlags,
+} from "@/api/scripts/repair-flags";
 import {
   absentTextSourcesStatement,
   carriesAbsentPublisherText,
@@ -110,8 +114,16 @@ const USAGE = `Usage: bun run src/scripts/repair-publisher-absent-text.ts [optio
   --apply        Write the repairs. Omitted, the run only reports.
   --dry-run      Report only, the default. Accepted so it cannot be mistaken
                  for a flag this script ignores; contradicts --apply.
-  --limit <n>    Rows this run may repair (default ${String(DEFAULT_LIMIT)}).
+  --limit <n>    Rows this run may repair, and rows a report may promise
+                 (default ${String(DEFAULT_LIMIT)}).
   --page <n>     Rows one statement examines (default ${String(DEFAULT_PAGE_SIZE)}).`;
+
+// Before anything is opened or locked: a run that names a flag this repair
+// does not have is a run whose operator expects something else of it. The
+// source-scoping and resume flags an earlier revision documented are among
+// them, and widening silently from one source to all of them is exactly the
+// outcome the check exists to prevent.
+rejectUnknownFlags({ known: ["limit", "page"], usage: USAGE });
 
 const apply = readApplyFlag(USAGE);
 
@@ -223,7 +235,12 @@ const repairRow = async (
   });
 
 let scanned = 0;
-let matched = 0;
+/**
+ * Rows changed, or — in a report — rows that would be changed. One counter for
+ * both, because `--limit` bounds the report exactly as it bounds the apply it
+ * previews: a report that walked past the allowance would promise a run the
+ * apply then stops short of.
+ */
 let repaired = 0;
 let superseded = 0;
 
@@ -243,7 +260,6 @@ for (const source of sources) {
     cursor = page.cursor;
     examinedHere += page.scanned;
     scanned += page.scanned;
-    matched += page.ids.length;
 
     for (const entityId of page.ids) {
       // The allowance is per row, not per page: a page is read whole, so a run
@@ -253,6 +269,7 @@ for (const source of sources) {
         break;
       }
       if (!apply) {
+        repaired += 1;
         continue;
       }
       if (await repairRow(source, entityId)) {
@@ -271,12 +288,16 @@ for (const source of sources) {
 console.info(
   apply
     ? `${scanned.toLocaleString()} rows examined: ` +
-        `${matched.toLocaleString()} carry a marker, ` +
         `${repaired.toLocaleString()} repaired, ` +
         `${superseded.toLocaleString()} changed under the run.`
     : `${scanned.toLocaleString()} rows examined: ` +
-        `${matched.toLocaleString()} carry a marker and would be repaired.`,
+        `${repaired.toLocaleString()} would be repaired.`,
 );
+if (repaired + superseded >= limit) {
+  console.info(
+    `Stopped at --limit ${String(limit)}; re-run to continue where this left off.`,
+  );
+}
 
 console.info(
   apply


### PR DESCRIPTION
Bound each statement by rows examined rather than rows matched, so the walk cannot read to the end of a source looking for rows that are no longer there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Data repair operations now process records in bounded pages, improving reliability for large datasets.
  - Progress advances consistently through examined records, including pages with no matching records.
  - Report and apply modes now use the same record limit and clearly indicate when that limit is reached.
  - Repair commands now reject unrecognised options before starting database work.
  - Processing preserves source-specific handling and avoids repeatedly reprocessing unchanged records.

- **Tests**
  - Expanded coverage validates paging, source selection, record updates, formatting, key handling, repeat-run behaviour and precise pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->