### PR TITLE
feat(landing): open patch releases with notes in the changelog by default

### DIFF
--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -170,6 +170,7 @@ const formatReleaseDate = (publishedAt: string) =>
                       id={release.slug}
                       class="changelog-entry changelog-patch-release rounded-lg"
                       data-static-release
+                      open
                     >
                       <summary class="changelog-patch-summary flex min-h-14 cursor-pointer flex-wrap items-center gap-x-4 gap-y-1 px-5 py-3 sm:flex-nowrap sm:px-6">
                         <span
@@ -868,7 +869,9 @@ const formatReleaseDate = (publishedAt: string) =>
       const details = document.createElement("details");
       details.id = releaseAnchorId(release.tag_name);
       details.className = "changelog-entry changelog-patch-release rounded-lg";
-      details.open = decodeURIComponent(window.location.hash.slice(1)) === details.id;
+      // A patch that carries real notes reads like any other release; only
+      // maintenance groups start collapsed.
+      details.open = true;
 
       const summary = document.createElement("summary");
       summary.className =


### PR DESCRIPTION
Patch releases that carry real release notes now render expanded on /changelog, both in the server-rendered list and in the live feed. Maintenance groups keep starting collapsed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Patch releases in the changelog are now expanded by default for easier browsing.
  - URL hash navigation continues to expand and scroll to the selected release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->