### PR TITLE
fix(ai-catalog): source the Nova rates and capabilities from their own upstream records

### DIFF
--- a/.changeset/nova-upstream-rate-and-capability-sources.md
+++ b/.changeset/nova-upstream-rate-and-capability-sources.md
@@ -1,0 +1,5 @@
+---
+"@stll/ai-catalog": patch
+---
+
+Source the Bedrock Nova rates and capabilities from their own models.dev records, now that upstream publishes the US inference-profile IDs directly. Rates and capability values are unchanged; Nova Pro and Nova Lite keep document input through a reviewed override, because models.dev lists no PDF modality for them.

--- a/packages/ai-catalog/src/capabilities-overrides.ts
+++ b/packages/ai-catalog/src/capabilities-overrides.ts
@@ -19,34 +19,4 @@ export type CapabilityOverride = {
 
 export const CAPABILITY_OVERRIDES: Partial<
   Record<OfferedBYOKModelId, CapabilityOverride>
-> = {
-  "us.amazon.nova-pro-v1:0": {
-    documentInput: true,
-    documentInputReason:
-      "2026-08-20: AWS documents PDF input for Nova Pro through Bedrock Converse",
-    reasoningEfforts: null,
-    temperatureSupported: true,
-    reason:
-      "2026-07-20: absent from the models.dev amazon-bedrock catalog; " +
-      "Bedrock Converse accepts temperature and Nova has no reasoning dial",
-  },
-  "us.amazon.nova-lite-v1:0": {
-    documentInput: true,
-    documentInputReason:
-      "2026-08-20: AWS documents PDF input for Nova Lite through Bedrock Converse",
-    reasoningEfforts: null,
-    temperatureSupported: true,
-    reason:
-      "2026-07-20: absent from the models.dev amazon-bedrock catalog; " +
-      "Bedrock Converse accepts temperature and Nova has no reasoning dial",
-  },
-  "us.amazon.nova-micro-v1:0": {
-    documentInput: false,
-    documentInputReason: "2026-08-20: AWS documents Nova Micro as text-only",
-    reasoningEfforts: null,
-    temperatureSupported: true,
-    reason:
-      "2026-07-20: absent from the models.dev amazon-bedrock catalog; " +
-      "Bedrock Converse accepts temperature and Nova has no reasoning dial",
-  },
-};
+> = {};

--- a/packages/ai-catalog/src/capabilities.gen.ts
+++ b/packages/ai-catalog/src/capabilities.gen.ts
@@ -77,9 +77,9 @@ export const MODEL_DOCUMENT_INPUT_OPTIONS = {
   bedrock: [
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    // override: 2026-08-20: AWS documents PDF input for Nova Pro through Bedrock Converse
+    // override: 2026-09-09: AWS documents PDF input for Nova Pro through Bedrock Converse; models.dev lists text, image and video only
     "us.amazon.nova-pro-v1:0",
-    // override: 2026-08-20: AWS documents PDF input for Nova Lite through Bedrock Converse
+    // override: 2026-09-09: AWS documents PDF input for Nova Lite through Bedrock Converse; models.dev lists text, image and video only
     "us.amazon.nova-lite-v1:0",
   ],
   mistral: [],
@@ -137,11 +137,8 @@ export const MODEL_REASONING_EFFORTS = {
   "claude-haiku-4-5-20251001": null,
   "us.anthropic.claude-sonnet-4-5-20250929-v1:0": null,
   "us.anthropic.claude-haiku-4-5-20251001-v1:0": null,
-  // override: 2026-07-20: absent from the models.dev amazon-bedrock catalog; Bedrock Converse accepts temperature and Nova has no reasoning dial
   "us.amazon.nova-pro-v1:0": null,
-  // override: 2026-07-20: absent from the models.dev amazon-bedrock catalog; Bedrock Converse accepts temperature and Nova has no reasoning dial
   "us.amazon.nova-lite-v1:0": null,
-  // override: 2026-07-20: absent from the models.dev amazon-bedrock catalog; Bedrock Converse accepts temperature and Nova has no reasoning dial
   "us.amazon.nova-micro-v1:0": null,
   "openai.gpt-oss-120b-1:0": ["low", "medium", "high"],
   "openai.gpt-oss-20b-1:0": ["low", "medium", "high"],

--- a/packages/ai-catalog/src/document-input-overrides.ts
+++ b/packages/ai-catalog/src/document-input-overrides.ts
@@ -33,4 +33,16 @@ export const DOCUMENT_INPUT_OVERRIDES: Partial<
       "2026-08-20: OpenAI Responses accepts input_file PDF content for this " +
       "vision-capable model; models.dev currently omits the pdf modality",
   },
+  "us.amazon.nova-pro-v1:0": {
+    supported: true,
+    reason:
+      "2026-09-09: AWS documents PDF input for Nova Pro through Bedrock " +
+      "Converse; models.dev lists text, image and video only",
+  },
+  "us.amazon.nova-lite-v1:0": {
+    supported: true,
+    reason:
+      "2026-09-09: AWS documents PDF input for Nova Lite through Bedrock " +
+      "Converse; models.dev lists text, image and video only",
+  },
 };

--- a/packages/ai-catalog/src/model-rate-policy.ts
+++ b/packages/ai-catalog/src/model-rate-policy.ts
@@ -56,34 +56,7 @@ export const RETAINED_MODELS_DEV_RATE_ENTRIES = {
 /**
  * Exact mappings where Stella uses a provider routing ID while models.dev
  * publishes pricing under the corresponding base model ID. Generation rejects
- * a mapping once models.dev begins publishing the Stella ID directly.
+ * a mapping once models.dev begins publishing the Stella ID directly, so the
+ * map is empty whenever upstream covers every offered ID.
  */
-export const MODELS_DEV_RATE_SOURCE_ALIASES = defineRateSourceAliases({
-  "us.amazon.nova-pro-v1:0": {
-    modelId: "amazon.nova-pro-v1:0",
-    provider: "amazon-bedrock",
-    reason:
-      "2026-09-03: stella uses the Bedrock US inference-profile ID; " +
-      "models.dev prices its corresponding base model ID",
-    sourceUrl:
-      "https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html",
-  },
-  "us.amazon.nova-lite-v1:0": {
-    modelId: "amazon.nova-lite-v1:0",
-    provider: "amazon-bedrock",
-    reason:
-      "2026-09-03: stella uses the Bedrock US inference-profile ID; " +
-      "models.dev prices its corresponding base model ID",
-    sourceUrl:
-      "https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html",
-  },
-  "us.amazon.nova-micro-v1:0": {
-    modelId: "amazon.nova-micro-v1:0",
-    provider: "amazon-bedrock",
-    reason:
-      "2026-09-03: stella uses the Bedrock US inference-profile ID; " +
-      "models.dev prices its corresponding base model ID",
-    sourceUrl:
-      "https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html",
-  },
-});
+export const MODELS_DEV_RATE_SOURCE_ALIASES = defineRateSourceAliases({});

--- a/packages/ai-catalog/src/model-rates.gen.ts
+++ b/packages/ai-catalog/src/model-rates.gen.ts
@@ -276,27 +276,21 @@ export const MODEL_RATES = {
     cachedInputPerMTok: 10_000,
     cachedWriteInputPerMTok: 125_000,
   },
-  // models.dev: amazon-bedrock:amazon.nova-pro-v1:0
-  // reviewed source mapping: 2026-09-03: stella uses the Bedrock US inference-profile ID; models.dev prices its corresponding base model ID
-  // reviewed source: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+  // models.dev: amazon-bedrock:us.amazon.nova-pro-v1:0
   "us.amazon.nova-pro-v1:0": {
     kind: "flat",
     inputPerMTok: 80_000,
     outputPerMTok: 320_000,
     cachedInputPerMTok: 20_000,
   },
-  // models.dev: amazon-bedrock:amazon.nova-lite-v1:0
-  // reviewed source mapping: 2026-09-03: stella uses the Bedrock US inference-profile ID; models.dev prices its corresponding base model ID
-  // reviewed source: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+  // models.dev: amazon-bedrock:us.amazon.nova-lite-v1:0
   "us.amazon.nova-lite-v1:0": {
     kind: "flat",
     inputPerMTok: 6000,
     outputPerMTok: 24_000,
     cachedInputPerMTok: 1500,
   },
-  // models.dev: amazon-bedrock:amazon.nova-micro-v1:0
-  // reviewed source mapping: 2026-09-03: stella uses the Bedrock US inference-profile ID; models.dev prices its corresponding base model ID
-  // reviewed source: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+  // models.dev: amazon-bedrock:us.amazon.nova-micro-v1:0
   "us.amazon.nova-micro-v1:0": {
     kind: "flat",
     inputPerMTok: 3500,


### PR DESCRIPTION
## Proposed change

The scheduled [Model Catalog Upstream Check](https://github.com/stella/stella/actions/runs/34312077617) fails on `main`:

```
Panic: us.amazon.nova-pro-v1:0: models.dev now publishes the stella ID
directly; delete its rate-source alias
```

models.dev has begun publishing the Bedrock US inference-profile IDs (`us.amazon.nova-pro-v1:0`, `-lite`, `-micro`) as records of their own, at the same rates as the base IDs it already carried. That makes two hand-written mappings redundant at once, and both of their guards fire:

- `MODELS_DEV_RATE_SOURCE_ALIASES` pointed each Nova ID at its base model for pricing. Rate generation rejects an alias once upstream publishes the stella ID.
- `CAPABILITY_OVERRIDES` declared the three models' capabilities because they were absent from the amazon-bedrock catalog. The capability generator rejects an override for a model upstream covers. `check:model-catalog` never reached this one: the rate script exits first.

Both sets of entries are deleted so sourced data owns them. Rates and capability values are unchanged, so the generated files only lose the provenance comments that pointed at the base IDs:

```diff
-  // models.dev: amazon-bedrock:amazon.nova-pro-v1:0
-  // reviewed source mapping: 2026-09-03: stella uses the Bedrock US inference-profile ID; …
-  // reviewed source: https://docs.aws.amazon.com/…/cross-region-inference.html
+  // models.dev: amazon-bedrock:us.amazon.nova-pro-v1:0
   "us.amazon.nova-pro-v1:0": {
```

One correction has to survive the move. Capability generation derives document input from `modalities.input` containing `pdf`, and models.dev lists Nova Pro and Nova Lite as text, image and video only, omitting the PDF input Bedrock Converse accepts. Deleting their override alone would have dropped both models out of `MODEL_DOCUMENT_INPUT_OPTIONS`. Their document input moves to a dated `DOCUMENT_INPUT_OVERRIDES` entry instead, the seam for a record that exists but under-reports file input; that guard in turn rejects the entry once upstream agrees. Nova Micro is text-only upstream, which matches what its override declared, so it needs none.

Both maps are now empty. They are the reviewed seams the generators validate against, not dead code: an empty map is the correct state while upstream covers every offered ID.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | `bun run check:model-catalog` (both halves) passes; `@stll/ai-catalog` (68), `@stll/scripts` (269) and `apps/api` `unit-model.test.ts` (32) pass; typecheck and lint clean on both changed packages.
- [ ] DARK MODE SUPPORT | Not applicable: no UI changes.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no visual changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_014asTCC7f5RVQRjGZA65zbU)_