### PR TITLE
perf(api): bound the projection convergence probe

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
@@ -32,6 +32,10 @@ const CLEANUP_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
 const ORPHAN_APPLIED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
   "0198e331-e578-7000-8000-000000000304",
 );
+const CONVERGED_ENTITY_ID = "0198e331-e578-7000-8000-000000000309";
+const CONVERGED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000310",
+);
 const ERASING_ENTITY_ID = "0198e331-e578-7000-8000-000000000305";
 const SETTLED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
   "0198e331-e578-7000-8000-000000000306",
@@ -43,6 +47,7 @@ const UNREFERENCED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
 const INDEX_ID = "case_law_v5_cs_sk";
 const FINGERPRINT = "a".repeat(64);
 const ERASING_FINGERPRINT = "d".repeat(64);
+const CONVERGED_FINGERPRINT = "e".repeat(64);
 const NOW = new Date("2026-08-26T00:00:00.000Z");
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
@@ -227,6 +232,35 @@ test("the launch probe waits out the engine publish delay", async () => {
 // referenced ones must not let that reference offset an unreferenced applied
 // revision elsewhere in the generation and read as convergence.
 test("a settling erasure cannot offset an unreferenced applied revision", async () => {
+  // Its own converged entity, so the case holds whether this test runs alone
+  // or after the ones above.
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: CONVERGED_INTENT_ID,
+    ...TARGET,
+    entityId: CONVERGED_ENTITY_ID,
+    epoch: 1n,
+    fingerprint: CONVERGED_FINGERPRINT,
+    indexId: INDEX_ID,
+    status: "applied",
+    appendStartedAt: NOW,
+    appendCommittedAt: NOW,
+    expectedDocumentCount: 1,
+    appliedAt: NOW,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    ...TARGET,
+    entityId: CONVERGED_ENTITY_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: CONVERGED_FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+    appliedAction: "upsert",
+    appliedEpoch: 1n,
+    appliedRevision: CONVERGED_INTENT_ID,
+    appliedFingerprint: CONVERGED_FINGERPRINT,
+    appliedIndexId: INDEX_ID,
+    appliedAt: NOW,
+  });
   expect(await readStatus()).toBe("ready_for_census");
 
   await db.insert(corpusIndexProjectionIntents).values({
@@ -287,4 +321,11 @@ test("a settling erasure cannot offset an unreferenced applied revision", async 
     .delete(corpusIndexProjectionIntents)
     .where(eq(corpusIndexProjectionIntents.id, UNREFERENCED_INTENT_ID));
   expect(await readStatus()).toBe("ready_for_census");
+
+  await db
+    .delete(corpusIndexProjectionStates)
+    .where(eq(corpusIndexProjectionStates.entityId, CONVERGED_ENTITY_ID));
+  await db
+    .delete(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, CONVERGED_INTENT_ID));
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
@@ -32,8 +32,17 @@ const CLEANUP_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
 const ORPHAN_APPLIED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
   "0198e331-e578-7000-8000-000000000304",
 );
+const ERASING_ENTITY_ID = "0198e331-e578-7000-8000-000000000305";
+const SETTLED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000306",
+);
+const UNREFERENCED_ENTITY_ID = "0198e331-e578-7000-8000-000000000307";
+const UNREFERENCED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000308",
+);
 const INDEX_ID = "case_law_v5_cs_sk";
 const FINGERPRINT = "a".repeat(64);
+const ERASING_FINGERPRINT = "d".repeat(64);
 const NOW = new Date("2026-08-26T00:00:00.000Z");
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
@@ -209,5 +218,73 @@ test("the launch probe waits out the engine publish delay", async () => {
       appliedAt: published,
     })
     .where(eq(corpusIndexProjectionIntents.id, APPLIED_INTENT_ID));
+  expect(await readStatus()).toBe("ready_for_census");
+});
+
+// An entity whose erasure is still settling keeps its exact revision pointer
+// until every revision of that entity is proven deleted, so its state names a
+// revision that is no longer `applied`. Counting applied revisions against
+// referenced ones must not let that reference offset an unreferenced applied
+// revision elsewhere in the generation and read as convergence.
+test("a settling erasure cannot offset an unreferenced applied revision", async () => {
+  expect(await readStatus()).toBe("ready_for_census");
+
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: SETTLED_INTENT_ID,
+    ...TARGET,
+    entityId: ERASING_ENTITY_ID,
+    epoch: 1n,
+    fingerprint: ERASING_FINGERPRINT,
+    indexId: INDEX_ID,
+    status: "settled",
+    appendStartedAt: NOW,
+    appendCommittedAt: NOW,
+    appendPublishBarrierAt: NOW,
+    cleanupNotBefore: NOW,
+    cleanupStartedAt: NOW,
+    deleteOpstamp: 42n,
+    deleteTaskCreatedAt: NOW,
+    settledAt: NOW,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    ...TARGET,
+    entityId: ERASING_ENTITY_ID,
+    desiredAction: "erase",
+    desiredEpoch: 2n,
+    appliedAction: "upsert",
+    appliedEpoch: 1n,
+    appliedRevision: SETTLED_INTENT_ID,
+    appliedFingerprint: ERASING_FINGERPRINT,
+    appliedIndexId: INDEX_ID,
+    appliedAt: NOW,
+  });
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: UNREFERENCED_INTENT_ID,
+    ...TARGET,
+    entityId: UNREFERENCED_ENTITY_ID,
+    epoch: 1n,
+    fingerprint: "c".repeat(64),
+    indexId: INDEX_ID,
+    status: "applied",
+    appendStartedAt: NOW,
+    appendCommittedAt: NOW,
+    expectedDocumentCount: 1,
+    appliedAt: NOW,
+  });
+  // Two applied revisions and two referenced ones, and the census still waits:
+  // the erasure owes the index an exact action.
+  expect(await readStatus()).toBe("pending");
+
+  await db
+    .delete(corpusIndexProjectionStates)
+    .where(eq(corpusIndexProjectionStates.entityId, ERASING_ENTITY_ID));
+  await db
+    .delete(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, SETTLED_INTENT_ID));
+  expect(await readStatus()).toBe("intent_outstanding");
+
+  await db
+    .delete(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, UNREFERENCED_INTENT_ID));
   expect(await readStatus()).toBe("ready_for_census");
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-convergence.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-convergence.ts
@@ -47,6 +47,15 @@ const stateScope = ({
     eq(corpusIndexProjectionStates.generation, generation),
   );
 
+const intentScope = ({
+  family,
+  generation,
+}: CorpusIndexProjectionConvergenceTarget) =>
+  and(
+    eq(corpusIndexProjectionIntents.family, family),
+    eq(corpusIndexProjectionIntents.generation, generation),
+  );
+
 const rowsOf = (result: unknown): unknown[] => {
   if (Array.isArray(result)) {
     return result;
@@ -58,19 +67,79 @@ const rowsOf = (result: unknown): unknown[] => {
 };
 
 /**
- * Constant-time PostgreSQL precondition for a fresh zero-drift engine census.
- * The publish probe runs only once the queue is otherwise converged, so the
- * common answer still costs one round trip.
+ * Whether any revision of the generation can still change the engine, asked
+ * only once the state queue is quiet.
+ *
+ * "Outstanding" is unchanged: a blocking revision, or an `applied` revision
+ * that no state row names as authoritative. Read as an anti-join, the second
+ * half probes the state index once per applied revision, so it grew with the
+ * generation while holding the exclusive mutation fence. The same question is
+ * a count identity, and two index-only scans answer it:
+ *
+ * - `applied_revision` is a foreign key carrying family, generation, entity,
+ *   epoch, fingerprint and index id, and the applied shape check makes those
+ *   columns non-null exactly when `applied_revision` is, so every reference
+ *   names a revision of this generation and neither count leaves the scope.
+ * - `corpus_index_projection_states_applied_revision_uidx` is unique, so
+ *   distinct states name distinct revisions and the reference count is the
+ *   number of referenced revisions.
+ * - Every path that takes a referenced revision out of `applied` (replacement
+ *   preparation, erasure claim, census drift repair) leaves that entity's
+ *   state needing work or blocked in the same transaction, and the reference
+ *   is repointed or cleared only when the state converges again. Reaching
+ *   this question means no such state exists, so the referenced revisions are
+ *   a subset of the applied ones and the counts agree exactly when every
+ *   applied revision is referenced.
+ */
+const readOutstandingCorpusProjectionIntentTx = async (
+  tx: Transaction,
+  target: CorpusIndexProjectionConvergenceTarget,
+): Promise<boolean> => {
+  const result: unknown = await tx.execute(sql`
+    SELECT EXISTS (
+      SELECT 1
+      FROM ${corpusIndexProjectionIntents}
+      WHERE ${intentScope(target)}
+        AND ${inArray(
+          corpusIndexProjectionIntents.status,
+          CORPUS_INDEX_LAUNCH_BLOCKING_INTENT_STATUSES,
+        )}
+    ) OR (
+      SELECT count(*)
+      FROM ${corpusIndexProjectionIntents}
+      WHERE ${intentScope(target)}
+        AND ${corpusIndexProjectionIntents.status} = 'applied'
+    ) <> (
+      SELECT count(*)
+      FROM ${corpusIndexProjectionStates}
+      WHERE ${stateScope(target)}
+        -- The applied shape check makes these two conjuncts one condition.
+        -- Spelling both is what the applied-census partial index requires to
+        -- answer the count without touching the table.
+        AND ${corpusIndexProjectionStates.appliedAction} = 'upsert'
+        AND ${corpusIndexProjectionStates.appliedRevision} IS NOT NULL
+    ) AS "hasOutstandingIntent"
+  `);
+  const observation = rowsOf(result).at(0);
+  if (
+    !isRecord(observation) ||
+    typeof observation["hasOutstandingIntent"] !== "boolean"
+  ) {
+    return panic("Corpus projection intent probe returned malformed row");
+  }
+  return observation["hasOutstandingIntent"];
+};
+
+/**
+ * PostgreSQL precondition for a fresh zero-drift engine census. The state
+ * queue answers in one round trip; the intent and publish probes run only once
+ * it is quiet, so a generation with work left still costs one round trip.
  */
 export const readCorpusIndexProjectionConvergenceTx = async (
   tx: Transaction,
   target: CorpusIndexProjectionConvergenceTarget,
 ): Promise<CorpusIndexProjectionConvergenceStatus> => {
   const scope = stateScope(target);
-  const intentScope = and(
-    eq(corpusIndexProjectionIntents.family, target.family),
-    eq(corpusIndexProjectionIntents.generation, target.generation),
-  );
   const result: unknown = await tx.execute(sql`
     SELECT EXISTS (
       SELECT 1 FROM ${corpusIndexProjectionStates} WHERE ${scope}
@@ -88,36 +157,14 @@ export const readCorpusIndexProjectionConvergenceTx = async (
       FROM ${corpusIndexProjectionStates}
       WHERE ${scope}
         AND ${corpusIndexProjectionNeedsWork(corpusIndexProjectionStates)}
-    ) AS "hasPendingState",
-    EXISTS (
-      SELECT 1
-      FROM ${corpusIndexProjectionIntents}
-      WHERE ${intentScope}
-        AND (
-          ${inArray(
-            corpusIndexProjectionIntents.status,
-            CORPUS_INDEX_LAUNCH_BLOCKING_INTENT_STATUSES,
-          )}
-          OR (
-            ${corpusIndexProjectionIntents.status} = 'applied'
-            AND NOT EXISTS (
-              SELECT 1
-              FROM ${corpusIndexProjectionStates}
-              WHERE ${scope}
-                AND ${corpusIndexProjectionStates.appliedRevision} =
-                    ${corpusIndexProjectionIntents.id}
-            )
-          )
-        )
-    ) AS "hasOutstandingIntent"
+    ) AS "hasPendingState"
   `);
   const observation = rowsOf(result).at(0);
   if (
     !isRecord(observation) ||
     typeof observation["hasState"] !== "boolean" ||
     typeof observation["hasBlockedState"] !== "boolean" ||
-    typeof observation["hasPendingState"] !== "boolean" ||
-    typeof observation["hasOutstandingIntent"] !== "boolean"
+    typeof observation["hasPendingState"] !== "boolean"
   ) {
     return panic("Corpus projection convergence probe returned malformed row");
   }
@@ -130,7 +177,7 @@ export const readCorpusIndexProjectionConvergenceTx = async (
   if (observation["hasPendingState"]) {
     return CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.pending;
   }
-  if (observation["hasOutstandingIntent"]) {
+  if (await readOutstandingCorpusProjectionIntentTx(tx, target)) {
     return CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.intentOutstanding;
   }
   const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
@@ -143,7 +190,7 @@ export const readCorpusIndexProjectionConvergenceTx = async (
     .from(corpusIndexProjectionIntents)
     .where(
       and(
-        intentScope,
+        intentScope(target),
         eq(corpusIndexProjectionIntents.status, "applied"),
         sql`NOT ${corpusProjectionAppendIsPublished(manifest)}`,
       ),


### PR DESCRIPTION
The outstanding-intent branch was an anti-join, so PostgreSQL probed the state
index once per applied revision while the probe held the exclusive projection
mutation fence.

It now compares two index-only counts: applied revisions in the generation, and
state rows naming an applied revision. `applied_revision` is a foreign key
carrying family and generation and is uniquely indexed, so both counts range
over the same scope and count distinct revisions. The probe asks only once no
state is blocked and none needs work, which is exactly when every referenced
revision is `applied`, so equal counts mean no applied revision is unreferenced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legal-search corpus convergence checks to more accurately detect outstanding or unreferenced changes.
  - Prevented settling erasures from incorrectly masking revisions that still require processing.
  - Updated status reporting so the corpus remains pending until all relevant changes are accounted for, then transitions correctly to the next applicable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->