### PR TITLE
fix(api): walk the SAOS dump in date shards and identify the crawler

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -178,8 +178,11 @@ DATABASE_RLS_POOL_MAX="5"
 # DB_SSLMODE="require"
 
 # --- External data -----------------------------------------------------
-# [secret] Optional. Ingestion user agent.
-# INGESTION_USER_AGENT=""
+# [secret] Optional. User-Agent sent to court publishers. Defaults to a stella
+# product identifier with the build version and a contact URL; set it so a
+# fork does not identify as the upstream project. Browser-like values are
+# refused by publishers that gate bots.
+# INGESTION_USER_AGENT="acme-ingestion/1.0 (+https://example.com/contact)"
 
 # [internal] Optional. Web search provider.
 # WEB_SEARCH_PROVIDER=""

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cursor-conformance.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cursor-conformance.test.ts
@@ -28,6 +28,7 @@ import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import type { AdapterKey } from "@/api/handlers/case-law/consts";
 import type { SourceAdapter } from "@/api/handlers/case-law/ingestion/adapter";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
+import { PL_COURTS_DUMP_SHARDS } from "@/api/handlers/case-law/ingestion/adapters/pl-courts";
 import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 // ── Bounds ───────────────────────────────────────────────
@@ -44,6 +45,12 @@ import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
  * backfill and then close one full live-window lap. 192 leaves both shapes
  * ample headroom while an adapter that never converges still fails in
  * seconds rather than running until the test times out.
+ *
+ * An adapter whose catch-up is a walk per shard rather than a step per
+ * slice declares its own `maxWalkSteps` below, derived from its shard list.
+ * Raising this shared ceiling instead would hand every other adapter the
+ * same allowance and stop the suite noticing that one of them stopped
+ * converging.
  */
 const MAX_WALK_STEPS = 192;
 
@@ -55,6 +62,23 @@ const MAX_WALK_STEPS = 192;
  */
 /** Walks are stubbed and sleepless, but CZ ÚS still drives ~2000 requests. */
 const WALK_TIMEOUT_MS = 120_000;
+
+/**
+ * What the pl-courts stub gives one date shard: a full page and a short one.
+ * The full page proves the offset advances inside a shard; the short page is
+ * the signal the walk hands over on. Two steps per shard, and the whole
+ * static shard list is one bounded catch-up before the crawl reaches its
+ * recent lane and parks there.
+ */
+const PL_DUMP_PAGE_SIZE = 100;
+const PL_DUMP_SHARD_ENTRIES = 150;
+const PL_DUMP_STEPS_PER_SHARD = Math.ceil(
+  PL_DUMP_SHARD_ENTRIES / PL_DUMP_PAGE_SIZE,
+);
+
+/** The catch-up, plus the lane's own step and the one that closes the loop. */
+const PL_DUMP_CATCH_UP_STEPS =
+  PL_COURTS_DUMP_SHARDS.length * PL_DUMP_STEPS_PER_SHARD + 4;
 
 /** Stands in for the null start cursor when keying the sequence. */
 const START_OF_WALK = "<null>";
@@ -123,6 +147,14 @@ type AdapterCoverage =
       readonly maxSteadyStateCursors: number;
       /** Adapter-specific cost of one legitimate steady-state lap. */
       readonly maxSteadyStatePositions: number;
+      /**
+       * Steps this adapter's one-time catch-up may take before the cursor
+       * sequence has to have closed a loop. Omitted means
+       * {@link MAX_WALK_STEPS}: only an adapter that crosses a declared
+       * list of bounded walks needs more, and its budget is derived from
+       * that list rather than chosen.
+       */
+      readonly maxWalkSteps?: number;
     }
   | { readonly disposition: "excluded"; readonly reason: string };
 
@@ -220,13 +252,23 @@ const ADAPTER_CONFORMANCE = {
   },
   [ADAPTER_KEYS.PL_COURTS]: {
     disposition: "exercised",
+    // Two answers, because the crawl asks two questions. A date shard is
+    // history and stays populated: an empty one could not tell a correct
+    // handover from a walk that reset to its own first page. The lane that
+    // keeps the crawl current asks what changed lately, and on a source
+    // whose every item is already stored, nothing did.
     exhaustedSource: ({ url }) => {
-      const page = Number(new URL(url).searchParams.get("pageNumber"));
-      const pageSize = 100;
-      const archiveEntries = 501;
+      const params = new URL(url).searchParams;
+      if (params.has("sinceModificationDate")) {
+        return jsonResponse({ items: [] });
+      }
+      const page = Number(params.get("pageNumber"));
       const count = Math.max(
         0,
-        Math.min(pageSize, archiveEntries - page * pageSize),
+        Math.min(
+          PL_DUMP_PAGE_SIZE,
+          PL_DUMP_SHARD_ENTRIES - page * PL_DUMP_PAGE_SIZE,
+        ),
       );
       return jsonResponse({
         items: Array.from({ length: count }, () => ({})),
@@ -234,6 +276,7 @@ const ADAPTER_CONFORMANCE = {
     },
     maxSteadyStateCursors: 4,
     maxSteadyStatePositions: 1,
+    maxWalkSteps: PL_DUMP_CATCH_UP_STEPS,
   },
   [ADAPTER_KEYS.PL_SN]: {
     disposition: "exercised",
@@ -366,15 +409,22 @@ type WalkOutcome =
       readonly message: string;
     };
 
-const walkExhausted = async (
-  adapter: SourceAdapter,
-  respond: ExhaustedSource,
-): Promise<WalkOutcome> => {
+type WalkExhaustedOptions = {
+  readonly adapter: SourceAdapter;
+  readonly maxSteps: number;
+  readonly respond: ExhaustedSource;
+};
+
+const walkExhausted = async ({
+  adapter,
+  maxSteps,
+  respond,
+}: WalkExhaustedOptions): Promise<WalkOutcome> => {
   const steps: WalkStep[] = [];
   const firstSeenAt = new Map<string, number>();
   let cursor: string | null = null;
 
-  for (let step = 0; step < MAX_WALK_STEPS; step++) {
+  for (let step = 0; step < maxSteps; step++) {
     const key = cursor ?? START_OF_WALK;
     const seenAt = firstSeenAt.get(key);
     if (seenAt !== undefined) {
@@ -461,7 +511,12 @@ describe("an exhausted source leaves every adapter parked", () => {
           return;
         }
 
-        const outcome = await walkExhausted(adapter, coverage.exhaustedSource);
+        const maxSteps = coverage.maxWalkSteps ?? MAX_WALK_STEPS;
+        const outcome = await walkExhausted({
+          adapter,
+          maxSteps,
+          respond: coverage.exhaustedSource,
+        });
 
         switch (outcome.type) {
           case "errored": {
@@ -476,7 +531,7 @@ describe("an exhausted source leaves every adapter parked", () => {
           }
           case "diverged": {
             throw new Error(
-              `${key}: still emitting never-before-seen cursors after ${MAX_WALK_STEPS} steps against an exhausted source, so the sweep never converges. Sequence: ${formatSequence(outcome.steps)}`,
+              `${key}: still emitting never-before-seen cursors after ${maxSteps} steps against an exhausted source, so the sweep never converges. Sequence: ${formatSequence(outcome.steps)}`,
             );
           }
           case "converged": {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -728,3 +728,53 @@ describe("traversal cursors survive the paths that write them", () => {
     expect(bounded[0]).not.toHaveProperty("windowItems");
   });
 });
+
+/**
+ * A walk with nowhere to go next can either park at the end of the collection
+ * or start itself over. Naming itself as its successor is how it says the
+ * latter, which is what a walk over a filtered window that keeps refilling
+ * needs: parking would leave it re-reading only the tail.
+ */
+describe("a walk that names itself as its successor", () => {
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  const selfRestartingFetch = (followedBy: string | null) =>
+    createPagePaginatedFetch<TestResponse>({
+      adapterKey: "test",
+      pageSize: 3,
+      firstPage: 0,
+      buildRequest: (page) => ({
+        url: `https://example.com/test-api?page=${page}`,
+      }),
+      traversal: [
+        {
+          name: "recent",
+          buildRequest: (page) => ({
+            url: `https://example.com/test-api?page=${page}`,
+          }),
+          followedBy,
+        },
+      ],
+      parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+      extractItems: (data) => ({ items: data.results, total: data.total }),
+      parseItem: async (raw) => itemToDecision(asTestRaw<TestItem>(raw)),
+    });
+
+  test("returns to its own head once a page comes up short", async () => {
+    await saveFixture(FIXTURE_NAME, makeFixture([{ id: 1 }], 1));
+    restore = await mockFetchWithFixtures([
+      { pattern: "/test-api", fixture: FIXTURE_NAME },
+    ]);
+
+    const restarted = await selfRestartingFetch("recent")("recent:9", {});
+    const parked = await selfRestartingFetch(null)("recent:9", {});
+
+    expect(restarted.unwrap().nextCursor).toBe("recent:0");
+    expect(parked.unwrap().nextCursor).toBe("recent:10");
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fc from "fast-check";
 
@@ -8,6 +9,7 @@ import {
   TEXT_ABSENCE_REASON,
   absentDecisionTextFields,
 } from "@/api/lib/case-law/decision-text";
+import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { asTestRaw, readTestJson } from "@/api/tests/helpers/test-tool-set";
 
 import type { FirstPageNumber } from "./pagination";
@@ -57,7 +59,8 @@ const createTestFetch = (opts?: {
       url: `https://example.com/test-api?page=${page}`,
     }),
 
-    parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+    parseResponse: async (resp) =>
+      Result.ok(await readTestJson<TestResponse>(resp)),
 
     extractItems: (data) => ({
       items: data.results,
@@ -210,6 +213,44 @@ describe("createPagePaginatedFetch", () => {
     expect(page.nextCursor).toBe("offset:27");
   });
 
+  /**
+   * The page an adapter refuses is a page nobody read, so it must fail rather
+   * than arrive empty: an empty page advances a cursor, and for a traversal
+   * it ends the walk it was in. Failing holds the cursor, and the same page
+   * is asked for again next cycle.
+   */
+  test("a refused body fails the page instead of emptying it", async () => {
+    await saveFixture(FIXTURE_NAME, makeFixture([{ id: 1 }], 10));
+    restore = await mockFetchWithFixtures([
+      { pattern: "/test-api", fixture: FIXTURE_NAME },
+    ]);
+
+    const refusal = new AdapterFetchError({
+      message: "test: the body states no results array",
+      adapterKey: "test",
+      cursor: null,
+    });
+    const fetchPage = createPagePaginatedFetch<TestResponse>({
+      adapterKey: "test",
+      pageSize: 3,
+      firstPage: 1,
+      buildRequest: (page) => ({
+        url: `https://example.com/test-api?page=${page}`,
+      }),
+      parseResponse: async () => await Promise.resolve(Result.err(refusal)),
+      extractItems: (data) => ({ items: data.results, total: data.total }),
+      parseItem: async (raw) => itemToDecision(asTestRaw<TestItem>(raw)),
+    });
+
+    const result = await fetchPage("offset:3", {});
+
+    expect(result.isErr()).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.error.message).toBe("test: the body states no results array");
+  });
+
   test("returns error for invalid cursor", async () => {
     const fetchPage = createTestFetch();
     for (const cursor of [
@@ -283,7 +324,8 @@ describe("createPagePaginatedFetch", () => {
       buildRequest: (page) => ({
         url: `https://example.com/test-api?page=${page}&pageSize=20`,
       }),
-      parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+      parseResponse: async (resp) =>
+        Result.ok(await readTestJson<TestResponse>(resp)),
       extractItems: (data) => ({
         items: data.results,
         total: data.total,
@@ -308,7 +350,8 @@ describe("createPagePaginatedFetch", () => {
       buildRequest: (page) => ({
         url: `https://example.com/test-api?page=${page}&pageSize=100`,
       }),
-      parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+      parseResponse: async (resp) =>
+        Result.ok(await readTestJson<TestResponse>(resp)),
       extractItems: (data) => ({
         items: data.results,
         total: data.total,
@@ -344,7 +387,8 @@ describe("createPagePaginatedFetch", () => {
       buildRequest: (page) => ({
         url: `https://example.com/test-api?page=${page}`,
       }),
-      parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+      parseResponse: async (resp) =>
+        Result.ok(await readTestJson<TestResponse>(resp)),
       extractItems: (data) => ({
         items: data.results,
         total: data.total,
@@ -750,7 +794,8 @@ test("a walk whose name carries the cursor separator is refused", () => {
           followedBy: null,
         },
       ],
-      parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+      parseResponse: async (resp) =>
+        Result.ok(await readTestJson<TestResponse>(resp)),
       extractItems: (data) => ({ items: data.results, total: data.total }),
       parseItem: async (raw) => itemToDecision(asTestRaw<TestItem>(raw)),
     });
@@ -792,7 +837,8 @@ describe("a walk that names itself as its successor", () => {
           followedBy,
         },
       ],
-      parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+      parseResponse: async (resp) =>
+        Result.ok(await readTestJson<TestResponse>(resp)),
       extractItems: (data) => ({ items: data.results, total: data.total }),
       parseItem: async (raw) => itemToDecision(asTestRaw<TestItem>(raw)),
     });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -730,6 +730,38 @@ describe("traversal cursors survive the paths that write them", () => {
 });
 
 /**
+ * A cursor is split on its first colon, so a walk whose name carries one is
+ * unfindable: every cursor it writes decodes as "no walk", and the crawl
+ * restarts at the first walk on every step while its logs and its cursors
+ * both look plausible. Refusing the name is the only point at which that is
+ * visible.
+ */
+test("a walk whose name carries the cursor separator is refused", () => {
+  const withName = (name: string) =>
+    createPagePaginatedFetch<TestResponse>({
+      adapterKey: "test",
+      pageSize: 3,
+      firstPage: 0,
+      buildRequest: () => ({ url: "https://example.com/test-api?page=0" }),
+      traversal: [
+        {
+          name,
+          buildRequest: () => ({ url: "https://example.com/test-api?page=0" }),
+          followedBy: null,
+        },
+      ],
+      parseResponse: async (resp) => await readTestJson<TestResponse>(resp),
+      extractItems: (data) => ({ items: data.results, total: data.total }),
+      parseItem: async (raw) => itemToDecision(asTestRaw<TestItem>(raw)),
+    });
+
+  expect(() => withName("m:2014-03")).toThrow(
+    /traversal walk "m:2014-03" contains :/u,
+  );
+  expect(() => withName("m-2014-03")).not.toThrow();
+});
+
+/**
  * A walk with nowhere to go next can either park at the end of the collection
  * or start itself over. Naming itself as its successor is how it says the
  * latter, which is what a walk over a filtered window that keeps refilling

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -7,7 +7,7 @@
  * multi-language) should implement fetchPage directly.
  */
 
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 
 import { ADAPTER_TIMEOUT } from "@/api/handlers/case-law/consts";
 import type {
@@ -29,7 +29,10 @@ import { logger } from "@/api/lib/observability/logger";
  */
 /** One ordered walk over a collection, named so a cursor can carry it. */
 export type TraversalMode = {
-  /** Persisted as the cursor prefix. Stable: changing it restarts the walk. */
+  /**
+   * Persisted as the cursor prefix. Stable: changing it restarts the walk,
+   * and it may not contain {@link TRAVERSAL_CURSOR_SEPARATOR}.
+   */
   name: string;
   /** Request for a page within this walk. */
   buildRequest: (page: number) => { url: string; init?: RequestInit };
@@ -203,6 +206,16 @@ const SERVER_ERROR_RETRIES = 2;
  * a page that answers this way forever holds its cursor forever.
  */
 const BAD_GATEWAY_STATUS = 502;
+
+/**
+ * What divides a walk's name from its offset in a cursor. A cursor is split
+ * on the FIRST one, so a name containing it names a walk that does not
+ * exist: every cursor the walk writes then decodes as "no walk", which
+ * restarts the crawl from the first walk on every step, silently and
+ * forever. `assertNamesCarryNoSeparator` refuses that at construction.
+ */
+const TRAVERSAL_CURSOR_SEPARATOR = ":";
+
 const OFFSET_CURSOR_PREFIX = "offset:";
 const CANONICAL_NON_NEGATIVE_INTEGER_PATTERN = /^(?:0|[1-9]\d*)$/u;
 
@@ -267,7 +280,7 @@ export const decodeTraversalCursor = (
   if (cursor === null) {
     return { mode: first, offset: 0 };
   }
-  const separator = cursor.indexOf(":");
+  const separator = cursor.indexOf(TRAVERSAL_CURSOR_SEPARATOR);
   const named = modes.find((mode) => mode.name === cursor.slice(0, separator));
   if (separator === -1 || named === undefined) {
     return { mode: first, offset: 0 };
@@ -279,7 +292,20 @@ export const decodeTraversalCursor = (
 };
 
 export const encodeTraversalCursor = (mode: string, offset: number): string =>
-  `${mode}:${offset}`;
+  `${mode}${TRAVERSAL_CURSOR_SEPARATOR}${offset}`;
+
+const assertNamesCarryNoSeparator = (
+  adapterKey: string,
+  modes: readonly TraversalMode[],
+): void => {
+  for (const { name } of modes) {
+    if (name.includes(TRAVERSAL_CURSOR_SEPARATOR)) {
+      panic(
+        `${adapterKey}: traversal walk "${name}" contains ${TRAVERSAL_CURSOR_SEPARATOR}, which its cursors are split on`,
+      );
+    }
+  }
+};
 
 type ParsedPageItems = {
   decisions: IngestionResult[];
@@ -386,6 +412,9 @@ export const createPagePaginatedFetch = <TResponse>(
 ) => {
   const { firstPage } = opts;
   const modes = opts.traversal;
+  if (modes !== undefined) {
+    assertNamesCarryNoSeparator(opts.adapterKey, modes);
+  }
 
   return async (
     cursor: string | null,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -36,6 +36,12 @@ export type TraversalMode = {
   /**
    * Where to continue once this walk reaches the end of the collection, or
    * null to stay in it.
+   *
+   * A walk may name itself. The handover writes `<successor>:0` either way,
+   * so naming itself restarts this same walk from its own head — which is
+   * what a walk that has to keep re-reading the same filtered window wants,
+   * and what `null` cannot express: `null` parks the cursor at the end
+   * instead, where the next cycle re-reads only the tail.
    */
   followedBy: string | null;
   /**

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -115,10 +115,23 @@ type PagePaginationOptions<TResponse> = {
    */
   traversal?: readonly TraversalMode[] | undefined;
   /**
-   * Parse the raw response into a typed result.
-   * Should throw on unexpected response shapes.
+   * Read the publisher's body into a typed page.
+   *
+   * An answer this adapter will not read is `Result.err`, not an exception:
+   * the page then fails and its cursor is held, so the same page is asked
+   * for again next cycle rather than being passed on as something it is not.
+   * Reading a malformed body as an empty page is the failure this shape
+   * exists to prevent — for a walk that hands over on a short page, an empty
+   * page means the collection ended.
+   *
+   * A body that is not the declared format at all still rejects, because
+   * `response.json()` does; that one keeps its single retry below, since a
+   * publisher under load answers a 200 with an HTML notice and then answers
+   * properly.
    */
-  parseResponse: (response: Response) => Promise<TResponse>;
+  parseResponse: (
+    response: Response,
+  ) => Promise<Result<TResponse, AdapterFetchError>>;
   /**
    * Extract items from the parsed response.
    * Return the items and optional total count.
@@ -167,7 +180,7 @@ type PagePaginationOptions<TResponse> = {
  *     buildRequest: (page) => ({
  *       url: `https://api.example.com/search?page=${page}`,
  *     }),
- *     parseResponse: async (resp) => resp.json(),
+ *     parseResponse: async (resp) => Result.ok(await resp.json()),
  *     extractItems: (data) => ({
  *       items: data.results,
  *       total: data.totalCount,
@@ -420,9 +433,9 @@ export const createPagePaginatedFetch = <TResponse>(
     cursor: string | null,
     _config: Record<string, unknown>,
     signal?: AbortSignal,
-  ): Promise<Result<SyncPage, AdapterFetchError>> =>
-    await Result.tryPromise({
-      try: async () => {
+  ): Promise<Result<SyncPage, AdapterFetchError>> => {
+    const attempt = await Result.tryPromise({
+      try: async (): Promise<Result<SyncPage, AdapterFetchError>> => {
         const walk = modes ? decodeTraversalCursor(cursor, modes) : null;
         const offset = walk
           ? walk.offset
@@ -485,10 +498,10 @@ export const createPagePaginatedFetch = <TResponse>(
               page: String(page),
               retries: String(SERVER_ERROR_RETRIES),
             });
-            return {
+            return Result.ok({
               decisions: [],
               nextCursor: encode(pageStartOffset + opts.pageSize),
-            };
+            });
           }
           throw error;
         }
@@ -513,10 +526,10 @@ export const createPagePaginatedFetch = <TResponse>(
               httpStatus: String(response.status),
               page: String(page),
             });
-            return {
+            return Result.ok({
               decisions: [],
               nextCursor: encode(pageStartOffset + opts.pageSize),
-            };
+            });
           }
 
           throw new AdapterFetchError({
@@ -527,13 +540,27 @@ export const createPagePaginatedFetch = <TResponse>(
           });
         }
 
-        let data: TResponse;
-        try {
-          data = await opts.parseResponse(response);
-        } catch (parseError) {
-          // Some court APIs return HTML error pages with 200 status
-          // (rate limits, maintenance). Retry once after a delay.
-          if (parseError instanceof SyntaxError) {
+        const retryFailed = (detail: string): AdapterFetchError =>
+          new AdapterFetchError({
+            message: `${opts.adapterKey}: page ${page} retry ${detail}`,
+            adapterKey: opts.adapterKey,
+            cursor,
+          });
+
+        // A refusal comes back as Err and ends the page here: the adapter
+        // read the body and will not have it, which one more request cannot
+        // change. Only a body that would not parse at all is retried.
+        const readPage = async (): Promise<
+          Result<TResponse, AdapterFetchError>
+        > => {
+          try {
+            return await opts.parseResponse(response);
+          } catch (parseError) {
+            // Some court APIs return HTML error pages with 200 status
+            // (rate limits, maintenance). Retry once after a delay.
+            if (!(parseError instanceof SyntaxError)) {
+              throw parseError;
+            }
             const contentType =
               response.headers.get("content-type") ?? "unknown";
             logger.warn("case_law.ingestion.page_unparseable_retry", {
@@ -548,32 +575,41 @@ export const createPagePaginatedFetch = <TResponse>(
               adapterKey: opts.adapterKey,
             });
             if (!retryResponse.ok) {
-              throw new AdapterFetchError({
-                message: `${opts.adapterKey}: retry HTTP ${retryResponse.status}`,
-                adapterKey: opts.adapterKey,
-                cursor,
-                httpStatus: retryResponse.status,
-              });
+              return Result.err(
+                new AdapterFetchError({
+                  message: `${opts.adapterKey}: retry HTTP ${retryResponse.status}`,
+                  adapterKey: opts.adapterKey,
+                  cursor,
+                  httpStatus: retryResponse.status,
+                }),
+              );
             }
             try {
-              data = await opts.parseResponse(retryResponse);
+              const retried = await opts.parseResponse(retryResponse);
+              return Result.isError(retried)
+                ? Result.err(
+                    retryFailed(`validation failed: ${retried.error.message}`),
+                  )
+                : retried;
             } catch (retryParseError) {
               const retryContentType =
                 retryResponse.headers.get("content-type") ?? "unknown";
-              const detail =
-                retryParseError instanceof SyntaxError
-                  ? `unparseable (content-type: ${retryContentType})`
-                  : `validation failed: ${retryParseError instanceof Error ? retryParseError.message : String(retryParseError)}`;
-              throw new AdapterFetchError({
-                message: `${opts.adapterKey}: page ${page} retry ${detail}`,
-                adapterKey: opts.adapterKey,
-                cursor,
-              });
+              return Result.err(
+                retryFailed(
+                  retryParseError instanceof SyntaxError
+                    ? `unparseable (content-type: ${retryContentType})`
+                    : `validation failed: ${retryParseError instanceof Error ? retryParseError.message : String(retryParseError)}`,
+                ),
+              );
             }
-          } else {
-            throw parseError;
           }
+        };
+
+        const parsed = await readPage();
+        if (Result.isError(parsed)) {
+          return parsed;
         }
+        const data = parsed.value;
         const fetchMs = Math.round(performance.now() - fetchT0);
         const { items: fetchedItems, total } = opts.extractItems(data);
         const items = fetchedItems.slice(itemsAlreadyFetched);
@@ -661,8 +697,13 @@ export const createPagePaginatedFetch = <TResponse>(
           nextCursor = encodeTraversalCursor(successor, 0);
         }
 
-        return { decisions, nextCursor, sourceUrl: url };
+        return Result.ok({ decisions, nextCursor, sourceUrl: url });
       },
       catch: adapterCatch(opts.adapterKey, cursor),
     });
+
+    // The walk's own refusals and the thrown ones arrive nested one level
+    // apart; both are the same failure to the caller.
+    return attempt.andThen((page) => page);
+  };
 };

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
@@ -245,12 +245,13 @@ describe("a dump answer the crawl cannot read", () => {
 
   const answerWith = (body: unknown) => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = asFetchMock(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(body), {
-          headers: { "Content-Type": "application/json; charset=utf-8" },
-        }),
-      ),
+    globalThis.fetch = asFetchMock(
+      async () =>
+        await Promise.resolve(
+          new Response(JSON.stringify(body), {
+            headers: { "Content-Type": "application/json; charset=utf-8" },
+          }),
+        ),
     );
     restore = () => {
       globalThis.fetch = originalFetch;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
@@ -13,7 +13,8 @@
  * is asserted here is what the publisher would be asked for.
  */
 
-import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { afterEach, describe, expect, test } from "bun:test";
 import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
@@ -24,8 +25,10 @@ import {
   PL_COURTS_DUMP_SHARDS,
   PL_COURTS_FIRST_SLICE,
   PL_COURTS_RECENT_LOOKBACK_DAYS,
+  plCourtsAdapter,
   plCourtsRecentSince,
 } from "@/api/handlers/case-law/ingestion/adapters/pl-courts";
+import { asFetchMock } from "@/api/tests/helpers/test-tool-set";
 
 const RECENT_MODE = "recent";
 const HEAD_SHARD = "before-1986";
@@ -224,6 +227,63 @@ describe("where each walk hands over", () => {
     const last = PL_COURTS_DUMP_SHARDS.at(-1);
     expect(last?.name).toBe(RECENT_MODE);
     expect(last?.followedBy).toBe(RECENT_MODE);
+  });
+});
+
+/**
+ * What a shard walk does with an answer it cannot read.
+ *
+ * An empty page is how a shard says it is finished, so a payload read as
+ * empty is a payload that ends a shard. A malformed answer must therefore
+ * not be read as empty: it has to fail the page, which holds the cursor and
+ * asks the same shard again next cycle, rather than handing over and leaving
+ * the rest of that shard unread until some later sweep.
+ */
+describe("a dump answer the crawl cannot read", () => {
+  const MID_SHARD_CURSOR = "m-2014-03:0";
+  let restore: (() => void) | undefined;
+
+  const answerWith = (body: unknown) => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = asFetchMock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(body), {
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+        }),
+      ),
+    );
+    restore = () => {
+      globalThis.fetch = originalFetch;
+    };
+  };
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  test("a page with no items array fails instead of ending the shard", async () => {
+    answerWith({ queryTemplate: {} });
+
+    const result = await plCourtsAdapter.fetchPage(MID_SHARD_CURSOR, {});
+
+    expect(Result.isOk(result)).toBe(false);
+    if (Result.isOk(result)) {
+      return;
+    }
+    expect(result.error.message).toContain("no items array");
+  });
+
+  test("a page that states no judgments does end the shard", async () => {
+    answerWith({ items: [] });
+
+    const result = await plCourtsAdapter.fetchPage(MID_SHARD_CURSOR, {});
+
+    expect(Result.isOk(result)).toBe(true);
+    if (!Result.isOk(result)) {
+      return;
+    }
+    expect(result.value.nextCursor).toBe("m-2014-04:0");
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
@@ -117,11 +117,24 @@ describe("the dump's date shards partition the calendar", () => {
     const names = PL_COURTS_DUMP_SHARDS.map((mode) => mode.name);
     expect(new Set(names).size).toBe(names.length);
   });
+
+  /**
+   * A cursor is `<walk>:<offset>` split on the first colon, so a name
+   * carrying one decodes as some other walk — in practice as none, which
+   * restarts the crawl at the first shard on every step.
+   */
+  test("no name collides with the cursor separator", () => {
+    expect(
+      PL_COURTS_DUMP_SHARDS.map((mode) => mode.name).filter((name) =>
+        name.includes(":"),
+      ),
+    ).toEqual([]);
+  });
 });
 
 describe("what each walk asks the dump for", () => {
   test("a yearly shard bounds the whole calendar year", () => {
-    expect(Object.fromEntries(paramsOf("y:1995", 7))).toEqual({
+    expect(Object.fromEntries(paramsOf("y-1995", 7))).toEqual({
       pageSize: "100",
       pageNumber: "7",
       withGenerated: "true",
@@ -131,7 +144,7 @@ describe("what each walk asks the dump for", () => {
   });
 
   test("a monthly shard ends on the month's own last day", () => {
-    expect(Object.fromEntries(paramsOf("m:2014-03"))).toEqual({
+    expect(Object.fromEntries(paramsOf("m-2014-03"))).toEqual({
       pageSize: "100",
       pageNumber: "0",
       withGenerated: "true",
@@ -139,8 +152,8 @@ describe("what each walk asks the dump for", () => {
       judgmentEndDate: "2014-03-31",
     });
     // Month length is the calendar's answer, not the year's shape.
-    expect(paramsOf("m:2012-02").get("judgmentEndDate")).toBe("2012-02-29");
-    expect(paramsOf("m:2013-02").get("judgmentEndDate")).toBe("2013-02-28");
+    expect(paramsOf("m-2012-02").get("judgmentEndDate")).toBe("2012-02-29");
+    expect(paramsOf("m-2013-02").get("judgmentEndDate")).toBe("2013-02-28");
   });
 
   test("the head catch-all bounds only the end of its window", () => {
@@ -219,10 +232,12 @@ describe("where each walk hands over", () => {
  * at the first shard is how a crawl carrying such a cursor recovers.
  */
 test("a cursor from the offset walk restarts at the first shard", () => {
+  const [firstShard] = PL_COURTS_DUMP_SHARDS;
+  if (firstShard === undefined) {
+    throw new Error("pl-courts declares no walks");
+  }
+
   expect(
     decodeTraversalCursor("offset:1927900", PL_COURTS_DUMP_SHARDS),
-  ).toEqual({
-    mode: PL_COURTS_DUMP_SHARDS[0],
-    offset: 0,
-  });
+  ).toEqual({ mode: firstShard, offset: 0 });
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The date shards the pl-courts crawl walks the SAOS dump in.
+ *
+ * The shard list is the crawl's map of the collection, and everything that
+ * makes it wrong is silent. A gap between two shards hides every judgment
+ * whose date falls in it, for as long as the list stands. An overlap re-reads
+ * work already done. A shard name that moved with the calendar would rename a
+ * persisted cursor's prefix and restart the walk from the beginning. A chain
+ * that ends without returning to the recent lane parks the crawl on a shard
+ * nothing new is ever filed into.
+ *
+ * The windows are read back out of the URLs the modes actually build, so what
+ * is asserted here is what the publisher would be asked for.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+import { Temporal } from "@stll/time";
+
+import { decodeTraversalCursor } from "@/api/handlers/case-law/ingestion/adapters/pagination";
+import {
+  PL_COURTS_DUMP_SHARDS,
+  PL_COURTS_FIRST_SLICE,
+  PL_COURTS_RECENT_LOOKBACK_DAYS,
+  plCourtsRecentSince,
+} from "@/api/handlers/case-law/ingestion/adapters/pl-courts";
+
+const RECENT_MODE = "recent";
+const HEAD_SHARD = "before-1986";
+const TAIL_SHARD = "after-2030";
+const HORIZON_LAST_DAY = "2030-12-31";
+
+const paramsOf = (name: string, page = 0): URLSearchParams => {
+  const mode = PL_COURTS_DUMP_SHARDS.find((entry) => entry.name === name);
+  if (mode === undefined) {
+    throw new Error(`pl-courts declares no walk named ${name}`);
+  }
+  return new URL(mode.buildRequest(page).url).searchParams;
+};
+
+/**
+ * The judgment-date window a shard asks for. ISO dates order
+ * lexicographically, so containment is a string comparison and a null bound
+ * is an open side.
+ */
+type ShardWindow = {
+  name: string;
+  from: string | null;
+  to: string | null;
+};
+
+const dateShards: ShardWindow[] = PL_COURTS_DUMP_SHARDS.filter(
+  (mode) => mode.name !== RECENT_MODE,
+).map((mode) => {
+  const params = new URL(mode.buildRequest(0).url).searchParams;
+  return {
+    name: mode.name,
+    from: params.get("judgmentStartDate"),
+    to: params.get("judgmentEndDate"),
+  };
+});
+
+const covers = (shard: ShardWindow, day: string): boolean =>
+  (shard.from === null || shard.from <= day) &&
+  (shard.to === null || day <= shard.to);
+
+describe("the dump's date shards partition the calendar", () => {
+  const firstDay = Temporal.PlainDate.from(PL_COURTS_FIRST_SLICE);
+  const lastDay = Temporal.PlainDate.from(HORIZON_LAST_DAY);
+  const spanDays = firstDay.until(lastDay).total({ unit: "day" });
+
+  test("INVARIANT: every date the corpus covers is asked for exactly once", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: spanDays }), (dayOffset) => {
+        const day = firstDay.add({ days: dayOffset }).toString();
+        const matching = dateShards.filter((shard) => covers(shard, day));
+        expect(matching.map((shard) => shard.name)).toHaveLength(1);
+      }),
+      propertyConfig({ numRuns: 1000 }),
+    );
+  });
+
+  /**
+   * Contiguity extends the property above past the dates the corpus should
+   * hold: with both ends open and no seam anywhere, a record carrying a
+   * mangled year lands in a shard rather than in none.
+   */
+  test("each shard resumes the day the one before it ends", () => {
+    for (const [index, shard] of dateShards.slice(1).entries()) {
+      const previous = dateShards[index];
+      if (previous === undefined || previous.to === null) {
+        throw new Error(
+          `shard ${previous?.name ?? index} leaves its end open mid-list`,
+        );
+      }
+      expect({ shard: shard.name, from: shard.from }).toEqual({
+        shard: shard.name,
+        from: Temporal.PlainDate.from(previous.to).add({ days: 1 }).toString(),
+      });
+    }
+  });
+
+  test("the catch-alls are the only open-ended shards", () => {
+    expect(
+      dateShards.filter((shard) => shard.from === null).map(({ name }) => name),
+    ).toEqual([HEAD_SHARD]);
+    expect(
+      dateShards.filter((shard) => shard.to === null).map(({ name }) => name),
+    ).toEqual([TAIL_SHARD]);
+    expect(dateShards.at(0)?.name).toBe(HEAD_SHARD);
+    expect(dateShards.at(-1)?.name).toBe(TAIL_SHARD);
+  });
+
+  test("no two walks share a name", () => {
+    const names = PL_COURTS_DUMP_SHARDS.map((mode) => mode.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe("what each walk asks the dump for", () => {
+  test("a yearly shard bounds the whole calendar year", () => {
+    expect(Object.fromEntries(paramsOf("y:1995", 7))).toEqual({
+      pageSize: "100",
+      pageNumber: "7",
+      withGenerated: "true",
+      judgmentStartDate: "1995-01-01",
+      judgmentEndDate: "1995-12-31",
+    });
+  });
+
+  test("a monthly shard ends on the month's own last day", () => {
+    expect(Object.fromEntries(paramsOf("m:2014-03"))).toEqual({
+      pageSize: "100",
+      pageNumber: "0",
+      withGenerated: "true",
+      judgmentStartDate: "2014-03-01",
+      judgmentEndDate: "2014-03-31",
+    });
+    // Month length is the calendar's answer, not the year's shape.
+    expect(paramsOf("m:2012-02").get("judgmentEndDate")).toBe("2012-02-29");
+    expect(paramsOf("m:2013-02").get("judgmentEndDate")).toBe("2013-02-28");
+  });
+
+  test("the head catch-all bounds only the end of its window", () => {
+    const params = paramsOf(HEAD_SHARD);
+    expect(params.get("judgmentStartDate")).toBeNull();
+    expect(params.get("judgmentEndDate")).toBe(
+      Temporal.PlainDate.from(PL_COURTS_FIRST_SLICE)
+        .subtract({ days: 1 })
+        .toString(),
+    );
+  });
+
+  test("the tail catch-all bounds only the start of its window", () => {
+    const params = paramsOf(TAIL_SHARD);
+    expect(params.get("judgmentStartDate")).toBe("2031-01-01");
+    expect(params.get("judgmentEndDate")).toBeNull();
+  });
+
+  /**
+   * The lane the crawl settles into filters on modification rather than
+   * judgment date, so a judgment the publisher edited is listed again whatever
+   * date it carries.
+   */
+  test("the recent lane asks for modifications since a fixed lookback", () => {
+    expect(PL_COURTS_RECENT_LOOKBACK_DAYS).toBe(45);
+    expect(plCourtsRecentSince(Temporal.PlainDate.from("2026-09-10"))).toBe(
+      "2026-07-27T00:00:00.000",
+    );
+
+    const params = paramsOf(RECENT_MODE, 3);
+    expect(params.get("judgmentStartDate")).toBeNull();
+    expect(params.get("judgmentEndDate")).toBeNull();
+    expect(params.get("pageNumber")).toBe("3");
+    expect(params.get("pageSize")).toBe("100");
+    expect(params.get("withGenerated")).toBe("true");
+    expect(params.get("sinceModificationDate")).toBe(
+      plCourtsRecentSince(Temporal.Now.plainDateISO("UTC")),
+    );
+  });
+});
+
+describe("where each walk hands over", () => {
+  test("every walk is followed by the next one in the list", () => {
+    const names = PL_COURTS_DUMP_SHARDS.map((mode) => mode.name);
+    expect(names.at(-1)).toBe(RECENT_MODE);
+
+    expect(
+      PL_COURTS_DUMP_SHARDS.map((mode) => ({
+        from: mode.name,
+        to: mode.followedBy,
+      })),
+    ).toEqual(
+      names.map((name, index) => ({
+        from: name,
+        to: names[index + 1] ?? RECENT_MODE,
+      })),
+    );
+    expect(PL_COURTS_DUMP_SHARDS.at(-2)?.name).toBe(TAIL_SHARD);
+  });
+
+  /**
+   * Naming itself is what keeps the crawl at the head: the helper writes
+   * `<successor>:0` on handover, so the lane restarts from its own first page
+   * every time it runs dry.
+   */
+  test("the walk ends on the recent lane, which follows itself", () => {
+    const last = PL_COURTS_DUMP_SHARDS.at(-1);
+    expect(last?.name).toBe(RECENT_MODE);
+    expect(last?.followedBy).toBe(RECENT_MODE);
+  });
+});
+
+/**
+ * A cursor persisted before the shards existed named an item offset into the
+ * unfiltered dump, which points nowhere in a date-filtered walk. Restarting
+ * at the first shard is how a crawl carrying such a cursor recovers.
+ */
+test("a cursor from the offset walk restarts at the first shard", () => {
+  expect(
+    decodeTraversalCursor("offset:1927900", PL_COURTS_DUMP_SHARDS),
+  ).toEqual({
+    mode: PL_COURTS_DUMP_SHARDS[0],
+    offset: 0,
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-shards.test.ts
@@ -90,14 +90,15 @@ describe("the dump's date shards partition the calendar", () => {
   test("each shard resumes the day the one before it ends", () => {
     for (const [index, shard] of dateShards.slice(1).entries()) {
       const previous = dateShards[index];
-      if (previous === undefined || previous.to === null) {
+      const end = previous?.to;
+      if (end === undefined || end === null) {
         throw new Error(
           `shard ${previous?.name ?? index} leaves its end open mid-list`,
         );
       }
       expect({ shard: shard.name, from: shard.from }).toEqual({
         shard: shard.name,
-        from: Temporal.PlainDate.from(previous.to).add({ days: 1 }).toString(),
+        from: Temporal.PlainDate.from(end).add({ days: 1 }).toString(),
       });
     }
   });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -71,7 +71,7 @@ import { isRecord } from "@/api/lib/type-guards";
  * {@link PL_COURTS_RECENT_LOOKBACK_DAYS} days and, having no successor but
  * itself, restarts from its own head each time it runs dry.
  *
- * Cursor format: `<shard>:<item offset>` (e.g. "m:2014-03:1200"). A cursor
+ * Cursor format: `<shard>:<item offset>` (e.g. "m-2014-03:1200"). A cursor
  * naming no shard, including one written before the shards existed
  * ("offset:1927900"), restarts the walk at the first shard.
  */
@@ -180,7 +180,13 @@ const dumpRequest = (
   init: { headers: { Accept: JSON_MEDIA_TYPE } },
 });
 
-/** One shard's judgment-date filter; an absent bound is open on that side. */
+/**
+ * One shard's judgment-date filter; an absent bound is open on that side.
+ *
+ * A name carries no colon: it becomes a cursor prefix, and the cursor is
+ * split on the first one. `createPagePaginatedFetch` rejects a name that
+ * would collide with the separator.
+ */
 type DumpShard = {
   name: string;
   judgmentStartDate?: string;
@@ -200,7 +206,7 @@ const dumpShardRanges = (): DumpShard[] => {
 
   for (let year = firstDay.year; year <= YEARLY_SHARD_LAST_YEAR; year++) {
     shards.push({
-      name: `y:${year}`,
+      name: `y-${year}`,
       // The corpus opens mid-1986, and the catch-all above owns everything
       // before that day, so the first yearly shard starts there rather than
       // on 1 January: the shards then partition the calendar exactly.
@@ -224,7 +230,7 @@ const dumpShardRanges = (): DumpShard[] => {
     for (let month = 1; month <= 12; month++) {
       const first = Temporal.PlainDate.from({ year, month, day: 1 });
       shards.push({
-        name: `m:${year}-${String(month).padStart(2, "0")}`,
+        name: `m-${year}-${String(month).padStart(2, "0")}`,
         judgmentStartDate: first.toString(),
         judgmentEndDate: first.with({ day: first.daysInMonth }).toString(),
       });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -28,6 +28,7 @@ import type {
 } from "@/api/handlers/case-law/ingestion/adapter";
 import { createCalendarDaySliceWalk } from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
+import type { TraversalMode } from "@/api/handlers/case-law/ingestion/adapters/pagination";
 import {
   hashContent,
   INGESTION_USER_AGENT,
@@ -61,7 +62,18 @@ import { isRecord } from "@/api/lib/type-guards";
  * referenced cases, reporters, publication metadata, and the
  * original court document URL.
  *
- * Cursor format: item offset as string (e.g. "offset:100").
+ * The crawl walks the dump one judgment-date shard at a time rather than as
+ * one offset walk over the whole collection: see {@link PL_COURTS_DUMP_SHARDS}
+ * for why the collection has to be cut into bounded pieces and why the pieces
+ * are fixed. A shard ends where the publisher answers a page short of the
+ * page size, and the walk hands over to the next shard; the last shard hands
+ * over to a `recent` lane that asks for everything modified in the last
+ * {@link PL_COURTS_RECENT_LOOKBACK_DAYS} days and, having no successor but
+ * itself, restarts from its own head each time it runs dry.
+ *
+ * Cursor format: `<shard>:<item offset>` (e.g. "m:2014-03:1200"). A cursor
+ * naming no shard, including one written before the shards existed
+ * ("offset:1927900"), restarts the walk at the first shard.
  */
 
 const DUMP_URL = "https://www.saos.org.pl/api/dump/judgments";
@@ -130,11 +142,179 @@ export const PL_COURTS_LANGUAGE = "pl";
  * adjudicating in 1986, so the corpus has nothing genuinely older. The single
  * row the sort puts ahead of it carries a mangled four-digit year and is a
  * publisher typo rather than a judgment from that year; the crawl still
- * ingests it, since `fetchPage` walks the dump in id order and never consults
- * a date.
+ * ingests it, because the shard walk below opens with a catch-all for every
+ * date before this one.
  */
 export const PL_COURTS_FIRST_SLICE =
   ADAPTER_MANIFESTS[ADAPTER_KEYS.PL_COURTS].dateRange.fromInclusive;
+
+/** Last year the shard list covers with a single yearly shard. */
+const YEARLY_SHARD_LAST_YEAR = 2011;
+
+/**
+ * Last year the shard list names at all. Everything after it is one catch-all.
+ */
+const MONTHLY_SHARD_HORIZON_YEAR = 2030;
+
+/** The `recent` lane's name, which is also its own successor. */
+const RECENT_MODE = "recent";
+
+/**
+ * How far back the `recent` lane asks for modifications.
+ *
+ * Wider than the time a full shard walk takes, so a judgment edited while the
+ * walk was elsewhere is still listed when the lane comes round again.
+ */
+export const PL_COURTS_RECENT_LOOKBACK_DAYS = 45;
+
+const dumpRequest = (
+  page: number,
+  filters: Record<string, string>,
+): { url: string; init: RequestInit } => ({
+  url: `${DUMP_URL}?${new URLSearchParams({
+    pageSize: String(PAGE_SIZE),
+    pageNumber: String(page),
+    withGenerated: "true",
+    ...filters,
+  }).toString()}`,
+  init: { headers: { Accept: JSON_MEDIA_TYPE } },
+});
+
+/** One shard's judgment-date filter; an absent bound is open on that side. */
+type DumpShard = {
+  name: string;
+  judgmentStartDate?: string;
+  judgmentEndDate?: string;
+};
+
+const dumpShardRanges = (): DumpShard[] => {
+  const firstDay =
+    parsePlainDate(PL_COURTS_FIRST_SLICE) ??
+    panic(`pl-courts: unreadable first slice ${PL_COURTS_FIRST_SLICE}`);
+  const shards: DumpShard[] = [
+    {
+      name: `before-${firstDay.year}`,
+      judgmentEndDate: firstDay.subtract({ days: 1 }).toString(),
+    },
+  ];
+
+  for (let year = firstDay.year; year <= YEARLY_SHARD_LAST_YEAR; year++) {
+    shards.push({
+      name: `y:${year}`,
+      // The corpus opens mid-1986, and the catch-all above owns everything
+      // before that day, so the first yearly shard starts there rather than
+      // on 1 January: the shards then partition the calendar exactly.
+      judgmentStartDate:
+        year === firstDay.year
+          ? firstDay.toString()
+          : Temporal.PlainDate.from({ year, month: 1, day: 1 }).toString(),
+      judgmentEndDate: Temporal.PlainDate.from({
+        year,
+        month: 12,
+        day: 31,
+      }).toString(),
+    });
+  }
+
+  for (
+    let year = YEARLY_SHARD_LAST_YEAR + 1;
+    year <= MONTHLY_SHARD_HORIZON_YEAR;
+    year++
+  ) {
+    for (let month = 1; month <= 12; month++) {
+      const first = Temporal.PlainDate.from({ year, month, day: 1 });
+      shards.push({
+        name: `m:${year}-${String(month).padStart(2, "0")}`,
+        judgmentStartDate: first.toString(),
+        judgmentEndDate: first.with({ day: first.daysInMonth }).toString(),
+      });
+    }
+  }
+
+  shards.push({
+    name: `after-${MONTHLY_SHARD_HORIZON_YEAR}`,
+    judgmentStartDate: Temporal.PlainDate.from({
+      year: MONTHLY_SHARD_HORIZON_YEAR + 1,
+      month: 1,
+      day: 1,
+    }).toString(),
+  });
+
+  return shards;
+};
+
+/**
+ * The date the `recent` lane asks the publisher to list modifications from.
+ *
+ * Taken from a calendar day rather than an instant so the request is stable
+ * for the whole day and the lane cannot ask for a narrower window each time
+ * it restarts.
+ */
+export const plCourtsRecentSince = (today: Temporal.PlainDate): string =>
+  `${today.subtract({ days: PL_COURTS_RECENT_LOOKBACK_DAYS }).toString()}T00:00:00.000`;
+
+/** The shards in list order, each followed by the next, then the lane. */
+const buildDumpShardWalks = (): TraversalMode[] => {
+  const ranges = dumpShardRanges();
+  return [
+    ...ranges.map((shard, index) => ({
+      name: shard.name,
+      buildRequest: (page: number) =>
+        dumpRequest(page, {
+          ...(shard.judgmentStartDate === undefined
+            ? {}
+            : { judgmentStartDate: shard.judgmentStartDate }),
+          ...(shard.judgmentEndDate === undefined
+            ? {}
+            : { judgmentEndDate: shard.judgmentEndDate }),
+        }),
+      followedBy: ranges[index + 1]?.name ?? RECENT_MODE,
+    })),
+    {
+      name: RECENT_MODE,
+      buildRequest: (page: number) =>
+        dumpRequest(page, {
+          sinceModificationDate: plCourtsRecentSince(
+            Temporal.Now.plainDateISO("UTC"),
+          ),
+        }),
+      followedBy: RECENT_MODE,
+    },
+  ];
+};
+
+/**
+ * The ordered walks the crawl makes over the dump.
+ *
+ * The dump is a single collection of several hundred thousand judgments
+ * with no end the walker can recognise from inside it, so one offset walk
+ * over the whole thing is unbounded: every event that advances the cursor
+ * without reading a page (a timeout, a publisher-side 5xx) pushes it
+ * further past the tail, where each request costs seconds and answers with
+ * nothing. Filtering by judgment date bounds each walk instead. A shard's
+ * last page is short, which is the signal the pagination helper hands over
+ * on, so a walk that runs out of judgments moves to the next shard rather
+ * than deeper into empty offsets. A page that answers zero items in the
+ * middle of a shard hands over too: giving up the remainder of one shard is
+ * bounded loss, which giving up on an unbounded walk was not.
+ *
+ * The list is deliberately static and the horizon deliberately fixed. Shard
+ * names are persisted as cursor prefixes, so a cursor written in one month
+ * has to still name a shard in the next; a list derived from the current date
+ * renames its own tail as time passes and silently restarts the crawl. Empty
+ * months up to the horizon cost about a second each per full walk, which is
+ * cheaper than any scheme that keeps the list current.
+ *
+ * `judgmentDate` is publisher data and a few records carry years no judgment
+ * can hold, in both directions. The two catch-alls are open-ended so those
+ * records are still reachable: no date puts a judgment outside every shard.
+ *
+ * The tail catch-all is followed by {@link RECENT_MODE}, which names itself
+ * as its own successor and so restarts from its own head whenever it runs
+ * dry. That is where the crawl stays once the collection has been seen.
+ */
+export const PL_COURTS_DUMP_SHARDS: readonly TraversalMode[] =
+  buildDumpShardWalks();
 
 /**
  * Slices near the tip the reconciliation re-walks on a fast cadence.
@@ -1226,16 +1406,8 @@ export const plCourtsAdapter = defineSourceAdapter({
     listTimeoutMs: 60_000,
     itemConcurrency: ITEM_CONCURRENCY,
 
-    buildRequest: (page) => ({
-      url: `${DUMP_URL}?${new URLSearchParams({
-        pageSize: String(PAGE_SIZE),
-        pageNumber: String(page),
-        withGenerated: "true",
-      }).toString()}`,
-      init: {
-        headers: { Accept: "application/json" },
-      },
-    }),
+    buildRequest: (page) => dumpRequest(page, {}),
+    traversal: PL_COURTS_DUMP_SHARDS,
 
     parseResponse: async (response) => {
       const json: unknown = await response.json();

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -1,4 +1,4 @@
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 
 import { DECISION_IDENTIFIER_TYPES } from "@stll/legal-ast/decision-identifier";
 import type { DecisionIdentifier } from "@stll/legal-ast/decision-identifier";
@@ -1434,15 +1434,16 @@ export const plCourtsAdapter = defineSourceAdapter({
     // instead of being abandoned half-read.
     parseResponse: async (response) => {
       const json: unknown = await response.json();
-      if (!isSaosDumpPage(json)) {
-        throw new AdapterFetchError({
-          message: "SAOS dump API returned a payload with no items array",
-          adapterKey: ADAPTER_KEYS.PL_COURTS,
-          // Reading a page is not told which cursor asked for it.
-          cursor: null,
-        });
-      }
-      return json;
+      return isSaosDumpPage(json)
+        ? Result.ok(json)
+        : Result.err(
+            new AdapterFetchError({
+              message: "SAOS dump API returned a payload with no items array",
+              adapterKey: ADAPTER_KEYS.PL_COURTS,
+              // Reading a page is not told which cursor asked for it.
+              cursor: null,
+            }),
+          );
     },
 
     extractItems: (data) => ({ items: data.items }),

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -32,6 +32,7 @@ import type { TraversalMode } from "@/api/handlers/case-law/ingestion/adapters/p
 import {
   hashContent,
   INGESTION_USER_AGENT,
+  isArrayOf,
   isNullishArrayOf,
   isNullishNumber,
   isNullishString,
@@ -482,6 +483,9 @@ type SaosDumpResponse = {
   } | null;
 };
 
+/** A dump answer the crawl will read: `items` stated, whatever it holds. */
+type SaosDumpPage = SaosDumpResponse & { items: SaosItem[] };
+
 type SaosSearchResponse = {
   info?: {
     totalResults?: number | null;
@@ -650,8 +654,18 @@ export const normalizeSaosDumpItem = (
   ),
 });
 
-const isSaosDumpResponse = (value: unknown): value is SaosDumpResponse =>
-  isRecord(value) && isNullishArrayOf(value["items"], isRecord);
+/**
+ * A page of the dump, as opposed to anything else the endpoint may answer
+ * with under a 200.
+ *
+ * `items` has to be present and an array. Reading a payload that lacks it
+ * as a page of no judgments is what makes a malformed answer dangerous
+ * here: an empty page is the signal a date shard is finished, so one such
+ * answer would hand the walk to the next shard and leave the rest of the
+ * current one unread until a later sweep.
+ */
+const isSaosDumpPage = (value: unknown): value is SaosDumpPage =>
+  isRecord(value) && isArrayOf(value["items"], isRecord);
 
 const isSaosSearchResponse = (value: unknown): value is SaosSearchResponse =>
   isRecord(value) &&
@@ -1404,7 +1418,7 @@ export const plCourtsAdapter = defineSourceAdapter({
     buildDecision: buildPlCourtsFromPayload,
   },
 
-  fetchPage: createPagePaginatedFetch<SaosDumpResponse>({
+  fetchPage: createPagePaginatedFetch<SaosDumpPage>({
     adapterKey: ADAPTER_KEYS.PL_COURTS,
     pageSize: PAGE_SIZE,
     legacyPageSize: LEGACY_PAGE_SIZE,
@@ -1415,14 +1429,23 @@ export const plCourtsAdapter = defineSourceAdapter({
     buildRequest: (page) => dumpRequest(page, {}),
     traversal: PL_COURTS_DUMP_SHARDS,
 
+    // Refused rather than read as an empty page: throwing here fails the
+    // page, so the cursor holds and the shard is asked again next cycle
+    // instead of being abandoned half-read.
     parseResponse: async (response) => {
       const json: unknown = await response.json();
-      return isSaosDumpResponse(json) ? json : {};
+      if (!isSaosDumpPage(json)) {
+        throw new AdapterFetchError({
+          message: "SAOS dump API returned a payload with no items array",
+          adapterKey: ADAPTER_KEYS.PL_COURTS,
+          // Reading a page is not told which cursor asked for it.
+          cursor: null,
+        });
+      }
+      return json;
     },
 
-    extractItems: (data) => ({
-      items: normalizeOptionalArray(data.items),
-    }),
+    extractItems: (data) => ({ items: data.items }),
 
     parseItem: parseItemWithDetail,
   }),

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -1,4 +1,4 @@
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 
 import {
   ADAPTER_KEYS,
@@ -854,7 +854,7 @@ export const skCourtsAdapter = defineSourceAdapter({
 
     parseResponse: async (response) => {
       const json: unknown = await response.json();
-      return isSkApiResponse(json) ? json : {};
+      return Result.ok(isSkApiResponse(json) ? json : {});
     },
 
     extractItems: (data) => ({

--- a/apps/api/src/handlers/case-law/ingestion/adapters/utils.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/utils.ts
@@ -1,15 +1,23 @@
 /** Shared utilities for case-law ingestion adapters. */
 
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
+import { APP_VERSION } from "@/api/lib/version";
 
 /**
  * User-Agent sent on all court website requests.
+ *
+ * A product identifier with a version and a contact URL, not a browser
+ * string. Publishers increasingly put a bot challenge in front of anything
+ * claiming to be a browser, and answer it with an HTML page under a 4xx that
+ * no adapter can parse; identifying the crawler for what it is both clears
+ * those gates and gives the publisher someone to reach.
  *
  * Configurable via INGESTION_USER_AGENT env var so forks don't
  * accidentally identify as the upstream project.
  */
 export const INGESTION_USER_AGENT =
-  process.env["INGESTION_USER_AGENT"] ?? "Mozilla/5.0 (compatible)";
+  process.env["INGESTION_USER_AGENT"] ??
+  `stella-ingestion/${APP_VERSION} (+https://github.com/stella/stella)`;
 
 const CE_DATE_PATTERN =
   /^(?<day>\d{1,2})\.\s*(?<month>\d{1,2})\.\s*(?<year>\d{4})$/;

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -184,7 +184,10 @@ DATABASE_URL="postgres://stella_owner:password@postgres.example.internal:5432/st
 # DB_SSLMODE=""
 
 # --- External data -----------------------------------------------------
-# [secret] Optional. Ingestion user agent.
+# [secret] Optional. User-Agent sent to court publishers. Defaults to a stella
+# product identifier with the build version and a contact URL; set it so a
+# fork does not identify as the upstream project. Browser-like values are
+# refused by publishers that gate bots.
 # INGESTION_USER_AGENT=""
 
 # [internal] Optional. Web search provider.

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -180,6 +180,7 @@ const EXAMPLE_VALUES: Record<string, string> = {
   DB_USER: "postgres",
   EMAIL_PROVIDER: "smtp",
   EDGAR_USER_AGENT: "stella admin@example.com",
+  INGESTION_USER_AGENT: "acme-ingestion/1.0 (+https://example.com/contact)",
   FEEDBACK_EMAIL_TO: "maintainer@example.com",
   FRONTEND_URL: "http://localhost:3000",
   GOOGLE_GENERATIVE_AI_API_KEY: "key-test",
@@ -310,6 +311,11 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
     "HTTPS, a loopback sidecar, or a private deployment network.",
   GOTENBERG_USERNAME:
     "Username for the Gotenberg sidecar's HTTP basic authentication.",
+  INGESTION_USER_AGENT:
+    "User-Agent sent to court publishers. Defaults to a stella product " +
+    "identifier with the build version and a contact URL; set it so a fork " +
+    "does not identify as the upstream project. Browser-like values are " +
+    "refused by publishers that gate bots.",
   MICROSOFT_AUTH_CLIENT_ID:
     "Microsoft OAuth client ID; required when the matching web login flag is enabled.",
   MICROSOFT_AUTH_CLIENT_SECRET:

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -89,7 +89,7 @@
     "files": {}
   },
   "throw-outside-boundary": {
-    "count": 1091,
+    "count": 1089,
     "files": {
       "apps/api/src/handlers/case-law/decisions/latest.ts": 3,
       "apps/api/src/handlers/case-law/erasure.ts": 1,
@@ -100,7 +100,7 @@
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts": 9,
       "apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts": 11,
       "apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts": 5,
-      "apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts": 4,
+      "apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts": 2,
       "apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts": 5,
       "apps/api/src/handlers/case-law/ingestion/adapters/publisher-request-gate.ts": 2,
       "apps/api/src/handlers/case-law/ingestion/adapters/retry.ts": 1,


### PR DESCRIPTION
The SAOS publisher refuses browser-like user agents, so the ingestion default
becomes a product identifier with the build version and a contact URL; the
`INGESTION_USER_AGENT` override is unchanged.

The dump is then walked one judgment-date shard at a time (a static list of
yearly and monthly shards, plus open-ended catch-alls for dates outside the
corpus range) instead of as one unbounded offset walk. The chain ends on a
recent-modifications lane that names itself as its successor, so it restarts
from its own head. Cursors that name no shard restart the walk at the first
shard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Court-law ingestion now processes publisher data through date-based shards and a recurring recent-updates lane, improving coverage of historical and newly modified judgments.
  - Ingestion requests now use a product-identifying User-Agent with version and contact details by default.

- **Bug Fixes**
  - Pagination now handles self-restarting traversal flows and cursor names safely, with clearer validation for invalid traversal configurations.

- **Documentation**
  - Environment configuration examples now explain the User-Agent setting, including when forks should provide their own identifier and why browser-like values may be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->