### PR TITLE
fix(api): read the Redis endpoint from the base environment

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,8 +37,10 @@
 # invalid.
 # QUERY_EXPANSION_MODE="off"
 
-# [secret] Required. Valkey or Redis URL used for cross-instance broadcasts
-# and rate limits. Treated as secret because it may contain credentials.
+# [secret] Conditionally required when the API server or the
+# document-processing worker runs. Valkey or Redis URL used for cross-instance
+# broadcasts and rate limits. Treated as secret because it may contain
+# credentials.
 REDIS_URL="redis://localhost:6379"
 
 # [internal] Optional with a default. Whether a rediss:// connection verifies

--- a/apps/api/src/env-base-schema.test.ts
+++ b/apps/api/src/env-base-schema.test.ts
@@ -182,3 +182,39 @@ describe("query expansion mode", () => {
     ).toBe(false);
   });
 });
+
+describe("redis transport", () => {
+  test("a process without REDIS_URL passes the base invariant", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_STORAGE_MODE: "canonical",
+        CORPUS_PROJECTION_OWNER: "external",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects a plaintext Redis endpoint outside local development", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_STORAGE_MODE: "canonical",
+        CORPUS_PROJECTION_OWNER: "external",
+        REDIS_URL: "redis://cache.internal:6379",
+      }),
+    ).toBe(
+      "REDIS_URL must use rediss:// unless it targets loopback or Railway private networking.",
+    );
+  });
+
+  test("accepts a TLS Redis endpoint outside local development", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_STORAGE_MODE: "canonical",
+        CORPUS_PROJECTION_OWNER: "external",
+        REDIS_URL: "rediss://cache.internal:6380",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -24,6 +24,7 @@ import { QUERY_EXPANSION_MODES } from "@/api/lib/legal-search/query-expansion-mo
 import { isUsableStaticCredential } from "@/api/lib/s3/credentials";
 import {
   isLoopbackHostname,
+  isRailwayPrivateHostname,
   isTlsOrLoopbackUrl,
 } from "@/api/lib/secure-service-url";
 
@@ -219,6 +220,23 @@ export const envBaseServerSchema = {
   // against, so a continuation page is either ranked against that same
   // dictionary or refused as a stale cursor.
   QUERY_EXPANSION_MODE: v.optional(v.picklist(QUERY_EXPANSION_MODES), "off"),
+  /**
+   * Optional here because an entrypoint that boots with the base environment
+   * alone (a migration, a one-off script) may never open a connection. The
+   * API server and the document-processing worker always do, and
+   * `documentProcessingEnvInvariantViolation` requires it of them.
+   */
+  REDIS_URL: v.optional(v.pipe(v.string(), v.url())),
+  /**
+   * Whether a `rediss://` connection verifies the server's certificate chain.
+   * On by default. Set to false only where the endpoint presents a
+   * certificate no trust anchor can validate — a self-signed certificate
+   * bound to a private address, say — and the network itself is the boundary.
+   */
+  REDIS_TLS_REJECT_UNAUTHORIZED: v.optional(
+    v.pipe(v.string(), v.parseBoolean()),
+    "true",
+  ),
   isDev: v.boolean(),
 };
 
@@ -283,6 +301,7 @@ type EnvBaseInvariantInput = {
   DATABASE_URL: string;
   LEGAL_CORPUS_S3_BUCKET?: string | undefined;
   LEGAL_SEARCH_PROVIDER: "pg-fts" | "corpus-index";
+  REDIS_URL?: string | undefined;
   S3_ACCESS_KEY_ID?: string | undefined;
   S3_CREDENTIALS_PROVIDER: "auto" | "env" | "aws-runtime" | "none";
   S3_ENDPOINT: string;
@@ -329,6 +348,29 @@ const databaseTransportInvariantViolation = ({
   }
   if (!isDev && hasPublicLawDatabaseUrl) {
     return "Public-law database URLs are only supported in local development.";
+  }
+  return null;
+};
+
+const isSecureRedisUrl = (value: string) => {
+  const url = new URL(value);
+  return (
+    isTlsOrLoopbackUrl(value, {
+      plaintextProtocol: "redis:",
+      tlsProtocol: "rediss:",
+    }) ||
+    (url.protocol === "redis:" && isRailwayPrivateHostname(url.hostname))
+  );
+};
+
+// The transport rule lives with the key: every process that configures
+// REDIS_URL gets it, not only the ones whose entrypoint requires the key.
+const redisTransportInvariantViolation = ({
+  REDIS_URL,
+  isDev,
+}: EnvBaseInvariantInput): string | null => {
+  if (REDIS_URL !== undefined && !isDev && !isSecureRedisUrl(REDIS_URL)) {
+    return "REDIS_URL must use rediss:// unless it targets loopback or Railway private networking.";
   }
   return null;
 };
@@ -448,6 +490,7 @@ export const envBaseInvariantViolation = (
 ): string | null =>
   rollbackInputInvariantViolation(input) ??
   databaseTransportInvariantViolation(input) ??
+  redisTransportInvariantViolation(input) ??
   corpusEndpointInvariantViolation(input) ??
   publicLawTopologyInvariantViolation(input) ??
   storageAndIndexInvariantViolation(input);

--- a/apps/api/src/env-document-processing-worker-schema.ts
+++ b/apps/api/src/env-document-processing-worker-schema.ts
@@ -1,21 +1,6 @@
 import * as v from "valibot";
 
 import { DEPLOYED_NODE_ENVS, featureFlagSchema } from "@/api/env-base-schema";
-import {
-  isRailwayPrivateHostname,
-  isTlsOrLoopbackUrl,
-} from "@/api/lib/secure-service-url";
-
-const isSecureRedisUrl = (value: string) => {
-  const url = new URL(value);
-  return (
-    isTlsOrLoopbackUrl(value, {
-      plaintextProtocol: "redis:",
-      tlsProtocol: "rediss:",
-    }) ||
-    (url.protocol === "redis:" && isRailwayPrivateHostname(url.hostname))
-  );
-};
 
 /**
  * Environment shared by the API process and document-processing worker.
@@ -23,17 +8,6 @@ const isSecureRedisUrl = (value: string) => {
  * unrelated HTTP-server concerns such as auth, email, and Gotenberg.
  */
 export const envDocumentProcessingWorkerServerSchema = {
-  REDIS_URL: v.pipe(v.string(), v.url()),
-  /**
-   * Whether a `rediss://` connection verifies the server's certificate chain.
-   * On by default. Set to false only where the endpoint presents a
-   * certificate no trust anchor can validate — a self-signed certificate
-   * bound to a private address, say — and the network itself is the boundary.
-   */
-  REDIS_TLS_REJECT_UNAUTHORIZED: v.optional(
-    v.pipe(v.string(), v.parseBoolean()),
-    "true",
-  ),
   FEATURE_INBOX_DOCUMENT_SCOUTS: featureFlagSchema,
   DOCUMENT_OCR_MODEL_DIR: v.optional(v.string()),
   /**
@@ -57,16 +31,22 @@ export const envDocumentProcessingWorkerServerSchema = {
 type DocumentProcessingEnvInvariantInput = {
   contentEncryptionKey: string | undefined;
   nodeEnv: string | undefined;
-  redisUrl: string;
+  redisUrl: string | undefined;
 };
 
+/**
+ * REDIS_URL is declared in the base schema and optional there, so a process
+ * that runs with the base environment only never has to supply one. Both
+ * entrypoints validated here queue and broadcast over Redis, so for them its
+ * absence is a configuration error rather than an unused setting.
+ */
 export const documentProcessingEnvInvariantViolation = ({
   contentEncryptionKey,
   nodeEnv,
   redisUrl,
 }: DocumentProcessingEnvInvariantInput): string | null => {
-  if (DEPLOYED_NODE_ENVS.has(nodeEnv ?? "") && !isSecureRedisUrl(redisUrl)) {
-    return "REDIS_URL must use rediss:// unless it targets loopback or Railway private networking.";
+  if (redisUrl === undefined) {
+    return "REDIS_URL is required by the API server and the document-processing worker.";
   }
   if (DEPLOYED_NODE_ENVS.has(nodeEnv ?? "") && !contentEncryptionKey) {
     return "CONTENT_ENCRYPTION_KEY is required when NODE_ENV is 'production' or 'staging'.";

--- a/apps/api/src/env-document-processing-worker.test.ts
+++ b/apps/api/src/env-document-processing-worker.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, statSync } from "node:fs";
 import nodePath from "node:path";
+
+import {
+  apiSourceRoot,
+  collectApiModuleGraph,
+} from "@/api/tests/api-module-graph";
 
 const baseEnv = {
   DATABASE_URL: "postgres://postgres:postgres@localhost:5432/stella",
@@ -15,63 +19,10 @@ const workerEnvModuleUrl = new URL(
   import.meta.url,
 ).href;
 const repoRoot = new URL("../../..", import.meta.url).pathname;
-const apiSourceRoot = nodePath.resolve(repoRoot, "apps/api/src");
 const workerEntrypoint = nodePath.resolve(
   apiSourceRoot,
   "scripts/document-processing-worker.ts",
 );
-
-const resolveApiModule = (
-  importPath: string,
-  importer: string,
-): string | null => {
-  let basePath: string;
-  if (importPath.startsWith("@/api/")) {
-    basePath = nodePath.resolve(
-      apiSourceRoot,
-      importPath.slice("@/api/".length),
-    );
-  } else if (importPath.startsWith(".")) {
-    basePath = nodePath.resolve(nodePath.dirname(importer), importPath);
-  } else {
-    return null;
-  }
-
-  const candidates = [
-    basePath,
-    `${basePath}.ts`,
-    `${basePath}.tsx`,
-    nodePath.resolve(basePath, "index.ts"),
-    nodePath.resolve(basePath, "index.tsx"),
-  ];
-  return (
-    candidates.find(
-      (candidate) => existsSync(candidate) && statSync(candidate).isFile(),
-    ) ?? null
-  );
-};
-
-const collectApiModuleGraph = async (
-  entrypoint: string,
-  visited = new Set<string>(),
-): Promise<Set<string>> => {
-  if (visited.has(entrypoint)) {
-    return visited;
-  }
-  visited.add(entrypoint);
-  const source = await Bun.file(entrypoint).text();
-  const loader = entrypoint.endsWith(".tsx") ? "tsx" : "ts";
-  const imports = new Bun.Transpiler({ loader }).scan(source).imports;
-  const dependencies = imports
-    .map(({ path }) => resolveApiModule(path, entrypoint))
-    .filter((path): path is string => path !== null);
-  await Promise.all(
-    dependencies.map(
-      async (dependency) => await collectApiModuleGraph(dependency, visited),
-    ),
-  );
-  return visited;
-};
 
 const validateWorkerEnv = (env: Record<string, string | undefined> = baseEnv) =>
   Bun.spawnSync({
@@ -89,6 +40,16 @@ const validateWorkerEnv = (env: Record<string, string | undefined> = baseEnv) =>
 describe("document-processing worker environment", () => {
   test("boots without API auth, frontend, email, or Gotenberg settings", () => {
     expect(validateWorkerEnv().exitCode).toBe(0);
+  });
+
+  test("refuses to boot without a Redis endpoint", () => {
+    const withoutRedis = Object.fromEntries(
+      Object.entries(baseEnv).filter(([key]) => key !== "REDIS_URL"),
+    );
+    const result = validateWorkerEnv(withoutRedis);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("REDIS_URL is required");
   });
 
   test("accepts Railway private-network Redis in production", () => {

--- a/apps/api/src/env-document-processing-worker.ts
+++ b/apps/api/src/env-document-processing-worker.ts
@@ -26,7 +26,7 @@ const invariantViolation = documentProcessingEnvInvariantViolation({
   contentEncryptionKey:
     envDocumentProcessingWorkerSpecific.CONTENT_ENCRYPTION_KEY,
   nodeEnv: process.env.NODE_ENV,
-  redisUrl: envDocumentProcessingWorkerSpecific.REDIS_URL,
+  redisUrl: envBase.REDIS_URL,
 });
 if (invariantViolation !== null) {
   panic(invariantViolation);

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -1,8 +1,8 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { type BunRedisRawClient, createBunRedisClient } from "bullmq";
 import { type RedisOptions, RedisClient, sleep } from "bun";
 
-import { envDocumentProcessingWorker } from "@/api/env-document-processing-worker";
+import { envBase } from "@/api/env-base";
 import { RedisClientClosedError } from "@/api/lib/errors/tagged-errors";
 import { connectionErrorFields } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
@@ -29,6 +29,19 @@ export {
  * `Number.MAX_SAFE_INTEGER` is rejected with `ERR_OUT_OF_RANGE`.
  */
 const RECONNECT_ATTEMPT_LIMIT = 4_294_967_295;
+
+/**
+ * REDIS_URL is optional in the base environment because an entrypoint that
+ * boots with it alone (a migration, a one-off script) may never open a
+ * connection. Reaching this without one means a process that does open
+ * connections started without a Redis endpoint, so there is nothing to fall
+ * back to.
+ */
+const configuredRedisUrl = (): string =>
+  envBase.REDIS_URL ??
+  panic(
+    "REDIS_URL is not configured, and this process is opening a Redis client.",
+  );
 
 /**
  * The connection options a caller may tune. `maxRetries` is not among them:
@@ -81,10 +94,7 @@ class ConfiguredRedisClient
   override onconnect: () => void = () => undefined;
   readonly url: string;
 
-  constructor(
-    url = envDocumentProcessingWorker.REDIS_URL,
-    overrides?: RedisClientOverrides,
-  ) {
+  constructor(url: string, overrides?: RedisClientOverrides) {
     super(url, redisClientOptions(url, overrides));
     this.url = url;
     // Register one owned dispatcher on each of Bun's native `onconnect` /
@@ -149,7 +159,7 @@ class ConfiguredRedisClient
 export const createRedisClient = (
   overrides?: RedisClientOverrides,
 ): ConfiguredRedisClient =>
-  new ConfiguredRedisClient(envDocumentProcessingWorker.REDIS_URL, overrides);
+  new ConfiguredRedisClient(configuredRedisUrl(), overrides);
 
 // On a Railway cold start the API container can win the race against its
 // own Redis/Valkey service, so the very first connection attempt hits

--- a/apps/api/src/lib/redis-options.ts
+++ b/apps/api/src/lib/redis-options.ts
@@ -11,11 +11,11 @@
 
 import type { RedisOptions } from "bun";
 
-import { envDocumentProcessingWorker } from "@/api/env-document-processing-worker";
+import { envBase } from "@/api/env-base";
 
 export const redisConnectionOptions = (
-  url = envDocumentProcessingWorker.REDIS_URL,
-  rejectUnauthorized = envDocumentProcessingWorker.REDIS_TLS_REJECT_UNAUTHORIZED,
+  url: string,
+  rejectUnauthorized = envBase.REDIS_TLS_REJECT_UNAUTHORIZED,
 ): RedisOptions => {
   const useTls = url.toLowerCase().startsWith("rediss://");
   return useTls ? { tls: { rejectUnauthorized } } : {};

--- a/apps/api/src/lib/redis-outage.test.ts
+++ b/apps/api/src/lib/redis-outage.test.ts
@@ -107,9 +107,8 @@ describe("the outage under test", () => {
   // be running, or wherever the client has been mocked: every consumer below
   // would succeed for the ordinary reason.
   test("a real client cannot reach Valkey", async () => {
-    const { envDocumentProcessingWorker } =
-      await import("@/api/env-document-processing-worker");
-    expect(envDocumentProcessingWorker.REDIS_URL).toBe(UNREACHABLE_REDIS_URL);
+    const { envBase } = await import("@/api/env-base");
+    expect(envBase.REDIS_URL).toBe(UNREACHABLE_REDIS_URL);
 
     const client = createRedisClient({
       connectionTimeout: 500,

--- a/apps/api/src/tests/api-module-graph.ts
+++ b/apps/api/src/tests/api-module-graph.ts
@@ -1,0 +1,67 @@
+/**
+ * Static import graph of an apps/api module, resolved through the same alias
+ * the runtime uses.
+ *
+ * Boundary tests use it to assert that an entrypoint cannot reach a module it
+ * must not require. A dynamic import counts: the scanner reports it, and an
+ * environment module validates its settings the first time it evaluates,
+ * whenever that is.
+ */
+import { existsSync, statSync } from "node:fs";
+import nodePath from "node:path";
+
+const repoRoot = new URL("../../../..", import.meta.url).pathname;
+
+export const apiSourceRoot = nodePath.resolve(repoRoot, "apps/api/src");
+
+const resolveApiModule = (
+  importPath: string,
+  importer: string,
+): string | null => {
+  let basePath: string;
+  if (importPath.startsWith("@/api/")) {
+    basePath = nodePath.resolve(
+      apiSourceRoot,
+      importPath.slice("@/api/".length),
+    );
+  } else if (importPath.startsWith(".")) {
+    basePath = nodePath.resolve(nodePath.dirname(importer), importPath);
+  } else {
+    return null;
+  }
+
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    nodePath.resolve(basePath, "index.ts"),
+    nodePath.resolve(basePath, "index.tsx"),
+  ];
+  return (
+    candidates.find(
+      (candidate) => existsSync(candidate) && statSync(candidate).isFile(),
+    ) ?? null
+  );
+};
+
+export const collectApiModuleGraph = async (
+  entrypoint: string,
+  visited = new Set<string>(),
+): Promise<Set<string>> => {
+  if (visited.has(entrypoint)) {
+    return visited;
+  }
+  visited.add(entrypoint);
+  const source = await Bun.file(entrypoint).text();
+  const loader = entrypoint.endsWith(".tsx") ? "tsx" : "ts";
+  const imports = new Bun.Transpiler({ loader }).scan(source).imports;
+  const dependencies = imports
+    .map(({ path }) => resolveApiModule(path, entrypoint))
+    .filter((path): path is string => path !== null);
+  await Promise.all(
+    dependencies.map(
+      async (dependency) => await collectApiModuleGraph(dependency, visited),
+    ),
+  );
+  return visited;
+};

--- a/apps/api/src/tests/base-environment-boundary.test.ts
+++ b/apps/api/src/tests/base-environment-boundary.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import nodePath from "node:path";
+
+import {
+  apiSourceRoot,
+  collectApiModuleGraph,
+} from "@/api/tests/api-module-graph";
+
+/**
+ * Environment modules that validate settings a base-environment process is
+ * never given: the API server environment (auth, email, rendering) and the
+ * document-processing environment (a Redis endpoint it requires, the content
+ * encryption key). Both validate at import, so reaching either from the
+ * entrypoints below turns the first request into a boot failure.
+ */
+const FORBIDDEN_ENV_MODULES = ["env.ts", "env-document-processing-worker.ts"];
+
+/**
+ * What an entrypoint that boots with the base environment alone reaches
+ * through case-law ingestion. The publisher gate imports the Redis client
+ * dynamically, and a dynamic edge is still an edge: the module it names
+ * validates its environment the first time the gate reserves a slot.
+ */
+const BASE_ENVIRONMENT_ENTRYPOINTS = [
+  "lib/redis-client.ts",
+  "handlers/case-law/ingestion/adapters/publisher-request-gate.ts",
+];
+
+describe("modules reachable with the base environment only", () => {
+  test.each(BASE_ENVIRONMENT_ENTRYPOINTS)(
+    "%s requires neither the API nor the document-processing environment",
+    async (entrypoint) => {
+      const modules = await collectApiModuleGraph(
+        nodePath.resolve(apiSourceRoot, entrypoint),
+      );
+
+      // Asserted first: a graph that never reaches the Redis client would
+      // leave everything below passing for the wrong reason.
+      expect(modules).toContain(nodePath.resolve(apiSourceRoot, "env-base.ts"));
+
+      for (const forbidden of FORBIDDEN_ENV_MODULES) {
+        expect(modules).not.toContain(
+          nodePath.resolve(apiSourceRoot, forbidden),
+        );
+      }
+    },
+  );
+});

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -43,8 +43,10 @@ STELLA_API_ENV_FILE="deploy/selfhost/.env"
 # invalid.
 # QUERY_EXPANSION_MODE="off"
 
-# [secret] Required. Valkey or Redis URL used for cross-instance broadcasts
-# and rate limits. Treated as secret because it may contain credentials.
+# [secret] Conditionally required when the API server or the
+# document-processing worker runs. Valkey or Redis URL used for cross-instance
+# broadcasts and rate limits. Treated as secret because it may contain
+# credentials.
 REDIS_URL="rediss://valkey.example.internal:6379"
 
 # [internal] Optional with a default. Whether a rediss:// connection verifies

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -431,6 +431,7 @@ const CONDITIONAL_REQUIREMENT_NOTES: Record<string, string> = {
   CORPUS_PROJECTION_OWNER: "CORPUS_STORAGE_MODE is canonical",
   LEGAL_CORPUS_S3_BUCKET: "corpus storage is enabled in a deployed environment",
   MICROSOFT_AUTH_TENANT_ID: "Microsoft OAuth credentials are configured",
+  REDIS_URL: "the API server or the document-processing worker runs",
   S3_ACCESS_KEY_ID: 'S3_CREDENTIALS_PROVIDER is "env"',
   S3_SECRET_ACCESS_KEY: 'S3_CREDENTIALS_PROVIDER is "env"',
   SES_REGION: "EMAIL_PROVIDER is ses",


### PR DESCRIPTION
The Redis client validated the document-processing worker's environment, so an entrypoint that boots with the base environment alone failed on its first Redis use through the publisher request gate.

- `REDIS_URL` and `REDIS_TLS_REJECT_UNAUTHORIZED` move to the base schema: optional there, required by the API and worker invariants, transport rule alongside the key.
- The client panics by name when the endpoint is missing.
- A module-graph test keeps the Redis client and the publisher request gate off the API and worker environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redis configuration is now centrally supported for the API and document-processing worker.
  - Redis connections require secure transport outside local development, while approved private or local endpoints remain supported.
  - The document-processing worker now clearly reports an error when `REDIS_URL` is missing.

- **Documentation**
  - Environment variable examples now explain that `REDIS_URL` is required only when the API server or document-processing worker is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->