### PR TITLE
feat(api): weigh Polish courts by tier

### DIFF
--- a/apps/api/drizzle/20260911140000_case_law_court_weight_seed_pol/migration.sql
+++ b/apps/api/drizzle/20260911140000_case_law_court_weight_seed_pol/migration.sql
@@ -1,0 +1,86 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Court rank per jurisdiction: the declaration in
+-- apps/api/src/handlers/case-law/court-weight-seed.ts, rendered by
+-- courtWeightSeedSql() and held to it by court-weight-seed.test.ts.
+-- The declaration is the table's only writer: a pattern it no longer carries
+-- is dropped, a row an older seed left at another rank is brought to the
+-- declared one, then the missing rows are added on the (country,
+-- court_pattern) unique index, so the three are re-runnable; rollback re-runs
+-- the previous release's seed.
+-- stella-migration-safety: reviewed delete-data - drops only the (country, court_pattern) keys the declaration above no longer carries, from an operator-seeded registry of 17 rows; rollback re-runs the previous release's seed
+DELETE FROM "case_law_court_weights" w
+WHERE NOT EXISTS (
+  SELECT 1 FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny', 2, 'appeal', 5),
+  ('POL', 'sąd okręgowy', 2, 'regional', 4),
+  ('POL', 'krajowa izba odwoławcza', 1, 'procurement-review', 3),
+  ('POL', 'sąd rejonowy', 1, 'district', 2),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+  WHERE v.country = w."country" AND v.court_pattern = w."court_pattern"
+);
+--> statement-breakpoint
+UPDATE "case_law_court_weights" w
+SET "tier" = v.tier, "tier_label" = v.tier_label, "weight" = v.weight
+FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny', 2, 'appeal', 5),
+  ('POL', 'sąd okręgowy', 2, 'regional', 4),
+  ('POL', 'krajowa izba odwoławcza', 1, 'procurement-review', 3),
+  ('POL', 'sąd rejonowy', 1, 'district', 2),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern
+  AND (w."tier", w."tier_label", w."weight") IS DISTINCT FROM (v.tier, v.tier_label, v.weight);
+--> statement-breakpoint
+-- stella-migration-safety: reviewed insert-select - the source relation is a 17-row VALUES list, not a table, so the statement is bounded and instant; rollback deletes the same (country, court_pattern) keys
+INSERT INTO "case_law_court_weights" ("id", "country", "court_pattern", "tier", "tier_label", "weight")
+SELECT gen_random_uuid(), v.country, v.court_pattern, v.tier, v.tier_label, v.weight
+FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny', 2, 'appeal', 5),
+  ('POL', 'sąd okręgowy', 2, 'regional', 4),
+  ('POL', 'krajowa izba odwoławcza', 1, 'procurement-review', 3),
+  ('POL', 'sąd rejonowy', 1, 'district', 2),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+WHERE NOT EXISTS (
+  SELECT 1 FROM "case_law_court_weights" w
+  WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern
+);

--- a/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
@@ -10,25 +10,36 @@ import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 const MIGRATION = nodePath.resolve(
   import.meta.dir,
-  "../../../drizzle/20260902090000_case_law_court_weight_seed/migration.sql",
+  "../../../drizzle/20260911140000_case_law_court_weight_seed_pol/migration.sql",
 );
 
-test("the seed migration applies, brings a stale row to the declared rank, and is idempotent", async () => {
+test("the seed migration applies, reconciles stale rows, and is idempotent", async () => {
   const client = await createTestPglite();
   const db = drizzle({ client });
   const statements = (await Bun.file(MIGRATION).text())
     .split("--> statement-breakpoint")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
-  // A database seeded by an older script holds the key at another rank.
-  await db.insert(caseLawCourtWeights).values({
-    id: createSafeId<"caseLawCourtWeight">(),
-    country: "EU",
-    courtPattern: "general court",
-    tier: 1,
-    tierLabel: "stale",
-    weight: 1,
-  });
+  // A database seeded by an older script holds the key at another rank, and
+  // carries a pattern the declaration has since split into narrower ones.
+  await db.insert(caseLawCourtWeights).values([
+    {
+      id: createSafeId<"caseLawCourtWeight">(),
+      country: "EU",
+      courtPattern: "general court",
+      tier: 1,
+      tierLabel: "stale",
+      weight: 1,
+    },
+    {
+      id: createSafeId<"caseLawCourtWeight">(),
+      country: "POL",
+      courtPattern: "sąd apelacyjny|sąd okręgowy",
+      tier: 2,
+      tierLabel: "regional",
+      weight: 4,
+    },
+  ]);
   for (const statement of statements) {
     await db.execute(sql.raw(statement));
   }
@@ -39,6 +50,14 @@ test("the seed migration applies, brings a stale row to the declared rank, and i
       (row) => row.country === "EU" && row.courtPattern === "general court",
     ),
   ).toMatchObject({ tier: 3, tierLabel: "supreme", weight: 8 });
+  expect(
+    first.filter(
+      (row) =>
+        row.country === "POL" && /sąd apelacyjny/u.test(row.courtPattern),
+    ),
+  ).toMatchObject([
+    { courtPattern: "sąd apelacyjny", tierLabel: "appeal", weight: 5 },
+  ]);
   for (const statement of statements) {
     await db.execute(sql.raw(statement));
   }

--- a/apps/api/src/handlers/case-law/court-weight-seed.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.test.ts
@@ -15,7 +15,7 @@ import {
 
 const MIGRATION = nodePath.resolve(
   import.meta.dir,
-  "../../../drizzle/20260902090000_case_law_court_weight_seed/migration.sql",
+  "../../../drizzle/20260911140000_case_law_court_weight_seed_pol/migration.sql",
 );
 
 describe("court weight seed", () => {
@@ -58,6 +58,11 @@ describe("court weight seed", () => {
       ["POL", "Sąd Najwyższy", "supreme"],
       ["POL", "Naczelny Sąd Administracyjny", "supreme"],
       ["POL", "Trybunał Konstytucyjny", "constitutional"],
+      ["POL", "Sąd Apelacyjny w Krakowie", "appeal"],
+      ["POL", "Sąd Okręgowy w Warszawie", "regional"],
+      ["POL", "Sąd Rejonowy w Gdańsku", "district"],
+      ["POL", "Sąd Rejonowy dla Warszawy-Śródmieścia", "district"],
+      ["POL", "Krajowa Izba Odwoławcza", "procurement-review"],
       ["AUT", "OGH", "supreme"],
       ["AUT", "VwGH", "supreme"],
       ["AUT", "VfGH", "constitutional"],
@@ -75,6 +80,70 @@ describe("court weight seed", () => {
         court,
         label,
       ]);
+    }
+  });
+
+  test("Poland ranks every instance the feeds store, each pattern once", () => {
+    // The SAOS feed and the Supreme Court connector store these six court
+    // names; a name two patterns both match would take whichever the
+    // precedence order happens to reach first.
+    expect(COURT_WEIGHT_SEED.filter((row) => row.country === "POL")).toEqual([
+      {
+        country: "POL",
+        courtPattern: "trybunał konstytucyjny",
+        tier: 4,
+        tierLabel: "constitutional",
+        weight: 10,
+      },
+      {
+        country: "POL",
+        courtPattern: "sąd najwyższy|naczelny sąd administracyjny",
+        tier: 3,
+        tierLabel: "supreme",
+        weight: 8,
+      },
+      {
+        country: "POL",
+        courtPattern: "sąd apelacyjny",
+        tier: 2,
+        tierLabel: "appeal",
+        weight: 5,
+      },
+      {
+        country: "POL",
+        courtPattern: "sąd okręgowy",
+        tier: 2,
+        tierLabel: "regional",
+        weight: 4,
+      },
+      {
+        country: "POL",
+        courtPattern: "krajowa izba odwoławcza",
+        tier: 1,
+        tierLabel: "procurement-review",
+        weight: 3,
+      },
+      {
+        country: "POL",
+        courtPattern: "sąd rejonowy",
+        tier: 1,
+        tierLabel: "district",
+        weight: 2,
+      },
+    ]);
+    const polish = [
+      "Trybunał Konstytucyjny",
+      "Sąd Najwyższy",
+      "Sąd Apelacyjny w Krakowie",
+      "Sąd Okręgowy w Warszawie",
+      "Krajowa Izba Odwoławcza",
+      "Sąd Rejonowy dla Warszawy-Śródmieścia",
+    ];
+    for (const court of polish) {
+      const matched = seededCourtWeightEntries("POL").filter((entry) =>
+        entry.pattern.test(court),
+      );
+      expect([court, matched.length]).toEqual([court, 1]);
     }
   });
 

--- a/apps/api/src/handlers/case-law/court-weight-seed.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.ts
@@ -11,11 +11,11 @@ import type {
 } from "@/api/lib/case-law/court-weights";
 
 /**
- * The court rank declaration every jurisdiction ships with. The migration
- * `case_law_court_weight_seed` inserts exactly these rows, so a deployed
- * database is never without them; `seed-court-weights.ts` re-upserts them
- * after an edit here, and `court-weight-seed.test.ts` holds the migration to
- * this list. Ranking code reads the table, never this constant.
+ * The court rank declaration every jurisdiction ships with. The latest
+ * `case_law_court_weight_seed*` migration inserts exactly these rows, so a
+ * deployed database is never without them; `seed-court-weights.ts` re-upserts
+ * them after an edit here, and `court-weight-seed.test.ts` holds that
+ * migration to this list. Ranking code reads the table, never this constant.
  */
 
 export type CourtWeightSeedRow = {
@@ -71,7 +71,12 @@ export const COURT_WEIGHT_SEED: readonly CourtWeightSeedRow[] = [
     tierLabel: "regional",
     weight: 4,
   },
-  // Poland
+  // Poland. The feeds store the full court name with its seat appended
+  // ("Sąd Okręgowy w Warszawie", "Sąd Rejonowy dla Warszawy-Śródmieścia"),
+  // so each rank is the court's name without the seat. Appeal and regional
+  // share tier 2 and differ by weight, the way the tier scale allows one
+  // instance to outrank another without adding a tier the search blend
+  // would have to rescale.
   {
     country: "POL",
     courtPattern: "trybunał konstytucyjny",
@@ -88,10 +93,31 @@ export const COURT_WEIGHT_SEED: readonly CourtWeightSeedRow[] = [
   },
   {
     country: "POL",
-    courtPattern: "sąd apelacyjny|sąd okręgowy",
+    courtPattern: "sąd apelacyjny",
+    tier: 2,
+    tierLabel: "appeal",
+    weight: 5,
+  },
+  {
+    country: "POL",
+    courtPattern: "sąd okręgowy",
     tier: 2,
     tierLabel: "regional",
     weight: 4,
+  },
+  {
+    country: "POL",
+    courtPattern: "krajowa izba odwoławcza",
+    tier: 1,
+    tierLabel: "procurement-review",
+    weight: 3,
+  },
+  {
+    country: "POL",
+    courtPattern: "sąd rejonowy",
+    tier: 1,
+    tierLabel: "district",
+    weight: 2,
   },
   // Austria. The RIS feeds store the court as the publisher's abbreviation
   // (`OGH`, `VwGH`, `VfGH`) or as the full name with the abbreviation in
@@ -185,9 +211,12 @@ const SEED_COLUMNS =
 /**
  * The statements the seed migration carries, rendered from the list above
  * so the two cannot drift: the migration file is compared to this text.
- * The declaration is the table's only writer, so a row an older seed left
- * at another rank is brought to the declared one before the missing rows
- * are added; both statements read the VALUES list, never a table.
+ * The declaration is the table's only writer, so a pattern it no longer
+ * carries is dropped and a row an older seed left at another rank is brought
+ * to the declared one before the missing rows are added. A superseded pattern
+ * left behind would keep matching court names the declaration now ranks
+ * elsewhere, and which of the two wins is a precedence accident. Every
+ * statement reads the VALUES list, never a table.
  */
 export const courtWeightSeedSql = (): string => {
   const values = [
@@ -197,6 +226,14 @@ export const courtWeightSeedSql = (): string => {
         `  (${sqlLiteral(row.country)}, ${sqlLiteral(row.courtPattern)}, ${String(row.tier)}, ${sqlLiteral(row.tierLabel)}, ${String(row.weight)})`,
     ).join(",\n"),
     `) AS v (${SEED_COLUMNS})`,
+  ].join("\n");
+  const remove = [
+    `-- stella-migration-safety: reviewed delete-data - drops only the (country, court_pattern) keys the declaration above no longer carries, from an operator-seeded registry of ${String(COURT_WEIGHT_SEED.length)} rows; rollback re-runs the previous release's seed`,
+    'DELETE FROM "case_law_court_weights" w',
+    "WHERE NOT EXISTS (",
+    `  SELECT 1 FROM ${values}`,
+    '  WHERE v.country = w."country" AND v.court_pattern = w."court_pattern"',
+    ");",
   ].join("\n");
   const update = [
     'UPDATE "case_law_court_weights" w',
@@ -208,7 +245,7 @@ export const courtWeightSeedSql = (): string => {
   // The arbiter is a unique index, not a named constraint, so the rows that
   // already exist are skipped by an anti-join rather than ON CONFLICT.
   const insert = [
-    "-- stella-migration-safety: reviewed insert-select - the source relation is a fourteen-row VALUES list, not a table, so the statement is bounded and instant; rollback deletes the same (country, court_pattern) keys",
+    `-- stella-migration-safety: reviewed insert-select - the source relation is a ${String(COURT_WEIGHT_SEED.length)}-row VALUES list, not a table, so the statement is bounded and instant; rollback deletes the same (country, court_pattern) keys`,
     `INSERT INTO "case_law_court_weights" ("id", ${SEED_COLUMNS})`,
     "SELECT gen_random_uuid(), v.country, v.court_pattern, v.tier, v.tier_label, v.weight",
     `FROM ${values}`,
@@ -217,5 +254,5 @@ export const courtWeightSeedSql = (): string => {
     '  WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern',
     ");",
   ].join("\n");
-  return [update, "--> statement-breakpoint", insert].join("\n");
+  return [remove, update, insert].join("\n--> statement-breakpoint\n");
 };


### PR DESCRIPTION
POL court weights, one pattern per stored court name:
- 4/10 constitutional `trybunał konstytucyjny`; 3/8 supreme `sąd najwyższy|naczelny sąd administracyjny`
- 2/5 appeal `sąd apelacyjny`; 2/4 regional `sąd okręgowy`
- 1/3 procurement-review `krajowa izba odwoławcza`; 1/2 district `sąd rejonowy`. The seed migration now also deletes patterns the declaration no longer carries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Polish court classification and ranking, distinguishing appeal, regional, district and procurement-review courts.
  * Court-weight data now stays aligned with the latest court definitions, including corrected tiers and ranking weights.

* **Bug Fixes**
  * Corrected recognition of Polish court names so stored variants receive the appropriate classification and ranking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->