### PR TITLE
fix(api): mark search snippets on the engine's window and stop marking stem collisions

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -25,7 +25,11 @@ import { corpusIndexBrowseFacets } from "@/api/lib/legal-search/corpus-index-fac
 import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import { caseLawCorpusQueryFields } from "@/api/lib/legal-search/corpus-index-read-contract";
-import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
+import { markCorpusFragment } from "@/api/lib/legal-search/corpus-passage-highlight";
+import {
+  caseLawCorpusQuery,
+  tokenizeCorpusFreeText,
+} from "@/api/lib/legal-search/corpus-query";
 import {
   decodeCorpusSearchCursor,
   encodeCorpusSearchCursor,
@@ -53,6 +57,7 @@ import {
   definePublicLawSharedQuery,
   PUBLIC_LAW_SHARED_QUERY,
 } from "@/api/lib/public-law-shared-query";
+import { stripSearchHighlightMarkup } from "@/api/lib/search/highlight";
 
 /**
  * corpus index legal-search provider: two-stage retrieve-then-rerank.
@@ -73,7 +78,15 @@ import {
 const toNullableString = (x: unknown): string | null =>
   x === null ? null : JSON.stringify(x);
 
-const extractSnippet = (
+/**
+ * The engine's snippet as plain text: the window it cut, without its own marks.
+ *
+ * corpus index wraps matched terms in `<b>` and escapes the surrounding text,
+ * so the swap below hands `stripSearchHighlightMarkup` the one tag it strips.
+ * The marks the response carries are put back by
+ * {@link markCorpusFragment}, which reads the same terms the reader typed.
+ */
+const engineSnippetText = (
   snippet: Record<string, unknown> | undefined,
 ): string | null => {
   const text = snippet?.["text"];
@@ -81,10 +94,9 @@ const extractSnippet = (
   if (typeof raw !== "string" || raw.length === 0) {
     return null;
   }
-  // corpus index wraps matched terms in <b>; the UI renders <mark>. corpus index
-  // escapes the surrounding text, so this swap is safe. Aligning fully
-  // with the pg ts_headline pipeline is a follow-up.
-  return raw.replaceAll("<b>", "<mark>").replaceAll("</b>", "</mark>");
+  return stripSearchHighlightMarkup(
+    raw.replaceAll("<b>", "<mark>").replaceAll("</b>", "</mark>"),
+  );
 };
 
 type RehydrateCorpusIndexCandidatesOptions = {
@@ -223,6 +235,10 @@ const searchResult = async (
     );
   }
 
+  // The reader's own words, not the expanded query: an expansion term is a
+  // reason a document ranks, not a word the reader asked to see marked.
+  const snippetTokens = tokenizeCorpusFreeText(query.query);
+
   const searchPage = await readCorpusIndexSearchPage({
     cluster: serving.cluster,
     indexId,
@@ -234,7 +250,21 @@ const searchResult = async (
       const id = hit["document_id"];
       return typeof id === "string" && isUuid(id) ? id : null;
     },
-    extractSnippet,
+    // The engine picks the window, the marks are put on here: the engine marks
+    // the tokens its query names, so an inflected form is left unmarked inside
+    // a window that was returned for it, and a quoted phrase is marked word by
+    // word. Marking the window the engine already sent back keeps that off the
+    // read path: no passage is fetched per hit.
+    extractSnippet: (snippet) => {
+      const text = engineSnippetText(snippet);
+      return text === null
+        ? null
+        : markCorpusFragment({
+            text,
+            tokens: snippetTokens,
+            language: stemming?.language ?? null,
+          });
+    },
     // Upper bound for the pagination early-stop: scanning may end only once
     // no unseen candidate could out-blend the page cursor. Saturated
     // authority is bounded by 1, so the bound reads nothing from the corpus.

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
@@ -3,14 +3,18 @@ import { describe, expect, test } from "bun:test";
 import {
   CORPUS_SNIPPET_MAX_CHARS,
   highlightCorpusPassage,
+  markCorpusFragment,
 } from "@/api/lib/legal-search/corpus-passage-highlight";
 import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
 import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
-import { searchHighlightMarks } from "@/api/lib/search/highlight";
+import {
+  searchHighlightMarks,
+  stripSearchHighlightMarkup,
+} from "@/api/lib/search/highlight";
 
 /**
- * Window selection, the forms a passage word is matched by, the mark format,
- * and the cuts: whole words only, budget respected, empty passage empty.
+ * Window selection, the forms a word is matched by, the mark format, and the
+ * cuts: whole words only, budget respected, empty passage empty.
  */
 
 const highlight = (
@@ -23,6 +27,13 @@ const highlight = (
     tokens: tokenizeCorpusFreeText(query),
     language: options.language === undefined ? "cs" : options.language,
     maxChars: options.maxChars,
+  });
+
+const mark = (fragment: string, query: string) =>
+  markCorpusFragment({
+    text: fragment,
+    tokens: tokenizeCorpusFreeText(query),
+    language: "cs",
   });
 
 describe("window selection", () => {
@@ -131,6 +142,42 @@ describe("matching", () => {
     const { html } = highlight(passage, '"dobré mravy" mravy');
 
     expect(searchHighlightMarks(html)).toEqual(["dobré mravy"]);
+  });
+});
+
+describe("stem matching", () => {
+  test("marks the inflections of the query's term", () => {
+    const fragment =
+      "Soud přiznal náhradu škody, náhrady nákladů i náhradu újmy.";
+
+    expect(searchHighlightMarks(mark(fragment, "náhrada"))).toEqual([
+      "náhradu",
+      "náhrady",
+      "náhradu",
+    ]);
+  });
+
+  test("leaves a word whose stem matches only once the accents are folded", () => {
+    const fragment =
+      "Nájemce nemusí být v bytě přítomen; ukončení nájemního bytu se ho týká.";
+
+    expect(searchHighlightMarks(mark(fragment, "nájemního bytu"))).toEqual([
+      "bytě",
+      "nájemního",
+      "bytu",
+    ]);
+  });
+});
+
+describe("markCorpusFragment", () => {
+  test("marks every match and keeps the fragment whole, however long", () => {
+    const fragment = `Smlouva & ${"slovo ".repeat(40)}náhrada škody.`;
+
+    const html = mark(fragment, "škoda");
+
+    expect(html).toContain("&amp;");
+    expect(stripSearchHighlightMarkup(html)).toBe(fragment);
+    expect(searchHighlightMarks(html)).toEqual(["škody"]);
   });
 });
 

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
@@ -157,7 +157,16 @@ describe("stem matching", () => {
     ]);
   });
 
-  test("leaves a word whose stem matches only once the accents are folded", () => {
+  test("marks the accented inflections of a query typed without diacritics", () => {
+    const fragment = "Soud přiznal náhrady nákladů; náhrada škody trvá.";
+
+    expect(searchHighlightMarks(mark(fragment, "nahradu"))).toEqual([
+      "náhrady",
+      "náhrada",
+    ]);
+  });
+
+  test("leaves a word whose short stem matches only once the accents are folded", () => {
     const fragment =
       "Nájemce nemusí být v bytě přítomen; ukončení nájemního bytu se ho týká.";
 

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
@@ -96,10 +96,10 @@ const queryTermWords = (
   language: MorphologyLanguage | null,
 ): QueryTermWords[] =>
   tokens.flatMap((token) => {
-    const words = corpusTokens(token.value).map((word) => ({
-      folded: foldCorpusTerm(word),
-      ...wordStem(word, language),
-    }));
+    const words = corpusTokens(token.value).map((word) => {
+      const { stem, foldedStem } = wordStem(word, language);
+      return { folded: foldCorpusTerm(word), stem, foldedStem };
+    });
     // One dropped word makes the whole term unmatchable: a term is its word,
     // and a phrase needs every one of its words to match adjacently.
     return words.length === 0 ||
@@ -114,12 +114,14 @@ const passageWords = (
 ): PassageWord[] =>
   corpusTokenSpans(text).map((span) => {
     const folded = foldCorpusTerm(span.value);
+    const { stem, foldedStem } = wordStem(span.value, language);
     return {
       value: span.value,
       start: span.start,
       end: span.end,
       folded,
-      ...wordStem(span.value, language),
+      stem,
+      foldedStem,
       indexed: isIndexedTerm(folded),
     };
   });

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
@@ -1,13 +1,15 @@
 /**
- * Cut a fragment out of a corpus passage and mark the query's matches in it.
+ * Mark a query's matches in corpus text, either in a fragment a caller already
+ * holds ({@link markCorpusFragment}) or in one cut from a whole passage
+ * ({@link highlightCorpusPassage}).
  *
- * Takes the passage text, the query's tokens (`tokenizeCorpusFreeText`) and the
- * language both sides are stemmed in. Returns the fragment twice: as
- * HTML-escaped text with `<mark>` around each matched run, and as plain text.
+ * Takes the text, the query's tokens (`tokenizeCorpusFreeText`) and the
+ * language both sides are stemmed in, and returns HTML-escaped text with
+ * `<mark>` around each matched run.
  *
- * A passage word matches a query word when their folded surfaces are equal or
- * their stems are; a phrase token matches consecutive passage words. Splitting,
- * folding and stemming come from `corpus-tokens`, `@stll/text-normalize` and
+ * A word matches a query word when their folded surfaces are equal or their
+ * stems are; a phrase token matches consecutive words. Splitting, folding and
+ * stemming come from `corpus-tokens`, `@stll/text-normalize` and
  * `morphology/stem`. Pure.
  */
 
@@ -47,7 +49,7 @@ const isIndexedTerm = (folded: string): boolean =>
 /** A word of the query, as the two forms a passage word is compared against. */
 type QueryWord = {
   folded: string;
-  /** Empty when the language has no stemmer. */
+  /** The stem with its accents; empty when the language has no stemmer. */
   stem: string;
 };
 
@@ -62,11 +64,21 @@ type PassageWord = CorpusTokenSpan & {
   indexed: boolean;
 };
 
-const stemFolded = (
+/**
+ * The stem as the stemmer writes it: lower-cased and NFC, accents kept.
+ *
+ * Not folded, and that is the whole rule. Stemming runs before folding because
+ * the suffix tables are written over accented characters, so an accent inside
+ * a stem is a letter the algorithm read; folding the stem afterwards merges
+ * words that are not forms of each other, because the endings that separate
+ * them are already gone ("bytu" stems to "byt", "být" to itself, and both fold
+ * to "byt"). A query typed without diacritics still reaches the accented text
+ * through the folded surface.
+ */
+const stemTerm = (
   value: string,
   language: MorphologyLanguage | null,
-): string =>
-  language === null ? "" : foldCorpusTerm(stemLegalTerm(value, language));
+): string => (language === null ? "" : stemLegalTerm(value, language));
 
 const queryTermWords = (
   tokens: readonly CorpusQueryToken[],
@@ -75,7 +87,7 @@ const queryTermWords = (
   tokens.flatMap((token) => {
     const words = corpusTokens(token.value).map((word) => ({
       folded: foldCorpusTerm(word),
-      stem: stemFolded(word, language),
+      stem: stemTerm(word, language),
     }));
     // One dropped word makes the whole term unmatchable: a term is its word,
     // and a phrase needs every one of its words to match adjacently.
@@ -96,11 +108,12 @@ const passageWords = (
       start: span.start,
       end: span.end,
       folded,
-      stem: stemFolded(span.value, language),
+      stem: stemTerm(span.value, language),
       indexed: isIndexedTerm(folded),
     };
   });
 
+/** Same folded surface, or same stem; see {@link stemTerm} for the asymmetry. */
 const wordMatches = (word: PassageWord, queryWord: QueryWord): boolean =>
   word.indexed &&
   (word.folded === queryWord.folded ||
@@ -131,8 +144,11 @@ const termMatches = (
   return matches;
 };
 
-/** A candidate fragment, as a half-open range of passage words. */
-type Window = { start: number; end: number; terms: number; matches: number };
+/** A half-open range of words, `end` exclusive. */
+type WordRange = { start: number; end: number };
+
+/** A candidate fragment, as a range of passage words and what it holds. */
+type Window = WordRange & { terms: number; matches: number };
 
 /**
  * The window a fragment is cut from: most distinct matched terms, then most
@@ -220,11 +236,11 @@ type MarkRange = { start: number; end: number };
 const markRanges = (
   words: readonly PassageWord[],
   matches: readonly TermMatch[],
-  window: Window,
+  range: WordRange,
 ): MarkRange[] => {
   const ranges: MarkRange[] = [];
   for (const match of matches) {
-    if (match.start < window.start || match.end > window.end) {
+    if (match.start < range.start || match.end > range.end) {
       continue;
     }
     const startWord = words.at(match.start);
@@ -258,6 +274,38 @@ const markFragment = (
     cursor = range.end;
   }
   return html + escapeSearchHtml(text.slice(cursor, to));
+};
+
+type MarkCorpusFragmentOptions = {
+  /** The fragment to mark, whole; the caller has already chosen the window. */
+  text: string;
+  /** The query's tokens, from `tokenizeCorpusFreeText`. */
+  tokens: readonly CorpusQueryToken[];
+  /** The language both sides are stemmed in; null stems neither. */
+  language: MorphologyLanguage | null;
+};
+
+/**
+ * `text`, HTML-escaped, with `<mark>` around every run `tokens` matches.
+ *
+ * Nothing is cut: a fragment chosen elsewhere keeps its own edges, marks and
+ * all.
+ */
+export const markCorpusFragment = ({
+  text,
+  tokens,
+  language,
+}: MarkCorpusFragmentOptions): string => {
+  // The spans below index the NFC form, so the marked text is cut from it too.
+  const normalized = normalizeCorpusText(text);
+  const words = passageWords(normalized, language);
+  const matches = termMatches(words, queryTermWords(tokens, language));
+  return markFragment(
+    normalized,
+    0,
+    normalized.length,
+    markRanges(words, matches, { start: 0, end: words.length }),
+  );
 };
 
 type CorpusPassageFragment = {

--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.ts
@@ -46,39 +46,50 @@ export const foldCorpusTerm = (value: string): string =>
 const isIndexedTerm = (folded: string): boolean =>
   Buffer.byteLength(folded, "utf-8") < CORPUS_TOKEN_LENGTH_LIMIT_BYTES;
 
-/** A word of the query, as the two forms a passage word is compared against. */
-type QueryWord = {
-  folded: string;
-  /** The stem with its accents; empty when the language has no stemmer. */
+/** The stem forms a word is matched by; both empty without a stemmer. */
+type WordStem = {
+  /** The stem as the stemmer writes it: lower-cased, NFC, accents kept. */
   stem: string;
+  /** The same stem, ASCII-folded, as the index holds it. */
+  foldedStem: string;
 };
+
+/** A word of the query, as the forms a passage word is compared against. */
+type QueryWord = WordStem & { folded: string };
 
 /** One query token's words, in order; a phrase carries more than one. */
 type QueryTermWords = readonly QueryWord[];
 
 /** A passage word, folded and stemmed once so the scan below can be a scan. */
-type PassageWord = CorpusTokenSpan & {
-  folded: string;
-  stem: string;
-  /** False for a token `remove_long` drops; such a word matches nothing. */
-  indexed: boolean;
-};
+type PassageWord = CorpusTokenSpan &
+  WordStem & {
+    folded: string;
+    /** False for a token `remove_long` drops; such a word matches nothing. */
+    indexed: boolean;
+  };
 
 /**
- * The stem as the stemmer writes it: lower-cased and NFC, accents kept.
+ * Letters a folded stem needs before a folded-stem match is taken on its own.
  *
- * Not folded, and that is the whole rule. Stemming runs before folding because
- * the suffix tables are written over accented characters, so an accent inside
- * a stem is a letter the algorithm read; folding the stem afterwards merges
- * words that are not forms of each other, because the endings that separate
- * them are already gone ("bytu" stems to "byt", "být" to itself, and both fold
- * to "byt"). A query typed without diacritics still reaches the accented text
- * through the folded surface.
+ * Stemming runs before folding, because the suffix tables are written over
+ * accented characters; folding the stem afterwards can merge words that are
+ * not forms of each other, and the shorter the stem, the more of it a single
+ * accent decides ("bytu" stems to "byt", "být" to itself, and both fold to
+ * "byt"). Past this length the fold is what carries a query typed without
+ * diacritics onto accented text, which is how most of them are typed.
  */
-const stemTerm = (
+const FOLDED_STEM_MIN_LENGTH = 4;
+
+const wordStem = (
   value: string,
   language: MorphologyLanguage | null,
-): string => (language === null ? "" : stemLegalTerm(value, language));
+): WordStem => {
+  if (language === null) {
+    return { stem: "", foldedStem: "" };
+  }
+  const stem = stemLegalTerm(value, language);
+  return { stem, foldedStem: foldCorpusTerm(stem) };
+};
 
 const queryTermWords = (
   tokens: readonly CorpusQueryToken[],
@@ -87,7 +98,7 @@ const queryTermWords = (
   tokens.flatMap((token) => {
     const words = corpusTokens(token.value).map((word) => ({
       folded: foldCorpusTerm(word),
-      stem: stemTerm(word, language),
+      ...wordStem(word, language),
     }));
     // One dropped word makes the whole term unmatchable: a term is its word,
     // and a phrase needs every one of its words to match adjacently.
@@ -108,16 +119,28 @@ const passageWords = (
       start: span.start,
       end: span.end,
       folded,
-      stem: stemTerm(span.value, language),
+      ...wordStem(span.value, language),
       indexed: isIndexedTerm(folded),
     };
   });
 
-/** Same folded surface, or same stem; see {@link stemTerm} for the asymmetry. */
+/**
+ * Same stem: folded once the folded stem is long enough to stand on its own,
+ * accents and all below that length. See {@link FOLDED_STEM_MIN_LENGTH}.
+ */
+const stemMatches = (word: PassageWord, queryWord: QueryWord): boolean => {
+  if (queryWord.stem === "") {
+    return false;
+  }
+  return queryWord.foldedStem.length >= FOLDED_STEM_MIN_LENGTH
+    ? word.foldedStem === queryWord.foldedStem
+    : word.stem === queryWord.stem;
+};
+
+/** Same folded surface, or same stem. */
 const wordMatches = (word: PassageWord, queryWord: QueryWord): boolean =>
   word.indexed &&
-  (word.folded === queryWord.folded ||
-    (queryWord.stem !== "" && word.stem === queryWord.stem));
+  (word.folded === queryWord.folded || stemMatches(word, queryWord));
 
 /** One term matching a run of passage words; `end` is exclusive. */
 type TermMatch = { termIndex: number; start: number; end: number };

--- a/apps/api/src/scripts/corpus-snippet-compare-report.test.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare-report.test.ts
@@ -147,41 +147,41 @@ describe("compareSnippetFragments", () => {
 
     expect(
       compareSnippetFragments({
-        engineSnippet: snippet,
-        apiSnippet: snippet,
+        snippetFragment: snippet,
+        passageFragment: snippet,
       }),
     ).toEqual({
       overlap: 1,
-      engineMarks: ["skody"],
-      apiMarks: ["skody"],
+      snippetMarks: ["skody"],
+      passageMarks: ["skody"],
       marks: "identical",
     });
   });
 
-  test("reports the API side marking more than the engine", () => {
+  test("reports the passage side marking more than the snippet", () => {
     const comparison = compareSnippetFragments({
-      engineSnippet: "náhrada <mark>škody</mark> z prodlení",
-      apiSnippet: "náhrada <mark>škody</mark> z <mark>prodlení</mark>",
+      snippetFragment: "náhrada <mark>škody</mark> z prodlení",
+      passageFragment: "náhrada <mark>škody</mark> z <mark>prodlení</mark>",
     });
 
     expect(comparison.overlap).toBe(1);
-    expect(comparison.marks).toBe("api_superset");
-    expect(comparison.apiMarks).toEqual(["prodleni", "skody"]);
+    expect(comparison.marks).toBe("passage_superset");
+    expect(comparison.passageMarks).toEqual(["prodleni", "skody"]);
   });
 
   test("reports marks neither side covers", () => {
     expect(
       compareSnippetFragments({
-        engineSnippet: "<mark>škody</mark> a prodlení",
-        apiSnippet: "škody a <mark>prodlení</mark>",
+        snippetFragment: "<mark>škody</mark> a prodlení",
+        passageFragment: "škody a <mark>prodlení</mark>",
       }).marks,
     ).toBe("divergent");
   });
 
   test("scores fragments cut from different places of the passage", () => {
     const comparison = compareSnippetFragments({
-      engineSnippet: "alpha beta gamma delta",
-      apiSnippet: "gamma delta epsilon zeta",
+      snippetFragment: "alpha beta gamma delta",
+      passageFragment: "gamma delta epsilon zeta",
     });
 
     // Two words shared of six distinct.
@@ -191,8 +191,8 @@ describe("compareSnippetFragments", () => {
   test("scores disjoint fragments as no overlap", () => {
     expect(
       compareSnippetFragments({
-        engineSnippet: "alpha beta",
-        apiSnippet: "gamma delta",
+        snippetFragment: "alpha beta",
+        passageFragment: "gamma delta",
       }).overlap,
     ).toBe(0);
   });
@@ -200,8 +200,8 @@ describe("compareSnippetFragments", () => {
   test("compares the escaped text, not the entities", () => {
     expect(
       compareSnippetFragments({
-        engineSnippet: "smlouva &amp; podmínky",
-        apiSnippet: "smlouva &amp; podmínky",
+        snippetFragment: "smlouva &amp; podmínky",
+        passageFragment: "smlouva &amp; podmínky",
       }).overlap,
     ).toBe(1);
   });
@@ -223,11 +223,11 @@ const row = (): SnippetCompareQueryRow => ({
       anchorId: "p1",
       outcome: {
         status: "compared",
-        engineFragment: "náhrada <mark>škody</mark> z prodlení",
-        apiFragment: "náhrada <mark>škody</mark> z prodlení",
+        snippetFragment: "náhrada <mark>škody</mark> z prodlení",
+        passageFragment: "náhrada <mark>škody</mark> z prodlení",
         comparison: compareSnippetFragments({
-          engineSnippet: "náhrada <mark>škody</mark> z prodlení",
-          apiSnippet: "náhrada <mark>škody</mark> z prodlení",
+          snippetFragment: "náhrada <mark>škody</mark> z prodlení",
+          passageFragment: "náhrada <mark>škody</mark> z prodlení",
         }),
         highlightMs: 2,
       },
@@ -237,11 +237,11 @@ const row = (): SnippetCompareQueryRow => ({
       anchorId: "p2",
       outcome: {
         status: "compared",
-        engineFragment: "<mark>škody</mark> alpha beta",
-        apiFragment: "gamma delta epsilon",
+        snippetFragment: "<mark>škody</mark> alpha beta",
+        passageFragment: "gamma delta epsilon",
         comparison: compareSnippetFragments({
-          engineSnippet: "<mark>škody</mark> alpha beta",
-          apiSnippet: "gamma delta epsilon",
+          snippetFragment: "<mark>škody</mark> alpha beta",
+          passageFragment: "gamma delta epsilon",
         }),
         highlightMs: 4,
       },
@@ -262,12 +262,12 @@ describe("summarizeSnippetComparison", () => {
     expect(summary.hits).toBe(3);
     expect(summary.compared).toBe(2);
     expect(summary.skipped.unanchored).toBe(1);
-    expect(summary.skipped.no_engine_snippet).toBe(0);
+    expect(summary.skipped.no_snippet).toBe(0);
     expect(summary.marks.identical).toBe(1);
-    // The second hit's API fragment marks nothing the engine marked.
-    expect(summary.marks.engine_superset).toBe(1);
+    // The second hit's passage fragment marks nothing the snippet marked.
+    expect(summary.marks.snippet_superset).toBe(1);
     expect(summary.overlapAtLeastHalfShare).toBe(0.5);
-    expect(summary.apiMarksCoverEngineShare).toBe(0.5);
+    expect(summary.passageMarksCoverSnippetShare).toBe(0.5);
     expect(summary.timings.highlightMsTotal).toBe(6);
     expect(summary.timings.highlightMsMedian).toBe(3);
     expect(summary.timings.searchMsTotal).toBe(40);
@@ -292,8 +292,8 @@ describe("renderSnippetCompareMarkdown", () => {
     expect(markdown).toContain("- queries: 1");
     expect(markdown).toContain("- overlap >= 0.5: 50.0%");
     expect(markdown).toContain("## cze-a — cze: náhrada škody");
-    expect(markdown).toContain("| 1 | engine |");
-    expect(markdown).toContain("| 1 | api |");
+    expect(markdown).toContain("| 1 | snippet |");
+    expect(markdown).toContain("| 1 | passage |");
     expect(markdown).toContain("not compared: unanchored");
   });
 
@@ -303,7 +303,7 @@ describe("renderSnippetCompareMarkdown", () => {
     if (first?.outcome.status !== "compared") {
       throw new Error("fixture must hold a compared hit");
     }
-    first.outcome.engineFragment = "alpha | beta\ngamma";
+    first.outcome.snippetFragment = "alpha | beta\ngamma";
 
     const markdown = renderSnippetCompareMarkdown(
       snippetCompareReport([withPipes]),

--- a/apps/api/src/scripts/corpus-snippet-compare-report.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare-report.ts
@@ -144,8 +144,8 @@ export const parseSnippetCompareArgs = (
 /** How the two sides' marked terms relate. */
 const MARK_AGREEMENTS = [
   "identical",
-  "api_superset",
-  "engine_superset",
+  "passage_superset",
+  "snippet_superset",
   "divergent",
 ] as const;
 type MarkAgreement = (typeof MARK_AGREEMENTS)[number];
@@ -155,7 +155,7 @@ const SNIPPET_COMPARE_SKIPS = [
   "unanchored",
   "no_payload",
   "anchor_not_found",
-  "no_engine_snippet",
+  "no_snippet",
 ] as const;
 type SnippetCompareSkip = (typeof SNIPPET_COMPARE_SKIPS)[number];
 
@@ -180,8 +180,8 @@ type FragmentComparison = {
    */
   overlap: number;
   /** Distinct folded terms each side marked. */
-  engineMarks: string[];
-  apiMarks: string[];
+  snippetMarks: string[];
+  passageMarks: string[];
   marks: MarkAgreement;
 };
 
@@ -211,38 +211,38 @@ const markedTerms = (snippet: string): Set<string> =>
   new Set(searchHighlightMarks(snippet).flatMap(foldedWords));
 
 const markAgreement = (
-  engine: Set<string>,
-  api: Set<string>,
+  snippet: Set<string>,
+  passage: Set<string>,
 ): MarkAgreement => {
-  const apiCoversEngine = [...engine].every((term) => api.has(term));
-  const engineCoversApi = [...api].every((term) => engine.has(term));
-  if (apiCoversEngine && engineCoversApi) {
+  const passageCoversSnippet = [...snippet].every((term) => passage.has(term));
+  const snippetCoversPassage = [...passage].every((term) => snippet.has(term));
+  if (passageCoversSnippet && snippetCoversPassage) {
     return "identical";
   }
-  if (apiCoversEngine) {
-    return "api_superset";
+  if (passageCoversSnippet) {
+    return "passage_superset";
   }
-  return engineCoversApi ? "engine_superset" : "divergent";
+  return snippetCoversPassage ? "snippet_superset" : "divergent";
 };
 
 /** One hit's two fragments, compared. Both are `<mark>`-format snippets. */
 export const compareSnippetFragments = ({
-  engineSnippet,
-  apiSnippet,
+  snippetFragment,
+  passageFragment,
 }: {
-  engineSnippet: string;
-  apiSnippet: string;
+  snippetFragment: string;
+  passageFragment: string;
 }): FragmentComparison => {
-  const engineMarks = markedTerms(engineSnippet);
-  const apiMarks = markedTerms(apiSnippet);
+  const snippetMarks = markedTerms(snippetFragment);
+  const passageMarks = markedTerms(passageFragment);
   return {
     overlap: multisetOverlap(
-      foldedWords(stripSearchHighlightMarkup(engineSnippet)),
-      foldedWords(stripSearchHighlightMarkup(apiSnippet)),
+      foldedWords(stripSearchHighlightMarkup(snippetFragment)),
+      foldedWords(stripSearchHighlightMarkup(passageFragment)),
     ),
-    engineMarks: [...engineMarks].sort(),
-    apiMarks: [...apiMarks].sort(),
-    marks: markAgreement(engineMarks, apiMarks),
+    snippetMarks: [...snippetMarks].sort(),
+    passageMarks: [...passageMarks].sort(),
+    marks: markAgreement(snippetMarks, passageMarks),
   };
 };
 
@@ -250,9 +250,9 @@ export type SnippetCompareOutcome =
   | {
       status: "compared";
       /** The snippet the search returned for this hit. */
-      engineFragment: string;
+      snippetFragment: string;
       /** The fragment cut here from the same passage. */
-      apiFragment: string;
+      passageFragment: string;
       comparison: FragmentComparison;
       /** Wall time of the cut alone, storage reads excluded. */
       highlightMs: number;
@@ -282,7 +282,7 @@ type SnippetCompareSummary = {
   marks: Record<MarkAgreement, number>;
   /** Share of compared hits, so an empty run reports 0 rather than NaN. */
   overlapAtLeastHalfShare: number;
-  apiMarksCoverEngineShare: number;
+  passageMarksCoverSnippetShare: number;
   medianOverlap: number;
   timings: {
     searchMsMedian: number;
@@ -322,19 +322,19 @@ export const summarizeSnippetComparison = (
     unanchored: 0,
     no_payload: 0,
     anchor_not_found: 0,
-    no_engine_snippet: 0,
+    no_snippet: 0,
   };
   const marks: Record<MarkAgreement, number> = {
     identical: 0,
-    api_superset: 0,
-    engine_superset: 0,
+    passage_superset: 0,
+    snippet_superset: 0,
     divergent: 0,
   };
   const overlaps: number[] = [];
   const highlightMs: number[] = [];
   let hits = 0;
   let overlapAtLeastHalf = 0;
-  let apiMarksCoverEngine = 0;
+  let passageMarksCoverEngine = 0;
 
   for (const row of rows) {
     for (const { outcome } of row.hits) {
@@ -351,9 +351,9 @@ export const summarizeSnippetComparison = (
       }
       if (
         outcome.comparison.marks === "identical" ||
-        outcome.comparison.marks === "api_superset"
+        outcome.comparison.marks === "passage_superset"
       ) {
-        apiMarksCoverEngine += 1;
+        passageMarksCoverEngine += 1;
       }
     }
   }
@@ -368,7 +368,7 @@ export const summarizeSnippetComparison = (
     skipped,
     marks,
     overlapAtLeastHalfShare: share(overlapAtLeastHalf),
-    apiMarksCoverEngineShare: share(apiMarksCoverEngine),
+    passageMarksCoverSnippetShare: share(passageMarksCoverEngine),
     medianOverlap: median(overlaps),
     timings: {
       searchMsMedian: median(rows.map(({ searchMs }) => searchMs)),
@@ -411,15 +411,16 @@ export const renderSnippetCompareMarkdown = (
   const lines: string[] = [
     "# Passage fragments per hit",
     "",
-    "Overlap is the Jaccard index of the fragments' folded word multisets;",
-    "marks are compared as folded terms.",
+    "`snippet` is the fragment the search returned, `passage` the one cut here",
+    "from the hit's whole passage. Overlap is the Jaccard index of the",
+    "fragments' folded word multisets; marks are compared as folded terms.",
     "",
     "## Summary",
     "",
     `- queries: ${summary.queries}`,
     `- hits: ${summary.hits}, compared: ${summary.compared}`,
     `- overlap >= 0.5: ${percent(summary.overlapAtLeastHalfShare)} of compared hits`,
-    `- api marks cover engine marks: ${percent(summary.apiMarksCoverEngineShare)}`,
+    `- passage marks cover snippet marks: ${percent(summary.passageMarksCoverSnippetShare)}`,
     `- median overlap: ${ratio(summary.medianOverlap)}`,
     "",
     "| measure | median | total |",
@@ -457,10 +458,10 @@ export const renderSnippetCompareMarkdown = (
         );
         continue;
       }
-      const { comparison, engineFragment, apiFragment } = hit.outcome;
+      const { comparison, snippetFragment, passageFragment } = hit.outcome;
       lines.push(
-        `| ${rank} | engine | ${ratio(comparison.overlap)} | ${comparison.marks} | ${cell(engineFragment)} |`,
-        `| ${rank} | api | | | ${cell(apiFragment)} |`,
+        `| ${rank} | snippet | ${ratio(comparison.overlap)} | ${comparison.marks} | ${cell(snippetFragment)} |`,
+        `| ${rank} | passage | | | ${cell(passageFragment)} |`,
       );
     }
     lines.push("");

--- a/apps/api/src/scripts/corpus-snippet-compare.ts
+++ b/apps/api/src/scripts/corpus-snippet-compare.ts
@@ -29,8 +29,10 @@ import {
 } from "@/api/scripts/corpus-snippet-compare-report";
 
 /**
- * Runs each query of a query set, cuts a fragment from every hit's passage and
- * writes a JSON and a Markdown report of both fragments per hit to `--out-dir`.
+ * Runs each query of a query set and writes a JSON and a Markdown report of
+ * two fragments per hit to `--out-dir`: the snippet the search returned, and
+ * one cut here from the hit's whole passage. Both carry the same marks, so
+ * what the report measures is the window each fragment covers.
  *
  * The query file is JSON: an array of `{ id, text, country }`; a sample is
  * committed as corpus-snippet-compare.sample.json. Reads only (read-only
@@ -113,7 +115,7 @@ const compareHit = ({
     return { status: "skipped", reason: passageSkipReason(passage.status) };
   }
   if (hit.headline === null) {
-    return { status: "skipped", reason: "no_engine_snippet" };
+    return { status: "skipped", reason: "no_snippet" };
   }
   const startedAt = performance.now();
   const fragment = highlightCorpusPassage({
@@ -124,11 +126,11 @@ const compareHit = ({
   const highlightMs = performance.now() - startedAt;
   return {
     status: "compared",
-    engineFragment: hit.headline,
-    apiFragment: fragment.html,
+    snippetFragment: hit.headline,
+    passageFragment: fragment.html,
     comparison: compareSnippetFragments({
-      engineSnippet: hit.headline,
-      apiSnippet: fragment.html,
+      snippetFragment: hit.headline,
+      passageFragment: fragment.html,
     }),
     highlightMs,
   };


### PR DESCRIPTION
Case-law snippets are marked from the reader's own terms on the fragment the index returns, so no passage is read per hit.

A folded-stem match is accepted only when the folded stem has at least four letters; below that a word marks on an exact accented stem or an exact folded surface. "nahradu" still marks "náhrada" and "náhrady"; "být" no longer marks for "bytu".

The snippet script reports the returned snippet against a fragment cut from the whole passage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legal-search snippets so highlights consistently reflect the reader’s query terms.
  * Preserved accents while supporting accent-insensitive matching.
  * Ensured highlighted fragments remain intact without cutting through the matched text.

* **Refactor**
  * Updated snippet comparison reports and terminology to distinguish snippets from passages more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->