### PR TITLE
fix(case-law): browse facets and corpus status on the law page

### DIFF
--- a/apps/api/drizzle/20260912160000_case_law_decisions_country_updated_idx/migration.sql
+++ b/apps/api/drizzle/20260912160000_case_law_decisions_country_updated_idx/migration.sql
@@ -1,0 +1,37 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Access path for the corpus status's "when did this country's case law last
+-- change": the newest row of one country. Walking the global
+-- (updated_at, id) index from the top and filtering on country reads every
+-- newer row of every other country first, so a large ingestion batch elsewhere
+-- turns the single-row lookup into a scan of that batch. Led by country, the
+-- walk stops at the first row.
+--
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent
+-- build, then restore and reopen a transaction for Drizzle's migration row.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- Retry cleanup for this migration's own index: a cancelled concurrent build
+-- can leave an INVALID index that would otherwise block recreation by name.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_country_updated_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_decisions_country_updated_idx"
+  ON "case_law_decisions" ("country", "updated_at" DESC, "id" DESC);
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -573,6 +573,12 @@ export const caseLawDecisions = p.pgTable(
     p
       .index("case_law_decisions_updated_id_idx")
       .on(t.updatedAt.desc(), t.id.desc()),
+    // The corpus status's newest row of one country: led by country so the
+    // walk stops at the first row instead of filtering past every newer row
+    // of the other countries.
+    p
+      .index("case_law_decisions_country_updated_idx")
+      .on(t.country, t.updatedAt.desc(), t.id.desc()),
     p
       .index("case_law_decisions_citation_authority_idx")
       .on(t.citationAuthority),

--- a/apps/api/src/handlers/case-law/decisions/browse-order.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/browse-order.db.test.ts
@@ -12,6 +12,7 @@ import type {
   CaseLawPublicReadDb,
   CaseLawPublicReadTransaction,
 } from "@/api/lib/case-law-public-read-db";
+import type { LegalBrowseFacets } from "@/api/lib/legal-search/types";
 import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
 import {
   createTestPglite,
@@ -261,6 +262,13 @@ test(
   DB_TEST_TIMEOUT_MS,
 );
 
+/** The facets a jurisdiction has none of; the shelf orders by name instead. */
+const noFacets = async (): Promise<LegalBrowseFacets> => ({
+  country: [],
+  court: [],
+  year: [],
+});
+
 test(
   "the shelf's courts are the jurisdiction's apex courts, not its busiest",
   async () => {
@@ -268,6 +276,7 @@ test(
       caseLawDb,
       country: "SVK",
       entries: seededCourtWeightEntries("SVK"),
+      readFacets: noFacets,
     });
     // Six district judgments outnumber the one supreme judgment; rank wins.
     expect(courts).toEqual([
@@ -281,6 +290,28 @@ test(
     expect(
       shelf.map((group) => group.decisions.map((d) => d.caseNumber)),
     ).toEqual([["1 Cdo 9/2024"]]);
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "a court the facets do not list still reaches the shelf",
+  async () => {
+    const courts = await readShelfCourts({
+      caseLawDb,
+      country: "SVK",
+      entries: seededCourtWeightEntries("SVK"),
+      // The facet cap holds the jurisdiction's largest courts, which an apex
+      // court need not be among: the buckets order the shelf, never fill it.
+      readFacets: async () => ({
+        country: [],
+        court: [{ value: "Okresný súd Bratislava I", count: 6 }],
+        year: [],
+      }),
+    });
+    expect(courts).toEqual([
+      { court: "Najvyšší súd Slovenskej republiky", tierLabel: "supreme" },
+    ]);
   },
   DB_TEST_TIMEOUT_MS,
 );

--- a/apps/api/src/handlers/case-law/decisions/facets.ts
+++ b/apps/api/src/handlers/case-law/decisions/facets.ts
@@ -4,8 +4,12 @@ import type { Static } from "elysia";
 
 import { publicCaseLawCountry } from "@stll/api-contract/case-law-launch-readiness";
 
-import { readNonRedistributableCaseLawSourceIds } from "@/api/lib/case-law/non-redistributable-sources";
+import {
+  type NonRedistributableSourcesError,
+  readNonRedistributableCaseLawSourceIds,
+} from "@/api/lib/case-law/non-redistributable-sources";
 import { errorTag } from "@/api/lib/errors/utils";
+import type { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import { createBrowseFacetsCache } from "@/api/lib/legal-search/browse-facets-cache";
 import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
 import { getLegalSearchProvider } from "@/api/lib/legal-search/provider";
@@ -48,24 +52,25 @@ export const listDecisionFacetsHandler = async ({
   return await readBrowseFacets(publicCountry);
 };
 
+type BrowseFacetsReadError =
+  | LegalBrowseFacetsError
+  | NonRedistributableSourcesError;
+
 /**
- * Cached facets for a validated jurisdiction. Degrades
- * to an empty set on any failure: facets are navigation chrome, and the
- * callers (the facets route, the newest-decisions shelf) render without them.
+ * Cached facets for a validated jurisdiction, with the failure kept as a
+ * value for a caller whose answer depends on them (the corpus status counts
+ * from the country bucket, and a missing bucket must not read as zero).
  */
-export const readBrowseFacets = async (
+export const readBrowseFacetsResult = async (
   country: string,
-): Promise<LegalBrowseFacets> => {
+): Promise<Result<LegalBrowseFacets, BrowseFacetsReadError>> => {
   // Read ahead of the cache, not inside it: source policy is an input to the
   // answer, so a revocation has to change the cache key. Reading it behind the
   // cache would keep a revoked source's buckets public for a whole window.
   // Failing closed here is deliberate — no facets beats stale ones.
   const excludedSourceIds = await readNonRedistributableCaseLawSourceIds();
   if (Result.isError(excludedSourceIds)) {
-    logger.warn("case_law.browse_facets.unavailable", {
-      "error.type": errorTag(excludedSourceIds.error),
-    });
-    return EMPTY_FACETS;
+    return excludedSourceIds;
   }
 
   // The accepted code is case-insensitive, but the providers are not equally
@@ -73,14 +78,25 @@ export const readBrowseFacets = async (
   // path compares it to the stored column, which is upper-case. Canonicalising
   // once here is what keeps the two answering the same question — and keeps
   // one jurisdiction to one cache entry.
-  const result = await browseFacets({
+  return await browseFacets({
     jurisdiction: country.toUpperCase(),
     excludedSourceIds: excludedSourceIds.value,
     limit: LIMITS.caseLawFacetLimit,
   });
+};
+
+/**
+ * The same facets, degraded to an empty set on any failure: facets are
+ * navigation chrome, and the callers (the facets route, the newest-decisions
+ * shelf) render without them.
+ */
+export const readBrowseFacets = async (
+  country: string,
+): Promise<LegalBrowseFacets> => {
+  const result = await readBrowseFacetsResult(country);
   if (Result.isError(result)) {
-    // Facets are navigation chrome: an empty set collapses the selects into
-    // free-text filters, which is a degraded page, not a broken one.
+    // An empty set collapses the selects into free-text filters, which is a
+    // degraded page, not a broken one.
     logger.warn("case_law.browse_facets.unavailable", {
       "error.type": errorTag(result.error),
     });

--- a/apps/api/src/handlers/case-law/decisions/facets.ts
+++ b/apps/api/src/handlers/case-law/decisions/facets.ts
@@ -56,11 +56,37 @@ type BrowseFacetsReadError =
   | LegalBrowseFacetsError
   | NonRedistributableSourcesError;
 
+export type BrowseFacetsUnderPolicyRead = {
+  country: string;
+  /** Sources whose redistribution is currently revoked; part of the cache key. */
+  excludedSourceIds: readonly string[];
+};
+
 /**
- * Cached facets for a validated jurisdiction, with the failure kept as a
- * value for a caller whose answer depends on them (the corpus status counts
- * from the country bucket, and a missing bucket must not read as zero).
+ * Cached facets for a validated jurisdiction under a source policy the
+ * caller already holds, so a reader combining the facets with another
+ * policy-scoped read (the corpus status) answers from one policy snapshot.
+ * The failure stays a value: the status counts from the country bucket, and
+ * a missing bucket must not read as zero.
  */
+export const readBrowseFacetsUnderPolicy = async ({
+  country,
+  excludedSourceIds,
+}: BrowseFacetsUnderPolicyRead): Promise<
+  Result<LegalBrowseFacets, LegalBrowseFacetsError>
+> =>
+  // The accepted code is case-insensitive, but the providers are not equally
+  // so: the corpus index lowercases it into an index name while the Postgres
+  // path compares it to the stored column, which is upper-case. Canonicalising
+  // once here is what keeps the two answering the same question — and keeps
+  // one jurisdiction to one cache entry.
+  await browseFacets({
+    jurisdiction: country.toUpperCase(),
+    excludedSourceIds,
+    limit: LIMITS.caseLawFacetLimit,
+  });
+
+/** The same facets under the current source policy. */
 export const readBrowseFacetsResult = async (
   country: string,
 ): Promise<Result<LegalBrowseFacets, BrowseFacetsReadError>> => {
@@ -72,16 +98,9 @@ export const readBrowseFacetsResult = async (
   if (Result.isError(excludedSourceIds)) {
     return excludedSourceIds;
   }
-
-  // The accepted code is case-insensitive, but the providers are not equally
-  // so: the corpus index lowercases it into an index name while the Postgres
-  // path compares it to the stored column, which is upper-case. Canonicalising
-  // once here is what keeps the two answering the same question — and keeps
-  // one jurisdiction to one cache entry.
-  return await browseFacets({
-    jurisdiction: country.toUpperCase(),
+  return await readBrowseFacetsUnderPolicy({
+    country,
     excludedSourceIds: excludedSourceIds.value,
-    limit: LIMITS.caseLawFacetLimit,
   });
 };
 

--- a/apps/api/src/handlers/case-law/decisions/latest.ts
+++ b/apps/api/src/handlers/case-law/decisions/latest.ts
@@ -6,6 +6,7 @@ import type { Static } from "elysia";
 import { publicCaseLawCountry } from "@stll/api-contract/case-law-launch-readiness";
 import type { DecisionHeadnotePreview } from "@stll/api-contract/case-law-text-field";
 
+import { readBrowseFacets } from "@/api/handlers/case-law/decisions/facets";
 import { decisionDateSortKeySql } from "@/api/handlers/case-law/decisions/list";
 import {
   loadShelfCourtEntries,
@@ -258,6 +259,7 @@ const loadLatestDecisions = async ({
         caseLawDb,
         country,
         entries: await loadShelfCourtEntries(country),
+        readFacets: readBrowseFacets,
       });
       const groups = await readLatestDecisionsByCourt({
         caseLawDb,

--- a/apps/api/src/handlers/case-law/decisions/shelf-courts.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/shelf-courts.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { seededCourtWeightEntries } from "@/api/handlers/case-law/court-weight-seed";
-import { selectShelfCourts } from "@/api/handlers/case-law/decisions/shelf-courts";
+import {
+  courtDocketSizes,
+  selectShelfCourts,
+} from "@/api/handlers/case-law/decisions/shelf-courts";
+import type { FacetBucket } from "@/api/lib/search/types";
 
 const entriesFor = seededCourtWeightEntries;
 
@@ -60,5 +64,42 @@ describe("selectShelfCourts", () => {
     expect(shelf).toEqual([
       { court: "COURT OF JUSTICE", tierLabel: "constitutional" },
     ]);
+  });
+});
+
+/** The shelf as it is composed: courts from the table, counts from the facets. */
+const shelfOf = (courts: readonly string[], buckets: FacetBucket[]) =>
+  selectShelfCourts({
+    counts: courtDocketSizes({ courts, buckets }),
+    entries: entriesFor("CZE"),
+    limit: 4,
+  }).map((shelfCourt) => shelfCourt.court);
+
+describe("the shelf composed from the table's courts and the facets", () => {
+  test("the facet bucket, not the name, orders a tier", () => {
+    expect(
+      shelfOf(
+        ["Nejvyšší soud", "Nejvyšší správní soud"],
+        [
+          { value: "Nejvyšší správní soud", count: 9000 },
+          { value: "Nejvyšší soud", count: 10 },
+        ],
+      ),
+    ).toEqual(["Nejvyšší správní soud", "Nejvyšší soud"]);
+  });
+
+  test("a court the facet cap left out is listed after its tier's counted courts, by name", () => {
+    expect(
+      shelfOf(
+        ["Nejvyšší správní soud", "Nejvyšší soud ČR", "Nejvyšší soud"],
+        [{ value: "Nejvyšší soud", count: 50 }],
+      ),
+    ).toEqual(["Nejvyšší soud", "Nejvyšší soud ČR", "Nejvyšší správní soud"]);
+  });
+
+  test("without facets every court is still listed, in name order", () => {
+    expect(
+      shelfOf(["Nejvyšší správní soud", "Nejvyšší soud", "Ústavní soud"], []),
+    ).toEqual(["Ústavní soud", "Nejvyšší soud", "Nejvyšší správní soud"]);
   });
 });

--- a/apps/api/src/handlers/case-law/decisions/shelf-courts.ts
+++ b/apps/api/src/handlers/case-law/decisions/shelf-courts.ts
@@ -5,8 +5,10 @@ import {
   type CourtWeightEntry,
   loadCourtWeightsForCountry,
 } from "@/api/lib/case-law/court-weights";
+import type { LegalBrowseFacets } from "@/api/lib/legal-search/types";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
+import type { FacetBucket } from "@/api/lib/search/types";
 
 /**
  * Which courts the entry shelf shows: the jurisdiction's apex courts by
@@ -24,6 +26,13 @@ const SHELF_TIER_LABELS: ReadonlySet<string> = new Set([
 /** How many stored spellings of one apex court the candidate bound allows for. */
 const SHELF_SPELLINGS_PER_COURT = 3;
 
+/**
+ * A court of the jurisdiction with the docket size the browse facets report
+ * for it. The count orders courts within a tier and nothing else: it never
+ * decides which courts exist. The facets hold only the jurisdiction's largest
+ * `LIMITS.caseLawFacetLimit` courts, so a court with no bucket counts as zero
+ * and orders after its tier's bucketed courts, then by name.
+ */
 export type CourtCount = {
   court: string;
   count: number;
@@ -46,40 +55,80 @@ const rowsOf = (result: unknown): Record<string, unknown>[] => {
   return Array.isArray(rows) ? rows.filter(isRecord) : [];
 };
 
-type ReadCourtCountsOptions = {
+type ReadCourtNamesOptions = {
   caseLawDb: CaseLawPublicReadDb;
   country: string;
 };
 
 /**
- * Every court of the jurisdiction with its decision count. Deliberately
- * join-free: the statement is a parallel index-only walk of the
- * `(country, court, date)` index (planner cost 550k for the largest
- * jurisdiction, against 1.4M with a bitmap heap scan once the sources table
- * is joined in for `source_id`). Source policy is applied by the shelf
- * statement that follows, which drops a court whose public rows are none;
- * the cap on shown courts is taken after that, so a withheld court cannot
- * hold a slot. The counts only order courts within a tier.
+ * Every court spelling the jurisdiction holds, by loose index scan: one
+ * `min(court)` per distinct court, each a descent of the
+ * `(country, court, date)` index. 611 buffers and 3.5 ms on the production
+ * reader, for a jurisdiction with 116 courts.
+ *
+ * `GROUP BY court` is what this replaces, and its planner cost said nothing:
+ * priced as a cheap parallel index-only scan, it reads every index entry of
+ * the country and, where the pages are not all-visible, falls back to the
+ * heap — 216k heap fetches, 966,716 shared buffers, 284 ms warm and ~11 s
+ * cold, on every five-minute cache miss. The lateral that follows touches
+ * 261 buffers, so the count was the whole cold cost, and cold it exceeded the
+ * page's 10 s critical-query timeout.
+ *
+ * Join-free by design: source policy is applied by the shelf statement that
+ * follows, which drops a court whose public rows are none; the cap on shown
+ * courts is taken after that, so a withheld court cannot hold a slot.
  */
-export const readCourtCounts = async ({
+const readCourtNames = async ({
   caseLawDb,
   country,
-}: ReadCourtCountsOptions): Promise<CourtCount[]> => {
+}: ReadCourtNamesOptions): Promise<string[]> => {
   const result: unknown = await caseLawDb(
     async (tx) =>
       await tx.execute(sql`
-        SELECT d.court, count(*)::int AS decision_count
-        FROM case_law_decisions d
-        WHERE d.country = ${country}
-        GROUP BY d.court
+        WITH RECURSIVE court_walk AS (
+          SELECT min(d.court) AS court
+          FROM case_law_decisions d
+          WHERE d.country = ${country}
+          UNION ALL
+          SELECT (
+            SELECT min(d.court)
+            FROM case_law_decisions d
+            WHERE d.country = ${country}
+              AND d.court > court_walk.court
+          )
+          FROM court_walk
+          WHERE court_walk.court IS NOT NULL
+        )
+        SELECT court_walk.court
+        FROM court_walk
+        WHERE court_walk.court IS NOT NULL
       `),
   );
   return rowsOf(result).flatMap((row) => {
     const court = row["court"];
-    return typeof court === "string" && court.length > 0
-      ? [{ court, count: Number(row["decision_count"]) || 0 }]
-      : [];
+    return typeof court === "string" && court.length > 0 ? [court] : [];
   });
+};
+
+type CourtDocketSizesOptions = {
+  /** Every court the table holds; presence on the shelf is decided here alone. */
+  courts: readonly string[];
+  /** The browse facets' `court` buckets: the largest courts, exact counts. */
+  buckets: readonly FacetBucket[];
+};
+
+/** Each court with its facet count, zero for a court the buckets do not name. */
+export const courtDocketSizes = ({
+  courts,
+  buckets,
+}: CourtDocketSizesOptions): CourtCount[] => {
+  const countByCourt = new Map(
+    buckets.map(({ value, count }) => [value, count]),
+  );
+  return courts.map((court) => ({
+    court,
+    count: countByCourt.get(court) ?? 0,
+  }));
 };
 
 type SelectShelfCourtsOptions = {
@@ -104,9 +153,10 @@ const byCodePoint = (a: string, b: string): number => {
 };
 
 /**
- * Apex courts first by tier, then by docket size within a tier, capped at
- * `limit`. A court no entry matches, or one whose label is below the shelf,
- * is left out.
+ * Apex courts first by tier, then by docket size within a tier, then by name,
+ * capped at `limit`. A court no entry matches, or one whose label is below the
+ * shelf, is left out. An uncounted court is ordered last within its tier, never
+ * dropped: the count ranks courts, it does not admit them.
  */
 export const selectShelfCourts = ({
   counts,
@@ -149,6 +199,12 @@ type ReadShelfCourtsOptions = {
   caseLawDb: CaseLawPublicReadDb;
   country: string;
   entries: readonly CourtWeightEntry[];
+  /**
+   * The jurisdiction's browse facets, whose `court` buckets order the shelf
+   * within a tier. It degrades to empty facets, and the shelf then lists the
+   * same courts in name order.
+   */
+  readFacets: (country: string) => Promise<LegalBrowseFacets>;
 };
 
 /** The shelf's courts for a jurisdiction, ranked by the given entries. */
@@ -156,17 +212,22 @@ export const readShelfCourts = async ({
   caseLawDb,
   country,
   entries,
+  readFacets,
 }: ReadShelfCourtsOptions): Promise<ShelfCourt[]> => {
-  const counts = await readCourtCounts({ caseLawDb, country });
+  const [courts, facets] = await Promise.all([
+    readCourtNames({ caseLawDb, country }),
+    readFacets(country),
+  ]);
+  const counts = courtDocketSizes({ courts, buckets: facets.court });
   // Candidates, not the shown set: a publisher spells an apex court several
   // ways, and the shelf statement drops the spellings with no public rows
   // before the caller caps what it shows.
-  const courts = selectShelfCourts({
+  const shelf = selectShelfCourts({
     counts,
     entries,
     limit: LIMITS.caseLawLatestCourts * SHELF_SPELLINGS_PER_COURT,
   });
-  if (courts.length === 0 && counts.length > 0) {
+  if (shelf.length === 0 && counts.length > 0) {
     // Rows exist but none rank as an apex court: a seed or a court-name
     // spelling has drifted from the corpus. The page shows no shelf rather
     // than a wrong one, and this is the only trace of why.
@@ -175,5 +236,5 @@ export const readShelfCourts = async ({
       courts: counts.length,
     });
   }
-  return courts;
+  return shelf;
 };

--- a/apps/api/src/handlers/case-law/decisions/sitemap.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/sitemap.test.ts
@@ -16,7 +16,6 @@ import {
   decisionYearSql,
   listSitemapShardDecisionsHandler,
 } from "@/api/handlers/case-law/decisions/sitemap";
-import { readCaseLawCorpusStatusQuery } from "@/api/handlers/case-law/decisions/status";
 import { createSafeId } from "@/api/lib/branded-types";
 import type {
   CaseLawPublicReadDb,
@@ -208,7 +207,7 @@ test("sitemap shards reject countries outside the public list", async () => {
   expect(unavailable.code).toBe(404);
 });
 
-test("public list and status reads stay inside the country boundary", async () => {
+test("the public list read stays inside the country boundary", async () => {
   const country =
     publicCaseLawCountry("CZE") ?? panic("Expected a public test country.");
   const listed = await listDecisionsHandler({ country, limit: 10 }, caseLawDb);
@@ -217,13 +216,4 @@ test("public list and status reads stay inside the country boundary", async () =
     expect(listed.items).toHaveLength(4);
     expect(listed.items.every((item) => item.country === country)).toBe(true);
   }
-
-  const corpusStatus = await caseLawDb(
-    async (tx) =>
-      await readCaseLawCorpusStatusQuery(tx, {
-        country,
-        excludedSourceIds: [],
-      }),
-  );
-  expect(corpusStatus.decisions).toBe(4);
 });

--- a/apps/api/src/handlers/case-law/decisions/status.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/status.db.test.ts
@@ -1,0 +1,151 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { panic } from "better-result";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { publicCaseLawCountry } from "@stll/api-contract/case-law-launch-readiness";
+
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { readCaseLawCorpusStatusQuery } from "@/api/handlers/case-law/decisions/status";
+import { createSafeId, type SafeId } from "@/api/lib/branded-types";
+import type {
+  CaseLawPublicReadDb,
+  CaseLawPublicReadTransaction,
+} from "@/api/lib/case-law-public-read-db";
+import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
+import {
+  createTestPglite,
+  withPublicLawReaderRole,
+} from "@/api/tests/pglite-test-db";
+
+/**
+ * The timestamp beside the search box is the newest decision the public
+ * surface may show: newest of the country rather than of the corpus, of an
+ * admitted source rather than of any, and unknown when nothing qualifies.
+ */
+
+/** Same budget as the schema push: an embedded Postgres is not fast. */
+const DB_TEST_TIMEOUT_MS = 120_000;
+
+const COUNTRY =
+  publicCaseLawCountry("CZE") ?? panic("CZE is a public case-law country");
+
+const openSourceId = createSafeId<"caseLawSource">();
+const restrictedSourceId = createSafeId<"caseLawSource">();
+
+const NEWEST_OPEN = "2026-03-04T05:06:07.000Z";
+const NEWEST_RESTRICTED = "2026-06-07T08:09:10.000Z";
+
+let client: PGlite;
+let caseLawDb: CaseLawPublicReadDb;
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    const db = drizzle({ client });
+    const readDb = async <T>(
+      fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
+    ) =>
+      await withPublicLawReaderRole(db, async (roleTx) => {
+        // SAFETY: the role transaction supplies the select surface the read uses.
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test handle stands in for a transaction
+        const tx = roleTx as unknown as CaseLawPublicReadTransaction;
+        return await fn(tx);
+      });
+    // SAFETY: brand-only wrapper; the read never inspects the marker.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
+    caseLawDb = readDb as unknown as CaseLawPublicReadDb;
+
+    await db.insert(caseLawSources).values([
+      caseLawSourceRow({
+        adapterKey: "open",
+        id: openSourceId,
+        name: "open",
+      }),
+      caseLawSourceRow({
+        adapterKey: "restricted",
+        id: restrictedSourceId,
+        name: "restricted",
+      }),
+    ]);
+    // Oldest first, so a read that answers with a row rather than with the
+    // newest row cannot pass by luck of the insertion order.
+    await db.insert(caseLawDecisions).values([
+      {
+        caseNumber: "oldest",
+        country: "CZE",
+        court: "Court",
+        language: "cs",
+        sourceId: openSourceId,
+        updatedAt: new Date("2026-01-02T03:04:05.000Z"),
+      },
+      {
+        caseNumber: "another country, newer still",
+        country: "SVK",
+        court: "Court",
+        language: "sk",
+        sourceId: openSourceId,
+        updatedAt: new Date("2026-09-10T11:12:13.000Z"),
+      },
+      {
+        caseNumber: "newest open",
+        country: "CZE",
+        court: "Court",
+        language: "cs",
+        sourceId: openSourceId,
+        updatedAt: new Date(NEWEST_OPEN),
+      },
+      {
+        caseNumber: "newest restricted",
+        country: "CZE",
+        court: "Court",
+        language: "cs",
+        sourceId: restrictedSourceId,
+        updatedAt: new Date(NEWEST_RESTRICTED),
+      },
+    ]);
+  },
+  { timeout: DB_TEST_TIMEOUT_MS },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+/** The instant the read reported, so the serialized offset is not the subject. */
+const readUpdatedAt = async (
+  excludedSourceIds: readonly SafeId<"caseLawSource">[],
+) => {
+  const updatedAt = await caseLawDb(
+    async (tx) =>
+      await readCaseLawCorpusStatusQuery(tx, {
+        country: COUNTRY,
+        excludedSourceIds,
+      }),
+  );
+  return updatedAt === null ? null : new Date(updatedAt).toISOString();
+};
+
+test(
+  "reports the newest decision of its country, not of the corpus",
+  async () => {
+    expect(await readUpdatedAt([])).toBe(NEWEST_RESTRICTED);
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "skips an excluded source's newer decision",
+  async () => {
+    expect(await readUpdatedAt([restrictedSourceId])).toBe(NEWEST_OPEN);
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "reports nothing when no decision is admitted",
+  async () => {
+    expect(await readUpdatedAt([openSourceId, restrictedSourceId])).toBeNull();
+  },
+  DB_TEST_TIMEOUT_MS,
+);

--- a/apps/api/src/handlers/case-law/decisions/status.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/status.test.ts
@@ -29,7 +29,7 @@ const load = async (
   const result = await loadCaseLawCorpusStatus({
     country: COUNTRY,
     excludedSourceIds: [],
-    readFacets: async (country) => {
+    readFacets: async ({ country }) => {
       scopes.push(country);
       return await readFacets(country);
     },
@@ -80,4 +80,22 @@ test("a failed facets read fails the status instead of reporting zero", async ()
     throw new TypeError("expected the facets failure to reach the caller");
   }
   expect(result.error.message).toBe("corpus index unreachable");
+});
+
+test("a facets read that rejects fails the status as a value", async () => {
+  // The load sits behind a cache that keeps whatever promise it is handed;
+  // a rejection would be replayed to every caller for the whole window.
+  const result = await loadCaseLawCorpusStatus({
+    country: COUNTRY,
+    excludedSourceIds: [],
+    readFacets: async () => {
+      throw new TypeError("provider crashed");
+    },
+    readUpdatedAt: async () => UPDATED_AT,
+  });
+
+  if (!Result.isError(result)) {
+    throw new TypeError("expected the rejection to become an error value");
+  }
+  expect(result.error.message).toBe("provider crashed");
 });

--- a/apps/api/src/handlers/case-law/decisions/status.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/status.test.ts
@@ -1,0 +1,83 @@
+import { panic, Result } from "better-result";
+import { expect, test } from "bun:test";
+
+import { publicCaseLawCountry } from "@stll/api-contract/case-law-launch-readiness";
+
+import { loadCaseLawCorpusStatus } from "@/api/handlers/case-law/decisions/status";
+import type { LegalBrowseFacets } from "@/api/lib/legal-search/types";
+
+/**
+ * The number beside the search box is the corpus index's own count for the
+ * scoped jurisdiction, so it says what a search can find and agrees with the
+ * facets the same page renders. Nothing here counts rows.
+ */
+
+const COUNTRY =
+  publicCaseLawCountry("CZE") ?? panic("CZE is a public case-law country");
+const UPDATED_AT = "2026-09-11T08:00:00+00:00";
+
+const facetsOf = (
+  country: LegalBrowseFacets["country"],
+): LegalBrowseFacets => ({ country, court: [], year: [] });
+
+const load = async (
+  readFacets: (
+    country: string,
+  ) => Promise<Result<LegalBrowseFacets, { message: string }>>,
+) => {
+  const scopes: string[] = [];
+  const result = await loadCaseLawCorpusStatus({
+    country: COUNTRY,
+    excludedSourceIds: [],
+    readFacets: async (country) => {
+      scopes.push(country);
+      return await readFacets(country);
+    },
+    readUpdatedAt: async () => UPDATED_AT,
+  });
+  return { result, scopes };
+};
+
+test("counts the bucket of the jurisdiction it was scoped to", async () => {
+  const { result, scopes } = await load(async () =>
+    Result.ok(
+      facetsOf([
+        { value: "SVK", count: 7 },
+        { value: "CZE", count: 1_034_211 },
+      ]),
+    ),
+  );
+
+  expect(scopes).toEqual(["CZE"]);
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+  // Buckets are count-ordered, so the jurisdiction's own bucket is wherever
+  // its size puts it: reading the first one would report another country's.
+  expect(result.value).toEqual({
+    decisions: 1_034_211,
+    updatedAt: UPDATED_AT,
+  });
+});
+
+test("reports nothing for a jurisdiction the corpus has no bucket for", async () => {
+  const { result } = await load(async () => Result.ok(facetsOf([])));
+
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+  expect(result.value).toEqual({ decisions: 0, updatedAt: UPDATED_AT });
+});
+
+test("a failed facets read fails the status instead of reporting zero", async () => {
+  const { result } = await load(async () =>
+    Result.err(new Error("corpus index unreachable")),
+  );
+
+  // Zero decisions is a fact about the corpus; the caller degrades to an
+  // unknown status and logs, which it can only do if the failure reaches it.
+  if (!Result.isError(result)) {
+    throw new TypeError("expected the facets failure to reach the caller");
+  }
+  expect(result.error.message).toBe("corpus index unreachable");
+});

--- a/apps/api/src/handlers/case-law/decisions/status.ts
+++ b/apps/api/src/handlers/case-law/decisions/status.ts
@@ -9,7 +9,7 @@ import {
 } from "@stll/api-contract/case-law-launch-readiness";
 
 import { caseLawDecisions } from "@/api/db/schema";
-import { readBrowseFacetsResult } from "@/api/handlers/case-law/decisions/facets";
+import { readBrowseFacetsUnderPolicy } from "@/api/handlers/case-law/decisions/facets";
 import type { SafeId } from "@/api/lib/branded-types";
 import type {
   CaseLawPublicReadDb,
@@ -57,11 +57,13 @@ type ReadCaseLawCorpusStatusQuery = Static<
 >;
 
 /**
- * The newest public decision's timestamp: `case_law_decisions_updated_id_idx`
- * walked newest first and stopped at the first row the country and the source
- * policy admit. `max(updated_at)` cannot express that — an aggregate under a
- * country predicate has to read every row the predicate matches, which on a
- * corpus this size is a heap scan of a million rows per request.
+ * The newest public decision's timestamp:
+ * `case_law_decisions_country_updated_idx` walked newest first within the
+ * country and stopped at the first row the source policy admits. Led by
+ * country so a large ingestion batch elsewhere is never walked past.
+ * `max(updated_at)` cannot express that — an aggregate under a country
+ * predicate has to read every row the predicate matches, which on a corpus
+ * this size is a heap scan of a million rows per request.
  */
 export const readCaseLawCorpusStatusQuery = definePublicLawSharedQuery(
   PUBLIC_LAW_SHARED_QUERY.caseLawCorpusStatus,
@@ -96,18 +98,27 @@ type CorpusStatusLoad = CorpusUpdatedAtRead & {
   /**
    * The facets with their failure kept: a facets read that degraded to an
    * empty set would count as a corpus of zero decisions beside a real
-   * timestamp, which is a wrong number, not an unknown status.
+   * timestamp, which is a wrong number, not an unknown status. Both reads
+   * take the same source-policy snapshot, so the count and the timestamp
+   * describe one set of decisions.
    */
   readFacets: (
-    country: string,
+    read: CorpusUpdatedAtRead,
   ) => Promise<Result<LegalBrowseFacets, { message: string }>>;
   readUpdatedAt: (read: CorpusUpdatedAtRead) => Promise<string | null>;
 };
 
+const corpusStatusError = (fallback: string) => (cause: unknown) =>
+  new CorpusStatusError({
+    message: cause instanceof Error ? cause.message : fallback,
+    cause,
+  });
+
 /**
  * Both halves of the status, each from the read that already answers it
  * cheaply: the count from the facets this page asks for anyway, the timestamp
- * from one index row.
+ * from one index row. Each read is normalised to a value: the cache that
+ * holds the load would otherwise keep a rejected promise for a full window.
  */
 export const loadCaseLawCorpusStatus = async ({
   country,
@@ -117,25 +128,25 @@ export const loadCaseLawCorpusStatus = async ({
 }: CorpusStatusLoad): Promise<
   Result<CaseLawCorpusStatus, CorpusStatusError>
 > => {
+  const read = { country, excludedSourceIds };
   const [facets, updatedAt] = await Promise.all([
-    readFacets(country),
     Result.tryPromise({
-      try: async () => await readUpdatedAt({ country, excludedSourceIds }),
-      catch: (cause) =>
-        new CorpusStatusError({
-          message:
-            cause instanceof Error
-              ? cause.message
-              : "reading the newest public decision failed",
-          cause,
-        }),
+      try: async () => await readFacets(read),
+      catch: corpusStatusError("reading the browse facets failed"),
+    }),
+    Result.tryPromise({
+      try: async () => await readUpdatedAt(read),
+      catch: corpusStatusError("reading the newest public decision failed"),
     }),
   ]);
   if (Result.isError(facets)) {
+    return facets;
+  }
+  if (Result.isError(facets.value)) {
     return Result.err(
       new CorpusStatusError({
-        message: facets.error.message,
-        cause: facets.error,
+        message: facets.value.error.message,
+        cause: facets.value.error,
       }),
     );
   }
@@ -144,7 +155,9 @@ export const loadCaseLawCorpusStatus = async ({
   }
   // A jurisdiction the corpus holds nothing for has no bucket at all: that is
   // the empty corpus, not a missed lookup.
-  const bucket = facets.value.country.find(({ value }) => value === country);
+  const bucket = facets.value.value.country.find(
+    ({ value }) => value === country,
+  );
   return Result.ok({
     decisions: bucket?.count ?? 0,
     updatedAt: updatedAt.value,
@@ -194,7 +207,7 @@ export const readCaseLawCorpusStatusHandler = async (
   const result = await corpusStatus({
     country: publicCountry,
     excludedSourceIds: excludedSourceIds.value,
-    readFacets: readBrowseFacetsResult,
+    readFacets: readBrowseFacetsUnderPolicy,
     readUpdatedAt: async (read) =>
       await caseLawDb(
         async (tx) => await readCaseLawCorpusStatusQuery(tx, read),

--- a/apps/api/src/handlers/case-law/decisions/status.ts
+++ b/apps/api/src/handlers/case-law/decisions/status.ts
@@ -1,5 +1,5 @@
 import { Result, TaggedError } from "better-result";
-import { and, eq, notInArray, sql } from "drizzle-orm";
+import { and, desc, eq, notInArray, sql } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
 
@@ -7,9 +7,9 @@ import {
   publicCaseLawCountry,
   type PublicCaseLawCountry,
 } from "@stll/api-contract/case-law-launch-readiness";
-import { Temporal } from "@stll/time";
 
 import { caseLawDecisions } from "@/api/db/schema";
+import { readBrowseFacetsResult } from "@/api/handlers/case-law/decisions/facets";
 import type { SafeId } from "@/api/lib/branded-types";
 import type {
   CaseLawPublicReadDb,
@@ -17,15 +17,21 @@ import type {
 } from "@/api/lib/case-law-public-read-db";
 import { readNonRedistributableCaseLawSourceIds } from "@/api/lib/case-law/non-redistributable-sources";
 import { errorTag } from "@/api/lib/errors/utils";
+import { createTtlResultCache } from "@/api/lib/legal-search/browse-facets-cache";
+import type { LegalBrowseFacets } from "@/api/lib/legal-search/types";
 import { logger } from "@/api/lib/observability/logger";
 import {
   definePublicLawSharedQuery,
   PUBLIC_LAW_SHARED_QUERY,
 } from "@/api/lib/public-law-shared-query";
 
-/** How much public case law the database holds and when it last changed. */
+/** How much public case law the corpus serves and when it last changed. */
 export type CaseLawCorpusStatus = {
-  /** The number of public decisions in the requested country. */
+  /**
+   * Decisions of the requested country the corpus index serves, so the number
+   * beside the search box is the number a search can find. It is read from the
+   * browse facets, and is the count their country bucket shows.
+   */
   decisions: number;
   /** ISO 8601, or null while the public table is empty. */
   updatedAt: string | null;
@@ -36,7 +42,7 @@ class CorpusStatusError extends TaggedError("CorpusStatusError")<{
   cause?: unknown;
 }> {}
 
-type CorpusStatusLoad = {
+type CorpusUpdatedAtRead = {
   country: PublicCaseLawCountry;
   /** The sources a public surface may not count, as the other public reads exclude them. */
   excludedSourceIds: readonly SafeId<"caseLawSource">[];
@@ -51,21 +57,23 @@ type ReadCaseLawCorpusStatusQuery = Static<
 >;
 
 /**
- * One country-scoped aggregate. The country index bounds the scan, and the
- * short-lived cache keeps it off the request path after the first read.
+ * The newest public decision's timestamp: `case_law_decisions_updated_id_idx`
+ * walked newest first and stopped at the first row the country and the source
+ * policy admit. `max(updated_at)` cannot express that — an aggregate under a
+ * country predicate has to read every row the predicate matches, which on a
+ * corpus this size is a heap scan of a million rows per request.
  */
 export const readCaseLawCorpusStatusQuery = definePublicLawSharedQuery(
   PUBLIC_LAW_SHARED_QUERY.caseLawCorpusStatus,
   async (
     tx: CaseLawPublicReadTransaction,
-    { country, excludedSourceIds }: CorpusStatusLoad,
-  ): Promise<CaseLawCorpusStatus> => {
+    { country, excludedSourceIds }: CorpusUpdatedAtRead,
+  ): Promise<string | null> => {
     const [row] = await tx
       .select({
-        decisions: sql<number>`count(*)::int`,
         updatedAt: sql<
           string | null
-        >`to_json(max(${caseLawDecisions.updatedAt})) #>> '{}'`,
+        >`to_json(${caseLawDecisions.updatedAt}) #>> '{}'`,
       })
       .from(caseLawDecisions)
       .where(
@@ -75,22 +83,93 @@ export const readCaseLawCorpusStatusQuery = definePublicLawSharedQuery(
             ? undefined
             : notInArray(caseLawDecisions.sourceId, [...excludedSourceIds]),
         ),
-      );
+      )
+      // The index's own order, so the walk stops at the first admitted row.
+      .orderBy(desc(caseLawDecisions.updatedAt), desc(caseLawDecisions.id))
+      .limit(1);
 
-    return {
-      decisions: row?.decisions ?? 0,
-      updatedAt: row?.updatedAt ?? null,
-    };
+    return row?.updatedAt ?? null;
   },
 );
 
-const STATUS_CACHE_TTL_MS = 5 * 60 * 1000;
+type CorpusStatusLoad = CorpusUpdatedAtRead & {
+  /**
+   * The facets with their failure kept: a facets read that degraded to an
+   * empty set would count as a corpus of zero decisions beside a real
+   * timestamp, which is a wrong number, not an unknown status.
+   */
+  readFacets: (
+    country: string,
+  ) => Promise<Result<LegalBrowseFacets, { message: string }>>;
+  readUpdatedAt: (read: CorpusUpdatedAtRead) => Promise<string | null>;
+};
 
-let cached: {
-  key: string;
-  readAt: number;
-  value: CaseLawCorpusStatus;
-} | null = null;
+/**
+ * Both halves of the status, each from the read that already answers it
+ * cheaply: the count from the facets this page asks for anyway, the timestamp
+ * from one index row.
+ */
+export const loadCaseLawCorpusStatus = async ({
+  country,
+  excludedSourceIds,
+  readFacets,
+  readUpdatedAt,
+}: CorpusStatusLoad): Promise<
+  Result<CaseLawCorpusStatus, CorpusStatusError>
+> => {
+  const [facets, updatedAt] = await Promise.all([
+    readFacets(country),
+    Result.tryPromise({
+      try: async () => await readUpdatedAt({ country, excludedSourceIds }),
+      catch: (cause) =>
+        new CorpusStatusError({
+          message:
+            cause instanceof Error
+              ? cause.message
+              : "reading the newest public decision failed",
+          cause,
+        }),
+    }),
+  ]);
+  if (Result.isError(facets)) {
+    return Result.err(
+      new CorpusStatusError({
+        message: facets.error.message,
+        cause: facets.error,
+      }),
+    );
+  }
+  if (Result.isError(updatedAt)) {
+    return updatedAt;
+  }
+  // A jurisdiction the corpus holds nothing for has no bucket at all: that is
+  // the empty corpus, not a missed lookup.
+  const bucket = facets.value.country.find(({ value }) => value === country);
+  return Result.ok({
+    decisions: bucket?.count ?? 0,
+    updatedAt: updatedAt.value,
+  });
+};
+
+const STATUS_CACHE_TTL_MS = 5 * 60 * 1000;
+const STATUS_CACHE_MAX_ENTRIES = 16;
+/**
+ * A failure is held briefly instead of being retried by the next request: the
+ * timestamp read shares a pool of two connections with the rest of the page,
+ * so a read that fails slowly must not be re-entered request after request.
+ */
+const STATUS_CACHE_FAILURE_TTL_MS = 30 * 1000;
+
+const corpusStatus = createTtlResultCache({
+  load: loadCaseLawCorpusStatus,
+  // Source policy is an input to the answer, so a revocation changes the key
+  // instead of waiting out the window; sorted because the set has no order.
+  key: ({ country, excludedSourceIds }: CorpusStatusLoad) =>
+    `${country}:${excludedSourceIds.toSorted().join(",")}`,
+  ttlMs: STATUS_CACHE_TTL_MS,
+  failureTtlMs: STATUS_CACHE_FAILURE_TTL_MS,
+  maxEntries: STATUS_CACHE_MAX_ENTRIES,
+});
 
 const EMPTY_STATUS: CaseLawCorpusStatus = { decisions: 0, updatedAt: null };
 
@@ -111,29 +190,15 @@ export const readCaseLawCorpusStatusHandler = async (
     });
     return EMPTY_STATUS;
   }
-  const key = `${publicCountry}:${excludedSourceIds.value.toSorted().join(",")}`;
-  const now = Temporal.Now.instant().epochMilliseconds;
-  if (cached?.key === key && now - cached.readAt < STATUS_CACHE_TTL_MS) {
-    return cached.value;
-  }
 
-  const result = await Result.tryPromise({
-    try: async () =>
+  const result = await corpusStatus({
+    country: publicCountry,
+    excludedSourceIds: excludedSourceIds.value,
+    readFacets: readBrowseFacetsResult,
+    readUpdatedAt: async (read) =>
       await caseLawDb(
-        async (tx) =>
-          await readCaseLawCorpusStatusQuery(tx, {
-            country: publicCountry,
-            excludedSourceIds: excludedSourceIds.value,
-          }),
+        async (tx) => await readCaseLawCorpusStatusQuery(tx, read),
       ),
-    catch: (cause) =>
-      new CorpusStatusError({
-        message:
-          cause instanceof Error
-            ? cause.message
-            : "reading the case-law corpus status failed",
-        cause,
-      }),
   });
   if (Result.isError(result)) {
     // The status is a hint beside the box, not the page: degrade to "unknown".
@@ -143,6 +208,5 @@ export const readCaseLawCorpusStatusHandler = async (
     return EMPTY_STATUS;
   }
 
-  cached = { key, readAt: now, value: result.value };
   return result.value;
 };

--- a/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
@@ -217,3 +217,27 @@ test("retries once the failure window closes", async () => {
 
   expect(calls()).toBe(2);
 });
+
+test("a slow failure is held from the moment it settles", async () => {
+  let calls = 0;
+  const read = createTtlResultCache({
+    load: async (query: string) => {
+      calls += 1;
+      // Longer than the hold: a hold counted from the start would have
+      // expired before the failure even arrived.
+      await Bun.sleep(30);
+      return Result.err(
+        new LegalBrowseFacetsError({ message: `${query} down` }),
+      );
+    },
+    key: (query: string) => query,
+    ttlMs: 60_000,
+    failureTtlMs: 10,
+    maxEntries: 3,
+  });
+
+  await read("engine");
+  await read("engine");
+
+  expect(calls).toBe(1);
+});

--- a/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
@@ -2,7 +2,10 @@ import { Result } from "better-result";
 import { expect, test } from "bun:test";
 
 import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
-import { createBrowseFacetsCache } from "@/api/lib/legal-search/browse-facets-cache";
+import {
+  createBrowseFacetsCache,
+  createTtlResultCache,
+} from "@/api/lib/legal-search/browse-facets-cache";
 import type {
   LegalBrowseFacets,
   LegalBrowseFacetsQuery,
@@ -172,4 +175,45 @@ test("expires an entry once its window closes", async () => {
   await browseFacets({ excludedSourceIds: [], limit: 20 });
 
   expect(calls).toBe(2);
+});
+
+/**
+ * A load that fails cheaply is better retried at once, which is the default
+ * above. A load that fails slowly is not: retrying it per request keeps one
+ * call in flight for as long as the dependency stays degraded, so its caller
+ * asks for a hold instead.
+ */
+const failingCacheOf = (failureTtlMs: number) => {
+  let calls = 0;
+  const read = createTtlResultCache({
+    load: async (query: string) => {
+      calls += 1;
+      return Result.err(
+        new LegalBrowseFacetsError({ message: `${query} down` }),
+      );
+    },
+    key: (query: string) => query,
+    ttlMs: 60_000,
+    failureTtlMs,
+    maxEntries: 3,
+  });
+  return { calls: () => calls, read };
+};
+
+test("holds a failure for the window its caller asked for", async () => {
+  const { calls, read } = failingCacheOf(60_000);
+
+  await read("engine");
+  await read("engine");
+
+  expect(calls()).toBe(1);
+});
+
+test("retries once the failure window closes", async () => {
+  const { calls, read } = failingCacheOf(0);
+
+  await read("engine");
+  await read("engine");
+
+  expect(calls()).toBe(2);
 });

--- a/apps/api/src/lib/legal-search/browse-facets-cache.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.ts
@@ -29,6 +29,13 @@ type TtlResultCacheOptions<TQuery, TValue, TError> = {
   key: (query: TQuery) => string;
   ttlMs: number;
   /**
+   * How long a failed load is held before the next request may retry it.
+   * Omitted, a failure is evicted at once, which is right for a load that is
+   * cheap to repeat; a load that fails slowly needs the hold, or a degraded
+   * dependency keeps one call in flight for as long as it stays degraded.
+   */
+  failureTtlMs?: number;
+  /**
    * Caller-influenced inputs (a jurisdiction validated against a pattern, not
    * a closed list) make the key space unbounded, so it is bounded here rather
    * than left to grow. The corpus has a handful of jurisdictions, so eviction
@@ -50,6 +57,7 @@ export const createTtlResultCache = <TQuery, TValue, TError>({
   load,
   key: keyOf,
   ttlMs,
+  failureTtlMs,
   maxEntries,
 }: TtlResultCacheOptions<TQuery, TValue, TError>) => {
   const entries = new Map<string, CacheEntry<TValue, TError>>();
@@ -80,10 +88,16 @@ export const createTtlResultCache = <TQuery, TValue, TError>({
     }
 
     const result = await entry.pending;
-    // A failure must not pin an empty answer for the whole window. Drop it
-    // only while this call still owns the entry, so a newer one survives.
+    // A failure must not pin an empty answer for the whole window: it is
+    // dropped, or held for the shorter failure window where the caller asked
+    // for one. Either way only while this call still owns the entry, so a
+    // newer one survives.
     if (Result.isError(result) && entries.get(key) === entry) {
-      entries.delete(key);
+      if (failureTtlMs === undefined) {
+        entries.delete(key);
+      } else {
+        entry.expiresAt = now + failureTtlMs;
+      }
     }
     return result;
   };

--- a/apps/api/src/lib/legal-search/browse-facets-cache.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.ts
@@ -91,12 +91,14 @@ export const createTtlResultCache = <TQuery, TValue, TError>({
     // A failure must not pin an empty answer for the whole window: it is
     // dropped, or held for the shorter failure window where the caller asked
     // for one. Either way only while this call still owns the entry, so a
-    // newer one survives.
+    // newer one survives. The hold starts when the load settles, not when it
+    // began: a load that fails slowly would otherwise use up its own hold.
     if (Result.isError(result) && entries.get(key) === entry) {
       if (failureTtlMs === undefined) {
         entries.delete(key);
       } else {
-        entry.expiresAt = now + failureTtlMs;
+        entry.expiresAt =
+          Temporal.Now.instant().epochMilliseconds + failureTtlMs;
       }
     }
     return result;

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -82,25 +82,67 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-const termsAggregation = (
-  buckets: { key: string | number; count: number }[],
-) => ({
+type TermsBucket = { key: string | number; count: number };
+
+/**
+ * The engine reports `doc_count_error_upper_bound` for a `_count`-ordered
+ * terms aggregation, where the merged per-split top-k can miss a term, and
+ * omits it entirely for a `_key`-ordered one. A fixture that carried the
+ * bound everywhere would never show the parser the shape production sends.
+ */
+const keyOrderedAggregation = (buckets: TermsBucket[]) => ({
   buckets: buckets.map(({ key, count }) => ({ key, doc_count: count })),
-  doc_count_error_upper_bound: 0,
   sum_other_doc_count: 0,
 });
+const countOrderedAggregation = (buckets: TermsBucket[]) => ({
+  ...keyOrderedAggregation(buckets),
+  doc_count_error_upper_bound: 0,
+});
 
+/** Trimmed from a production response to the request the code sends. */
 const engineResponse = () => ({
   aggregations: {
-    country: termsAggregation([{ key: "CZE", count: 1_271_387 }]),
-    court: termsAggregation([{ key: "Nejvyšší soud", count: 203_722 }]),
+    country: countOrderedAggregation([{ key: "CZE", count: 1_034_713 }]),
+    court: countOrderedAggregation([
+      { key: "Nejvyšší soud", count: 165_146 },
+      { key: "Ústavní soud", count: 104_627 },
+      { key: "Nejvyšší správní soud", count: 79_436 },
+    ]),
     // A u64 fast field comes back as a JSON float.
-    year: termsAggregation([{ key: 2024, count: 1_425_310 }]),
+    year: keyOrderedAggregation([
+      { key: 2026, count: 42_961 },
+      { key: 2025, count: 85_590 },
+      { key: 2024, count: 85_939 },
+    ]),
   },
 });
 
+const aggregationsSchema = v.record(
+  v.string(),
+  v.record(v.string(), v.unknown()),
+);
+
+const respondedAggregations = (): Record<string, Record<string, unknown>> =>
+  v.parse(aggregationsSchema, engineResponse().aggregations);
+
+const respondedAggregation = (name: string): Record<string, unknown> =>
+  v.parse(v.record(v.string(), v.unknown()), respondedAggregations()[name]);
+
 const requestedAggregations = (): Record<string, unknown> =>
   v.parse(v.record(v.string(), v.unknown()), requests.at(0)?.body["aggs"]);
+
+const orderingsSchema = v.record(
+  v.string(),
+  v.object({ terms: v.object({ order: v.record(v.string(), v.string()) }) }),
+);
+
+/** Facet name to the single key of the order it was requested with. */
+const requestedOrderings = (): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(v.parse(orderingsSchema, requests.at(0)?.body["aggs"])).map(
+      ([name, { terms }]) => [name, Object.keys(terms.order).join(",")],
+    ),
+  );
 
 test("aggregates over opening passages only, so buckets count decisions", async () => {
   responseBody = engineResponse();
@@ -161,13 +203,100 @@ test("reads string and numeric bucket keys into the same bucket shape", async ()
     throw result.error;
   }
 
-  expect(result.value.country).toEqual([{ value: "CZE", count: 1_271_387 }]);
-  expect(result.value.court).toEqual([
-    { value: "Nejvyšší soud", count: 203_722 },
-  ]);
+  expect(result.value.country).toEqual([{ value: "CZE", count: 1_034_713 }]);
+  expect(result.value.court.at(0)).toEqual({
+    value: "Nejvyšší soud",
+    count: 165_146,
+  });
   // The year facet's contract is a string bucket value, as the Postgres path
-  // produced with to_char; "2024", never "2024.0".
-  expect(result.value.year).toEqual([{ value: "2024", count: 1_425_310 }]);
+  // produced with to_char; "2026", never "2026.0".
+  expect(result.value.year.at(0)).toEqual({ value: "2026", count: 42_961 });
+});
+
+test("the fixture omits the exactness bound exactly where the engine does", async () => {
+  responseBody = engineResponse();
+
+  await corpusIndexBrowseFacets({ excludedSourceIds: [], limit: 20 });
+
+  // Binds the fixture to the ordering the code actually requests, so changing
+  // a facet's order cannot leave a fixture the engine would never send.
+  expect(
+    Object.fromEntries(
+      Object.entries(respondedAggregations()).map(([name, aggregation]) => [
+        name,
+        "doc_count_error_upper_bound" in aggregation,
+      ]),
+    ),
+  ).toEqual(
+    Object.fromEntries(
+      Object.entries(requestedOrderings()).map(([name, orderedBy]) => [
+        name,
+        orderedBy === "_count",
+      ]),
+    ),
+  );
+});
+
+test("a key-ordered facet is exact without a bound the engine never sends", async () => {
+  responseBody = engineResponse();
+  // The fault boundary: rejecting this facet emptied all three in production.
+  expect("doc_count_error_upper_bound" in respondedAggregation("year")).toBe(
+    false,
+  );
+
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+
+  expect(result.value.year).toEqual([
+    { value: "2026", count: 42_961 },
+    { value: "2025", count: 85_590 },
+    { value: "2024", count: 85_939 },
+  ]);
+  expect(result.value.country).not.toHaveLength(0);
+  expect(result.value.court).not.toHaveLength(0);
+});
+
+test("a key-ordered facet stating an error bound fails like any other", async () => {
+  responseBody = {
+    aggregations: {
+      ...engineResponse().aggregations,
+      year: {
+        ...keyOrderedAggregation([{ key: 2026, count: 42_961 }]),
+        // Absence is the contract, not a licence to ignore a stated bound.
+        doc_count_error_upper_bound: 17,
+      },
+    },
+  };
+
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
+
+  expect(Result.isError(result)).toBe(true);
+});
+
+test("a count-ordered facet missing its error bound fails", async () => {
+  responseBody = {
+    aggregations: {
+      ...engineResponse().aggregations,
+      // The engine always states the bound for `_count` ordering, so its
+      // absence here is an unrecognized response, not an exact one.
+      court: keyOrderedAggregation([{ key: "Nejvyšší soud", count: 165_146 }]),
+    },
+  };
+
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
+
+  expect(Result.isError(result)).toBe(true);
 });
 
 test("scopes to one jurisdiction index, and to the generation glob without one", async () => {
@@ -250,7 +379,7 @@ test("an approximate aggregation fails rather than serving wrong counts", async 
     aggregations: {
       ...engineResponse().aggregations,
       court: {
-        ...termsAggregation([{ key: "Nejvyšší soud", count: 203_722 }]),
+        ...countOrderedAggregation([{ key: "Nejvyšší soud", count: 165_146 }]),
         // The engine's own statement that the merged top-k is not exact.
         doc_count_error_upper_bound: 17,
       },
@@ -287,7 +416,7 @@ test("an unreadable aggregation fails rather than reporting an empty corpus", as
 });
 
 test("a missing aggregation fails rather than reporting an empty corpus", async () => {
-  responseBody = { aggregations: { country: termsAggregation([]) } };
+  responseBody = { aggregations: { country: countOrderedAggregation([]) } };
 
   const result = await corpusIndexBrowseFacets({
     excludedSourceIds: [],

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -78,9 +78,11 @@ const browseFacetsQuery = ({
 /**
  * Per-split candidate depth behind each bucket. Terms aggregations merge
  * per-split top-k lists, so a depth at `size` alone makes counts approximate
- * across many splits; at this depth the engine reports a
- * `doc_count_error_upper_bound` of 0 for every browse facet at current corpus
- * size, i.e. the counts are exact.
+ * across many splits. The engine reports a `doc_count_error_upper_bound` for
+ * `_count`-ordered aggregations only, and at this depth it reports 0 for both
+ * of them at current corpus size. For the `_key`-ordered `year` facet it
+ * reports no bound at all, so exactness there rests on this depth exceeding
+ * the field's cardinality: a few decades of years.
  */
 const FACET_SEGMENT_SIZE = 5000;
 
@@ -131,17 +133,23 @@ const buildAggregations = (
  * never an empty facet: silently reporting "no courts" would look like a
  * corpus with no decisions.
  */
-const parseTermsBuckets = (aggregation: unknown): FacetBucket[] | null => {
+const parseTermsBuckets = (
+  aggregation: unknown,
+  order: BrowseFacetSpec["order"],
+): FacetBucket[] | null => {
   if (!isRecord(aggregation) || !Array.isArray(aggregation["buckets"])) {
     return null;
   }
 
   // `FACET_SEGMENT_SIZE` is a claim about the corpus, not a property of the
-  // engine, and corpus growth or a split-topology change can outgrow it. The
-  // engine states when it has: anything but a reported zero means the counts
-  // are approximate, and serving them would put wrong numbers next to every
-  // court with nothing to notice.
-  if (aggregation["doc_count_error_upper_bound"] !== 0) {
+  // engine, and corpus growth or a split-topology change can outgrow it. A
+  // reported bound above zero is the engine saying it has: the counts are
+  // approximate, and serving them would put wrong numbers next to every court
+  // with nothing to notice. The engine reports the bound for `_count` ordering
+  // only, so its absence is the contract for a `_key`-ordered facet and a
+  // missing shape for any other.
+  const bound = aggregation["doc_count_error_upper_bound"];
+  if (bound === undefined ? !("_key" in order) : bound !== 0) {
     return null;
   }
 
@@ -217,9 +225,15 @@ export const corpusIndexBrowseFacets = async (
     );
   }
 
-  const country = parseTermsBuckets(aggregated.value["country"]);
-  const court = parseTermsBuckets(aggregated.value["court"]);
-  const year = parseTermsBuckets(aggregated.value["year"]);
+  // The parse reads each facet under the ordering its own spec requested: the
+  // engine's exactness bound is ordering-dependent.
+  const specs = browseFacetSpecs(readContract.yearFacetField);
+  const country = parseTermsBuckets(
+    aggregated.value["country"],
+    specs.country.order,
+  );
+  const court = parseTermsBuckets(aggregated.value["court"], specs.court.order);
+  const year = parseTermsBuckets(aggregated.value["year"], specs.year.order);
   if (country === null || court === null || year === null) {
     return Result.err(
       new LegalBrowseFacetsError({

--- a/apps/web/src/routes/law/index.tsx
+++ b/apps/web/src/routes/law/index.tsx
@@ -51,7 +51,6 @@ import {
 } from "@/features/case-law/components/decision-cells";
 import { openDecisionMatch } from "@/features/case-law/open-decision-match";
 import {
-  caseLawCorpusStatusOptions,
   decisionFacetsOptions,
   latestDecisionsOptions,
 } from "@/features/case-law/queries/decisions";
@@ -181,7 +180,6 @@ export const Route = createFileRoute("/law/")({
     const [latest] = await Promise.all([
       ensureRouteQueryData(queryClient, latestDecisionsOptions(scope)),
       ensureRouteQueryData(queryClient, decisionFacetsOptions(scope)),
-      ensureRouteQueryData(queryClient, caseLawCorpusStatusOptions(scope)),
       statuteCountry === null
         ? Promise.resolve(null)
         : ensureRouteQueryData(queryClient, legislationShelfOptions(scope)),


### PR DESCRIPTION
Three production defects on /law.

- The key-ordered year facet carries no `doc_count_error_upper_bound` (the engine reports it for count-ordered terms only), so the exactness guard rejected it and every browse facet came back empty. The guard is now ordering-aware and the test fixture mirrors the engine per ordering.
- The corpus status ran `count(*)` with `max(updated_at)` over a country: a million-row heap scan that hit the 30 s statement timeout and held half of the public-law pool on every request. The count now comes from the cached browse facets, the timestamp from one walk of the `updated_at` index, failures are held for 30 s, and the /law loader no longer blocks on the status.
- The newest-decisions shelf counted decisions per court with a country-wide group-by: 966k buffers and about 11 s cold per cache miss. The court list now comes from a loose index scan (611 buffers) and the within-tier order from the same cached facets.