### PR TITLE
feat(ui): add ui-playground demo for BidiText

### DIFF
--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -39,6 +39,7 @@ import {
   AlertDialogTrigger,
 } from "@stll/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@stll/ui/avatar";
+import { BidiText } from "@stll/ui/bidi-text";
 import {
   Breadcrumb,
   BreadcrumbEllipsis,
@@ -234,6 +235,10 @@ const COMBOBOX_OPTIONS: ComboboxOption[] = [
   { id: "charlie", label: "Charlie Novak", detail: "Witness" },
   { id: "delta", label: "Delta Finance", detail: "Lender" },
 ];
+
+// Mixed LTR/RTL legal strings so bidi isolation is visible against unwrapped text.
+const BIDI_MIXED_PARTY = "شركة النور (C-123/45).";
+const BIDI_MIXED_CITATION = "حكم رقم Smith v Jones لعام.";
 
 const TABLE_ROWS = [
   {
@@ -1215,6 +1220,71 @@ export function UiPlayground() {
                     <span>Left</span>
                     <Separator orientation="vertical" />
                     <span>Right</span>
+                  </div>
+                </div>
+              </PlaygroundSection>
+
+              <PlaygroundSection
+                description="dir isolation for mixed LTR/RTL user text. Compare an unwrapped string with BidiText so punctuation and neighboring runs stay in place."
+                title="BidiText"
+              >
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-muted-foreground text-xs">
+                      Unwrapped
+                    </span>
+                    <div className="rounded-lg border px-3 py-2 text-sm">
+                      {BIDI_MIXED_PARTY}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-muted-foreground text-xs">
+                      Isolated
+                    </span>
+                    <div className="rounded-lg border px-3 py-2 text-sm">
+                      <BidiText>{BIDI_MIXED_PARTY}</BidiText>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <span className="text-muted-foreground text-xs">
+                    {'as="span" next to surrounding LTR'}
+                  </span>
+                  <p className="rounded-lg border px-3 py-2 text-sm">
+                    Filed against{" "}
+                    <BidiText as="span">{BIDI_MIXED_PARTY}</BidiText> yesterday.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-3 text-sm">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-muted-foreground text-xs">
+                      {'as="div"'}
+                    </span>
+                    <BidiText as="div">{BIDI_MIXED_CITATION}</BidiText>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-muted-foreground text-xs">
+                      {'as="p"'}
+                    </span>
+                    <BidiText as="p">{BIDI_MIXED_CITATION}</BidiText>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-muted-foreground text-xs">
+                      {'direction="rtl"'}
+                    </span>
+                    <BidiText as="div" direction="rtl">
+                      {BIDI_MIXED_CITATION}
+                    </BidiText>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-muted-foreground text-xs">
+                      {'direction="ltr"'}
+                    </span>
+                    <BidiText as="div" direction="ltr">
+                      {BIDI_MIXED_CITATION}
+                    </BidiText>
                   </div>
                 </div>
               </PlaygroundSection>


### PR DESCRIPTION
### Description

Adds a `BidiText` demo section to the UI playground (Data tab) so mixed LTR/RTL text isolation is visible.

The section compares an unwrapped string with `BidiText`, then shows `as=\"span\"` next to surrounding LTR copy, plus `as=\"div\"` / `as=\"p\"` and `direction=\"rtl\"` / `direction=\"ltr\"` variants.

### Motivation

`packages/ui/src/components/bidi-text.tsx` had no playground demo. Maintainers asked for one with a mixed LTR/RTL string next to an unwrapped control for contrast.

### Additional details

- File: `apps/web/src/routes/dev/-components/ui-playground.tsx`
- Matches existing `PlaygroundSection` layout/heading style
- Mixed-script samples left untranslated on purpose so isolation stays obvious; no new i18n keys; no backend

Fixes #1658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a BidiText playground section demonstrating mixed left-to-right and right-to-left text.
  * Added side-by-side examples comparing unwrapped text with isolated BidiText rendering.
  * Added demonstrations across span, div, and paragraph formats.
  * Added explicit left-to-right and right-to-left direction examples to help illustrate bidirectional text behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->