### PR TITLE
fix: add inspector chat scroll padding so actions clear follow-ups

### DIFF
--- a/apps/web/src/components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/components/inspector/chat-tab-panel.tsx
@@ -625,8 +625,12 @@ export const ChatTabPanel = ({
         >
           <Conversation className="min-h-0 flex-1">
             {/* Bottom padding keeps the last messages readable above the
-                floating composer block (veil + pill + status row). */}
-            <ConversationContent className="gap-3 pb-32">
+                floating composer block (veil + pill + status row). Extra
+                space when follow-up chips are showing so Copy/Retry can
+                scroll clear of the chip row. */}
+            <ConversationContent
+              className={cn("gap-3", hasSuggestedFollowups ? "pb-44" : "pb-32")}
+            >
               {messages.length === 0 && !isGenerating && !error ? (
                 <ChatEmptyState
                   onSelectPrompt={handleSelectPrompt}


### PR DESCRIPTION
### Description

When Inspector follow-up suggestion chips are showing, the transcript now uses a bit more bottom padding (`pb-44` instead of `pb-32`) so Copy/Retry can scroll above the chip row. Padding stays `pb-32` when there are no chips.

### Motivation

Fixes #1684 — Copy and Retry overlapped the next suggested questions even when scrolled to the bottom.

### Additional details

- File: `apps/web/src/components/inspector/chat-tab-panel.tsx`
- Spacing-only change using existing Tailwind padding classes
- Before/after screenshots: not included (could not run the app in the agent environment). Happy to add if maintainers want a follow-up

Fixes #1684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat transcript spacing when suggested follow-up chips are displayed, keeping Copy and Retry actions accessible without being obscured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->