### PR TITLE
fix(template-conditions): export the reserved words so the condition property test never generates one as a path

### DIFF
--- a/.changeset/condition-reserved-words.md
+++ b/.changeset/condition-reserved-words.md
@@ -1,0 +1,5 @@
+---
+"@stll/template-conditions": patch
+---
+
+Export the reserved words of the condition language.

--- a/apps/api/src/lib/docx/block-directives-properties.test.ts
+++ b/apps/api/src/lib/docx/block-directives-properties.test.ts
@@ -13,6 +13,7 @@ import JSZip from "jszip";
 import * as slimdom from "slimdom";
 
 import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
+import { CONDITION_RESERVED_WORDS } from "@stll/template-conditions";
 
 import {
   evaluateCondition,
@@ -75,6 +76,7 @@ const extractTexts = async (buffer: Buffer): Promise<string[]> => {
 // ── Arbitraries ──────────────────────────────────────────
 
 const IDENT_RE = /^[a-z]{2,10}$/u;
+const RESERVED_WORDS: ReadonlySet<string> = new Set(CONDITION_RESERVED_WORDS);
 const LEAF_RE = /^[A-Za-z0-9 ]{1,20}$/u;
 const IDENT_UNDERSCORE_RE = /^[a-z_]{1,8}$/u;
 const HAS_LETTER_RE = /[a-z]/u;
@@ -84,7 +86,7 @@ const DIRECTIVE_RE = /\{\{[#/]/u;
 /** XML-safe identifier (letters only, 2-10 chars). */
 const identifier = fc
   .stringMatching(IDENT_RE)
-  .filter((s) => s !== "and" && s !== "or" && s !== "true" && s !== "false");
+  .filter((s) => !RESERVED_WORDS.has(s));
 
 /** XML-safe leaf value (no special chars). */
 const leafValue = fc.stringMatching(LEAF_RE).filter((s) => s.trim().length > 0);

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -155,7 +155,7 @@ export const evaluateCondition = (
   );
 };
 
-export { parseCondition } from "./parse.js";
+export { CONDITION_RESERVED_WORDS, parseCondition } from "./parse.js";
 export { referencedConditionPaths } from "./referenced-paths.js";
 
 // Value-returning arithmetic evaluator for computed fields. Kept separate

--- a/packages/template-conditions/src/parse.ts
+++ b/packages/template-conditions/src/parse.ts
@@ -56,13 +56,41 @@ type Token =
 const escapeRegexLiteral = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 
+/** Bare words the tokenizer reads as operators or literals; a data path can
+ *  never be one of them. */
+export const CONDITION_RESERVED_WORDS = [
+  "and",
+  "or",
+  "not",
+  "in",
+  "is",
+  "defined",
+  "true",
+  "false",
+] as const;
+
+type ConditionKeyword = Exclude<
+  (typeof CONDITION_RESERVED_WORDS)[number],
+  "true" | "false"
+>;
+
+const RESERVED_WORDS: ReadonlySet<string> = new Set(CONDITION_RESERVED_WORDS);
+
+const isConditionKeyword = (raw: string): raw is ConditionKeyword =>
+  raw !== "true" && raw !== "false" && RESERVED_WORDS.has(raw);
+
+/** The keyword alternation of the tokenizer, derived from the same list. */
+const KEYWORD_PATTERN = CONDITION_RESERVED_WORDS.filter(isConditionKeyword)
+  .map((word) => String.raw`${word}\b`)
+  .join("|");
+
 const COMPARE_SYMBOL_PATTERN = Object.keys(COMPARE_SYMBOL_TO_OP)
   .sort((left, right) => right.length - left.length)
   .map(escapeRegexLiteral)
   .join("|");
 
 const NON_STRING_TOKEN_RE = new RegExp(
-  String.raw`(?<token>${COMPARE_SYMBOL_PATTERN}|and\b|or\b|not\b|in\b|is\b|defined\b|[()]|-?\d[\p{N}_.]*|[\p{L}\p{N}_.]+(?:-[\p{L}\p{N}_.]+)*)`,
+  String.raw`(?<token>${COMPARE_SYMBOL_PATTERN}|${KEYWORD_PATTERN}|[()]|-?\d[\p{N}_.]*|[\p{L}\p{N}_.]+(?:-[\p{L}\p{N}_.]+)*)`,
   "uy",
 );
 
@@ -95,29 +123,6 @@ const scanString = (expr: string, start: number): StringScan => {
   }
   return { content: expr.slice(start + 1), end: expr.length };
 };
-
-/** Bare words the tokenizer reads as operators or literals; a data path can
- *  never be one of them. */
-export const CONDITION_RESERVED_WORDS = [
-  "and",
-  "or",
-  "not",
-  "in",
-  "is",
-  "defined",
-  "true",
-  "false",
-] as const;
-
-type ConditionKeyword = Exclude<
-  (typeof CONDITION_RESERVED_WORDS)[number],
-  "true" | "false"
->;
-
-const RESERVED_WORDS: ReadonlySet<string> = new Set(CONDITION_RESERVED_WORDS);
-
-const isConditionKeyword = (raw: string): raw is ConditionKeyword =>
-  raw !== "true" && raw !== "false" && RESERVED_WORDS.has(raw);
 
 const classifyNonString = (raw: string): Token => {
   if (isConditionKeyword(raw)) {

--- a/packages/template-conditions/src/parse.ts
+++ b/packages/template-conditions/src/parse.ts
@@ -96,24 +96,32 @@ const scanString = (expr: string, start: number): StringScan => {
   return { content: expr.slice(start + 1), end: expr.length };
 };
 
+/** Bare words the tokenizer reads as operators or literals; a data path can
+ *  never be one of them. */
+export const CONDITION_RESERVED_WORDS = [
+  "and",
+  "or",
+  "not",
+  "in",
+  "is",
+  "defined",
+  "true",
+  "false",
+] as const;
+
+type ConditionKeyword = Exclude<
+  (typeof CONDITION_RESERVED_WORDS)[number],
+  "true" | "false"
+>;
+
+const RESERVED_WORDS: ReadonlySet<string> = new Set(CONDITION_RESERVED_WORDS);
+
+const isConditionKeyword = (raw: string): raw is ConditionKeyword =>
+  raw !== "true" && raw !== "false" && RESERVED_WORDS.has(raw);
+
 const classifyNonString = (raw: string): Token => {
-  if (raw === "and") {
-    return { type: "and" };
-  }
-  if (raw === "or") {
-    return { type: "or" };
-  }
-  if (raw === "not") {
-    return { type: "not" };
-  }
-  if (raw === "in") {
-    return { type: "in" };
-  }
-  if (raw === "is") {
-    return { type: "is" };
-  }
-  if (raw === "defined") {
-    return { type: "defined" };
+  if (isConditionKeyword(raw)) {
+    return { type: raw };
   }
   if (isCompareSymbol(raw)) {
     return { type: "op", raw };


### PR DESCRIPTION
The tokenizer's keyword list becomes one exported constant; the block-directive property test filters its identifier generator on it instead of a hand-kept subset (which lacked `not`, `in`, `is` and `defined`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardised recognition of reserved words in template conditions.
  - Exposed the complete reserved-word list through the template-conditions package.
  - Preserved existing handling of `true` and `false` as value literals.

- **Tests**
  - Updated identifier-generation tests to use the shared reserved-word list, supporting consistent validation as the condition grammar evolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->