### PR TITLE
feat(api): floor a source's reconciliation sweep from its configuration

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -1050,6 +1050,58 @@ test("a configured floor is where the sweep stops, and nothing below it is owed"
   expect(await ledgerRow(floored, swept)).toBeUndefined();
 });
 
+test("rows below a configured floor are no longer the source's backlog", async () => {
+  // Raising the floor leaves behind whatever the source swept under the old
+  // one. Those rows are still work to every read of the ledger: a short row
+  // below the floor can never settle, so it would be re-listed on every turn
+  // and the excluded range would be crawled forever by the backlog instead of
+  // the sweep. One row of each kind the ledger can offer, all below the floor.
+  // The tip window's own start, so the sweep is exhausted at the floor and
+  // the rows below it are the only work anything could still offer.
+  const floor = day(-(TIP_WINDOW_DAYS - 1));
+  const sourceId = await seedSource({
+    reconciliation: { firstSlice: floor },
+  });
+  await seedFreshTip(sourceId);
+  const long = new Date(
+    NOW.getTime() - RECONCILIATION_SETTLED_RECHECK_MS - DAY_IN_MS,
+  );
+  const rested = new Date(
+    NOW.getTime() - RECONCILIATION_FAILED_SLICE_RETRY_MS - DAY_IN_MS,
+  );
+  // Short and stale: priority 3 would take it.
+  await seedSlice({
+    sourceId,
+    slice: stepDay(floor, -1),
+    reported: 2,
+    collected: 0,
+    checkedAt: addUtcDays(NOW, -2),
+  });
+  // Failed and rested: priority 4 would take it.
+  await db.insert(caseLawCoverageSlices).values({
+    id: createSafeId<"caseLawCoverageSlice">(),
+    sourceId,
+    slice: stepDay(floor, -2),
+    reported: null,
+    collected: null,
+    walkError: "AdapterFetchError: listing refused",
+    checkedAt: rested,
+  });
+  // Settled long ago: priority 6 would take it.
+  await seedSlice({
+    sourceId,
+    slice: stepDay(floor, -3),
+    reported: 2,
+    collected: 2,
+    checkedAt: long,
+  });
+
+  // Idle covers all three at once: any read still reaching below the floor
+  // would answer this turn with one of them.
+  expect(await runUnit(sourceId)).toEqual({ type: "idle" });
+  expect(listed).toEqual([]);
+});
+
 test("a floor nothing can walk holds the source rather than being ignored", async () => {
   const sourceId = await seedSource({
     reconciliation: { firstSlice: "the last two years" },

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -252,11 +252,17 @@ const caseNumberStub: SourceReconciliation = {
   },
 };
 
-const seedSource = async (): Promise<SafeId<"caseLawSource">> => {
+/** `config` is what an operator states about this source; `{}` is the default. */
+const seedSource = async (
+  config: Record<string, unknown> = {},
+): Promise<SafeId<"caseLawSource">> => {
   const id = createSafeId<"caseLawSource">();
-  await db
-    .insert(caseLawSources)
-    .values({ id, adapterKey: `reconciliation-${id}`, name: "engine fixture" });
+  await db.insert(caseLawSources).values({
+    id,
+    adapterKey: `reconciliation-${id}`,
+    name: "engine fixture",
+    config,
+  });
   return id;
 };
 
@@ -1017,6 +1023,58 @@ test("a slice the publisher will not list is recorded, and the sweep moves past 
     summary: { slice: behind, reason: SLICE_WALK_REASON.SWEEP },
   });
   expect(listed.map(({ slice }) => slice)).toEqual([refused, behind]);
+});
+
+test("a configured floor is where the sweep stops, and nothing below it is owed", async () => {
+  // The floor an operator puts under a source: the publisher serves older
+  // history, this deployment does not sweep it. Asserted against the same
+  // stub without one, because a source with nothing to sweep either way
+  // would pass whatever the floor did.
+  const swept = day(-TIP_WINDOW_DAYS);
+  const unfloored = await seedSource();
+  await seedFreshTip(unfloored);
+
+  expect(await runUnit(unfloored)).toMatchObject({
+    type: "worked",
+    summary: { slice: swept, reason: SLICE_WALK_REASON.SWEEP },
+  });
+
+  const floored = await seedSource({
+    reconciliation: { firstSlice: day(-(TIP_WINDOW_DAYS - 1)) },
+  });
+  await seedFreshTip(floored);
+
+  // Idle rather than short: the excluded range is not history this source
+  // owes, so no row is written for it and nothing reports it uncovered.
+  expect(await runUnit(floored)).toEqual({ type: "idle" });
+  expect(await ledgerRow(floored, swept)).toBeUndefined();
+});
+
+test("a floor nothing can walk holds the source rather than being ignored", async () => {
+  const sourceId = await seedSource({
+    reconciliation: { firstSlice: "the last two years" },
+  });
+  await seedFreshTip(sourceId);
+
+  const outcome = await runUnit(sourceId);
+
+  // Not idle: an idle turn says the source is surveyed and settled, which is
+  // what a mistyped floor must never be mistaken for.
+  expect(outcome).toEqual({ type: "misconfigured" });
+  // Nothing listed and nothing recorded: the turn ends before any work is
+  // chosen, so a floor an operator mistyped cannot sweep the wrong range.
+  expect(listed).toEqual([]);
+  expect(await ledgerRow(sourceId, day(-TIP_WINDOW_DAYS))).toBeUndefined();
+  // The tally counts these turns without naming the value behind them, so
+  // this record is the only place it reaches an operator.
+  const rejected = logs
+    .at("ERROR")
+    .find(
+      ({ message }) => message === "case_law.reconciliation.floor_rejected",
+    );
+  expect(String(rejected?.attributes?.["reason"])).toContain(
+    "the last two years",
+  );
 });
 
 test("a failed walk of a counted slice keeps its counts and marks it failed", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -534,6 +534,13 @@ type SelectStaleShortSlicesOptions = {
   sourceId: SafeId<"caseLawSource">;
   staleBefore: Date;
   /**
+   * The source's effective first slice. Every read of the ledger's backlog
+   * shares it: a row below the floor records history this deployment no
+   * longer sweeps, and selecting one would re-list the range the floor
+   * excluded — forever, since a short row below it can never settle.
+   */
+  fromSlice: string;
+  /**
    * Slices held for retry, excluded in the query rather than by the caller.
    * The read is a bounded oldest-first window, so a held row filtered
    * afterwards still occupies a place in it: enough of them fill the window
@@ -549,7 +556,12 @@ type SelectStaleShortSlicesOptions = {
  */
 const selectStaleShortSlices = async (
   scopedDb: ScopedDb,
-  { heldSlices, sourceId, staleBefore }: SelectStaleShortSlicesOptions,
+  {
+    fromSlice,
+    heldSlices,
+    sourceId,
+    staleBefore,
+  }: SelectStaleShortSlicesOptions,
 ): Promise<LedgerSlice[]> => {
   const rows = await scopedDb(
     async (tx) =>
@@ -564,6 +576,7 @@ const selectStaleShortSlices = async (
         .where(
           and(
             eq(caseLawCoverageSlices.sourceId, sourceId),
+            gte(caseLawCoverageSlices.slice, fromSlice),
             lt(caseLawCoverageSlices.collected, caseLawCoverageSlices.reported),
             // A short row whose later walk failed belongs to the retry arm.
             isNull(caseLawCoverageSlices.walkError),
@@ -612,6 +625,13 @@ type SelectRecheckCandidateOptions = {
   /** The tip window's own start; slices at or above it are re-walked anyway. */
   belowSlice: string;
   /**
+   * The source's effective first slice. Every read of the ledger's backlog
+   * shares it: a row below the floor records history this deployment no
+   * longer sweeps, and selecting one would re-list the range the floor
+   * excluded — forever, since a short row below it can never settle.
+   */
+  fromSlice: string;
+  /**
    * Held slices, excluded here for the same reason the backlog query excludes
    * them: this read is `LIMIT 1`, so a held row filtered afterwards is the
    * whole candidate set and the source reports idle while a later settled row
@@ -623,7 +643,12 @@ type SelectRecheckCandidateOptions = {
 
 const selectRecheckCandidate = async (
   scopedDb: ScopedDb,
-  { belowSlice, heldSlices, sourceId }: SelectRecheckCandidateOptions,
+  {
+    belowSlice,
+    fromSlice,
+    heldSlices,
+    sourceId,
+  }: SelectRecheckCandidateOptions,
 ): Promise<LedgerSlice | null> => {
   const row = (
     await scopedDb(
@@ -639,6 +664,7 @@ const selectRecheckCandidate = async (
           .where(
             and(
               eq(caseLawCoverageSlices.sourceId, sourceId),
+              gte(caseLawCoverageSlices.slice, fromSlice),
               lt(caseLawCoverageSlices.slice, belowSlice),
               gte(
                 caseLawCoverageSlices.collected,
@@ -659,6 +685,13 @@ const selectRecheckCandidate = async (
 
 type SelectFailedSliceCandidateOptions = {
   sourceId: SafeId<"caseLawSource">;
+  /**
+   * The source's effective first slice. Every read of the ledger's backlog
+   * shares it: a row below the floor records history this deployment no
+   * longer sweeps, and selecting one would re-list the range the floor
+   * excluded — forever, since a short row below it can never settle.
+   */
+  fromSlice: string;
   /** Held slices, excluded for the same reason the recheck excludes them. */
   heldSlices: string[];
 };
@@ -670,7 +703,7 @@ type SelectFailedSliceCandidateOptions = {
  */
 const selectFailedSliceCandidate = async (
   scopedDb: ScopedDb,
-  { heldSlices, sourceId }: SelectFailedSliceCandidateOptions,
+  { fromSlice, heldSlices, sourceId }: SelectFailedSliceCandidateOptions,
 ): Promise<FailedSliceCandidate | null> =>
   (
     await scopedDb(
@@ -684,6 +717,7 @@ const selectFailedSliceCandidate = async (
           .where(
             and(
               eq(caseLawCoverageSlices.sourceId, sourceId),
+              gte(caseLawCoverageSlices.slice, fromSlice),
               isNotNull(caseLawCoverageSlices.walkError),
               heldSlices.length === 0
                 ? undefined
@@ -695,8 +729,14 @@ const selectFailedSliceCandidate = async (
     )
   ).at(0) ?? null;
 
+type SelectOldestLedgerSliceOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  /** The source's effective first slice; see the backlog reads above. */
+  fromSlice: string;
+};
+
 /**
- * The oldest slice this source has any ledger row for.
+ * The oldest slice at or above the floor that this source has a ledger row for.
  *
  * The historical sweep fills downward and contiguously from the tip window, so
  * this single aggregate is its frontier: the slice below it is the newest one
@@ -705,7 +745,7 @@ const selectFailedSliceCandidate = async (
  */
 const selectOldestLedgerSlice = async (
   scopedDb: ScopedDb,
-  sourceId: SafeId<"caseLawSource">,
+  { fromSlice, sourceId }: SelectOldestLedgerSliceOptions,
 ): Promise<string | null> => {
   const row = (
     await scopedDb(
@@ -713,7 +753,12 @@ const selectOldestLedgerSlice = async (
         await tx
           .select({ oldest: min(caseLawCoverageSlices.slice) })
           .from(caseLawCoverageSlices)
-          .where(eq(caseLawCoverageSlices.sourceId, sourceId))
+          .where(
+            and(
+              eq(caseLawCoverageSlices.sourceId, sourceId),
+              gte(caseLawCoverageSlices.slice, fromSlice),
+            ),
+          )
           .limit(1),
     )
   ).at(0);
@@ -1197,6 +1242,12 @@ export const runReconciliationWorkUnit = async ({
   // sweep and the recheck may reach for: the tip is re-walked on its own
   // cadence and needs neither.
   const tipStart = tipSlices.at(-1) ?? reconciliation.sliceOf(startedAt);
+  // The floor under every read of the ledger below, so the backlog, the retry
+  // arm, the recheck and the sweep's frontier all describe the same range.
+  // Rows below it are history the source once swept and no longer covers:
+  // left selectable, a short one among them can never settle and would be
+  // re-listed on every turn.
+  const fromSlice = reconciliation.firstSlice;
 
   // Dropped as they come due rather than left to accumulate: the map is the
   // process's memory of what it has just failed to walk, and an expired entry
@@ -1219,8 +1270,13 @@ export const runReconciliationWorkUnit = async ({
     failedCandidate,
   ] = await Promise.all([
     selectTipCheckedAt(scopedDb, sourceId, tipSlices),
-    selectStaleShortSlices(scopedDb, { sourceId, staleBefore, heldSlices }),
-    selectOldestLedgerSlice(scopedDb, sourceId),
+    selectStaleShortSlices(scopedDb, {
+      sourceId,
+      staleBefore,
+      heldSlices,
+      fromSlice,
+    }),
+    selectOldestLedgerSlice(scopedDb, { sourceId, fromSlice }),
     hasDueParkedItems(scopedDb, sourceId, startedAt),
     // Asked every turn rather than only once the higher priorities come up
     // empty: idle is the steady state of a surveyed source, so the branch
@@ -1230,8 +1286,9 @@ export const runReconciliationWorkUnit = async ({
       sourceId,
       belowSlice: tipStart,
       heldSlices,
+      fromSlice,
     }),
-    selectFailedSliceCandidate(scopedDb, { sourceId, heldSlices }),
+    selectFailedSliceCandidate(scopedDb, { sourceId, heldSlices, fromSlice }),
   ]);
 
   const terminalBySlice = await countTerminalReconciliationItemsBySlice(

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -23,7 +23,7 @@
  * counted them could never settle.
  */
 
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import type { SQL } from "drizzle-orm";
 import {
   and,
@@ -41,6 +41,7 @@ import type { ScopedDb } from "@/api/db/safe-db";
 import {
   caseLawCoverageSlices,
   caseLawDecisions,
+  caseLawSources,
   RECONCILIATION_ITEM_STATUS,
 } from "@/api/db/schema";
 import {
@@ -63,6 +64,7 @@ import {
   RECONCILIATION_FAILED_SLICE_RETRY_MS,
   RECONCILIATION_SETTLED_RECHECK_MS,
   RECONCILIATION_SLICE_STALE_MS,
+  floorSliceWalk,
   partitionShortSliceCandidates,
   selectReconciliationWorkUnit,
   tipWindowSlices,
@@ -233,7 +235,15 @@ const emptySummary = (
 export type ReconciliationUnitOutcome =
   | { type: "worked"; summary: ReconciliationUnitSummary }
   | { type: "idle" }
-  | { type: "leased" };
+  | { type: "leased" }
+  /**
+   * The source states something no unit can act on — today, a sweep floor
+   * that is no slice of this source. Nothing was walked, and nothing will be
+   * until an operator changes the row: obeying the value would sweep a range
+   * nobody chose, and ignoring it would sweep the range the source excluded
+   * while every turn still reported success.
+   */
+  | { type: "misconfigured" };
 
 /**
  * How long this process holds a slice whose walk threw before offering it
@@ -710,6 +720,28 @@ const selectOldestLedgerSlice = async (
   return row?.oldest ?? null;
 };
 
+/**
+ * The source's configuration as of this unit.
+ *
+ * Read per unit rather than handed in once: the floor it carries is operator
+ * input, and a daemon that read it at startup would hold a narrowed sweep
+ * open, or a widened one shut, until the process was replaced.
+ */
+const selectSourceConfig = async (
+  scopedDb: ScopedDb,
+  sourceId: SafeId<"caseLawSource">,
+): Promise<unknown> =>
+  (
+    await scopedDb(
+      async (tx) =>
+        await tx
+          .select({ config: caseLawSources.config })
+          .from(caseLawSources)
+          .where(eq(caseLawSources.id, sourceId))
+          .limit(1),
+    )
+  ).at(0)?.config;
+
 /** Whether any parked item for this source has come due. */
 const hasDueParkedItems = async (
   scopedDb: ScopedDb,
@@ -1118,7 +1150,7 @@ export const runReconciliationWorkUnit = async ({
   adapterKey,
   fetchDelayMs,
   now,
-  reconciliation,
+  reconciliation: adapterReconciliation,
   scopedDb,
   sleep,
   sliceIngestBudget = DEFAULT_SLICE_INGEST_BUDGET,
@@ -1135,6 +1167,28 @@ export const runReconciliationWorkUnit = async ({
     );
   }
   const startedAt = now();
+
+  // Everything below reads the floored walk, so the configured floor is
+  // applied here rather than at each place that would otherwise have to
+  // remember it: the tip window, the sweep, and the frontier between them.
+  const floored = floorSliceWalk({
+    adapterKey,
+    config: await selectSourceConfig(scopedDb, sourceId),
+    now: startedAt,
+    walk: adapterReconciliation,
+  });
+  if (Result.isError(floored)) {
+    // Logged here because the loop's window tally counts these turns without
+    // saying what cannot be used: the value an operator has to fix leaves
+    // the process only through this record.
+    logger.error("case_law.reconciliation.floor_rejected", {
+      adapterKey,
+      reason: floored.error.message,
+    });
+    return { type: "misconfigured" };
+  }
+  const reconciliation = floored.value;
+
   const tipSlices = tipWindowSlices(reconciliation, startedAt);
   const staleBefore = new Date(
     startedAt.getTime() - RECONCILIATION_SLICE_STALE_MS,

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
@@ -192,10 +192,21 @@ describe("floorSliceWalk", () => {
   });
 
   test("a floor nothing can walk holds the source rather than being ignored", () => {
+    // The in-range values below are only a test of the shape check while they
+    // sort inside the source's own range: ordering already refuses anything
+    // above the tip.
+    expect(reconciliation.firstSlice < "2024-foo").toBe(true);
+    expect(toUtcDateString(NOW) > "2024-foo").toBe(true);
+
     const unusable = [
       // Not a slice at all: obeyed as written it sorts above every slice the
       // source has and stops the sweep dead, in silence.
       { reconciliation: { firstSlice: "yesterday" } },
+      // Worse, because ordering alone accepts it: it sorts between the feed's
+      // first slice and today's, so it would quietly floor the sweep at
+      // whatever "2024-" sorts against rather than at a day anyone chose.
+      { reconciliation: { firstSlice: "2024-foo" } },
+      { reconciliation: { firstSlice: "2024-01" } },
       { reconciliation: { firstSlice: "2026-09-31" } },
       { reconciliation: { firstSlice: "" } },
       { reconciliation: { firstSlice: 20_240_101 } },

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
@@ -13,6 +13,7 @@
  * ledger depends on.
  */
 
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import { DAY_IN_MS } from "@stll/time";
@@ -31,12 +32,14 @@ import {
   RECONCILIATION_SETTLED_RECHECK_MS,
   RECONCILIATION_SLICE_STALE_MS,
   SLICE_WALK_REASON,
+  floorSliceWalk,
   isSliceSettled,
   partitionShortSliceCandidates,
   selectReconciliationWorkUnit,
   tipWindowSlices,
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import { toUtcDateString } from "@/api/lib/dates";
+import { ConfigurationError } from "@/api/lib/errors/tagged-errors";
 import {
   listingIdentityKey,
   parseListingIdentityKey,
@@ -126,6 +129,95 @@ describe("tipWindowSlices", () => {
     expect(reconciliation.nextSlice("2026-03-28")).toBe("2026-03-29");
     expect(reconciliation.previousSlice(reconciliation.firstSlice)).toBeNull();
     expect(reconciliation.nextSlice(toUtcDateString(new Date()))).toBeNull();
+  });
+});
+
+/**
+ * The floor a deployment puts under a source's sweep.
+ *
+ * Every failure here is silent. A floor that is obeyed where it should be
+ * refused sweeps a range nobody asked for; one that is ignored where it
+ * should be obeyed keeps re-listing history the deployment excluded, and
+ * every unit still reports success. The floor is also the only input that
+ * reaches the walk from outside the code, so the shapes an operator can
+ * actually type are the cases worth stating.
+ */
+describe("floorSliceWalk", () => {
+  const CONFIGURED_FLOOR = "2024-01-01";
+  const floor = (config: unknown) =>
+    floorSliceWalk({
+      adapterKey: "cz-regional",
+      config,
+      now: NOW,
+      walk: reconciliation,
+    });
+
+  test("a source that states no floor walks the adapter's own history", () => {
+    // Including a configuration that states everything else a source needs:
+    // the floor is one key among whatever that row carries.
+    for (const config of [
+      {},
+      { walks: [{ name: "recent", kind: "window" }] },
+    ]) {
+      expect(floor(config).unwrap()).toBe(reconciliation);
+    }
+  });
+
+  test("a configured floor later than the adapter's is where the sweep stops", () => {
+    // The fixture only tests the floor if the adapter would have gone below
+    // it, which is the whole point of configuring one.
+    expect(reconciliation.previousSlice(CONFIGURED_FLOOR)).toBe("2023-12-31");
+
+    const floored = floor({
+      reconciliation: { firstSlice: CONFIGURED_FLOOR },
+    }).unwrap();
+
+    expect(floored.firstSlice).toBe(CONFIGURED_FLOOR);
+    expect(floored.previousSlice(CONFIGURED_FLOOR)).toBeNull();
+    expect(floored.previousSlice("2024-01-02")).toBe(CONFIGURED_FLOOR);
+    // The tip window is bounded by the same floor, so nothing the ledger is
+    // asked to cover — the window, the frontier it bounds, the sweep below
+    // it — reaches the range the source excluded.
+    expect(
+      tipWindowSlices(floored, new Date(`${CONFIGURED_FLOOR}T12:00:00.000Z`)),
+    ).toEqual([CONFIGURED_FLOOR]);
+  });
+
+  test("a configured floor earlier than the adapter's cannot widen the sweep", () => {
+    // The publisher does not serve it, so asking for it would sweep slices
+    // that can only ever come back empty.
+    const floored = floor({ reconciliation: { firstSlice: "2019-01-01" } });
+
+    expect(floored.unwrap()).toBe(reconciliation);
+  });
+
+  test("a floor nothing can walk holds the source rather than being ignored", () => {
+    const unusable = [
+      // Not a slice at all: obeyed as written it sorts above every slice the
+      // source has and stops the sweep dead, in silence.
+      { reconciliation: { firstSlice: "yesterday" } },
+      { reconciliation: { firstSlice: "2026-09-31" } },
+      { reconciliation: { firstSlice: "" } },
+      { reconciliation: { firstSlice: 20_240_101 } },
+      { reconciliation: "2024-01-01" },
+    ];
+
+    for (const config of unusable) {
+      const refused = floor(config);
+      expect(Result.isError(refused)).toBe(true);
+      if (Result.isError(refused)) {
+        expect(refused.error).toBeInstanceOf(ConfigurationError);
+        expect(refused.error.message).toContain("cz-regional");
+      }
+    }
+  });
+
+  test("a configuration that is not an object states no floor", () => {
+    // The column is JSON and older rows hold a string; a value that cannot
+    // carry the key is a source without a floor, not a broken one.
+    for (const config of ["cz-regional", null, 7, ["2024-01-01"]]) {
+      expect(floor(config).unwrap()).toBe(reconciliation);
+    }
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
@@ -9,11 +9,14 @@
  * never reaches a fixed point looks like a loop that is always busy.
  */
 
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
+import * as v from "valibot";
 
 import { DAY_IN_MS } from "@stll/time";
 
+import { ConfigurationError } from "@/api/lib/errors/tagged-errors";
 import type { SourceSliceWalk } from "@/api/lib/legal-search/ingestion-types";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * How long a slice's ledger row stays authoritative. A publisher keeps adding
@@ -150,6 +153,102 @@ export const partitionShortSliceCandidates = (
     }
   }
   return partition;
+};
+
+/**
+ * The floor a source's own configuration puts under its slice walk.
+ *
+ * Loose, like the walk policy beside it: the configuration carries whatever
+ * else that source needs, and an absent key is a source with no floor.
+ */
+const sliceFloorSchema = v.looseObject({
+  reconciliation: v.optional(
+    v.looseObject({
+      firstSlice: v.optional(v.pipe(v.string(), v.minLength(1))),
+    }),
+  ),
+});
+
+export type FloorSliceWalkOptions<TWalk extends SourceSliceWalk> = {
+  /** Names the source in the refusal an operator reads. */
+  adapterKey: string;
+  /** The source's `config` column, whatever JSON the row holds. */
+  config: unknown;
+  now: Date;
+  walk: TWalk;
+};
+
+/**
+ * The walk a source is actually swept over: the adapter's, floored by its
+ * configuration.
+ *
+ * The adapter's `firstSlice` is what the publisher can serve; the
+ * configuration says how much of that this deployment sweeps. The effective
+ * floor is therefore the later of the two — a configured floor may narrow the
+ * sweep, never widen it past what the publisher has — and it is applied by
+ * replacing the walk, so everything downstream (the tip window, the sweep's
+ * next slice, whatever the ledger is asked to cover) reads one floor rather
+ * than each re-deriving it.
+ *
+ * The configured value is compared, never handed to the adapter: it is a
+ * slice in the adapter's own grammar as an operator typed it, and a walk that
+ * parses its slices panics on one it cannot read. Comparison is enough, since
+ * slices sort in walk order. The one thing comparison cannot catch is a value
+ * that is no slice at all, which would silently stop the sweep dead, so a
+ * floor above the source's newest slice is refused rather than obeyed.
+ */
+export const floorSliceWalk = <TWalk extends SourceSliceWalk>({
+  adapterKey,
+  config,
+  now,
+  walk,
+}: FloorSliceWalkOptions<TWalk>): Result<TWalk, ConfigurationError> => {
+  const refuse = (detail: string): Result<never, ConfigurationError> =>
+    Result.err(
+      new ConfigurationError({
+        message: `${adapterKey}: unusable reconciliation floor — ${detail}`,
+      }),
+    );
+
+  // The column is JSON, so a row can hold any JSON value and older rows do
+  // hold a string. A value that is not an object cannot carry the key, so it
+  // states no floor rather than a broken one; only a stated floor can be
+  // malformed, and that is refused below.
+  if (!isRecord(config)) {
+    return Result.ok(walk);
+  }
+
+  const parsed = v.safeParse(sliceFloorSchema, config);
+  if (!parsed.success) {
+    return refuse(v.summarize(parsed.issues));
+  }
+
+  const configured = parsed.output.reconciliation?.firstSlice;
+  if (configured === undefined) {
+    return Result.ok(walk);
+  }
+
+  const tip = walk.sliceOf(now);
+  if (configured > tip) {
+    return refuse(
+      `"${configured}" sorts after the newest slice this source has, "${tip}"`,
+    );
+  }
+
+  // A floor at or below the publisher's own first slice asks for history the
+  // publisher does not serve; the adapter's floor stands.
+  if (configured <= walk.firstSlice) {
+    return Result.ok(walk);
+  }
+
+  return Result.ok({
+    ...walk,
+    firstSlice: configured,
+    previousSlice: (slice: string): string | null => {
+      const previous = walk.previousSlice(slice);
+      return previous === null || previous < configured ? null : previous;
+    },
+  });
 };
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
@@ -169,6 +169,27 @@ const sliceFloorSchema = v.looseObject({
   ),
 });
 
+/**
+ * Whether two slices are written the same way: digits where the other has
+ * digits, the same characters everywhere else.
+ *
+ * A slice grammar lives in its adapter, so this compares a candidate against
+ * a slice the adapter produced instead of restating one: `2024-foo` against
+ * `2020-10-01` differs, `2001-ufs` against `1993-ufs` does not. It says
+ * nothing about what the value means — `2010-13` is shaped like a month —
+ * only that it is not written like something this source walks.
+ */
+const sharesSliceShape = (candidate: string, known: string): boolean => {
+  if (candidate.length !== known.length) {
+    return false;
+  }
+  const isDigit = (char: string): boolean => char >= "0" && char <= "9";
+  return Array.from(known).every((char, index) => {
+    const candidateChar = candidate.charAt(index);
+    return isDigit(char) ? isDigit(candidateChar) : candidateChar === char;
+  });
+};
+
 export type FloorSliceWalkOptions<TWalk extends SourceSliceWalk> = {
   /** Names the source in the refusal an operator reads. */
   adapterKey: string;
@@ -193,9 +214,10 @@ export type FloorSliceWalkOptions<TWalk extends SourceSliceWalk> = {
  * The configured value is compared, never handed to the adapter: it is a
  * slice in the adapter's own grammar as an operator typed it, and a walk that
  * parses its slices panics on one it cannot read. Comparison is enough, since
- * slices sort in walk order. The one thing comparison cannot catch is a value
- * that is no slice at all, which would silently stop the sweep dead, so a
- * floor above the source's newest slice is refused rather than obeyed.
+ * slices sort in walk order. What comparison alone cannot catch is a value
+ * that is no slice at all, which would narrow the sweep to a boundary nobody
+ * chose, so a floor is refused unless it is written like a slice this source
+ * walks and sits at or below the source's newest one.
  */
 export const floorSliceWalk = <TWalk extends SourceSliceWalk>({
   adapterKey,
@@ -229,6 +251,19 @@ export const floorSliceWalk = <TWalk extends SourceSliceWalk>({
   }
 
   const tip = walk.sliceOf(now);
+  // Shape first, because ordering cannot catch a value that sorts inside the
+  // source's range without being one of its slices: "2024-foo" sits between
+  // a 2020 first slice and a 2026 tip, and floors the sweep at whatever
+  // "2024-" happens to sort against. The shapes come from two slices the
+  // adapter itself produced, so nothing here has to know a grammar, and an
+  // adapter that changes one cannot leave a stale copy behind.
+  if (
+    ![walk.firstSlice, tip].some((known) => sharesSliceShape(configured, known))
+  ) {
+    return refuse(
+      `"${configured}" is not shaped like a slice of this source, such as "${tip}"`,
+    );
+  }
   if (configured > tip) {
     return refuse(
       `"${configured}" sorts after the newest slice this source has, "${tip}"`,

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -1440,6 +1440,8 @@ export const runCaseLawIngest = async (
               return { turn: RECONCILIATION_TURN.LEASED };
             case "idle":
               return { turn: RECONCILIATION_TURN.IDLE };
+            case "misconfigured":
+              return { turn: RECONCILIATION_TURN.MISCONFIGURED };
             default: {
               outcome satisfies never;
               return panic(
@@ -1468,6 +1470,7 @@ export const runCaseLawIngest = async (
             `worked=${summary.worked} ` +
             `idle=${summary.idle} ` +
             `leased=${summary.leased} ` +
+            `misconfigured=${summary.misconfigured} ` +
             `listed=${summary.listed} ` +
             `keyable=${summary.keyable} ` +
             `unidentifiable=${summary.unidentifiable} ` +

--- a/apps/legal-atlas-runner/src/runners/case-law-reconciliation.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-reconciliation.ts
@@ -25,6 +25,13 @@ export const RECONCILIATION_TURN = {
   IDLE: "idle",
   /** Another writer holds the source. Not an error; asked again next turn. */
   LEASED: "leased",
+  /**
+   * The source states something no unit can act on. Nothing was asked of the
+   * publisher and nothing will be until an operator changes the row, so the
+   * turn is neither work nor an idle source: counted on its own, or a
+   * misconfigured source would read as a settled one.
+   */
+  MISCONFIGURED: "misconfigured",
 } as const;
 
 export type ReconciliationTurn =
@@ -77,6 +84,8 @@ export type ReconciliationSweepSummary = ReconciliationCounts & {
   idle: number;
   /** Turns that found the source held by another writer. */
   leased: number;
+  /** Turns that found the source stating something no unit can act on. */
+  misconfigured: number;
   /** Turns that threw, wherever the throw came from. */
   errored: number;
   /**
@@ -99,6 +108,7 @@ const emptySummary = (): ReconciliationSweepSummary => ({
   worked: 0,
   idle: 0,
   leased: 0,
+  misconfigured: 0,
   errored: 0,
   lastError: undefined,
   erroredSources: [],
@@ -122,8 +132,10 @@ const emptySummary = (): ReconciliationSweepSummary => ({
  */
 const summaryIsEmpty = ({
   errored,
+  misconfigured,
   worked,
-}: ReconciliationSweepSummary): boolean => worked === 0 && errored === 0;
+}: ReconciliationSweepSummary): boolean =>
+  worked === 0 && errored === 0 && misconfigured === 0;
 
 const addCounts = (
   summary: ReconciliationSweepSummary,
@@ -277,6 +289,9 @@ export const runCaseLawReconciliationLoop = async ({
             break;
           case RECONCILIATION_TURN.LEASED:
             summary.leased += 1;
+            break;
+          case RECONCILIATION_TURN.MISCONFIGURED:
+            summary.misconfigured += 1;
             break;
           default:
             break;


### PR DESCRIPTION
`case_law_sources.config` gains a `reconciliation: { firstSlice? }` key beside `walks`, validated with valibot.
The effective floor is the later of the adapter's `firstSlice` and the configured one, so configuration can only narrow a sweep, never widen it.
One helper replaces the walk, so the tip window, the sweep frontier and the slices the ledger is asked to cover all read the same floor.
A floor that is no slice of the source returns a new `misconfigured` unit outcome and logs the value, rather than being ignored or obeyed.
Tests cover no floor, a later floor, an earlier floor, a malformed floor and a non-object config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a minimum slice boundary during case-law reconciliation.
  - Reconciliation now limits sweeps and review windows to the configured boundary.
  - Sources without a configured boundary continue using the adapter’s existing history.

- **Bug Fixes**
  - Invalid or unusable boundary settings are rejected safely without listing or writing records.
  - Misconfigured sources are reported separately in reconciliation results and summaries, improving visibility into configuration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->