### PR TITLE
test(api): add highlight fixtures per language

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-passage-highlight.test.ts
@@ -7,6 +7,29 @@ import {
 } from "@/api/lib/legal-search/corpus-passage-highlight";
 import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
 import { corpusTokens } from "@/api/lib/legal-search/corpus-tokens";
+import csHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/cs.json";
+import daHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/da.json";
+import deHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/de.json";
+import elHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/el.json";
+import enHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/en.json";
+import esHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/es.json";
+import etHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/et.json";
+import fiHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/fi.json";
+import frHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/fr.json";
+import gaHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/ga.json";
+import huHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/hu.json";
+import itHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/it.json";
+import ltHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/lt.json";
+import nlHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/nl.json";
+import plHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/pl.json";
+import ptHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/pt.json";
+import roHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/ro.json";
+import skHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/sk.json";
+import svHighlightFixture from "@/api/lib/legal-search/fixtures/highlight/sv.json";
+import {
+  MORPHOLOGY_LANGUAGES,
+  type MorphologyLanguage,
+} from "@/api/lib/legal-search/morphology/stem";
 import {
   searchHighlightMarks,
   stripSearchHighlightMarkup,
@@ -16,6 +39,51 @@ import {
  * Window selection, the forms a word is matched by, the mark format, and the
  * cuts: whole words only, budget respected, empty passage empty.
  */
+
+type HighlightFixtureCase = {
+  readonly query: string;
+  readonly passage: string;
+};
+
+type HighlightFixture = {
+  readonly mustMark: readonly HighlightFixtureCase[];
+  readonly mustNotMark: readonly HighlightFixtureCase[];
+};
+
+const HIGHLIGHT_FIXTURES = {
+  cs: csHighlightFixture,
+  da: daHighlightFixture,
+  de: deHighlightFixture,
+  el: elHighlightFixture,
+  en: enHighlightFixture,
+  es: esHighlightFixture,
+  et: etHighlightFixture,
+  fi: fiHighlightFixture,
+  fr: frHighlightFixture,
+  ga: gaHighlightFixture,
+  hu: huHighlightFixture,
+  it: itHighlightFixture,
+  lt: ltHighlightFixture,
+  nl: nlHighlightFixture,
+  pl: plHighlightFixture,
+  pt: ptHighlightFixture,
+  ro: roHighlightFixture,
+  sk: skHighlightFixture,
+  sv: svHighlightFixture,
+} as const satisfies Record<MorphologyLanguage, HighlightFixture>;
+
+type FixtureMarksOptions = HighlightFixtureCase & {
+  readonly language: MorphologyLanguage;
+};
+
+const fixtureMarks = ({ language, passage, query }: FixtureMarksOptions) =>
+  searchHighlightMarks(
+    markCorpusFragment({
+      text: passage,
+      tokens: tokenizeCorpusFreeText(query),
+      language,
+    }),
+  );
 
 const highlight = (
   passage: string,
@@ -176,6 +244,33 @@ describe("stem matching", () => {
       "bytu",
     ]);
   });
+});
+
+describe("language marking fixtures", () => {
+  test("cover every declared stemming language exactly once", () => {
+    expect(Object.keys(HIGHLIGHT_FIXTURES).toSorted()).toEqual(
+      [...MORPHOLOGY_LANGUAGES].toSorted(),
+    );
+  });
+
+  for (const language of MORPHOLOGY_LANGUAGES) {
+    test(`${language} applies required and excluded marks`, () => {
+      const fixture = HIGHLIGHT_FIXTURES[language];
+      expect(fixture.mustMark.length).toBeGreaterThan(0);
+      expect(fixture.mustNotMark.length).toBeGreaterThan(0);
+
+      for (const { passage, query } of fixture.mustMark) {
+        expect(corpusTokens(query)).toEqual([query]);
+        expect(corpusTokens(passage)).toEqual([passage]);
+        expect(fixtureMarks({ language, passage, query })).toEqual([passage]);
+      }
+      for (const { passage, query } of fixture.mustNotMark) {
+        expect(corpusTokens(query)).toEqual([query]);
+        expect(corpusTokens(passage)).toEqual([passage]);
+        expect(fixtureMarks({ language, passage, query })).toEqual([]);
+      }
+    });
+  }
 });
 
 describe("markCorpusFragment", () => {

--- a/apps/api/src/lib/legal-search/fixtures/highlight/cs.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/cs.json
@@ -1,0 +1,7 @@
+{
+  "mustMark": [
+    { "query": "nahradu", "passage": "náhrady" },
+    { "query": "skody", "passage": "škody" }
+  ],
+  "mustNotMark": [{ "query": "bytu", "passage": "být" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/da.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/da.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "dom", "passage": "dommene" }],
+  "mustNotMark": [{ "query": "dom", "passage": "aftale" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/de.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/de.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "urteil", "passage": "urteile" }],
+  "mustNotMark": [{ "query": "urteil", "passage": "vertrag" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/el.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/el.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "απόφαση", "passage": "αποφάσεις" }],
+  "mustNotMark": [{ "query": "απόφαση", "passage": "σύμβαση" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/en.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/en.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "judgment", "passage": "judgments" }],
+  "mustNotMark": [{ "query": "judgment", "passage": "contract" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/es.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/es.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "sentencia", "passage": "sentencias" }],
+  "mustNotMark": [{ "query": "sentencia", "passage": "contrato" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/et.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/et.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "lepingud", "passage": "lepingu" }],
+  "mustNotMark": [{ "query": "lepingud", "passage": "kohus" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/fi.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/fi.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "sopimukset", "passage": "sopimuksen" }],
+  "mustNotMark": [{ "query": "sopimukset", "passage": "tuomio" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/fr.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/fr.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "jugement", "passage": "jugements" }],
+  "mustNotMark": [{ "query": "jugement", "passage": "contrat" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/ga.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/ga.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "comhaontacht", "passage": "comhaontachta" }],
+  "mustNotMark": [{ "query": "comhaontacht", "passage": "cúirt" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/hu.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/hu.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "szerződés", "passage": "szerződések" }],
+  "mustNotMark": [{ "query": "szerződés", "passage": "bíróság" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/it.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/it.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "sentenza", "passage": "sentenze" }],
+  "mustNotMark": [{ "query": "sentenza", "passage": "contratto" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/lt.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/lt.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "sprendimas", "passage": "sprendimai" }],
+  "mustNotMark": [{ "query": "sprendimas", "passage": "teismas" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/nl.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/nl.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "overeenkomst", "passage": "overeenkomsten" }],
+  "mustNotMark": [{ "query": "overeenkomst", "passage": "vonnis" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/pl.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/pl.json
@@ -1,0 +1,7 @@
+{
+  "mustMark": [
+    { "query": "wyrok", "passage": "wyroku" },
+    { "query": "sadu", "passage": "sądu" }
+  ],
+  "mustNotMark": [{ "query": "zadając", "passage": "żąda" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/pt.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/pt.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "sentença", "passage": "sentenças" }],
+  "mustNotMark": [{ "query": "sentença", "passage": "contrato" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/ro.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/ro.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "hotărâri", "passage": "hotărârile" }],
+  "mustNotMark": [{ "query": "hotărâri", "passage": "contract" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/sk.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/sk.json
@@ -1,0 +1,7 @@
+{
+  "mustMark": [
+    { "query": "rozsudkom", "passage": "rozsudkami" },
+    { "query": "sudu", "passage": "súdu" }
+  ],
+  "mustNotMark": [{ "query": "rady", "passage": "rád" }]
+}

--- a/apps/api/src/lib/legal-search/fixtures/highlight/sv.json
+++ b/apps/api/src/lib/legal-search/fixtures/highlight/sv.json
@@ -1,0 +1,4 @@
+{
+  "mustMark": [{ "query": "dom", "passage": "domarna" }],
+  "mustNotMark": [{ "query": "dom", "passage": "avtal" }]
+}


### PR DESCRIPTION
Add neutral required and excluded marking fixtures for every declared stemming language.
Bind the fixture map to the language union so a new stemmer requires a fixture.
Exercise each case through the production fragment marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legal search highlighting across 19 languages, including correct matching of inflected and accented terms.
  * Prevented unrelated terms from being highlighted in search results.

* **Tests**
  * Added comprehensive multilingual validation to confirm expected highlighting and non-highlighting behaviour across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->