### PR TITLE
chore: pre-push keeps only the second-scale checks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -41,6 +41,9 @@ pre-push:
     changeset:
       run: bun scripts/changeset-guard.ts --base origin/main
     secrets:
+      # The hook's stdin carries the ref updates the push would publish; the
+      # scanner scopes each gitleaks run to exactly those commits.
+      use_stdin: true
       run: bun run secrets:check:pushed
     ai-skills:
       run: bash scripts/check-ai-skill-sources.sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,27 +28,19 @@ pre-commit:
       glob: "{.agents/skills,.ai/local-skills,.ai/shared/skills,.claude/skills}/**"
       run: bash scripts/check-ai-skill-sources.sh
 
+# Pre-push keeps only checks that finish in about a second and whose failure
+# would cost a full CI round trip. Lint, typecheck, format, i18n, and the
+# query-cache type check run in CI only (pre-commit already formats staged
+# files and syncs i18n); run `bun run verify` locally when you want them
+# earlier.
 pre-push:
   parallel: false
   commands:
-    # Runs before the slow checks (lefthook orders commands by name): CI
-    # rejects a release-gated change with no changeset, and learning that from
-    # a finished workflow costs a full round trip. Same rule, same pathspecs
-    # (scripts/changeset-policy.json), two git diffs. Skips silently on a
-    # branch that touches no released package, and with LEFTHOOK=0.
+    # Same rule and pathspecs as CI (scripts/changeset-policy.json), two git
+    # diffs. Skips silently on a branch that touches no released package.
     changeset:
       run: bun scripts/changeset-guard.ts --base origin/main
-    code-check:
-      # Turbo caches lint and typecheck per affected workspace, including
-      # reverse dependants. Global inputs fall back to the full repo.
-      run: bun run code-check:affected -- --base origin/main
-    query-cache-types:
-      # Query producers and cache consumers can live in different files, so
-      # this checker always scans the full web project.
-      run: bun run check:query-cache-types
-    format:
-      run: bun run format --concurrency=2 -- --check
-    i18n:
-      run: bun run i18n:check
+    secrets:
+      run: bun run secrets:check:pushed
     ai-skills:
       run: bash scripts/check-ai-skill-sources.sh

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "code-check": "bun run env:check && bun run assets:check && bun scripts/check-oxlint-plugin-registry.ts && bash scripts/lint-oxlint-fixtures.sh && bash scripts/lint-root-scripts.sh && bun --cwd apps/landing typecheck && bun apps/landing/scripts/check-logical-properties.ts && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware --type-check .claude/mcp apps packages && bun run typecheck:repo",
     "code-check:affected": "bun scripts/code-check-affected.ts",
     "secrets:check:staged": "bash scripts/check-staged-secrets.sh",
+    "secrets:check:pushed": "bash scripts/check-pushed-secrets.sh",
     "dependencies:dedupe": "bun --no-env-file dedupe",
     "dependencies:dedupe:check": "bun --no-env-file dedupe --check",
     "dependencies:diff": "bun --no-env-file scripts/dependency-diff.ts",

--- a/scripts/check-pushed-secrets.sh
+++ b/scripts/check-pushed-secrets.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Scan the commits a push would publish for secrets. Runs from the pre-push
+# hook; everything else is validated in CI.
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "error: gitleaks is required for pre-push secret scanning." >&2
+  echo "Install it from https://github.com/gitleaks/gitleaks/releases" >&2
+  echo "  macOS (Homebrew): brew install gitleaks" >&2
+  echo "  Other platforms: use the releases page above" >&2
+  exit 1
+fi
+
+# Commits not yet on the default branch. A stale origin/main only widens the
+# range, so the scan still covers every commit the push carries.
+if base="$(git merge-base origin/main HEAD 2>/dev/null)"; then
+  range="${base}..HEAD"
+else
+  range="HEAD"
+fi
+
+exec gitleaks git --redact --no-banner --no-color --log-opts="${range}" .

--- a/scripts/check-pushed-secrets.sh
+++ b/scripts/check-pushed-secrets.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Scan the commits a push would publish for secrets. Runs from the pre-push
-# hook; everything else is validated in CI.
+# hook, which hands every ref update on stdin as
+# `<local-ref> <local-oid> <remote-ref> <remote-oid>`; each pushed ref is
+# scanned from what the remote already has to what it would receive, so an
+# explicit refspec (`git push origin other:other`) is covered, not only HEAD.
+# Everything else is validated in CI.
 set -euo pipefail
 
 if ! command -v gitleaks >/dev/null 2>&1; then
@@ -11,12 +15,39 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   exit 1
 fi
 
-# Commits not yet on the default branch. A stale origin/main only widens the
-# range, so the scan still covers every commit the push carries.
-if base="$(git merge-base origin/main HEAD 2>/dev/null)"; then
-  range="${base}..HEAD"
-else
-  range="HEAD"
+zero_oid="0000000000000000000000000000000000000000"
+ranges=()
+records=0
+
+if [[ ! -t 0 ]]; then
+  while read -r local_ref local_oid remote_ref remote_oid; do
+    [[ -z "${local_ref:-}" ]] && continue
+    records=$((records + 1))
+    # Deleting a remote ref publishes no commits.
+    [[ "${local_oid}" == "${zero_oid}" ]] && continue
+    if [[ "${remote_oid}" == "${zero_oid}" ]]; then
+      # New remote ref: everything not already on any remote-tracking ref.
+      ranges+=("${local_oid} --not --remotes")
+    else
+      ranges+=("${remote_oid}..${local_oid}")
+    fi
+  done
 fi
 
-exec gitleaks git --redact --no-banner --no-color --log-opts="${range}" .
+if [[ ${records} -gt 0 && ${#ranges[@]} -eq 0 ]]; then
+  echo "secrets: the push publishes no commits; nothing to scan." >&2
+  exit 0
+fi
+
+# Run by hand (no hook records): scan the current branch against origin/main.
+if [[ ${#ranges[@]} -eq 0 ]]; then
+  if base="$(git merge-base origin/main HEAD 2>/dev/null)"; then
+    ranges+=("${base}..HEAD")
+  else
+    ranges+=("HEAD")
+  fi
+fi
+
+for range in "${ranges[@]}"; do
+  gitleaks git --redact --no-banner --no-color --log-opts="${range}" .
+done


### PR DESCRIPTION
- pre-push runs the changeset guard, a gitleaks scan of the commits being pushed, and the AI-skill source check (each about a second)
- lint, typecheck, format, i18n, and query-cache checks run in CI only; `bun run verify` stays available locally, and pre-commit still formats staged files and syncs i18n
- `secrets:check:pushed` scans the merge-base..HEAD range, so a stale origin/main only widens the scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a pre-push check that scans outgoing commits for accidentally exposed secrets.
  - Added guidance when the required secret-scanning tool is not installed.

- **Chores**
  - Streamlined pre-push checks to focus on changeset validation and secret detection.
  - Other quality checks now run in CI, with a local verification command available for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->