### PR TITLE
feat(api): rank voivodeship administrative courts with the appeal tier

### DIFF
--- a/apps/api/drizzle/20260911180000_case_law_court_weight_seed_pol_wsa/migration.sql
+++ b/apps/api/drizzle/20260911180000_case_law_court_weight_seed_pol_wsa/migration.sql
@@ -1,0 +1,86 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Court rank per jurisdiction: the declaration in
+-- apps/api/src/handlers/case-law/court-weight-seed.ts, rendered by
+-- courtWeightSeedSql() and held to it by court-weight-seed.test.ts.
+-- The declaration is the table's only writer: a pattern it no longer carries
+-- is dropped, a row an older seed left at another rank is brought to the
+-- declared one, then the missing rows are added on the (country,
+-- court_pattern) unique index, so the three are re-runnable; rollback re-runs
+-- the previous release's seed.
+-- stella-migration-safety: reviewed delete-data - drops only the (country, court_pattern) keys the declaration above no longer carries, from an operator-seeded registry of 17 rows; rollback re-runs the previous release's seed
+DELETE FROM "case_law_court_weights" w
+WHERE NOT EXISTS (
+  SELECT 1 FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny|wojewódzki sąd administracyjny', 2, 'appeal', 5),
+  ('POL', 'sąd okręgowy', 2, 'regional', 4),
+  ('POL', 'krajowa izba odwoławcza', 1, 'procurement-review', 3),
+  ('POL', 'sąd rejonowy', 1, 'district', 2),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+  WHERE v.country = w."country" AND v.court_pattern = w."court_pattern"
+);
+--> statement-breakpoint
+UPDATE "case_law_court_weights" w
+SET "tier" = v.tier, "tier_label" = v.tier_label, "weight" = v.weight
+FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny|wojewódzki sąd administracyjny', 2, 'appeal', 5),
+  ('POL', 'sąd okręgowy', 2, 'regional', 4),
+  ('POL', 'krajowa izba odwoławcza', 1, 'procurement-review', 3),
+  ('POL', 'sąd rejonowy', 1, 'district', 2),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern
+  AND (w."tier", w."tier_label", w."weight") IS DISTINCT FROM (v.tier, v.tier_label, v.weight);
+--> statement-breakpoint
+-- stella-migration-safety: reviewed insert-select - the source relation is a 17-row VALUES list, not a table, so the statement is bounded and instant; rollback deletes the same (country, court_pattern) keys
+INSERT INTO "case_law_court_weights" ("id", "country", "court_pattern", "tier", "tier_label", "weight")
+SELECT gen_random_uuid(), v.country, v.court_pattern, v.tier, v.tier_label, v.weight
+FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny|wojewódzki sąd administracyjny', 2, 'appeal', 5),
+  ('POL', 'sąd okręgowy', 2, 'regional', 4),
+  ('POL', 'krajowa izba odwoławcza', 1, 'procurement-review', 3),
+  ('POL', 'sąd rejonowy', 1, 'district', 2),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+WHERE NOT EXISTS (
+  SELECT 1 FROM "case_law_court_weights" w
+  WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern
+);

--- a/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
@@ -10,7 +10,7 @@ import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 const MIGRATION = nodePath.resolve(
   import.meta.dir,
-  "../../../drizzle/20260911140000_case_law_court_weight_seed_pol/migration.sql",
+  "../../../drizzle/20260911180000_case_law_court_weight_seed_pol_wsa/migration.sql",
 );
 
 test("the seed migration applies, reconciles stale rows, and is idempotent", async () => {
@@ -21,7 +21,7 @@ test("the seed migration applies, reconciles stale rows, and is idempotent", asy
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
   // A database seeded by an older script holds the key at another rank, and
-  // carries a pattern the declaration has since split into narrower ones.
+  // carries a pattern the declaration has since widened.
   await db.insert(caseLawCourtWeights).values([
     {
       id: createSafeId<"caseLawCourtWeight">(),
@@ -34,10 +34,10 @@ test("the seed migration applies, reconciles stale rows, and is idempotent", asy
     {
       id: createSafeId<"caseLawCourtWeight">(),
       country: "POL",
-      courtPattern: "sąd apelacyjny|sąd okręgowy",
+      courtPattern: "sąd apelacyjny",
       tier: 2,
-      tierLabel: "regional",
-      weight: 4,
+      tierLabel: "appeal",
+      weight: 5,
     },
   ]);
   for (const statement of statements) {
@@ -56,7 +56,11 @@ test("the seed migration applies, reconciles stale rows, and is idempotent", asy
         row.country === "POL" && /sąd apelacyjny/u.test(row.courtPattern),
     ),
   ).toMatchObject([
-    { courtPattern: "sąd apelacyjny", tierLabel: "appeal", weight: 5 },
+    {
+      courtPattern: "sąd apelacyjny|wojewódzki sąd administracyjny",
+      tierLabel: "appeal",
+      weight: 5,
+    },
   ]);
   for (const statement of statements) {
     await db.execute(sql.raw(statement));

--- a/apps/api/src/handlers/case-law/court-weight-seed.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.test.ts
@@ -15,7 +15,7 @@ import {
 
 const MIGRATION = nodePath.resolve(
   import.meta.dir,
-  "../../../drizzle/20260911140000_case_law_court_weight_seed_pol/migration.sql",
+  "../../../drizzle/20260911180000_case_law_court_weight_seed_pol_wsa/migration.sql",
 );
 
 describe("court weight seed", () => {
@@ -59,6 +59,7 @@ describe("court weight seed", () => {
       ["POL", "Naczelny Sąd Administracyjny", "supreme"],
       ["POL", "Trybunał Konstytucyjny", "constitutional"],
       ["POL", "Sąd Apelacyjny w Krakowie", "appeal"],
+      ["POL", "Wojewódzki Sąd Administracyjny w Warszawie", "appeal"],
       ["POL", "Sąd Okręgowy w Warszawie", "regional"],
       ["POL", "Sąd Rejonowy w Gdańsku", "district"],
       ["POL", "Sąd Rejonowy dla Warszawy-Śródmieścia", "district"],
@@ -84,9 +85,11 @@ describe("court weight seed", () => {
   });
 
   test("Poland ranks every instance the feeds store, each pattern once", () => {
-    // The SAOS feed and the Supreme Court connector store these six court
-    // names; a name two patterns both match would take whichever the
-    // precedence order happens to reach first.
+    // The SAOS feed and the Supreme Court connector store these court names;
+    // a name two patterns both match would take whichever the precedence
+    // order happens to reach first. The administrative pair is the close
+    // one: only `naczelny` and `wojewódzki` separate the supreme row from
+    // the appeal row.
     expect(COURT_WEIGHT_SEED.filter((row) => row.country === "POL")).toEqual([
       {
         country: "POL",
@@ -104,7 +107,7 @@ describe("court weight seed", () => {
       },
       {
         country: "POL",
-        courtPattern: "sąd apelacyjny",
+        courtPattern: "sąd apelacyjny|wojewódzki sąd administracyjny",
         tier: 2,
         tierLabel: "appeal",
         weight: 5,
@@ -135,6 +138,7 @@ describe("court weight seed", () => {
       "Trybunał Konstytucyjny",
       "Sąd Najwyższy",
       "Sąd Apelacyjny w Krakowie",
+      "Wojewódzki Sąd Administracyjny w Warszawie",
       "Sąd Okręgowy w Warszawie",
       "Krajowa Izba Odwoławcza",
       "Sąd Rejonowy dla Warszawy-Śródmieścia",

--- a/apps/api/src/handlers/case-law/court-weight-seed.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.ts
@@ -76,7 +76,10 @@ export const COURT_WEIGHT_SEED: readonly CourtWeightSeedRow[] = [
   // so each rank is the court's name without the seat. Appeal and regional
   // share tier 2 and differ by weight, the way the tier scale allows one
   // instance to outrank another without adding a tier the search blend
-  // would have to rescale.
+  // would have to rescale. The voivodeship administrative courts sit with
+  // appeal rather than with district: they are the administrative branch's
+  // first instance, but what they review is an authority's decision, and the
+  // only court above them is the supreme one already ranked above.
   {
     country: "POL",
     courtPattern: "trybunał konstytucyjny",
@@ -93,7 +96,7 @@ export const COURT_WEIGHT_SEED: readonly CourtWeightSeedRow[] = [
   },
   {
     country: "POL",
-    courtPattern: "sąd apelacyjny",
+    courtPattern: "sąd apelacyjny|wojewódzki sąd administracyjny",
     tier: 2,
     tierLabel: "appeal",
     weight: 5,


### PR DESCRIPTION
POL appeal row widened: `sąd apelacyjny` -> `sąd apelacyjny|wojewódzki sąd administracyjny`.
Tier 2, label appeal, weight 5 unchanged; no other row changes.