### PR TITLE
perf(api): index the projection erasure claim

### DIFF
--- a/apps/api/drizzle/20260911120000_corpus_projection_erase_pending_idx/migration.sql
+++ b/apps/api/drizzle/20260911120000_corpus_projection_erase_pending_idx/migration.sql
@@ -1,0 +1,49 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent build
+-- (which takes no lock those timeouts guard), then restore and reopen a
+-- transaction for Drizzle's migration row. Same shape as
+-- 20260906120000_corpus_projection_outstanding_intent_idx.
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+
+-- Drop by name first: a cancelled concurrent build leaves an INVALID index
+-- behind, and IF NOT EXISTS would then skip recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "corpus_index_projection_states_erase_pending_idx";
+--> statement-breakpoint
+-- Every projection cycle of every generation claims the erasures that
+-- generation still owes, in pending-queue order. No partial index on this
+-- table matched that predicate: the pending, route and census indexes are
+-- keyed on work_status or on applied_action = 'upsert', neither of which the
+-- erasure predicate implies, so the claim read the whole table on every call
+-- even with nothing pending erasure. Keyed on the generation it claims within
+-- plus that queue order and partial on the answer, the claim reads the
+-- pending erasures alone. The predicate is generated from the expression the
+-- claim uses (corpusIndexProjectionErasureIsPending), which is what lets
+-- PostgreSQL prove the implication; the claim writes the action as a literal
+-- for the same reason, because a generic plan over a bound parameter proves
+-- nothing.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "corpus_index_projection_states_erase_pending_idx"
+  ON "corpus_index_projection_states" ("family", "generation", "updated_at", "entity_id")
+  WHERE "desired_action" = 'erase'
+    AND (
+      "applied_action" IS DISTINCT FROM 'erase'
+      OR "applied_epoch" IS DISTINCT FROM "desired_epoch"
+    );
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -10,6 +10,7 @@ import {
   CORPUS_INDEX_PROJECTION_WORK_STATUSES,
 } from "@/api/lib/legal-search/corpus-index-projection-contract";
 import {
+  corpusIndexProjectionErasureIsPending,
   corpusIndexProjectionIntentIsOutstanding,
   corpusIndexProjectionIsBlocked,
   corpusIndexProjectionNeedsWork,
@@ -444,6 +445,14 @@ export const corpusIndexProjectionStates = p.pgTable(
           AND ${t.appliedIndexId} IS NOT NULL
           AND ${t.desiredEpoch} > ${t.appliedEpoch}`,
       ),
+    // The erasure claim asks which entities of a generation still owe an
+    // erasure. Keyed on the generation it claims within and its queue order,
+    // partial on the answer, so a cycle with nothing pending reads the index
+    // rather than the table.
+    p
+      .index("corpus_index_projection_states_erase_pending_idx")
+      .on(t.family, t.generation, t.updatedAt, t.entityId)
+      .where(corpusIndexProjectionErasureIsPending(t)),
     p
       .index("corpus_index_projection_states_blocked_idx")
       .on(t.family, t.generation, t.entityId)

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-plan.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-plan.db.test.ts
@@ -1,0 +1,207 @@
+import { panic } from "better-result";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import { corpusIndexGenerations } from "@/api/db/schema";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { corpusProjectionErasureClaimQuery } from "@/api/lib/legal-search/corpus-index-projection-erasure-store";
+import { planLines } from "@/api/tests/helpers/explain-plan";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const INDEX_ID = "case_law_v5_cs_sk";
+/** The generation that owes erasures. */
+const ERASING = "case_law_v5";
+/** A generation of the same size with no erasure outstanding. */
+const QUIET = "case_law_v6";
+/** Entities converged or in flight for an append: never claimed by erasure. */
+const APPEND_ENTITIES = 4000;
+/** Erasures already applied at the desired epoch: out of the claim. */
+const APPLIED_ERASURES = 1000;
+/** Erasures still owed, half never applied and half applied at an older epoch. */
+const PENDING_ERASURES = 400;
+const LIMIT = 64;
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeEach(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+});
+
+afterEach(async () => {
+  await client.close();
+});
+
+const entity = (offset: string) =>
+  `('00000000-0000-4000-8000-' || lpad(to_hex(${offset}), 12, '0'))::uuid`;
+
+/** Distinct queue positions, so the claim's order is deterministic. */
+const updatedAt = (offset: string) =>
+  `('2026-08-20'::timestamptz + (${offset} || ' seconds')::interval)`;
+
+const seedGeneration = async (
+  generation: string,
+  pendingErasures: number,
+): Promise<void> => {
+  await db.insert(corpusIndexGenerations).values({
+    family: "case_law",
+    generation,
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
+    status: "building",
+  });
+  // The append population. It dwarfs the erasures and shares every column the
+  // claim filters on except the desired action.
+  await db.execute(
+    sql.raw(`
+    INSERT INTO corpus_index_projection_states
+      (family, generation, entity_id, desired_action, desired_epoch,
+       desired_fingerprint, desired_index_id, work_status, created_at, updated_at)
+    SELECT
+      'case_law', '${generation}', ${entity("i")}, 'upsert', 1,
+      lpad(to_hex(i), 64, '0'), '${INDEX_ID}', 'eligible',
+      '2026-08-01'::timestamptz, ${updatedAt("i")}
+    FROM generate_series(1, ${APPEND_ENTITIES}) AS i
+  `),
+  );
+  // Erasures the projection already applied at the desired epoch. They keep
+  // the erased desired action for as long as the generation lives, so only
+  // the applied half of the predicate separates them from the claim.
+  await db.execute(
+    sql.raw(`
+    INSERT INTO corpus_index_projection_states
+      (family, generation, entity_id, desired_action, desired_epoch,
+       work_status, applied_action, applied_epoch, applied_at, created_at,
+       updated_at)
+    SELECT
+      'case_law', '${generation}', ${entity(`i + ${APPEND_ENTITIES}`)},
+      'erase', 2, 'eligible', 'erase', 2, '2026-08-15'::timestamptz,
+      '2026-08-01'::timestamptz, ${updatedAt(`i + ${APPEND_ENTITIES}`)}
+    FROM generate_series(1, ${APPLIED_ERASURES}) AS i
+  `),
+  );
+  if (pendingErasures === 0) {
+    await db.execute(sql.raw("VACUUM ANALYZE corpus_index_projection_states"));
+    return;
+  }
+  const neverApplied = Math.ceil(pendingErasures / 2);
+  const offset = APPEND_ENTITIES + APPLIED_ERASURES;
+  // Owed, and nothing applied yet.
+  await db.execute(
+    sql.raw(`
+    INSERT INTO corpus_index_projection_states
+      (family, generation, entity_id, desired_action, desired_epoch,
+       work_status, created_at, updated_at)
+    SELECT
+      'case_law', '${generation}', ${entity(`i + ${offset}`)}, 'erase', 2,
+      'eligible', '2026-08-01'::timestamptz, ${updatedAt(`i + ${offset}`)}
+    FROM generate_series(1, ${neverApplied}) AS i
+  `),
+  );
+  // Owed again: erased once, then the entity came back and was erased at a
+  // later epoch. Only the epoch half of the predicate keeps these in.
+  await db.execute(
+    sql.raw(`
+    INSERT INTO corpus_index_projection_states
+      (family, generation, entity_id, desired_action, desired_epoch,
+       work_status, applied_action, applied_epoch, applied_at, created_at,
+       updated_at)
+    SELECT
+      'case_law', '${generation}',
+      ${entity(`i + ${offset + neverApplied}`)}, 'erase', 3, 'eligible',
+      'erase', 2, '2026-08-15'::timestamptz, '2026-08-01'::timestamptz,
+      ${updatedAt(`i + ${offset + neverApplied}`)}
+    FROM generate_series(1, ${pendingErasures - neverApplied}) AS i
+  `),
+  );
+  await db.execute(sql.raw("VACUUM ANALYZE corpus_index_projection_states"));
+};
+
+type ClaimPlan = {
+  buffers: number;
+  claimedRows: number;
+  plan: string;
+};
+
+const explainClaim = async (generation: string): Promise<ClaimPlan> =>
+  await db.transaction(async (transaction) => {
+    const tx = asTestRaw<Transaction>(transaction);
+    const claim = corpusProjectionErasureClaimQuery(tx, {
+      family: "case_law",
+      generation,
+      limit: LIMIT,
+      scopedEntityIds: null,
+    });
+    const plan = planLines(
+      await tx.execute(
+        sql`EXPLAIN (ANALYZE, BUFFERS, COSTS OFF) ${claim.getSQL()}`,
+      ),
+    ).join("\n");
+    const claimedRows = Number(
+      /^Limit .*rows=(\d+)/mu.exec(plan)?.[1] ?? Number.NaN,
+    );
+    const topBuffers = /^\s*Buffers: shared hit=(\d+)(?: read=(\d+))?/mu.exec(
+      plan,
+    );
+    const buffers =
+      Number(topBuffers?.[1] ?? Number.NaN) + Number(topBuffers?.[2] ?? 0);
+    if (!Number.isFinite(claimedRows) || !Number.isFinite(buffers)) {
+      return panic(`EXPLAIN output is not measurable:\n${plan}`);
+    }
+    return { buffers, claimedRows, plan };
+  });
+
+test("the erasure claim reads pending erasures, not the projection table", async () => {
+  await seedGeneration(ERASING, PENDING_ERASURES);
+  await seedGeneration(QUIET, 0);
+
+  const owed = await explainClaim(ERASING);
+  expect(owed.claimedRows).toBe(LIMIT);
+  expect(owed.plan).not.toContain("Seq Scan");
+  expect(owed.plan).toContain(
+    "corpus_index_projection_states_erase_pending_idx",
+  );
+  // The scan stops at the batch instead of sorting the generation, and every
+  // row it reads is one the claim wants. The predicate stays on the node as a
+  // recheck because the claim locks its rows; it removes nothing.
+  expect(owed.plan).not.toContain("Rows Removed by Filter");
+  expect(owed.plan).not.toContain("Sort");
+
+  // A generation with nothing pending is the common case: every cycle of
+  // every generation runs this claim. It must cost a probe, not a table.
+  const quiet = await explainClaim(QUIET);
+  expect(quiet.claimedRows).toBe(0);
+  expect(quiet.plan).not.toContain("Seq Scan");
+  expect(quiet.plan).toContain(
+    "corpus_index_projection_states_erase_pending_idx",
+  );
+  expect(quiet.buffers).toBeLessThanOrEqual(owed.buffers);
+  expect(quiet.buffers).toBeLessThanOrEqual(20);
+}, 600_000);
+
+test("the erasure claim writes its desired action as a literal", async () => {
+  const { params, sql: text } = corpusProjectionErasureClaimQuery(
+    asTestRaw<Transaction>(db),
+    {
+      family: "case_law",
+      generation: ERASING,
+      limit: LIMIT,
+      scopedEntityIds: null,
+    },
+  ).toSQL();
+
+  // A bound action would leave the planner nothing to prove the partial
+  // index's predicate from once the statement plans generically, and the
+  // claim would fall back to reading the table.
+  expect(text).toContain("'erase'");
+  expect(params).not.toContain("erase");
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
@@ -17,7 +17,10 @@ import {
   entityIdsForCorpusProjectionWorkScope,
   type CorpusProjectionScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
-import { corpusIndexProjectionIntentIsOutstanding } from "@/api/lib/legal-search/corpus-index-projection-sql";
+import {
+  corpusIndexProjectionErasureIsPending,
+  corpusIndexProjectionIntentIsOutstanding,
+} from "@/api/lib/legal-search/corpus-index-projection-sql";
 import { sqlCaseFragment } from "@/api/lib/sql-case-expression";
 
 export const CORPUS_PROJECTION_ERASURE_MAX_BATCH_SIZE = 256;
@@ -52,6 +55,52 @@ const validateLimit = (limit: number): number => {
   return limit;
 };
 
+type CorpusProjectionErasureClaimOptions = {
+  family: CorpusFamily;
+  generation: string;
+  limit: number;
+  scopedEntityIds: readonly string[] | null;
+};
+
+/**
+ * The erasure claim read. Exported so the plan guard explains the exact
+ * statement the erasure cycle issues rather than a copy of it.
+ */
+export const corpusProjectionErasureClaimQuery = (
+  tx: Transaction,
+  {
+    family,
+    generation,
+    limit,
+    scopedEntityIds,
+  }: CorpusProjectionErasureClaimOptions,
+) =>
+  tx
+    .select({
+      entityId: corpusIndexProjectionStates.entityId,
+      desiredEpoch: corpusIndexProjectionStates.desiredEpoch,
+    })
+    .from(corpusIndexProjectionStates)
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, family),
+        eq(corpusIndexProjectionStates.generation, generation),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionStates.entityId, scopedEntityIds),
+        corpusIndexProjectionErasureIsPending(corpusIndexProjectionStates),
+      ),
+    )
+    .orderBy(
+      asc(corpusIndexProjectionStates.updatedAt),
+      asc(corpusIndexProjectionStates.entityId),
+    )
+    .limit(limit)
+    .for("update", {
+      of: corpusIndexProjectionStates,
+      skipLocked: true,
+    });
+
 /**
  * Fence every pre-erasure append, then mark erasure applied only after each
  * exact revision is terminal. Engine I/O happens in the separate cleanup
@@ -76,35 +125,12 @@ export const advanceCorpusProjectionErasuresTx = async <
     family,
     generation,
   );
-  const states = await tx
-    .select({
-      entityId: corpusIndexProjectionStates.entityId,
-      desiredEpoch: corpusIndexProjectionStates.desiredEpoch,
-    })
-    .from(corpusIndexProjectionStates)
-    .where(
-      and(
-        eq(corpusIndexProjectionStates.family, family),
-        eq(corpusIndexProjectionStates.generation, generation),
-        scopedEntityIds === null
-          ? undefined
-          : inArray(corpusIndexProjectionStates.entityId, scopedEntityIds),
-        eq(corpusIndexProjectionStates.desiredAction, "erase"),
-        sql`(
-          ${corpusIndexProjectionStates.appliedAction} IS DISTINCT FROM 'erase'
-          OR ${corpusIndexProjectionStates.appliedEpoch} IS DISTINCT FROM ${corpusIndexProjectionStates.desiredEpoch}
-        )`,
-      ),
-    )
-    .orderBy(
-      asc(corpusIndexProjectionStates.updatedAt),
-      asc(corpusIndexProjectionStates.entityId),
-    )
-    .limit(limit)
-    .for("update", {
-      of: corpusIndexProjectionStates,
-      skipLocked: true,
-    });
+  const states = await corpusProjectionErasureClaimQuery(tx, {
+    family,
+    generation,
+    limit,
+    scopedEntityIds,
+  });
   if (states.length === 0) {
     return {
       claimedCount: 0,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-reservation-plan.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-reservation-plan.db.test.ts
@@ -10,7 +10,7 @@ import {
   corpusIndexManifestDigest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import { corpusProjectionReservationQueue } from "@/api/lib/legal-search/corpus-index-projection-store";
-import { isRecord } from "@/api/lib/type-guards";
+import { planLines } from "@/api/tests/helpers/explain-plan";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
@@ -201,24 +201,6 @@ const intentProbe = ({ lines }: ReservationPlan): string => {
   );
   return lines.slice(start, end === -1 ? undefined : end).join("\n");
 };
-
-const explainRows = (explained: unknown): unknown[] => {
-  if (Array.isArray(explained)) {
-    return explained;
-  }
-  if (isRecord(explained) && Array.isArray(explained["rows"])) {
-    return explained["rows"];
-  }
-  return panic("EXPLAIN did not return plan rows");
-};
-
-const planLines = (explained: unknown): string[] =>
-  explainRows(explained).map((row) => {
-    const text = isRecord(row) ? row["QUERY PLAN"] : undefined;
-    return typeof text === "string"
-      ? text
-      : panic("EXPLAIN row has no plan text");
-  });
 
 const explainReservation = async (): Promise<ReservationPlan> =>
   await db.transaction(async (transaction) => {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-sql.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-sql.ts
@@ -3,6 +3,7 @@ import { sql, type SQLWrapper } from "drizzle-orm";
 import {
   CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES,
   CORPUS_INDEX_QUIESCENT_INTENT_STATUSES,
+  type CorpusIndexDesiredAction,
 } from "@/api/lib/legal-search/corpus-index-projection-contract";
 
 const sqlLiteralValues = (values: readonly string[]) =>
@@ -64,3 +65,34 @@ export const corpusIndexProjectionProducesAppend = (status: SQLWrapper) =>
  */
 export const corpusIndexProjectionIntentIsOutstanding = (status: SQLWrapper) =>
   sql`${status} NOT IN (${sqlLiteralValues(CORPUS_INDEX_QUIESCENT_INTENT_STATUSES)})`;
+
+const ERASE_ACTION: CorpusIndexDesiredAction = "erase";
+const ERASE_ACTION_LITERAL = sql.raw(`'${ERASE_ACTION}'`);
+
+type CorpusProjectionErasureColumns = {
+  appliedAction: SQLWrapper;
+  appliedEpoch: SQLWrapper;
+  desiredAction: SQLWrapper;
+  desiredEpoch: SQLWrapper;
+};
+
+/**
+ * One source of truth for "this entity still owes the index an erasure",
+ * shared by the erasure claim and by the partial index that serves it. The
+ * action is written as a literal rather than bound: PostgreSQL uses a partial
+ * index only where it can prove the index predicate from the query's, and a
+ * generic plan over `desired_action = $n` proves nothing, so the claim would
+ * read the whole table however few erasures are pending.
+ */
+export const corpusIndexProjectionErasureIsPending = ({
+  appliedAction,
+  appliedEpoch,
+  desiredAction,
+  desiredEpoch,
+}: CorpusProjectionErasureColumns) => sql`(
+  ${desiredAction} = ${ERASE_ACTION_LITERAL}
+  AND (
+    ${appliedAction} IS DISTINCT FROM ${ERASE_ACTION_LITERAL}
+    OR ${appliedEpoch} IS DISTINCT FROM ${desiredEpoch}
+  )
+)`;

--- a/apps/api/src/tests/helpers/explain-plan.ts
+++ b/apps/api/src/tests/helpers/explain-plan.ts
@@ -1,0 +1,21 @@
+import { panic } from "better-result";
+
+import { isRecord } from "@/api/lib/type-guards";
+
+/**
+ * The plan text of an `EXPLAIN`, whatever shape the driver wraps its rows in.
+ * Plan guards assert against these lines, so a driver returning something
+ * unreadable must fail the test rather than an empty plan passing it.
+ */
+export const planLines = (explained: unknown): string[] => {
+  const rows = isRecord(explained) ? explained["rows"] : explained;
+  if (!Array.isArray(rows)) {
+    return panic("EXPLAIN did not return plan rows");
+  }
+  return rows.map((row: unknown) => {
+    const text = isRecord(row) ? row["QUERY PLAN"] : undefined;
+    return typeof text === "string"
+      ? text
+      : panic("EXPLAIN row has no plan text");
+  });
+};


### PR DESCRIPTION
The erasure claim's predicate (`desired_action = 'erase'` plus the applied-action and epoch test) matched no partial index on `corpus_index_projection_states`: the neighbours are keyed on `work_status` or on `applied_action = 'upsert'`. Every projection cycle of every generation therefore scanned the whole table, pending erasures or not.

`corpus_index_projection_states_erase_pending_idx` on `(family, generation, updated_at, entity_id)` is partial on that predicate. One shared expression generates both the claim's predicate and the index's, and the claim writes the action as a literal: a generic plan over a bound parameter proves nothing about a partial index.

The build is `CREATE INDEX CONCURRENTLY` with the migrator transaction split, same shape as `20260906120000_corpus_projection_outstanding_intent_idx`.

A plan guard explains the claim through the builder the executor calls and asserts the index serves it, with no `Seq Scan`, no `Sort`, and no rows removed by filter; without the index it fails on the seq scan.

Follow-up, not here: skipping the claim outright for a generation with nothing pending would need a bookkeeping counter that does not exist yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved processing of pending corpus index erasures by enabling more targeted database lookups.

* **Reliability**
  * Standardised pending-erasure detection across processing and database indexing.

* **Tests**
  * Added coverage confirming efficient query plans and correct erasure selection.
  * Improved reuse of query-plan parsing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->