### PR TITLE
fix(api): release a settlement lease a later turn has taken

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -8,6 +8,7 @@ import {
   isNull,
   lte,
   min,
+  ne,
   or,
   sql,
 } from "drizzle-orm";
@@ -701,9 +702,38 @@ export const releaseCorpusProjectionCleanupSettlementTx = async (
       ),
     )
     .returning({ id: corpusIndexProjectionIntents.id });
-  if (rows.length !== lease.intentIds.length) {
+  if (rows.length === lease.intentIds.length) {
+    return rows.length;
+  }
+  // The settlement claim re-leases a revision whose lease has expired, and it
+  // overwrites the token without matching the old one. A turn whose proof
+  // outran its own lease therefore finds a later turn holding the revisions it
+  // came to relinquish, which the claim path is written to produce: releasing
+  // what that turn owns would take its lease away, so this releases nothing.
+  // A revision that is neither released nor held by a later turn is the state
+  // nothing should have produced.
+  const released = new Set(rows.map(({ id }) => id));
+  const unreleased = lease.intentIds.filter((id) => !released.has(id));
+  // A null token compares unequal to nothing, so an unleased revision is not
+  // one of these and still reaches the panic below.
+  const reLeased = await tx
+    .select({ id: corpusIndexProjectionIntents.id })
+    .from(corpusIndexProjectionIntents)
+    .where(
+      and(
+        inArray(corpusIndexProjectionIntents.id, unreleased),
+        eq(corpusIndexProjectionIntents.indexId, lease.indexId),
+        eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
+        eq(
+          corpusIndexProjectionIntents.deleteOpstamp,
+          BigInt(lease.deleteOpstamp),
+        ),
+        ne(corpusIndexProjectionIntents.leaseToken, lease.leaseToken),
+      ),
+    );
+  if (reLeased.length !== unreleased.length) {
     return panic(
-      `Corpus projection settlement release matched ${rows.length} of ${lease.intentIds.length} leased revisions`,
+      `Corpus projection settlement release matched ${rows.length} of ${lease.intentIds.length} leased revisions, and ${unreleased.length - reLeased.length} of the rest are held by no later turn`,
     );
   }
   return rows.length;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -8,7 +8,6 @@ import {
   isNull,
   lte,
   min,
-  ne,
   or,
   sql,
 } from "drizzle-orm";
@@ -707,33 +706,30 @@ export const releaseCorpusProjectionCleanupSettlementTx = async (
   }
   // The settlement claim re-leases a revision whose lease has expired, and it
   // overwrites the token without matching the old one. A turn whose proof
-  // outran its own lease therefore finds a later turn holding the revisions it
-  // came to relinquish, which the claim path is written to produce: releasing
-  // what that turn owns would take its lease away, so this releases nothing.
-  // A revision that is neither released nor held by a later turn is the state
-  // nothing should have produced.
+  // outran its own lease therefore finds a successor owning the revisions it
+  // came to relinquish, which the claim path is written to produce. Where that
+  // successor has got to is not this turn's business: it may still hold the
+  // lease, or have released or settled it already, and every one of those
+  // clears this token. So the invariant is only that this lease is gone, not
+  // which state replaced it — enumerating the successor's states would make an
+  // ordinary finishing order panic.
   const released = new Set(rows.map(({ id }) => id));
   const unreleased = lease.intentIds.filter((id) => !released.has(id));
-  // A null token compares unequal to nothing, so an unleased revision is not
-  // one of these and still reaches the panic below.
-  const reLeased = await tx
+  const stillLeasedHere = await tx
     .select({ id: corpusIndexProjectionIntents.id })
     .from(corpusIndexProjectionIntents)
     .where(
       and(
         inArray(corpusIndexProjectionIntents.id, unreleased),
-        eq(corpusIndexProjectionIntents.indexId, lease.indexId),
-        eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
-        eq(
-          corpusIndexProjectionIntents.deleteOpstamp,
-          BigInt(lease.deleteOpstamp),
-        ),
-        ne(corpusIndexProjectionIntents.leaseToken, lease.leaseToken),
+        eq(corpusIndexProjectionIntents.leaseToken, lease.leaseToken),
       ),
     );
-  if (reLeased.length !== unreleased.length) {
+  // Carrying this token while failing the release predicate means the row left
+  // the index, status or delete task the lease was granted against without the
+  // lease ever being given up, which no transition writes.
+  if (stillLeasedHere.length > 0) {
     return panic(
-      `Corpus projection settlement release matched ${rows.length} of ${lease.intentIds.length} leased revisions, and ${unreleased.length - reLeased.length} of the rest are held by no later turn`,
+      `Corpus projection settlement release matched ${rows.length} of ${lease.intentIds.length} leased revisions, and ${stillLeasedHere.length} of the rest still carry this lease`,
     );
   }
   return rows.length;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -29,6 +29,7 @@ import {
 import {
   claimCorpusProjectionCleanupSettlementTx,
   claimCorpusProjectionCleanupTx,
+  type CorpusProjectionCleanupSettlementLease,
   CorpusProjectionCleanupSettlementProof,
   recordCorpusProjectionDeleteTx,
   recoverExpiredCorpusProjectionIntentsTx,
@@ -2914,7 +2915,10 @@ test("settlement proves the lease against the instant its delete task carries", 
   ).toEqual([{ status: "settled" }]);
 });
 
-test("a settlement release whose revisions a later turn holds releases none of them", async () => {
+// A settlement turn whose verification outlives its lease finds a successor
+// owning its revisions. The successor may be anywhere in its own turn by then,
+// so each of its states is a release the outrun turn must survive.
+const claimOutrunAndSuccessorLeases = async () => {
   await seedCommittedCleanupPair();
   // A lease written against a test clock in the past is already expired by the
   // database clock, which is the state the claim predicate re-leases.
@@ -2936,7 +2940,7 @@ test("a settlement release whose revisions a later turn holds releases none of t
   );
   const outrun =
     outrunLeases.at(0) ?? panic("Expected a projection settlement lease");
-  const laterLeases = await db.transaction(
+  const successorLeases = await db.transaction(
     async (tx) =>
       await claimCorpusProjectionCleanupSettlementTx(
         asTestRaw<Transaction>(tx),
@@ -2951,26 +2955,94 @@ test("a settlement release whose revisions a later turn holds releases none of t
         },
       ),
   );
-  expect(laterLeases.map(({ intentIds }) => intentIds)).toEqual([
-    outrun.intentIds,
-  ]);
+  const successor =
+    successorLeases.at(0) ?? panic("Expected a successor settlement lease");
+  expect(successor.intentIds).toEqual(outrun.intentIds);
+  return { outrun, successor };
+};
 
+const releaseSettlementLease = async (
+  lease: CorpusProjectionCleanupSettlementLease,
+): Promise<number> =>
+  await db.transaction(
+    async (tx) =>
+      await releaseCorpusProjectionCleanupSettlementTx(
+        asTestRaw<Transaction>(tx),
+        { lease },
+      ),
+  );
+
+const readFirstIntentLease = async () =>
+  await db
+    .select({
+      status: corpusIndexProjectionIntents.status,
+      leaseToken: corpusIndexProjectionIntents.leaseToken,
+    })
+    .from(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID));
+
+test("a settlement release whose revisions a successor still holds keeps the successor's lease", async () => {
+  const { outrun } = await claimOutrunAndSuccessorLeases();
+
+  expect(await releaseSettlementLease(outrun)).toBe(0);
+  expect(await readFirstIntentLease()).toEqual([
+    { status: "cleanup_committed", leaseToken: SECOND_LEASE_TOKEN },
+  ]);
+});
+
+test("a settlement release whose successor already released the revisions releases none", async () => {
+  const { outrun, successor } = await claimOutrunAndSuccessorLeases();
+  expect(await releaseSettlementLease(successor)).toBe(
+    successor.intentIds.length,
+  );
+
+  expect(await releaseSettlementLease(outrun)).toBe(0);
+  expect(await readFirstIntentLease()).toEqual([
+    { status: "cleanup_committed", leaseToken: null },
+  ]);
+});
+
+test("a settlement release whose successor already settled the revisions releases none", async () => {
+  const { outrun, successor } = await claimOutrunAndSuccessorLeases();
+  const settlingClient = {
+    readDeleteSettlement: async ({
+      requiredOpstamp,
+    }: {
+      requiredOpstamp: number;
+      deleteCreatedAt: Temporal.Instant | null;
+    }) =>
+      Result.ok({
+        requiredOpstamp,
+        provingSplits: 1,
+        excludedSplits: 1,
+        laggingSplits: 0,
+        minAppliedOpstamp: requiredOpstamp,
+        settled: true,
+      }),
+    search: async () => Result.ok({ numHits: 0, hits: [], snippets: [] }),
+  } satisfies Pick<CorpusIndexClient, "readDeleteSettlement" | "search">;
+  const verified = await CorpusProjectionCleanupSettlementProof.verify({
+    client: settlingClient,
+    lease: successor,
+  });
+  if (verified.isErr()) {
+    panic("Successor settlement verification failed", verified.error);
+  }
+  if (verified.value.status !== "verified") {
+    panic("Successor settlement unexpectedly remained pending");
+  }
+  const proof = verified.value.proof;
   expect(
     await db.transaction(
       async (tx) =>
-        await releaseCorpusProjectionCleanupSettlementTx(
-          asTestRaw<Transaction>(tx),
-          { lease: outrun },
-        ),
+        await settleCorpusProjectionCleanupTx(asTestRaw<Transaction>(tx), {
+          proof,
+        }),
     ),
-  ).toBe(0);
-  expect(
-    await db
-      .select({
-        status: corpusIndexProjectionIntents.status,
-        leaseToken: corpusIndexProjectionIntents.leaseToken,
-      })
-      .from(corpusIndexProjectionIntents)
-      .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID)),
-  ).toEqual([{ status: "cleanup_committed", leaseToken: SECOND_LEASE_TOKEN }]);
+  ).toBe(successor.intentIds.length);
+
+  expect(await releaseSettlementLease(outrun)).toBe(0);
+  expect(await readFirstIntentLease()).toEqual([
+    { status: "settled", leaseToken: null },
+  ]);
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -2913,3 +2913,64 @@ test("settlement proves the lease against the instant its delete task carries", 
       .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID)),
   ).toEqual([{ status: "settled" }]);
 });
+
+test("a settlement release whose revisions a later turn holds releases none of them", async () => {
+  await seedCommittedCleanupPair();
+  // A lease written against a test clock in the past is already expired by the
+  // database clock, which is the state the claim predicate re-leases.
+  const outrunLeases = await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupSettlementTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          limit: 10,
+          taskLimit: 1,
+          leaseMs: 60_000,
+          testNow: new Date("2026-08-25T12:00:00.000Z"),
+          newLeaseToken: () => ERASE_CLEANUP_TOKEN,
+        },
+      ),
+  );
+  const outrun =
+    outrunLeases.at(0) ?? panic("Expected a projection settlement lease");
+  const laterLeases = await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupSettlementTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          limit: 10,
+          taskLimit: 1,
+          leaseMs: 60_000,
+          newLeaseToken: () => SECOND_LEASE_TOKEN,
+        },
+      ),
+  );
+  expect(laterLeases.map(({ intentIds }) => intentIds)).toEqual([
+    outrun.intentIds,
+  ]);
+
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await releaseCorpusProjectionCleanupSettlementTx(
+          asTestRaw<Transaction>(tx),
+          { lease: outrun },
+        ),
+    ),
+  ).toBe(0);
+  expect(
+    await db
+      .select({
+        status: corpusIndexProjectionIntents.status,
+        leaseToken: corpusIndexProjectionIntents.leaseToken,
+      })
+      .from(corpusIndexProjectionIntents)
+      .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID)),
+  ).toEqual([{ status: "cleanup_committed", leaseToken: SECOND_LEASE_TOKEN }]);
+});


### PR DESCRIPTION
## Proposed change

`claimCorpusProjectionCleanupSettlementTx` treats an expired settlement lease as
claimable. Its `settleable` predicate ends with

```ts
or(
  isNull(corpusIndexProjectionIntents.leaseExpiresAt),
  sql`${corpusIndexProjectionIntents.leaseExpiresAt} <= clock_timestamp()`,
)
```

and the claim's `UPDATE` writes a fresh `leaseToken` matching on id and status
alone, never on the token it replaces. Expiry is how a settlement turn that
stops making progress hands its revisions to the next one, and the claim's own
comment says so: "a task another turn claimed in between simply yields no
lease".

`releaseCorpusProjectionCleanupSettlementTx` did not agree. It matches on
`leaseToken`, and graded every shortfall a `panic`:

```ts
if (rows.length !== lease.intentIds.length) {
  return panic(
    `Corpus projection settlement release matched ${rows.length} of ${lease.intentIds.length} leased revisions`,
  );
}
```

A turn only releases when `CorpusProjectionCleanupSettlementProof.verify` came
back `pending`, and that verification reads the index: `readDeleteSettlement`
lists published splits until two passes agree on their identities, then
`countCorpusProjectionRevisions` counts what is left. A verification that
outlasts its lease is not misuse; it is the case the claim predicate exists to
recover from. The turn then panicked on the state its own recovery path
produces, and took the whole cycle with it. `panic` is for impossible internal
invariants, and a lease that can expire mid-turn by construction is not one.

Losing the lease costs nothing. The successor owns those revisions and will
settle or release them, and if it stops too, its lease expires the same way. So
a revision a successor holds is relinquished by leaving it alone, and the
function returns the count it actually released.

What the release owes is only that this lease is gone, not which state replaced
it. Where the successor has got to by then is not this turn's business: it may
still hold the lease, or have already released or settled it, and every one of
those clears this token, as does `reopenCorpusProjectionCleanupTx`. So the check
is that no unreleased revision still carries this lease's token. Enumerating the
successor's states instead would panic on an ordinary finishing order: the second
commit here is that correction, and its two added cases fail against the first.

The panic survives for the state nothing writes: a revision still carrying this
token while failing the release predicate, which would mean it left the index,
status or delete task the lease was granted against without the lease ever being
given up.

`settleCorpusProjectionCleanupTx` is deliberately unchanged. It writes `settled`
under a proof, so a lost lease there means recording an outcome for revisions the
turn no longer owns; what that turn should do with its proof is a separate
question from relinquishing a lease.

### Test

Three cases, one per state a successor can be in when the outrun turn comes to
release. Each claims a lease against a test clock in the past, which
`clock_timestamp()` has already expired when it is written and is exactly the
state `settleable` re-leases, then lets a successor claim the same revisions:

- successor still holding the lease,
- successor already released it,
- successor already settled it, driven through `verify` and
  `settleCorpusProjectionCleanupTx` rather than a hand-written row.

The first fails on `main` with `Corpus projection settlement release matched 0 of
1 leased revisions`; the other two fail against this PR's first commit. Each also
asserts the successor's own state survives, which is what makes leaving the
revision alone the correct release.

Note `postgres-suites` does not run this file: `scripts/run-postgres-tests.ts`
discovers only test files whose text contains `STELLA_RUN_POSTGRES_TESTS`, and
`corpus-index-projection-store.db.test.ts` is one of the many `*.db.test.ts`
files without it. CI green therefore does not exercise these tests; the run below
is the evidence. Enrolling the file is a CI-time decision left out of this change.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun test src/lib/legal-search/corpus-index-projection-store.db.test.ts` is 31/31 against PostgreSQL 17 (29 existing plus the three cases above, one of them replacing an earlier single case); `tsc --noEmit -p apps/api` and `oxlint` on both changed files are clean.
- [ ] DARK MODE SUPPORT | Not applicable: no UI in this change.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI in this change.

Verified per package rather than through the aggregate pre-push hook, which
exhausts memory on this machine.
