### PR TITLE
fix: use registry-specific company formats

### DIFF
--- a/.changeset/registry-specific-company-formats.md
+++ b/.changeset/registry-specific-company-formats.md
@@ -1,0 +1,5 @@
+---
+"@stll/business-registries": minor
+---
+
+Export registry-specific built-in company formats and distinguish legal company specifications from registry references.

--- a/apps/api/src/handlers/desktop-registry/default-registry.ts
+++ b/apps/api/src/handlers/desktop-registry/default-registry.ts
@@ -9,7 +9,10 @@ const sole = <T>(entries: T[]): T | null => {
 };
 
 type DefaultRegistryOptions = {
-  registries: DesktopRegistryConfig["registries"];
+  registries: readonly Pick<
+    DesktopRegistryConfig["registries"][number],
+    "id" | "name"
+  >[];
   practiceJurisdictions: readonly PracticeJurisdiction[];
 };
 

--- a/apps/api/src/handlers/desktop-registry/service.ts
+++ b/apps/api/src/handlers/desktop-registry/service.ts
@@ -7,6 +7,7 @@ import type {
   DesktopRegistrySearchResponse,
   DesktopRegistrySearchResult,
 } from "@stll/api-contract/desktop-registry";
+import { BUSINESS_REGISTRY_FORMAT_CAPABILITIES } from "@stll/business-registries/default-formats";
 import { mapWithConcurrency } from "@stll/concurrency";
 
 import type { ScopedDb } from "@/api/db/safe-db";
@@ -133,7 +134,11 @@ export const getDesktopRegistryConfig = async (
   const registries = BUSINESS_REGISTRY_SLUGS.flatMap((id) => {
     const handler = dispatchResult.value[id];
     return handler.isDeployAvailable()
-      ? { id, name: `${handler.country} · ${handler.displayName}` }
+      ? {
+          id,
+          name: `${handler.country} · ${handler.displayName}`,
+          formatType: BUSINESS_REGISTRY_FORMAT_CAPABILITIES[id].type,
+        }
       : null;
   });
   const enabledRegistries = registries.filter((entry) => entry !== null);
@@ -204,7 +209,11 @@ export const searchDesktopRegistry = async (
       items: lookup.hits.slice(0, SEARCH_LIMIT),
       limit: DETAIL_CONCURRENCY,
       operation: async (hit) => {
-        if (formats.defaultFormat === null && registry !== "ares") {
+        if (
+          formats.defaultFormat === null &&
+          BUSINESS_REGISTRY_FORMAT_CAPABILITIES[registry].resultShape ===
+            "search-result"
+        ) {
           return Result.ok(hit);
         }
         const detail = await executeRegistryLookup({

--- a/apps/api/src/lib/docx/lookup-fields.test.ts
+++ b/apps/api/src/lib/docx/lookup-fields.test.ts
@@ -421,6 +421,39 @@ describe("renderLookupOutput", () => {
     ).toBe("**Żabka Polska sp. z o.o.**, seat in *Poznań*");
   });
 
+  test("uses the KRS registered seat instead of the postal-address city", () => {
+    const hit = {
+      ...KRS_HIT,
+      details: {
+        registry: "krs",
+        entity: {
+          krsNumber: KRS_HIT.id,
+          register: "RejP",
+          name: KRS_HIT.name,
+          legalForm: KRS_HIT.legalForm,
+          identifiers: { nip: null, regon: null },
+          shareCapital: null,
+          address: null,
+          registeredSeat: {
+            country: "POLSKA",
+            voivodeship: "MAZOWIECKIE",
+            county: "WARSZAWA",
+            commune: "WARSZAWA",
+            locality: "Warszawa",
+          },
+          email: null,
+          website: null,
+          status: { type: "active" },
+          registeredAt: null,
+          lastEntryAt: null,
+          registryUrl: KRS_HIT.registryUrl,
+        },
+      },
+    } satisfies BusinessRegistryHit;
+
+    expect(renderLookupOutput("seat in [seat]", hit)).toBe("seat in Warszawa");
+  });
+
   test("uses the built-in format for null and the generic fallback for blank custom formats", () => {
     const fallback =
       "Żabka Polska sp. z o.o., ul. Stanisława Matyi 8, 61-586 Poznań";

--- a/apps/api/src/lib/docx/lookup-fields.test.ts
+++ b/apps/api/src/lib/docx/lookup-fields.test.ts
@@ -108,21 +108,136 @@ describe("isPlausibleLookupValue", () => {
 });
 
 describe("renderLookupHit", () => {
-  test("renders name + text address", () => {
+  test("renders a registry-specific identification reference", () => {
     expect(renderLookupHit(KRS_HIT)).toBe(
-      "Żabka Polska sp. z o.o., ul. Stanisława Matyi 8, 61-586 Poznań",
+      "**Żabka Polska sp. z o.o.**, adres: ul. Stanisława Matyi 8, 61-586 Poznań, KRS: 0000123456",
     );
   });
 
-  test("falls back to the city, then to the name alone", () => {
+  test("omits missing registry particulars without dangling labels", () => {
     expect(
       renderLookupHit({
         ...KRS_HIT,
         address: { ...KRS_ADDRESS, textAddress: null },
       }),
-    ).toBe("Żabka Polska sp. z o.o., Poznań");
+    ).toBe("**Żabka Polska sp. z o.o.**, adres: Poznań, KRS: 0000123456");
     expect(renderLookupHit({ ...KRS_HIT, address: null })).toBe(
-      "Żabka Polska sp. z o.o.",
+      "**Żabka Polska sp. z o.o.**, KRS: 0000123456",
+    );
+  });
+
+  test("renders Companies House particulars in UK contract style", () => {
+    const hit = {
+      registry: "companies-house",
+      id: "01003142",
+      name: "ROLLS-ROYCE PLC",
+      legalForm: "plc",
+      address: {
+        line1: "Kings Place, 90 York Way",
+        line2: null,
+        postalCode: "N1 9FX",
+        city: "London",
+        region: null,
+        country: "United Kingdom",
+        textAddress: "Kings Place, 90 York Way, London, United Kingdom, N1 9FX",
+      },
+      registryUrl:
+        "https://find-and-update.company-information.service.gov.uk/company/01003142",
+      details: {
+        registry: "companies-house",
+        company: {
+          companyNumber: "01003142",
+          name: "ROLLS-ROYCE PLC",
+          status: { type: "active" },
+          statusDetail: null,
+          type: "plc",
+          subtype: null,
+          jurisdiction: "england-wales",
+          dateOfCreation: "1971-02-23",
+          dateOfCessation: null,
+          registeredOfficeAddress: null,
+          serviceAddress: null,
+          sicCodes: [],
+          accounts: null,
+          confirmationStatement: null,
+          hasCharges: null,
+          hasInsolvencyHistory: null,
+          hasBeenLiquidated: null,
+          previousNames: [],
+          registryUrl:
+            "https://find-and-update.company-information.service.gov.uk/company/01003142",
+        },
+      },
+    } satisfies BusinessRegistryHit;
+
+    expect(renderLookupOutput(null, hit)).toBe(
+      "**ROLLS-ROYCE PLC**, a public limited company registered in England and Wales under company number 01003142, whose registered office is at Kings Place, 90 York Way, London, United Kingdom, N1 9FX",
+    );
+  });
+
+  test("keeps a French legal entity's SIREN distinct from a branch SIRET", () => {
+    const headOffice = {
+      siret: "55208131700018",
+      isHeadOffice: true,
+      address: {
+        textAddress: "22 avenue de Wagram, 75008 Paris",
+        street: "22 avenue de Wagram",
+        postalCode: "75008",
+        city: "Paris",
+        country: "France",
+      },
+      activityCode: null,
+      status: { type: "open" },
+      createdAt: null,
+      closedAt: null,
+    } as const;
+    const branch = {
+      ...headOffice,
+      siret: "55208131701234",
+      isHeadOffice: false,
+      address: {
+        ...headOffice.address,
+        textAddress: "1 rue de Lyon, 69000 Lyon",
+        street: "1 rue de Lyon",
+        postalCode: "69000",
+        city: "Lyon",
+      },
+    } as const;
+    const hit = {
+      registry: "recherche-entreprises",
+      id: branch.siret,
+      name: "EXEMPLE SA",
+      legalForm: "5599",
+      address: {
+        line1: branch.address.street,
+        line2: null,
+        postalCode: branch.address.postalCode,
+        city: branch.address.city,
+        region: null,
+        country: branch.address.country,
+        textAddress: branch.address.textAddress,
+      },
+      registryUrl: "https://example.invalid/fr/552081317",
+      details: {
+        registry: "recherche-entreprises",
+        company: {
+          siren: "552081317",
+          name: "EXEMPLE SA",
+          legalFormCode: "5599",
+          shortName: null,
+          headOffice,
+          matchedEstablishment: branch,
+          status: { type: "active" },
+          registeredAt: null,
+          ceasedAt: null,
+          directors: [],
+          registryUrl: "https://example.invalid/fr/552081317",
+        },
+      },
+    } satisfies BusinessRegistryHit;
+
+    expect(renderLookupOutput(null, hit)).toBe(
+      "**EXEMPLE SA**, SIREN 552081317, siège social : 22 avenue de Wagram, 75008 Paris, SIRET 55208131701234",
     );
   });
 });
@@ -306,10 +421,12 @@ describe("renderLookupOutput", () => {
     ).toBe("**Żabka Polska sp. z o.o.**, seat in *Poznań*");
   });
 
-  test("falls back to the deterministic name + seat without a template", () => {
+  test("uses the built-in format for null and the generic fallback for blank custom formats", () => {
     const fallback =
       "Żabka Polska sp. z o.o., ul. Stanisława Matyi 8, 61-586 Poznań";
-    expect(renderLookupOutput(null, KRS_HIT)).toBe(fallback);
+    expect(renderLookupOutput(null, KRS_HIT)).toBe(
+      "**Żabka Polska sp. z o.o.**, adres: ul. Stanisława Matyi 8, 61-586 Poznań, KRS: 0000123456",
+    );
     expect(renderLookupOutput("  ", KRS_HIT)).toBe(fallback);
     // A template of only unknown tokens renders empty → same fallback.
     expect(renderLookupOutput("[no such token]", KRS_HIT)).toBe(fallback);

--- a/apps/api/src/lib/docx/lookup-fields.ts
+++ b/apps/api/src/lib/docx/lookup-fields.ts
@@ -33,6 +33,7 @@ import { validateOrgnr } from "@stll/business-registries/brreg";
 import { validateCompanyNumber } from "@stll/business-registries/companies-house";
 import {
   BUSINESS_REGISTRY_FORMAT_CAPABILITIES,
+  parseRegistryFormatMarkdown,
   type RegistryFormatSlug,
 } from "@stll/business-registries/default-formats";
 import { validateEstablishmentId } from "@stll/business-registries/denue";
@@ -475,6 +476,7 @@ const lookupTemplateTokens = (
     }
     case "krs": {
       const { entity } = details;
+      tokens["seat"] = entity.registeredSeat?.locality ?? null;
       tokens["registry number"] = entity.krsNumber;
       tokens["NIP"] = entity.identifiers.nip;
       tokens["REGON"] = entity.identifiers.regon;
@@ -598,38 +600,21 @@ export const renderLookupOutput = (
 
 // ── Inline markdown in the rendered output ───────────────
 
-/** `**bold**` / `*italic*` spans in the author's format template. Spans do
- *  not nest and cannot contain asterisks, and an italic `*` never pairs
- *  against a `**` delimiter (lookarounds); anything unmatched (a stray `*`,
- *  empty `****`, an asterisk inside a substituted value) stays literal. */
-const LOOKUP_MARKDOWN_RE =
-  /\*\*(?<bold>[^*]+)\*\*|(?<!\*)\*(?<italic>[^*]+)\*(?!\*)/gu;
-
 /**
  * Parse a rendered lookup output into formatted runs: `**bold**` and
  * `*italic*` spans become correspondingly formatted runs, everything else
  * stays a plain run. Unmatched asterisks are left literal.
  */
-export const parseLookupMarkdown = (text: string): RichRun[] => {
-  const runs: RichRun[] = [];
-  let cursor = 0;
-  for (const match of text.matchAll(LOOKUP_MARKDOWN_RE)) {
-    if (match.index > cursor) {
-      runs.push({ text: text.slice(cursor, match.index) });
+export const parseLookupMarkdown = (text: string): RichRun[] =>
+  parseRegistryFormatMarkdown(text).map(({ text: runText, style }) => {
+    if (style === "bold") {
+      return { text: runText, bold: true };
     }
-    const [, bold, italic] = match;
-    if (bold !== undefined) {
-      runs.push({ text: bold, bold: true });
-    } else if (italic !== undefined) {
-      runs.push({ text: italic, italic: true });
+    if (style === "italic") {
+      return { text: runText, italic: true };
     }
-    cursor = match.index + match[0].length;
-  }
-  if (cursor < text.length) {
-    runs.push({ text: text.slice(cursor) });
-  }
-  return runs;
-};
+    return { text: runText };
+  });
 
 /** Plain text of a rendered lookup output with the `**` / `*` formatting
  *  markers removed — the live-preview path renders plain text only. */

--- a/apps/api/src/lib/docx/lookup-fields.ts
+++ b/apps/api/src/lib/docx/lookup-fields.ts
@@ -24,7 +24,6 @@ import {
   getAresCourtNameInstrumental,
 } from "@stll/business-registries/ares/court-names";
 import {
-  ARES_DEFAULT_FORMAT,
   ARES_DEFAULT_FORMAT_PARTS,
   ARES_FILE_REFERENCE_TOKEN,
   isAresCommercialCompany,
@@ -32,6 +31,10 @@ import {
 import { getAresLegalFormName } from "@stll/business-registries/ares/legal-forms";
 import { validateOrgnr } from "@stll/business-registries/brreg";
 import { validateCompanyNumber } from "@stll/business-registries/companies-house";
+import {
+  BUSINESS_REGISTRY_FORMAT_CAPABILITIES,
+  type RegistryFormatSlug,
+} from "@stll/business-registries/default-formats";
 import { validateEstablishmentId } from "@stll/business-registries/denue";
 import { validateCik } from "@stll/business-registries/edgar";
 import { validateTaxId } from "@stll/business-registries/gcis";
@@ -65,6 +68,13 @@ import type {
   RichPatchValue,
   RichRun,
 } from "./types";
+
+true satisfies [
+  Exclude<LookupRegistry, RegistryFormatSlug>,
+  Exclude<RegistryFormatSlug, LookupRegistry>,
+] extends [never, never]
+  ? true
+  : never;
 
 // ── Registry-number plausibility ─────────────────────────
 
@@ -152,8 +162,181 @@ export const createDispatchLookupResolver =
 
 // ── Deterministic rendering ──────────────────────────────
 
-/** Registry-specific default, or "name, seat" when no legal-description
- *  default exists. Missing particulars never produce dangling clauses. */
+const COMPANIES_HOUSE_LEGAL_FORM_NAMES: Readonly<Record<string, string>> = {
+  plc: "public limited company",
+  ltd: "private limited company",
+  "private-limited-guarant-nsc":
+    "private company limited by guarantee without share capital",
+  "private-limited-guarant-nsc-limited-exemption":
+    "private company limited by guarantee without share capital",
+  "private-unlimited": "private unlimited company",
+  "private-unlimited-nsc": "private unlimited company without share capital",
+  llp: "limited liability partnership",
+  "limited-partnership": "limited partnership",
+};
+
+const COMPANIES_HOUSE_JURISDICTION_NAMES: Readonly<Record<string, string>> = {
+  "england-wales": "England and Wales",
+  england: "England",
+  wales: "Wales",
+  scotland: "Scotland",
+  "northern-ireland": "Northern Ireland",
+  "united-kingdom": "the United Kingdom",
+  "european-union": "the European Union",
+};
+
+const wordsFromCode = (value: string): string => value.replaceAll("-", " ");
+
+const companiesHouseLegalFormName = (value: string | null): string =>
+  value === null
+    ? "company"
+    : (COMPANIES_HOUSE_LEGAL_FORM_NAMES[value] ?? wordsFromCode(value));
+
+const companiesHouseJurisdictionName = (
+  value: string | null | undefined,
+): string | null =>
+  value === null || value === undefined
+    ? null
+    : (COMPANIES_HOUSE_JURISDICTION_NAMES[value] ??
+      `${wordsFromCode(value).charAt(0).toUpperCase()}${wordsFromCode(value).slice(1)}`);
+
+const addressText = (hit: BusinessRegistryHit): string | null =>
+  hit.address?.textAddress ?? hit.address?.city ?? null;
+
+const renderGenericLookupHit = (hit: BusinessRegistryHit): string =>
+  [hit.name, addressText(hit)].filter((part) => part !== null).join(", ");
+
+const renderLabelledParts = (
+  name: string,
+  parts: readonly (string | null)[],
+): string =>
+  [`**${name}**`, ...parts.filter((part) => part !== null)].join(", ");
+
+const renderBrregLookupHit = (hit: BusinessRegistryHit): string =>
+  renderLabelledParts(hit.name, [
+    hit.legalForm,
+    `organisasjonsnummer ${hit.id}`,
+    addressText(hit) === null ? null : `forretningsadresse ${addressText(hit)}`,
+  ]);
+
+const renderCompaniesHouseLookupHit = (hit: BusinessRegistryHit): string => {
+  const jurisdiction = companiesHouseJurisdictionName(
+    hit.details?.registry === "companies-house"
+      ? hit.details.company.jurisdiction
+      : null,
+  );
+  const registration = [
+    `a ${companiesHouseLegalFormName(hit.legalForm)}`,
+    jurisdiction === null ? null : `registered in ${jurisdiction}`,
+    `under company number ${hit.id}`,
+  ]
+    .filter((part) => part !== null)
+    .join(" ");
+  return renderLabelledParts(hit.name, [
+    registration,
+    addressText(hit) === null
+      ? null
+      : `whose registered office is at ${addressText(hit)}`,
+  ]);
+};
+
+const renderDenueLookupHit = (hit: BusinessRegistryHit): string =>
+  renderLabelledParts(hit.name, [
+    `DENUE establishment ${hit.id}`,
+    addressText(hit),
+  ]);
+
+const renderEdgarLookupHit = (hit: BusinessRegistryHit): string => {
+  const ein =
+    hit.details?.registry === "edgar" ? hit.details.company.ein : null;
+  return renderLabelledParts(hit.name, [
+    `SEC CIK ${hit.id}`,
+    ein === null ? null : `EIN ${ein}`,
+    addressText(hit),
+  ]);
+};
+
+const renderGcisLookupHit = (hit: BusinessRegistryHit): string => {
+  const authority =
+    hit.details?.registry === "gcis"
+      ? hit.details.company.registerOrganization
+      : null;
+  return [
+    `**${hit.name}**`,
+    `統一編號 ${hit.id}`,
+    addressText(hit) === null ? null : `公司所在地 ${addressText(hit)}`,
+    authority === null ? null : `登記機關 ${authority}`,
+  ]
+    .filter((part) => part !== null)
+    .join("，");
+};
+
+const renderKrsLookupHit = (hit: BusinessRegistryHit): string => {
+  const entity = hit.details?.registry === "krs" ? hit.details.entity : null;
+  return renderLabelledParts(hit.name, [
+    entity?.registeredSeat?.locality
+      ? `siedziba: ${entity.registeredSeat.locality}`
+      : null,
+    addressText(hit) === null ? null : `adres: ${addressText(hit)}`,
+    `KRS: ${hit.id}`,
+    entity?.identifiers.nip ? `NIP: ${entity.identifiers.nip}` : null,
+    entity?.identifiers.regon ? `REGON: ${entity.identifiers.regon}` : null,
+    entity?.shareCapital
+      ? `kapitał zakładowy: ${entity.shareCapital.amount} ${entity.shareCapital.currency}`
+      : null,
+  ]);
+};
+
+const renderOrsrLookupHit = (hit: BusinessRegistryHit): string => {
+  const company = hit.details?.registry === "orsr" ? hit.details.company : null;
+  const courtFile = company?.courtFile
+    ? formatCourtFile({
+        court: company.courtFile.court,
+        section: company.courtFile.section,
+        insert: company.courtFile.insertNumber,
+      })
+    : null;
+  return renderLabelledParts(hit.name, [
+    addressText(hit) === null ? null : `sídlo: ${addressText(hit)}`,
+    `IČO: ${hit.id}`,
+    courtFile === null ? null : `zápis v obchodnom registri: ${courtFile}`,
+  ]);
+};
+
+const renderPrhLookupHit = (hit: BusinessRegistryHit): string =>
+  renderLabelledParts(hit.name, [
+    `Y-tunnus ${hit.id}`,
+    addressText(hit) === null ? null : `osoite ${addressText(hit)}`,
+  ]);
+
+const renderRechercheEntreprisesLookupHit = (
+  hit: BusinessRegistryHit,
+): string => {
+  const company =
+    hit.details?.registry === "recherche-entreprises"
+      ? hit.details.company
+      : null;
+  const headOfficeAddress = company?.headOffice?.address?.textAddress;
+  let addressPart: string | null = null;
+  if (headOfficeAddress) {
+    addressPart = `siège social : ${headOfficeAddress}`;
+  } else if (addressText(hit) !== null) {
+    addressPart = `adresse : ${addressText(hit)}`;
+  }
+  return renderLabelledParts(hit.name, [
+    `SIREN ${company?.siren ?? hit.id}`,
+    addressPart,
+    company?.matchedEstablishment
+      ? `SIRET ${company.matchedEstablishment.siret}`
+      : null,
+  ]);
+};
+
+const renderViesLookupHit = (hit: BusinessRegistryHit): string =>
+  renderLabelledParts(hit.name, [`VAT number ${hit.id}`, addressText(hit)]);
+
+/** Registry-owned built-in output. Missing particulars never produce dangling
+ * clauses; non-company sources render an explicit registry reference. */
 export const renderLookupHit = (hit: BusinessRegistryHit): string => {
   if (hit.registry === "ares") {
     const tokens = lookupTemplateTokens(hit);
@@ -174,8 +357,31 @@ export const renderLookupHit = (hit: BusinessRegistryHit): string => {
     }
     return renderLookupTemplate(parts.join(", "), hit);
   }
-  const seat = hit.address?.textAddress ?? hit.address?.city ?? null;
-  return [hit.name, seat].filter((part) => part !== null).join(", ");
+  switch (hit.registry) {
+    case "brreg":
+      return renderBrregLookupHit(hit);
+    case "companies-house":
+      return renderCompaniesHouseLookupHit(hit);
+    case "denue":
+      return renderDenueLookupHit(hit);
+    case "edgar":
+      return renderEdgarLookupHit(hit);
+    case "gcis":
+      return renderGcisLookupHit(hit);
+    case "krs":
+      return renderKrsLookupHit(hit);
+    case "orsr":
+      return renderOrsrLookupHit(hit);
+    case "prh":
+      return renderPrhLookupHit(hit);
+    case "recherche-entreprises":
+      return renderRechercheEntreprisesLookupHit(hit);
+    case "vies":
+      return renderViesLookupHit(hit);
+    default: {
+      return assertNever(hit.registry);
+    }
+  }
 };
 
 /** "court, section insert" court-file reference, or null when the registry
@@ -281,9 +487,12 @@ const lookupTemplateTokens = (
     }
     case "companies-house": {
       const { company } = details;
+      tokens["legal form"] = companiesHouseLegalFormName(company.type);
       tokens["registry number"] = company.companyNumber;
       tokens["registered on"] = company.dateOfCreation;
-      tokens["jurisdiction"] = company.jurisdiction;
+      tokens["jurisdiction"] = companiesHouseJurisdictionName(
+        company.jurisdiction,
+      );
       break;
     }
     case "denue": {
@@ -309,6 +518,10 @@ const lookupTemplateTokens = (
       // sets it to the matched establishment's SIRET (14 digits) for a branch
       // lookup, falling back to the SIREN — overriding with `company.siren`
       // would drop the SIRET that selected the address.
+      tokens["SIREN"] = company.siren;
+      tokens["SIRET"] = company.matchedEstablishment?.siret ?? null;
+      tokens["head office address"] =
+        company.headOffice?.address?.textAddress ?? null;
       tokens["registered on"] = company.registeredAt;
       break;
     }
@@ -321,6 +534,7 @@ const lookupTemplateTokens = (
     case "gcis": {
       const { company } = details;
       tokens["registry number"] = company.taxId;
+      tokens["registering authority"] = company.registerOrganization;
       tokens["registered on"] = company.setupDate;
       break;
     }
@@ -363,12 +577,23 @@ export const renderLookupOutput = (
   format: string | null | undefined,
   hit: BusinessRegistryHit,
 ): string => {
-  const template = format?.trim() ?? "";
-  if (hit.registry === "ares" && template === ARES_DEFAULT_FORMAT) {
+  if (format === null || format === undefined) {
     return renderLookupHit(hit);
   }
-  const rendered = template === "" ? "" : renderLookupTemplate(template, hit);
-  return rendered !== "" ? rendered : renderLookupHit(hit);
+  const template = format.trim();
+  if (
+    template ===
+    BUSINESS_REGISTRY_FORMAT_CAPABILITIES[hit.registry].defaultFormat
+  ) {
+    return renderLookupHit(hit);
+  }
+  if (template === "") {
+    return hit.registry === "ares"
+      ? renderLookupHit(hit)
+      : renderGenericLookupHit(hit);
+  }
+  const rendered = renderLookupTemplate(template, hit);
+  return rendered !== "" ? rendered : renderGenericLookupHit(hit);
 };
 
 // ── Inline markdown in the rendered output ───────────────

--- a/apps/desktop/src/i18n/langs/ar.json
+++ b/apps/desktop/src/i18n/langs/ar.json
@@ -200,6 +200,7 @@
     "registryEmpty": "لا توجد نتائج في السجل.",
     "registryFormat": "التنسيق",
     "registryAddCompanyFormat": "إضافة قالب لمواصفات الشركة",
+    "registryAddRegistryFormat": "إضافة قالب لنتيجة السجل",
     "registrySearchHint": "اكتب للبحث في هذا السجل.",
     "registrySelect": "اختيار السجل",
     "registryErrorDisconnect": "تعذر فصل حساب السجل.",

--- a/apps/desktop/src/i18n/langs/cs.json
+++ b/apps/desktop/src/i18n/langs/cs.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Přidat šablonu specifikace společnosti",
+    "registryAddRegistryFormat": "Přidat šablonu výsledku z rejstříku",
     "registrySearchHint": "Začněte psát a prohledejte tento rejstřík.",
     "registrySelect": "Vybrat rejstřík",
     "registryErrorDisconnect": "Účet rejstříku nelze odpojit.",

--- a/apps/desktop/src/i18n/langs/de.json
+++ b/apps/desktop/src/i18n/langs/de.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Vorlage für Unternehmensangaben hinzufügen",
+    "registryAddRegistryFormat": "Vorlage für Registerergebnis hinzufügen",
     "registrySearchHint": "Tippen Sie, um dieses Register zu durchsuchen.",
     "registrySelect": "Register auswählen",
     "registryErrorDisconnect": "Das Registerkonto konnte nicht getrennt werden.",

--- a/apps/desktop/src/i18n/langs/en.json
+++ b/apps/desktop/src/i18n/langs/en.json
@@ -202,6 +202,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Add a company specification template",
+    "registryAddRegistryFormat": "Add a registry result template",
     "registrySearchHint": "Type to search this registry.",
     "registrySelect": "Select registry",
     "registryErrorDisconnect": "Registry account could not be disconnected.",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Añadir una plantilla de datos de empresa",
+    "registryAddRegistryFormat": "Añadir una plantilla de resultado del registro",
     "registrySearchHint": "Escribe para buscar en este registro.",
     "registrySelect": "Seleccionar registro",
     "registryErrorDisconnect": "No se pudo desconectar la cuenta del registro.",

--- a/apps/desktop/src/i18n/langs/et.json
+++ b/apps/desktop/src/i18n/langs/et.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Lisa ettevõtte andmete mall",
+    "registryAddRegistryFormat": "Lisa registritulemuse mall",
     "registrySearchHint": "Selle registri otsimiseks sisestage tekst.",
     "registrySelect": "Vali register",
     "registryErrorDisconnect": "Registrikonto ühenduse katkestamine ebaõnnestus.",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Ajouter un modèle de fiche d’entreprise",
+    "registryAddRegistryFormat": "Ajouter un modèle de résultat du registre",
     "registrySearchHint": "Saisissez du texte pour rechercher dans ce registre.",
     "registrySelect": "Sélectionner un registre",
     "registryErrorDisconnect": "Impossible de déconnecter le compte du registre.",

--- a/apps/desktop/src/i18n/langs/hu.json
+++ b/apps/desktop/src/i18n/langs/hu.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Cégadat-sablon hozzáadása",
+    "registryAddRegistryFormat": "Nyilvántartási eredmény sablonjának hozzáadása",
     "registrySearchHint": "Gépeljen a kereséshez ebben a nyilvántartásban.",
     "registrySelect": "Nyilvántartás kiválasztása",
     "registryErrorDisconnect": "A nyilvántartási fiókot nem sikerült leválasztani.",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Pridėti įmonės rekvizitų šabloną",
+    "registryAddRegistryFormat": "Pridėti registro rezultato šabloną",
     "registrySearchHint": "Įveskite tekstą, kad ieškotumėte šiame registre.",
     "registrySelect": "Pasirinkite registrą",
     "registryErrorDisconnect": "Nepavyko atjungti registro paskyros.",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Pievienot uzņēmuma rekvizītu veidni",
+    "registryAddRegistryFormat": "Pievienot reģistra rezultāta veidni",
     "registrySearchHint": "Rakstiet, lai meklētu šajā reģistrā.",
     "registrySelect": "Atlasīt reģistru",
     "registryErrorDisconnect": "Neizdevās atvienot reģistra kontu.",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Dodaj szablon danych spółki",
+    "registryAddRegistryFormat": "Dodaj szablon wyniku z rejestru",
     "registrySearchHint": "Zacznij pisać, aby przeszukać ten rejestr.",
     "registrySelect": "Wybierz rejestr",
     "registryErrorDisconnect": "Nie udało się odłączyć konta rejestru.",

--- a/apps/desktop/src/i18n/langs/pt-BR.json
+++ b/apps/desktop/src/i18n/langs/pt-BR.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Adicionar modelo de dados da empresa",
+    "registryAddRegistryFormat": "Adicionar um modelo de resultado do registro",
     "registrySearchHint": "Digite para pesquisar neste registro.",
     "registrySelect": "Selecionar registro",
     "registryErrorDisconnect": "Não foi possível desconectar a conta do registro.",

--- a/apps/desktop/src/i18n/langs/sk.json
+++ b/apps/desktop/src/i18n/langs/sk.json
@@ -200,6 +200,7 @@
     "registryEmpty": "No registry results.",
     "registryFormat": "Format",
     "registryAddCompanyFormat": "Pridať šablónu špecifikácie spoločnosti",
+    "registryAddRegistryFormat": "Pridať šablónu výsledku z registra",
     "registrySearchHint": "Začnite písať a prehľadajte tento register.",
     "registrySelect": "Vybrať register",
     "registryErrorDisconnect": "Účet registra sa nepodarilo odpojiť.",

--- a/apps/desktop/src/registry/RegistrySearch.tsx
+++ b/apps/desktop/src/registry/RegistrySearch.tsx
@@ -102,6 +102,10 @@ export const RegistrySearch = ({
   const connectionError = t("registryErrorState");
   const searchError = t("registryErrorSearch");
   const connected = connection?.status === "connected";
+  const formatType =
+    connection?.status === "connected"
+      ? connection.registries.find(({ id }) => id === registryId)?.formatType
+      : undefined;
   const trimmedQuery = query.trim();
   const scope = JSON.stringify([
     source,
@@ -606,7 +610,11 @@ export const RegistrySearch = ({
                       onClick={() => openCompanyFormat(card)}
                     >
                       <PlusIcon aria-hidden="true" />
-                      {t("registryAddCompanyFormat")}
+                      {t(
+                        formatType === "company-specification"
+                          ? "registryAddCompanyFormat"
+                          : "registryAddRegistryFormat",
+                      )}
                     </MenuItem>
                   </MenuPopup>
                 </Menu>

--- a/apps/desktop/src/registry/RegistrySearch.tsx
+++ b/apps/desktop/src/registry/RegistrySearch.tsx
@@ -611,9 +611,9 @@ export const RegistrySearch = ({
                     >
                       <PlusIcon aria-hidden="true" />
                       {t(
-                        formatType === "company-specification"
-                          ? "registryAddCompanyFormat"
-                          : "registryAddRegistryFormat",
+                        formatType === "registry-reference"
+                          ? "registryAddRegistryFormat"
+                          : "registryAddCompanyFormat",
                       )}
                     </MenuItem>
                   </MenuPopup>

--- a/apps/desktop/tests/browser/registry-interactions.playwright.spec.ts
+++ b/apps/desktop/tests/browser/registry-interactions.playwright.spec.ts
@@ -733,7 +733,12 @@ test("applies saved formatting and copies only the selected registry output", as
 test("opens the selected company's specification formats from the format menu", async ({
   page,
 }) => {
-  await openClipboard(page);
+  await openClipboard(page, {
+    status: "connected",
+    accountLabel: "https://api.example.test",
+    defaultRegistryId: "ares",
+    registries: [{ id: "ares", name: "Czech commercial registry" }],
+  });
   await activateRegistry(page);
   await page.getByRole("button", { name: "Format", exact: true }).click();
   await page

--- a/apps/desktop/tests/browser/registry-interactions.playwright.spec.ts
+++ b/apps/desktop/tests/browser/registry-interactions.playwright.spec.ts
@@ -11,8 +11,16 @@ import arMessages from "../../src/i18n/langs/ar.json" with { type: "json" };
 import enMessages from "../../src/i18n/langs/en.json" with { type: "json" };
 
 const REGISTRIES = [
-  { id: "ares", name: "Czech commercial registry" },
-  { id: "companies-house", name: "Companies House" },
+  {
+    id: "ares",
+    name: "Czech commercial registry",
+    formatType: "company-specification",
+  },
+  {
+    id: "companies-house",
+    name: "Companies House",
+    formatType: "company-specification",
+  },
 ] as const satisfies DesktopRegistryConfig["registries"];
 const SEARCH_RESPONSE = {
   defaultFormatId: "11111111-1111-4111-8111-111111111111",
@@ -740,6 +748,38 @@ test("opens the selected company's specification formats from the format menu", 
     .toContainEqual({
       command: "registry_open_company_format",
       args: { id: "company-1", registry: "ares" },
+    });
+});
+
+test("labels non-company directory templates as registry results", async ({
+  page,
+}) => {
+  await openClipboard(page, {
+    status: "connected",
+    accountLabel: "https://api.example.test",
+    defaultRegistryId: "denue",
+    registries: [
+      {
+        id: "denue",
+        name: "Mexico · INEGI DENUE",
+        formatType: "registry-reference",
+      },
+    ],
+  });
+  await activateRegistry(page);
+  await page.getByRole("button", { name: "Format", exact: true }).click();
+  await page
+    .getByRole("menuitem", {
+      name: "Add a registry result template",
+      exact: true,
+    })
+    .click();
+
+  await expect
+    .poll(async () => await readInvocations(page))
+    .toContainEqual({
+      command: "registry_open_company_format",
+      args: { id: "company-1", registry: "denue" },
     });
 });
 

--- a/apps/web/src/components/company-specification.tsx
+++ b/apps/web/src/components/company-specification.tsx
@@ -7,7 +7,11 @@ import { useDebounce } from "use-debounce";
 import { useTranslations } from "use-intl";
 
 import { isBusinessRegistryCredentialSlug } from "@stll/api-contract";
-import { BUSINESS_REGISTRY_FORMAT_CAPABILITIES } from "@stll/business-registries/default-formats";
+import {
+  BUSINESS_REGISTRY_FORMAT_CAPABILITIES,
+  parseRegistryFormatMarkdown,
+  stripRegistryFormatMarkdown,
+} from "@stll/business-registries/default-formats";
 import { copyToClipboard } from "@stll/clipboard";
 import { Button } from "@stll/ui/button";
 import { Field, FieldControl, FieldLabel } from "@stll/ui/field";
@@ -151,7 +155,9 @@ const CompanySpecificationEditor = ({
     if (data === undefined) {
       return;
     }
-    const copied = await copyToClipboard(data.rendered);
+    const copied = await copyToClipboard(
+      stripRegistryFormatMarkdown(data.rendered),
+    );
     if (Result.isError(copied)) {
       getAnalytics().captureError(copied.error);
       stellaToast.error(t("errors.actionFailed"));
@@ -230,7 +236,17 @@ const CompanySpecificationEditor = ({
         ) : null}
         {data ? (
           <p className="text-sm leading-6 whitespace-pre-wrap" dir="auto">
-            {data.rendered}
+            {parseRegistryFormatMarkdown(data.rendered).map(
+              ({ text: runText, style, start }) => {
+                if (style === "bold") {
+                  return <strong key={start}>{runText}</strong>;
+                }
+                if (style === "italic") {
+                  return <em key={start}>{runText}</em>;
+                }
+                return <span key={start}>{runText}</span>;
+              },
+            )}
           </p>
         ) : null}
         <div className="mt-1 flex items-center justify-end gap-1">

--- a/apps/web/src/components/company-specification.tsx
+++ b/apps/web/src/components/company-specification.tsx
@@ -7,6 +7,7 @@ import { useDebounce } from "use-debounce";
 import { useTranslations } from "use-intl";
 
 import { isBusinessRegistryCredentialSlug } from "@stll/api-contract";
+import { BUSINESS_REGISTRY_FORMAT_CAPABILITIES } from "@stll/business-registries/default-formats";
 import { copyToClipboard } from "@stll/clipboard";
 import { Button } from "@stll/ui/button";
 import { Field, FieldControl, FieldLabel } from "@stll/ui/field";
@@ -269,7 +270,12 @@ const CompanySpecificationEditor = ({
         type="button"
       >
         <CopyIcon />
-        {t("templates.copyCompanySpecification")}
+        {t(
+          BUSINESS_REGISTRY_FORMAT_CAPABILITIES[registry].type ===
+            "company-specification"
+            ? "templates.copyCompanySpecification"
+            : "templates.copyRegistryResult",
+        )}
       </Button>
     </section>
   );

--- a/apps/web/src/components/templates/registry-format-config.test.ts
+++ b/apps/web/src/components/templates/registry-format-config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isRegistryReseedableFormat,
+  REGISTRY_DEFAULT_FORMAT,
+} from "./registry-format-config";
+
+const PREVIOUS_KRS_DEFAULT_FORMAT =
+  "[company name] with its registered office at [address], entered in the Register of Entrepreneurs under KRS no. [registry number], kept by Krajowy Rejestr Sądowy, share capital of [share capital], Tax Identification Number (NIP) [NIP], Statistical Identification Number (REGON) [REGON]";
+
+describe("registry default reseeding", () => {
+  test("recognizes current built-in formats", () => {
+    expect(
+      isRegistryReseedableFormat("ares", REGISTRY_DEFAULT_FORMAT.ares),
+    ).toBe(true);
+  });
+
+  test("recognizes the persisted former KRS default", () => {
+    expect(isRegistryReseedableFormat("krs", PREVIOUS_KRS_DEFAULT_FORMAT)).toBe(
+      true,
+    );
+  });
+
+  test("preserves author-edited formats", () => {
+    expect(isRegistryReseedableFormat("krs", "custom [company name]")).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/components/templates/registry-format-config.ts
+++ b/apps/web/src/components/templates/registry-format-config.ts
@@ -87,6 +87,36 @@ export const REGISTRY_DEFAULT_FORMAT = {
   vies: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.vies.defaultFormat,
 } satisfies Record<LookupRegistry, string>;
 
+const PREVIOUS_KRS_DEFAULT_FORMAT =
+  "[company name] with its registered office at [address], entered in the Register of Entrepreneurs under KRS no. [registry number], kept by Krajowy Rejestr Sądowy, share capital of [share capital], Tax Identification Number (NIP) [NIP], Statistical Identification Number (REGON) [REGON]";
+
+/**
+ * Formats that still represent an untouched built-in row when switching a
+ * registry. The KRS entry covers persisted manifests from before the
+ * registry-specific defaults; remove it after a migration rewrites those rows.
+ */
+const REGISTRY_RESEEDABLE_FORMATS = {
+  ares: [REGISTRY_DEFAULT_FORMAT.ares],
+  brreg: [REGISTRY_DEFAULT_FORMAT.brreg],
+  "companies-house": [REGISTRY_DEFAULT_FORMAT["companies-house"]],
+  denue: [REGISTRY_DEFAULT_FORMAT.denue],
+  edgar: [REGISTRY_DEFAULT_FORMAT.edgar],
+  gcis: [REGISTRY_DEFAULT_FORMAT.gcis],
+  krs: [REGISTRY_DEFAULT_FORMAT.krs, PREVIOUS_KRS_DEFAULT_FORMAT],
+  orsr: [REGISTRY_DEFAULT_FORMAT.orsr],
+  prh: [REGISTRY_DEFAULT_FORMAT.prh],
+  "recherche-entreprises": [REGISTRY_DEFAULT_FORMAT["recherche-entreprises"]],
+  vies: [REGISTRY_DEFAULT_FORMAT.vies],
+} as const satisfies Record<LookupRegistry, readonly string[]>;
+
+export const isRegistryReseedableFormat = (
+  registry: LookupRegistry,
+  format: string,
+): boolean =>
+  REGISTRY_RESEEDABLE_FORMATS[registry].some(
+    (candidate) => candidate === format,
+  );
+
 /** Curated token examples shown in Template Studio tooltips. */
 export const REGISTRY_FIELD_EXAMPLES: Partial<
   Record<LookupRegistry, Record<string, string>>

--- a/apps/web/src/components/templates/registry-format-config.ts
+++ b/apps/web/src/components/templates/registry-format-config.ts
@@ -1,8 +1,6 @@
 import { ARES_COURT_INSTRUMENTAL_TOKEN } from "@stll/business-registries/ares/court-names";
-import {
-  ARES_DEFAULT_FORMAT,
-  ARES_FILE_REFERENCE_TOKEN,
-} from "@stll/business-registries/ares/default-format";
+import { ARES_FILE_REFERENCE_TOKEN } from "@stll/business-registries/ares/default-format";
+import { BUSINESS_REGISTRY_FORMAT_CAPABILITIES } from "@stll/business-registries/default-formats";
 
 import type { LookupRegistry } from "@/components/templates/template-field-manifest";
 
@@ -55,28 +53,39 @@ export const REGISTRY_RETURN_FIELDS: Record<LookupRegistry, readonly string[]> =
     ),
     brreg: [...REGISTRY_BASE_RETURN_FIELDS, "registered on"],
     prh: [...REGISTRY_BASE_RETURN_FIELDS, "registered on"],
-    "recherche-entreprises": [...REGISTRY_BASE_RETURN_FIELDS, "registered on"],
+    "recherche-entreprises": [
+      ...REGISTRY_BASE_RETURN_FIELDS,
+      "SIREN",
+      "SIRET",
+      "head office address",
+      "registered on",
+    ],
     edgar: [...REGISTRY_BASE_RETURN_FIELDS, "EIN"],
-    gcis: [...REGISTRY_BASE_RETURN_FIELDS, "registered on"],
+    gcis: [
+      ...REGISTRY_BASE_RETURN_FIELDS,
+      "registering authority",
+      "registered on",
+    ],
     vies: [...REGISTRY_BASE_RETURN_FIELDS, "VAT number"],
   };
 
-const GENERIC_DEFAULT_FORMAT = "[company name], [registry number], [address]";
-
-/** Default legal-description format seeded for each registry. */
-export const REGISTRY_DEFAULT_FORMAT: Record<LookupRegistry, string> = {
-  krs: "[company name] with its registered office at [address], entered in the Register of Entrepreneurs under KRS no. [registry number], kept by Krajowy Rejestr Sądowy, share capital of [share capital], Tax Identification Number (NIP) [NIP], Statistical Identification Number (REGON) [REGON]",
-  ares: ARES_DEFAULT_FORMAT,
-  orsr: GENERIC_DEFAULT_FORMAT,
-  "companies-house": GENERIC_DEFAULT_FORMAT,
-  denue: GENERIC_DEFAULT_FORMAT,
-  brreg: GENERIC_DEFAULT_FORMAT,
-  prh: GENERIC_DEFAULT_FORMAT,
-  "recherche-entreprises": GENERIC_DEFAULT_FORMAT,
-  edgar: GENERIC_DEFAULT_FORMAT,
-  gcis: GENERIC_DEFAULT_FORMAT,
-  vies: GENERIC_DEFAULT_FORMAT,
-};
+/** Built-in registry outputs shared with the desktop rendering path. */
+export const REGISTRY_DEFAULT_FORMAT = {
+  ares: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.ares.defaultFormat,
+  brreg: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.brreg.defaultFormat,
+  "companies-house":
+    BUSINESS_REGISTRY_FORMAT_CAPABILITIES["companies-house"].defaultFormat,
+  denue: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.denue.defaultFormat,
+  edgar: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.edgar.defaultFormat,
+  gcis: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.gcis.defaultFormat,
+  krs: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.krs.defaultFormat,
+  orsr: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.orsr.defaultFormat,
+  prh: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.prh.defaultFormat,
+  "recherche-entreprises":
+    BUSINESS_REGISTRY_FORMAT_CAPABILITIES["recherche-entreprises"]
+      .defaultFormat,
+  vies: BUSINESS_REGISTRY_FORMAT_CAPABILITIES.vies.defaultFormat,
+} satisfies Record<LookupRegistry, string>;
 
 /** Curated token examples shown in Template Studio tooltips. */
 export const REGISTRY_FIELD_EXAMPLES: Partial<

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -4310,6 +4310,7 @@
     "configureFields": "تهيئة الحقول",
     "confirmDelete": "سيؤدي هذا إلى حذف القالب نهائياً.",
     "copyCompanySpecification": "نسخ بيانات الشركة",
+    "copyRegistryResult": "نسخ نتيجة السجل",
     "createDocument": "إنشاء مستند",
     "createDocumentAnyway": "الإنشاء على أي حال",
     "createFromStyles": "البدء بأنماط مستند",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Nastavit pole",
     "confirmDelete": "Tímto trvale smažete vzor.",
     "copyCompanySpecification": "Kopírovat specifikaci společnosti",
+    "copyRegistryResult": "Kopírovat výsledek z rejstříku",
     "createDocument": "Vytvořit dokument",
     "createDocumentAnyway": "Přesto vytvořit",
     "createFromStyles": "Začít se styly dokumentu",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Felder konfigurieren",
     "confirmDelete": "Die Vorlage wird dauerhaft gelöscht.",
     "copyCompanySpecification": "Gesellschaftsangaben kopieren",
+    "copyRegistryResult": "Registerergebnis kopieren",
     "createDocument": "Dokument erstellen",
     "createDocumentAnyway": "Trotzdem erstellen",
     "createFromStyles": "Mit Dokumentformatvorlagen beginnen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Configure fields",
     "confirmDelete": "This will permanently delete the template.",
     "copyCompanySpecification": "Copy company specification",
+    "copyRegistryResult": "Copy registry result",
     "createDocument": "Create document",
     "createDocumentAnyway": "Create anyway",
     "createFromStyles": "Start with document styles",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Configurar campos",
     "confirmDelete": "Esto eliminará la plantilla permanentemente.",
     "copyCompanySpecification": "Copiar la identificación de la empresa",
+    "copyRegistryResult": "Copiar resultado del registro",
     "createDocument": "Crear documento",
     "createDocumentAnyway": "Crear de todos modos",
     "createFromStyles": "Empezar con estilos de documento",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Seadista väljad",
     "confirmDelete": "See kustutab malli jäädavalt.",
     "copyCompanySpecification": "Kopeeri ettevõtte andmed",
+    "copyRegistryResult": "Kopeeri registritulemus",
     "createDocument": "Loo dokument",
     "createDocumentAnyway": "Loo ikkagi",
     "createFromStyles": "Alusta dokumendi laadidega",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Configurer les champs",
     "confirmDelete": "Cela supprimera définitivement le modèle.",
     "copyCompanySpecification": "Copier l’identification de la société",
+    "copyRegistryResult": "Copier le résultat du registre",
     "createDocument": "Créer le document",
     "createDocumentAnyway": "Créer quand même",
     "createFromStyles": "Commencer avec les styles d’un document",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Mezők beállítása",
     "confirmDelete": "A sablon véglegesen törlődik.",
     "copyCompanySpecification": "Cégadatok másolása",
+    "copyRegistryResult": "Nyilvántartási eredmény másolása",
     "createDocument": "Dokumentum létrehozása",
     "createDocumentAnyway": "Létrehozás így is",
     "createFromStyles": "Kezdés dokumentumstílusokkal",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Konfigūruoti laukus",
     "confirmDelete": "Šablonas bus ištrintas negrįžtamai.",
     "copyCompanySpecification": "Kopijuoti įmonės rekvizitus",
+    "copyRegistryResult": "Kopijuoti registro rezultatą",
     "createDocument": "Sukurti dokumentą",
     "createDocumentAnyway": "Vis tiek sukurti",
     "createFromStyles": "Pradėti nuo dokumento stilių",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Konfigurēt laukus",
     "confirmDelete": "Veidne tiks neatgriezeniski dzēsta.",
     "copyCompanySpecification": "Kopēt uzņēmuma rekvizītus",
+    "copyRegistryResult": "Kopēt reģistra rezultātu",
     "createDocument": "Izveidot dokumentu",
     "createDocumentAnyway": "Tomēr izveidot",
     "createFromStyles": "Sākt ar dokumenta stiliem",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -4313,6 +4313,7 @@ type Messages = {
     "configureFields": "Configure fields";
     "confirmDelete": "This will permanently delete the template.";
     "copyCompanySpecification": "Copy company specification";
+    "copyRegistryResult": "Copy registry result";
     "createDocument": "Create document";
     "createDocumentAnyway": "Create anyway";
     "createFromStyles": "Start with document styles";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Skonfiguruj pola",
     "confirmDelete": "Szablon zostanie trwale usunięty.",
     "copyCompanySpecification": "Kopiuj oznaczenie spółki",
+    "copyRegistryResult": "Kopiuj wynik z rejestru",
     "createDocument": "Utwórz dokument",
     "createDocumentAnyway": "Utwórz mimo to",
     "createFromStyles": "Zacznij od stylów dokumentu",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Configurar campos",
     "confirmDelete": "Isso excluirá permanentemente o modelo.",
     "copyCompanySpecification": "Copiar a identificação da empresa",
+    "copyRegistryResult": "Copiar resultado do registro",
     "createDocument": "Criar documento",
     "createDocumentAnyway": "Criar mesmo assim",
     "createFromStyles": "Começar com estilos do documento",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -4310,6 +4310,7 @@
     "configureFields": "Nastaviť polia",
     "confirmDelete": "Vzor bude trvalo vymazaný.",
     "copyCompanySpecification": "Kopírovať špecifikáciu spoločnosti",
+    "copyRegistryResult": "Kopírovať výsledok z registra",
     "createDocument": "Vytvoriť dokument",
     "createDocumentAnyway": "Aj tak vytvoriť",
     "createFromStyles": "Začať so štýlmi dokumentu",

--- a/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
@@ -29,6 +29,7 @@ import { contentDir } from "@stll/ui/use-content-dir";
 import { cn } from "@stll/ui/utils";
 
 import {
+  isRegistryReseedableFormat,
   REGISTRY_DEFAULT_FORMAT,
   REGISTRY_FIELD_EXAMPLES,
   REGISTRY_RETURN_FIELDS,
@@ -401,7 +402,7 @@ const CompanyLookupConfig = ({
     const firstTemplate = first?.template.trim() ?? "";
     const isUntouched =
       firstTemplate === "" ||
-      firstTemplate === REGISTRY_DEFAULT_FORMAT[registry];
+      isRegistryReseedableFormat(registry, firstTemplate);
     if (first === undefined || !isUntouched) {
       setLookup({ registry: next });
       return;

--- a/packages/api-contract/src/desktop-registry.ts
+++ b/packages/api-contract/src/desktop-registry.ts
@@ -1,7 +1,11 @@
 import type { BusinessRegistrySlug } from "./business-registries";
 
 export type DesktopRegistryConfig = {
-  registries: { id: BusinessRegistrySlug; name: string }[];
+  registries: {
+    id: BusinessRegistrySlug;
+    name: string;
+    formatType: "company-specification" | "registry-reference";
+  }[];
   defaultRegistryId: BusinessRegistrySlug | null;
 };
 

--- a/packages/api-contract/src/desktop-registry.ts
+++ b/packages/api-contract/src/desktop-registry.ts
@@ -4,7 +4,8 @@ export type DesktopRegistryConfig = {
   registries: {
     id: BusinessRegistrySlug;
     name: string;
-    formatType: "company-specification" | "registry-reference";
+    /** Absent only when a newer desktop is connected to an older API. */
+    formatType?: "company-specification" | "registry-reference";
   }[];
   defaultRegistryId: BusinessRegistrySlug | null;
 };

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -55,6 +55,7 @@
     "./brreg": "./src/brreg/index.ts",
     "./cnpj": "./src/cnpj/index.ts",
     "./companies-house": "./src/companies-house/index.ts",
+    "./default-formats": "./src/default-formats.ts",
     "./cpf": "./src/cpf/index.ts",
     "./denue": "./src/denue/index.ts",
     "./edgar": "./src/edgar/index.ts",

--- a/packages/business-registries/src/default-formats.test.ts
+++ b/packages/business-registries/src/default-formats.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseRegistryFormatMarkdown,
+  stripRegistryFormatMarkdown,
+} from "./default-formats";
+
+describe("registry format markdown", () => {
+  test("parses supported emphasis for rich previews", () => {
+    expect(
+      parseRegistryFormatMarkdown("**ACME PLC**, an *active* company"),
+    ).toEqual([
+      { text: "ACME PLC", style: "bold", start: 0 },
+      { text: ", an ", style: "plain", start: 12 },
+      { text: "active", style: "italic", start: 17 },
+      { text: " company", style: "plain", start: 25 },
+    ]);
+  });
+
+  test("removes emphasis markers from plain-text clipboard output", () => {
+    expect(
+      stripRegistryFormatMarkdown("**ACME PLC**, an *active* company"),
+    ).toBe("ACME PLC, an active company");
+  });
+});

--- a/packages/business-registries/src/default-formats.ts
+++ b/packages/business-registries/src/default-formats.ts
@@ -40,6 +40,49 @@ export const REGISTRY_FORMAT_SLUGS: readonly [
 
 export type RegistryFormatSlug = (typeof REGISTRY_FORMAT_SLUGS)[number];
 
+export type RegistryFormatRun = {
+  text: string;
+  style: "plain" | "bold" | "italic";
+  start: number;
+};
+
+const REGISTRY_FORMAT_MARKDOWN_RE =
+  /\*\*(?<bold>[^*]+)\*\*|(?<!\*)\*(?<italic>[^*]+)\*(?!\*)/gu;
+
+/** Parse the bold and italic markers supported by registry format templates. */
+export const parseRegistryFormatMarkdown = (
+  text: string,
+): RegistryFormatRun[] => {
+  const runs: RegistryFormatRun[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(REGISTRY_FORMAT_MARKDOWN_RE)) {
+    if (match.index > cursor) {
+      runs.push({
+        text: text.slice(cursor, match.index),
+        style: "plain",
+        start: cursor,
+      });
+    }
+    const [, bold, italic] = match;
+    if (bold !== undefined) {
+      runs.push({ text: bold, style: "bold", start: match.index });
+    } else if (italic !== undefined) {
+      runs.push({ text: italic, style: "italic", start: match.index });
+    }
+    cursor = match.index + match[0].length;
+  }
+  if (cursor < text.length) {
+    runs.push({ text: text.slice(cursor), style: "plain", start: cursor });
+  }
+  return runs;
+};
+
+/** Remove supported format markers for plain-text clipboard output. */
+export const stripRegistryFormatMarkdown = (text: string): string =>
+  parseRegistryFormatMarkdown(text)
+    .map(({ text: runText }) => runText)
+    .join("");
+
 /**
  * Built-in output semantics for each registry. A company specification is
  * offered only when the upstream record contains the jurisdiction's core

--- a/packages/business-registries/src/default-formats.ts
+++ b/packages/business-registries/src/default-formats.ts
@@ -1,0 +1,116 @@
+import { ARES_DEFAULT_FORMAT } from "./ares/default-format.js";
+
+export type RegistryFormatCapability =
+  | {
+      type: "company-specification";
+      defaultFormat: string;
+      resultShape: "full-record";
+    }
+  | {
+      type: "registry-reference";
+      defaultFormat: string;
+      resultShape: "search-result" | "full-record";
+    };
+
+export const REGISTRY_FORMAT_SLUGS: readonly [
+  "ares",
+  "brreg",
+  "companies-house",
+  "denue",
+  "edgar",
+  "gcis",
+  "krs",
+  "orsr",
+  "prh",
+  "recherche-entreprises",
+  "vies",
+] = [
+  "ares",
+  "brreg",
+  "companies-house",
+  "denue",
+  "edgar",
+  "gcis",
+  "krs",
+  "orsr",
+  "prh",
+  "recherche-entreprises",
+  "vies",
+];
+
+export type RegistryFormatSlug = (typeof REGISTRY_FORMAT_SLUGS)[number];
+
+/**
+ * Built-in output semantics for each registry. A company specification is
+ * offered only when the upstream record contains the jurisdiction's core
+ * party-identification particulars. Directory, filer, VAT, and incomplete
+ * registry records are labelled as references instead.
+ */
+export const BUSINESS_REGISTRY_FORMAT_CAPABILITIES: Readonly<
+  Record<RegistryFormatSlug, RegistryFormatCapability>
+> = {
+  ares: {
+    type: "company-specification",
+    defaultFormat: ARES_DEFAULT_FORMAT,
+    resultShape: "full-record",
+  },
+  brreg: {
+    type: "company-specification",
+    defaultFormat:
+      "**[company name]**, [legal form], organisasjonsnummer [registry number], forretningsadresse [address]",
+    resultShape: "full-record",
+  },
+  "companies-house": {
+    type: "company-specification",
+    defaultFormat:
+      "**[company name]**, a [legal form] registered in [jurisdiction] under company number [registry number], whose registered office is at [address]",
+    resultShape: "full-record",
+  },
+  denue: {
+    type: "registry-reference",
+    defaultFormat:
+      "**[company name]**, DENUE establishment [registry number], [address]",
+    resultShape: "search-result",
+  },
+  edgar: {
+    type: "registry-reference",
+    defaultFormat:
+      "**[company name]**, SEC CIK [registry number], EIN [EIN], [address]",
+    resultShape: "full-record",
+  },
+  gcis: {
+    type: "company-specification",
+    defaultFormat:
+      "**[company name]**，統一編號 [registry number]，公司所在地 [address]，登記機關 [registering authority]",
+    resultShape: "full-record",
+  },
+  krs: {
+    type: "registry-reference",
+    defaultFormat:
+      "**[company name]**, siedziba: [seat], adres: [address], KRS: [registry number], NIP: [NIP], REGON: [REGON], kapitał zakładowy: [share capital]",
+    resultShape: "full-record",
+  },
+  orsr: {
+    type: "company-specification",
+    defaultFormat:
+      "**[company name]**, sídlo: [address], IČO: [registry number], zápis v obchodnom registri: [court file]",
+    resultShape: "full-record",
+  },
+  prh: {
+    type: "registry-reference",
+    defaultFormat:
+      "**[company name]**, Y-tunnus [registry number], osoite [address]",
+    resultShape: "search-result",
+  },
+  "recherche-entreprises": {
+    type: "registry-reference",
+    defaultFormat:
+      "**[company name]**, SIREN [SIREN], siège social : [head office address], SIRET [SIRET]",
+    resultShape: "full-record",
+  },
+  vies: {
+    type: "registry-reference",
+    defaultFormat: "**[company name]**, VAT number [VAT number], [address]",
+    resultShape: "full-record",
+  },
+};

--- a/scripts/knip-exports-baseline.json
+++ b/scripts/knip-exports-baseline.json
@@ -1,6 +1,6 @@
 {
   "apps/api": {
-    "count": 767,
+    "count": 764,
     "files": {
       "apps/api/scripts/lib/capability-catalog.ts": 9,
       "apps/api/scripts/lib/case-law-fixture-analyses.ts": 1,
@@ -25,7 +25,6 @@
       "apps/api/src/handlers/case-law/decisions/facets.ts": 1,
       "apps/api/src/handlers/case-law/decisions/latest.ts": 2,
       "apps/api/src/handlers/case-law/decisions/search-telemetry.ts": 2,
-      "apps/api/src/handlers/case-law/decisions/shelf-courts.ts": 2,
       "apps/api/src/handlers/case-law/document-ast.ts": 24,
       "apps/api/src/handlers/case-law/ingestion/adapters/at-ris-throttle.ts": 1,
       "apps/api/src/handlers/case-law/ingestion/adapters/retry.ts": 1,
@@ -143,7 +142,6 @@
       "apps/api/src/lib/case-law/document-ast.ts": 21,
       "apps/api/src/lib/case-law/language-alternates.ts": 1,
       "apps/api/src/lib/case-law/maintenance-lane.ts": 4,
-      "apps/api/src/lib/case-law/non-redistributable-sources.ts": 1,
       "apps/api/src/lib/case-law/research-answers.ts": 4,
       "apps/api/src/lib/case-law/research-saved-query.ts": 1,
       "apps/api/src/lib/chat/chat-tool-types.ts": 1,


### PR DESCRIPTION
The built-in company output previously treated non-Czech registry results as a company name and address, which omitted jurisdiction-specific party identifiers and overstated directory or filer records as contract-ready company specifications.

This adds one shared, exhaustive registry format contract used by desktop, web, and document rendering. Registries with sufficient particulars produce jurisdiction-specific company specifications; DENUE, EDGAR, KRS, PRH, RNE, and VIES produce clearly labelled registry references. Companies House now includes legal form, jurisdiction, company number, and registered office, while French output keeps legal-entity SIREN separate from establishment SIRET.

Validation: `bun run verify`; desktop browser tests in Chromium and WebKit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added registry-specific output formats for company specifications and registry references.
  - Registry results now show tailored details, including registration numbers, addresses and jurisdiction information where available.
  - Added support for copying registry results and creating registry-result templates.
  - Registry searches can use search-result data more efficiently across supported registries.
  - Registry-format previews now support bold and italic text.

- **Bug Fixes**
  - Improved fallback formatting for empty or unproductive custom templates.
  - Preserved custom formats when switching registries.

- **Documentation**
  - Added translations for registry-result actions across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->