### PR TITLE
fix(api): scale the publisher summary setup timeout

### DIFF
--- a/apps/api/src/lib/case-law/publisher-summary.db.test.ts
+++ b/apps/api/src/lib/case-law/publisher-summary.db.test.ts
@@ -7,7 +7,7 @@ import {
   DECISION_TEXT_ABSENCE_METADATA_KEY,
   TEXT_ABSENCE_REASON,
 } from "@stll/api-contract/case-law-text-field";
-import { propertyConfig } from "@stll/property-testing";
+import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
 
 import {
   PUBLISHER_SUMMARY_SOURCES,
@@ -70,7 +70,7 @@ beforeAll(
     client = await createTestPglite();
     db = drizzle({ client });
   },
-  { timeout: 120_000 },
+  { timeout: propertyTestTimeout(120_000) },
 );
 
 afterAll(async () => {


### PR DESCRIPTION
## Proposed change

`packages/scripts` guards that every explicit Bun timeout in a test file that runs a property (`fc.assert`) is scaled by `propertyTestTimeout`, so a nightly run whose `numRuns` grows by a factor also gets that much more wall clock before the hook is killed.

`apps/api/src/lib/case-law/publisher-summary.db.test.ts` has carried a fixed `{ timeout: 120_000 }` on its pglite `beforeAll` since the file was added. #3190 added an `fc.assert` to it, which brought the file into the guard's scope and turned that pre-existing fixed timeout into a violation:

```
apps/api/src/lib/case-law/publisher-summary.db.test.ts:73: beforeAll timeout is not factor-scaled
```

The scheduled full-test run at https://github.com/stella/stella/actions/runs/34437496071 fails on it, as `@stll/scripts#test`.

Scale the timeout with `propertyTestTimeout(120_000)`, matching the sibling pglite property suite in `apps/api/src/handlers/case-law/ingestion/replay.db.test.ts`, which sets the same base on the same kind of setup hook.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun --filter @stll/scripts test` (269 pass), `bun test src/lib/case-law/publisher-summary.db.test.ts` in `apps/api` (9 pass), and `bun run lint` across the monorepo.
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface changes.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-facing surface changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FiGrYiPeZHwdhJVdz7KhvS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardised the timeout configuration for a property-based test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->