### PR TITLE
fix: enforce release guards in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   # The merge queue builds main plus one pull request and merges only if this
-  # workflow reports `ci-result` success on that commit, so every check below
-  # also runs on the tree that will actually land.
+  # workflow reports `ci-result` success on that commit, so release-boundary
+  # checks must include merge_group and validate the tree that will land.
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -683,7 +683,9 @@ jobs:
         run: bun run i18n:check
 
       - name: Release changelog guard
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          || github.event_name == 'merge_group'
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: bash scripts/check-release-changelog.sh --base "origin/$BASE_REF"
@@ -691,13 +693,17 @@ jobs:
       # Same verdict the tag workflow gives after merge, delivered while the
       # release pull request can still wait for the Version Packages one.
       - name: Release CLI coupling guard
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          || github.event_name == 'merge_group'
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: bun scripts/check-cli-release-coupling.ts --base "origin/$BASE_REF"
 
       - name: Release marketing freshness warning
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          || github.event_name == 'merge_group'
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: |
@@ -1503,7 +1509,8 @@ jobs:
   release-typecheck:
     needs: ci-plan
     if: >-
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request'
+       || github.event_name == 'merge_group')
       && needs.ci-plan.outputs.release_typecheck_required == 'true'
       && needs.ci-plan.outputs.trusted == 'true'
     runs-on: ubuntu-latest

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -91,6 +91,11 @@ const workflowStep = (job: string, stepName: string): string =>
 const actionStep = (action: string, stepName: string): string =>
   stepOf(action, stepName, 4);
 
+const expectPullRequestAndMergeGroup = (source: string) => {
+  expect(source).toContain("github.event_name == 'pull_request'");
+  expect(source).toContain("github.event_name == 'merge_group'");
+};
+
 const workflowStepRun = (job: string, stepName: string): string => {
   const step = workflowStep(job, stepName);
   const runMarker = "\n        run: ";
@@ -384,7 +389,7 @@ describe("detect-e2e-changes", () => {
     expect(releaseTypecheck).toContain(
       "needs.ci-plan.outputs.release_typecheck_required == 'true'",
     );
-    expect(releaseTypecheck).toContain("github.event_name == 'pull_request'");
+    expectPullRequestAndMergeGroup(releaseTypecheck);
     expect(releaseTypecheck).toContain(
       "run: bun run typecheck && bun run typecheck:repo",
     );
@@ -397,6 +402,17 @@ describe("detect-e2e-changes", () => {
     );
     expect(result).toContain('$RELEASE_TYPECHECK_RESULT" == "failure"');
     expect(result).toContain('$RELEASE_TYPECHECK_RESULT" == "cancelled"');
+  });
+
+  test("revalidates release invariants on the merge queue tree", () => {
+    const ciChecks = workflowJob("ci-checks");
+    for (const stepName of [
+      "Release changelog guard",
+      "Release CLI coupling guard",
+      "Release marketing freshness warning",
+    ]) {
+      expectPullRequestAndMergeGroup(workflowStep(ciChecks, stepName));
+    }
   });
 
   test("checks the generated model rates only when their inputs change", () => {


### PR DESCRIPTION
## Summary

- run release changelog, CLI coupling, and marketing guards on merge-group commits
- run release typechecking against the exact merge-group tree
- guard the pull-request and merge-group event coverage with a CI workflow invariant test

## Incident reproduced

The v0.9.14 merge-group run skipped the release CLI coupling guard even though its tree contained a pending `@stll/cli` changeset. The post-merge tag workflow then rejected the same tree.

## Validation

- remote CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release validation now runs consistently for changes entering through merge queues as well as pull requests.
  - Changelog, command-line tooling, marketing freshness, and release type checks now validate the exact changes due to land.

- **Tests**
  - Added coverage to ensure all release-related checks apply to both supported integration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->